### PR TITLE
Fix issues #21 and #38

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -6,8 +6,8 @@
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="CSBAnnotator"/>
   <Description DefaultValue="Utility functions to annotate data in a fast and safe way"/>
-  <IconUrl DefaultValue="https://localhost:3000/assets/icon-32.png"/>
-  <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-80.png"/>
+  <IconUrl DefaultValue="https://localhost:5000/assets/icon-32.png"/>
+  <HighResolutionIconUrl DefaultValue="https://localhost:5000/assets/icon-80.png"/>
   <SupportUrl DefaultValue="https://csb.bio.uni-kl.de/"/>
   <AppDomains>
     <AppDomain>bio.uni-kl.de</AppDomain>
@@ -16,7 +16,7 @@
     <Host Name="Workbook"/>
   </Hosts>
   <DefaultSettings>
-    <SourceLocation DefaultValue="https://localhost:3000/"/>
+    <SourceLocation DefaultValue="https://localhost:5000/"/>
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -95,20 +95,20 @@
     </Hosts>
     <Resources>
       <bt:Images>
-        <bt:Image id="Icon.16x16" DefaultValue="https://localhost:3000/assets/icon-16.png"/>
-        <bt:Image id="Icon.20x20" DefaultValue="https://localhost:3000/assets/icon-20.png"/>
-        <bt:Image id="Icon.24x24" DefaultValue="https://localhost:3000/assets/icon-24.png"/>
-        <bt:Image id="Icon.32x32" DefaultValue="https://localhost:3000/assets/icon-32.png"/>
-        <bt:Image id="Icon.40x40" DefaultValue="https://localhost:3000/assets/icon-40.png"/>
-        <bt:Image id="Icon.48x48" DefaultValue="https://localhost:3000/assets/icon-48.png"/>
-        <bt:Image id="Icon.64x64" DefaultValue="https://localhost:3000/assets/icon-64.png"/>
-        <bt:Image id="Icon.80x80" DefaultValue="https://localhost:3000/assets/icon-80.png"/>
-        <bt:Image id="Icon.96x96" DefaultValue="https://localhost:3000/assets/icon-96.png"/>
+        <bt:Image id="Icon.16x16" DefaultValue="https://localhost:5000/assets/icon-16.png"/>
+        <bt:Image id="Icon.20x20" DefaultValue="https://localhost:5000/assets/icon-20.png"/>
+        <bt:Image id="Icon.24x24" DefaultValue="https://localhost:5000/assets/icon-24.png"/>
+        <bt:Image id="Icon.32x32" DefaultValue="https://localhost:5000/assets/icon-32.png"/>
+        <bt:Image id="Icon.40x40" DefaultValue="https://localhost:5000/assets/icon-40.png"/>
+        <bt:Image id="Icon.48x48" DefaultValue="https://localhost:5000/assets/icon-48.png"/>
+        <bt:Image id="Icon.64x64" DefaultValue="https://localhost:5000/assets/icon-64.png"/>
+        <bt:Image id="Icon.80x80" DefaultValue="https://localhost:5000/assets/icon-80.png"/>
+        <bt:Image id="Icon.96x96" DefaultValue="https://localhost:5000/assets/icon-96.png"/>
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
-        <bt:Url id="TermSearch.Url" DefaultValue="https://localhost:3000/#TermSearch"/>
-        <bt:Url id="AddBuildingBlock.Url" DefaultValue="https://localhost:3000/#AddBuildingBlock"/>
+        <bt:Url id="TermSearch.Url" DefaultValue="https://localhost:5000/#TermSearch"/>
+        <bt:Url id="AddBuildingBlock.Url" DefaultValue="https://localhost:5000/#AddBuildingBlock"/>
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started annotating your data for greater good!"/>

--- a/src/Client/Client.fs
+++ b/src/Client/Client.fs
@@ -34,8 +34,8 @@ let initializeAddIn () =
    
 
 // defines the initial state and initial command (= side-effect) of the application
-let init (pageOpt: Routing.Page option) : Model * Cmd<Msg> =
-    let loadCountCmd =
+let init (pageOpt: Routing.Route option) : Model * Cmd<Msg> =
+    let initialCmd =
         Cmd.batch [
             Cmd.OfPromise.either
                 initializeAddIn
@@ -49,13 +49,17 @@ let init (pageOpt: Routing.Page option) : Model * Cmd<Msg> =
                 (AnnotationTableExists >> ExcelInterop)
                 (GenericError >> Dev)
         ]
-    initializeModel pageOpt , loadCountCmd
+    let initialModel = initializeModel pageOpt
+    let route = (parseHash Routing.Routing.route) Browser.Dom.document.location
+    // The initial command from urlUpdate is not needed yet. As we use a reduced variant of subModels with no own Msg system.
+    let model, _ = urlUpdate route initialModel
+    model, initialCmd
 
 
 let view (model : Model) (dispatch : Msg -> unit) =
 
     match model.PageState.CurrentPage with
-    | Routing.Page.AddBuildingBlock ->
+    | Routing.Route.AddBuildingBlock ->
         BaseView.baseViewComponent model dispatch [
             AddBuildingBlockView.addBuildingBlockComponent model dispatch
         ] [
@@ -63,7 +67,7 @@ let view (model : Model) (dispatch : Msg -> unit) =
         ]
 
 
-    | Routing.Page.TermSearch ->
+    | Routing.Route.TermSearch ->
         BaseView.baseViewComponent model dispatch [
             TermSearchView.termSearchComponent model dispatch
         ] [
@@ -71,31 +75,31 @@ let view (model : Model) (dispatch : Msg -> unit) =
         ]
 
 
-    | Routing.Page.FilePicker ->
+    | Routing.Route.FilePicker ->
         BaseView.baseViewComponent model dispatch [
             FilePickerView.filePickerComponent model dispatch
         ] [
             str "Footer content"
         ]
 
-    | Routing.Page.ActivityLog ->
+    | Routing.Route.ActivityLog ->
         BaseView.baseViewComponent model dispatch [
             ActivityLogView.activityLogComponent model
         ] [
             str "Footer content"
         ]
 
-    | Routing.Page.NotFound ->
+    | Routing.Route.NotFound ->
         BaseView.baseViewComponent model dispatch [
             NotFoundView.notFoundComponent model dispatch
         ] [
             str "Footer content"
         ]
 
-    | Routing.Page.Home ->
+    | Routing.Route.Home ->
         Container.container [][
             div [][ str "This is the Swate web host. For a preview click on the following link." ]
-            a [ Href "/#termsearch"] [str "Termsearch"]
+            a [ Href (Routing.Route.toRouteUrl Routing.Route.TermSearch) ] [ str "Termsearch" ]
         ]
 
     //| _ ->
@@ -121,16 +125,17 @@ let view (model : Model) (dispatch : Msg -> unit) =
         //    ]
         //]
 
+
 #if DEBUG
 open Elmish.Debug
 open Elmish.HMR
 #endif
 
 Program.mkProgram init Update.update view
-|> Program.toNavigable (parseHash Routing.pageParser) Update.urlUpdate
 #if DEBUG
 |> Program.withConsoleTrace
 #endif
+|> Program.toNavigable (parseHash Routing.Routing.route) Update.urlUpdate
 |> Program.withReactBatched "elmish-app"
 #if DEBUG
 |> Program.withDebugger

--- a/src/Client/Client.fs
+++ b/src/Client/Client.fs
@@ -35,6 +35,10 @@ let initializeAddIn () =
 
 // defines the initial state and initial command (= side-effect) of the application
 let init (pageOpt: Routing.Route option) : Model * Cmd<Msg> =
+    let initialModel = initializeModel pageOpt
+    let route = (parseHash Routing.Routing.route) Browser.Dom.document.location
+    // The initial command from urlUpdate is not needed yet. As we use a reduced variant of subModels with no own Msg system.
+    let model, _ = urlUpdate route initialModel
     let initialCmd =
         Cmd.batch [
             Cmd.OfPromise.either
@@ -42,17 +46,7 @@ let init (pageOpt: Routing.Route option) : Model * Cmd<Msg> =
                 ()
                 (fun x -> (x.host.ToString(),x.platform.ToString()) |> Initialized |> ExcelInterop )
                 (fun x -> x |> GenericError |> Dev)
-            Cmd.ofMsg (FetchAllOntologies |> Request |> Api)
-            Cmd.OfPromise.either
-                OfficeInterop.checkIfAnnotationTableIsPresent
-                ()
-                (AnnotationTableExists >> ExcelInterop)
-                (GenericError >> Dev)
         ]
-    let initialModel = initializeModel pageOpt
-    let route = (parseHash Routing.Routing.route) Browser.Dom.document.location
-    // The initial command from urlUpdate is not needed yet. As we use a reduced variant of subModels with no own Msg system.
-    let model, _ = urlUpdate route initialModel
     model, initialCmd
 
 

--- a/src/Client/Messages.fs
+++ b/src/Client/Messages.fs
@@ -102,4 +102,5 @@ type Msg =
     | PersistentStorage     of PersistentStorageMsg
     | FilePicker            of FilePickerMsg
     | AddBuildingBlock      of AddBuildingBlockMsg
+    | UpdatePageState of Routing.Route option
     | DoNothing

--- a/src/Client/Model.fs
+++ b/src/Client/Model.fs
@@ -168,17 +168,17 @@ type ApiState = {
     }
 
 type PageState = {
-    CurrentPage : Routing.Page
+    CurrentPage : Routing.Route
     CurrentUrl  : string
 } with
-    static member init (pageOpt:Page option) = 
+    static member init (pageOpt:Route option) = 
         match pageOpt with
         | Some page -> {
             CurrentPage = page
-            CurrentUrl = Page.toPath page
+            CurrentUrl = Route.toRouteUrl page
             }
         | None -> {
-            CurrentPage = Page.Home
+            CurrentPage = Route.Home
             CurrentUrl = ""
             }
 
@@ -312,7 +312,7 @@ type Model = {
     }
 
 
-let initializeModel (pageOpt: Page option) = {
+let initializeModel (pageOpt: Route option) = {
     DebouncerState          = Debouncer             .create()
     PageState               = PageState             .init pageOpt
     PersistentStorageState  = PersistentStorageState.init ()

--- a/src/Client/Routing.fs
+++ b/src/Client/Routing.fs
@@ -6,31 +6,33 @@ open Fulma.Extensions.Wikiki
 
 /// The different pages of the application. If you add a new page, then add an entry here.
 [<RequireQualifiedAccess>]
-type Page =
-    | Home
-    | AddBuildingBlock
-    | TermSearch
-    | FilePicker
-    | ActivityLog
-    | NotFound
+type Route =
+| Home
+| AddBuildingBlock
+| TermSearch
+| FilePicker
+| ActivityLog
+| NotFound
 
-    static member toPath = function
-        | Page.Home                 -> "/"
-        | Page.AddBuildingBlock     -> "/#AddBuildingBlock"
-        | Page.TermSearch           -> "/#TermSearch"
-        | Page.FilePicker           -> "/#FilePicker"
-        | Page.ActivityLog          -> "/#ActivityLog"
-        | Page.NotFound             -> "/#NotFound"
+    static member toRouteUrl (route:Route) =
+        match route with
+        | Route.Home                 -> "/"
+        | Route.AddBuildingBlock     -> "/#AddBuildingBlock"
+        | Route.TermSearch           -> "/#TermSearch"
+        | Route.FilePicker           -> "/#FilePicker"
+        | Route.ActivityLog          -> "/#ActivityLog"
+        | Route.NotFound             -> "/#NotFound"
 
-    static member toString = function
-        | Page.Home                 -> ""
-        | Page.AddBuildingBlock     -> "AddBuildingBlock"
-        | Page.TermSearch           -> "TermSearch"
-        | Page.FilePicker           -> "FilePicker"
-        | Page.ActivityLog          -> "ActivityLog"
-        | Page.NotFound             -> "NotFound"
+    static member toString (route:Route) =
+        match route with
+        | Route.Home                 -> ""
+        | Route.AddBuildingBlock     -> "AddBuildingBlock"
+        | Route.TermSearch           -> "TermSearch"
+        | Route.FilePicker           -> "FilePicker"
+        | Route.ActivityLog          -> "ActivityLog"
+        | Route.NotFound             -> "NotFound"
 
-    static member toIcon =
+    static member toIcon (p: Route)=
         let createElem icons name =
             Fable.React.Standard.span [
                 Fable.React.Props.Class (Tooltip.ClassName + " " + Tooltip.IsTooltipRight + " " + Tooltip.IsMultiline)
@@ -43,26 +45,34 @@ type Page =
                 )
             )
 
-        fun (p: Page) ->
-            match p with
-            | Page.Home             -> createElem [Fa.Solid.Home    ] (p |> Page.toString)
-            | Page.TermSearch       -> createElem [Fa.Solid.SearchPlus   ] (p |> Page.toString)
-            | Page.AddBuildingBlock -> createElem [Fa.Solid.Columns; Fa.Solid.PlusCircle ] (p |> Page.toString)
-            | Page.FilePicker       -> createElem [Fa.Solid.FileUpload; ] (p |> Page.toString)
-            | Page.ActivityLog      -> createElem [Fa.Solid.History   ] (p |> Page.toString)
-            | _  -> Fa.i [Fa.Solid.QuestionCircle]   []
+        match p with
+        | Route.Home             -> createElem [Fa.Solid.Home    ] (p |> Route.toString)
+        | Route.TermSearch       -> createElem [Fa.Solid.SearchPlus   ] (p |> Route.toString)
+        | Route.AddBuildingBlock -> createElem [Fa.Solid.Columns; Fa.Solid.PlusCircle ] (p |> Route.toString)
+        | Route.FilePicker       -> createElem [Fa.Solid.FileUpload; ] (p |> Route.toString)
+        | Route.ActivityLog      -> createElem [Fa.Solid.History   ] (p |> Route.toString)
+        | _  -> Fa.i [Fa.Solid.QuestionCircle]   []
 
-/// The URL is turned into a Result.
-let pageParser : Parser<Page -> Page,_> =
-    oneOf [
-        map Page.Home               (s "")
-        map Page.TermSearch         (s "TermSearch")
-        map Page.AddBuildingBlock   (s "AddBuildingBlock")
-        map Page.FilePicker         (s "FilePicker")
-        map Page.ActivityLog        (s "ActivityLog")
-        map Page.NotFound           (s "NotFound")
-    ]
+///explained here: https://elmish.github.io/browser/routing.html
+//let curry f x y = f (x,y)
 
-//this would be the way to got if we would use push based routing, but i decided to use hash based routing. Ill leave this here for now as a note.
-//let urlParser location = parsePath pageParser location
+module Routing =
+
+    open Elmish.UrlParser
+    open Elmish.Navigation
+
+    /// The URL is turned into a Result.
+    let route : Parser<Route -> Route,_> =
+        oneOf [
+            map Route.Home               (s "")
+            map Route.TermSearch         (s "TermSearch")
+            map Route.AddBuildingBlock   (s "AddBuildingBlock")
+            map Route.FilePicker         (s "FilePicker")
+            map Route.ActivityLog        (s "ActivityLog")
+            map Route.NotFound           (s "NotFound")
+        ]
+
+    //this would be the way to got if we would use push based routing, but i decided to use hash based routing. Ill leave this here for now as a note.
+    //let urlParser location = parsePath pageParser location
+
 

--- a/src/Client/Update.fs
+++ b/src/Client/Update.fs
@@ -817,6 +817,22 @@ let handleAddBuildingBlockMsg (addBuildingBlockMsg:AddBuildingBlockMsg) (current
 let update (msg : Msg) (currentModel : Model) : Model * Cmd<Msg> =
     match msg with
     | DoNothing -> currentModel,Cmd.none
+    | UpdatePageState (pageOpt:Route option) ->
+        let nextPageState =
+            match pageOpt with
+            | Some page -> {
+                CurrentPage = page
+                CurrentUrl = Route.toRouteUrl page
+                }
+            | None -> {
+                CurrentPage = Route.Home
+                CurrentUrl = ""
+                }
+        let nextModel = {
+            currentModel with
+                PageState = nextPageState
+        }
+        nextModel, Cmd.none
     /// does not work due to office.js ->
     /// https://stackoverflow.com/questions/42642863/office-js-nullifies-browser-history-functions-breaking-history-usage
     //| Navigate route ->

--- a/src/Client/Update.fs
+++ b/src/Client/Update.fs
@@ -10,14 +10,13 @@ open Thoth.Elmish
 
 open System.Text.RegularExpressions
 
-let urlUpdate (result:Option<Page>) (currentModel:Model) : Model * Cmd<Msg> =
-    match result with
+let urlUpdate (route: Route option) (currentModel:Model) : Model * Cmd<Msg> =
+    match route with
     | Some page ->
-
         let nextPageState = {
             currentModel.PageState with
                 CurrentPage = page
-                CurrentUrl  = Page.toPath page
+                CurrentUrl  = Route.toRouteUrl page
         }
 
         let nextModel = {
@@ -25,12 +24,11 @@ let urlUpdate (result:Option<Page>) (currentModel:Model) : Model * Cmd<Msg> =
                 PageState = nextPageState
         }
         nextModel,Cmd.none
-
     | None ->
         //Browser.console.error("Error parsing url")
         let nextPageState = {
             currentModel.PageState with
-                CurrentPage = Page.NotFound
+                CurrentPage = Route.NotFound
         }
 
         let nextModel = {
@@ -808,6 +806,10 @@ let handleAddBuildingBlockMsg (addBuildingBlockMsg:AddBuildingBlockMsg) (current
 let update (msg : Msg) (currentModel : Model) : Model * Cmd<Msg> =
     match msg with
     | DoNothing -> currentModel,Cmd.none
+    /// does not work due to office.js ->
+    /// https://stackoverflow.com/questions/42642863/office-js-nullifies-browser-history-functions-breaking-history-usage
+    //| Navigate route ->
+    //    currentModel, Navigation.newUrl (Routing.Route.toRouteUrl route)
     | Bounce (delay, bounceId, msgToBounce) ->
 
         let (debouncerModel, debouncerCmd) =

--- a/src/Client/Update.fs
+++ b/src/Client/Update.fs
@@ -49,7 +49,18 @@ let handleExcelInteropMsg (excelInteropMsg: ExcelInteropMsg) (currentState:Excel
                 Platform    = p
         }
 
-        nextState, Cmd.ofMsg (("Info",welcomeMsg) |> (GenericLog >> Dev))
+        let cmd =
+            Cmd.batch [
+                Cmd.ofMsg (FetchAllOntologies |> Request |> Api)
+                Cmd.OfPromise.either
+                    OfficeInterop.checkIfAnnotationTableIsPresent
+                    ()
+                    (AnnotationTableExists >> ExcelInterop)
+                    (GenericError >> Dev)
+                Cmd.ofMsg (("Info",welcomeMsg) |> (GenericLog >> Dev))
+            ]
+
+        nextState, cmd
         
     | SyncContext passthroughMessage ->
         currentState,

--- a/src/Client/Views/BaseView.fs
+++ b/src/Client/Views/BaseView.fs
@@ -28,11 +28,13 @@ let createNavigationTab (pageLink: Routing.Route) (model:Model) (dispatch:Msg-> 
         ] [
             Text.span [] [
                 /// does not work for me in excel, and in excel online i have a fixed width that always shows the icon
-                let mediaQuery = window.matchMedia("(min-width:575px)")
-                if mediaQuery.matches then
-                    str (pageLink |> Routing.Route.toString)
-                else
-                    pageLink |> Routing.Route.toIcon
+                //let mediaQuery = window.matchMedia("(min-width:575px)")
+                //if mediaQuery.matches then
+                //    str (pageLink |> Routing.Route.toString)
+                //else
+                //    pageLink |> Routing.Route.toIcon
+                span [Class "hideUnder575px"][str (pageLink |> Routing.Route.toString)]
+                span [Class "hideOver575px"][pageLink |> Routing.Route.toIcon]
             ]
 
         ]

--- a/src/Client/Views/BaseView.fs
+++ b/src/Client/Views/BaseView.fs
@@ -12,10 +12,10 @@ open Browser.MediaQueryListExtensions
 
 open CustomComponents
 
-let createNavigationTab (pageLink: Routing.Page) (model:Model) (dispatch:Msg-> unit) =
+let createNavigationTab (pageLink: Routing.Route) (model:Model) (dispatch:Msg-> unit) =
     let isActive = (model.PageState.CurrentPage = pageLink)
     Tabs.tab [Tabs.Tab.IsActive isActive;] [
-        a [ Href (Routing.Page.toPath pageLink)
+        a [ Href (Routing.Route.toRouteUrl pageLink)
             Style [
                 if isActive then
                     BorderColor model.SiteStyleState.ColorMode.Accent
@@ -30,9 +30,9 @@ let createNavigationTab (pageLink: Routing.Page) (model:Model) (dispatch:Msg-> u
                 /// does not work for me in excel, and in excel online i have a fixed width that always shows the icon
                 let mediaQuery = window.matchMedia("(min-width:575px)")
                 if mediaQuery.matches then
-                    str (pageLink |> Routing.Page.toString)
+                    str (pageLink |> Routing.Route.toString)
                 else
-                    pageLink |> Routing.Page.toIcon
+                    pageLink |> Routing.Route.toIcon
             ]
 
         ]
@@ -56,10 +56,10 @@ let baseViewComponent (model: Model) (dispatch: Msg -> unit) (bodyChildren: Reac
                     ]
                 ]
             ] [
-                createNavigationTab Routing.Page.AddBuildingBlock   model dispatch
-                createNavigationTab Routing.Page.TermSearch         model dispatch
-                createNavigationTab Routing.Page.FilePicker         model dispatch
-                createNavigationTab Routing.Page.ActivityLog        model dispatch
+                createNavigationTab Routing.Route.AddBuildingBlock   model dispatch
+                createNavigationTab Routing.Route.TermSearch         model dispatch
+                createNavigationTab Routing.Route.FilePicker         model dispatch
+                createNavigationTab Routing.Route.ActivityLog        model dispatch
             ]
             br []
 

--- a/src/Client/Views/BaseView.fs
+++ b/src/Client/Views/BaseView.fs
@@ -15,7 +15,7 @@ open CustomComponents
 let createNavigationTab (pageLink: Routing.Route) (model:Model) (dispatch:Msg-> unit) =
     let isActive = (model.PageState.CurrentPage = pageLink)
     Tabs.tab [Tabs.Tab.IsActive isActive;] [
-        a [ Href (Routing.Route.toRouteUrl pageLink)
+        a [ //Href (Routing.Route.toRouteUrl pageLink)
             Style [
                 if isActive then
                     BorderColor model.SiteStyleState.ColorMode.Accent
@@ -25,6 +25,7 @@ let createNavigationTab (pageLink: Routing.Route) (model:Model) (dispatch:Msg-> 
                 else
                     BorderBottomColor model.SiteStyleState.ColorMode.Accent
             ]
+            OnClick (fun e -> UpdatePageState (Some pageLink) |> dispatch)
         ] [
             Text.span [] [
                 /// does not work for me in excel, and in excel online i have a fixed width that always shows the icon

--- a/src/Client/style.scss
+++ b/src/Client/style.scss
@@ -22,3 +22,21 @@ $family-primary: 'Open Sans';
 input::-ms-clear {
     display: none;
 }
+
+.hideOver575px {
+    display: none
+}
+
+.hideUnder575px {
+    display: unset
+}
+
+@media only screen and (max-width: 575px) {
+    .hideOver575px {
+        display: unset
+    }
+
+    .hideUnder575px {
+        display: none
+    }
+}

--- a/src/Server/DevelopmentConnectionString.fs
+++ b/src/Server/DevelopmentConnectionString.fs
@@ -1,4 +1,4 @@
 module DevelopmentConnectionString
 
 [<Literal>]
-let DevLocalConnectionString = "server=127.0.0.1;user id=root;password={PASSWORD}; port=42333;database=SwateDB;allowuservariables=True;persistsecurityinfo=True"
+let DevLocalConnectionString = "server=127.0.0.1;user id=root;password=example; port=42333;database=SwateDB;allowuservariables=True;persistsecurityinfo=True"


### PR DESCRIPTION
- Added two css classes. One hides elements over 575px and one hides elements under 575px. When used together we create elements that alternate between each other depending on the windowsize without loading the page new. Can be seen in BaseView.fs 36.
- Tried to fix the BUG from issue #21, due to which the page reloads after the first url change. Did some testing with a urlUpdate function in init but it didn't fix it. But now we can use a direct redicret from Route.Home. To get a better overview i changed some naming conventions to a pattern i am more used to, i hope this can be excused. Finally i think the most appropriate solution is: using the hash based routing for navigating to a specific app entry, but as we cannot use typical browsernavigation anyways as a excel add-in, we can now change the subpage by simply updating the PageState in the model, which lead, at least for me, to a smoother performance.