### PR TITLE
More context menu options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "Swate",
       "dependencies": {
         "@nfdi4plants/exceljs": "^0.3.0",
         "bulma": "^1.0.1",

--- a/src/Client/Client.fs
+++ b/src/Client/Client.fs
@@ -37,7 +37,8 @@ let View (model : Model) (dispatch : Msg -> unit) =
     let v = {colorstate with SetTheme = setColorstate}
     React.contextProvider(LocalStorage.Darkmode.themeContext, v,
         Html.div [
-            prop.className "flex grow w-full h-full"
+            prop.id "ClientView"
+            prop.className "flex w-full h-full overflow-auto"
             prop.children [
                 match model.PersistentStorageState.Host with
                 | Some Swatehost.Excel ->

--- a/src/Client/Client.fs
+++ b/src/Client/Client.fs
@@ -37,7 +37,7 @@ let View (model : Model) (dispatch : Msg -> unit) =
     let v = {colorstate with SetTheme = setColorstate}
     React.contextProvider(LocalStorage.Darkmode.themeContext, v,
         Html.div [
-            prop.className "flex grow"
+            prop.className "flex grow w-full h-full"
             prop.children [
                 match model.PersistentStorageState.Host with
                 | Some Swatehost.Excel ->

--- a/src/Client/Helper.fs
+++ b/src/Client/Helper.fs
@@ -148,21 +148,13 @@ type Navigator =
 [<Emit("navigator")>]
 let navigator : Navigator = jsNative
 
-/// <summary>
-/// take "count" many items from array if existing. if not enough items return as many as possible
-/// </summary>
-/// <param name="count"></param>
-/// <param name="array"></param>
-let takeFromArray (count: int) (array: 'a []) =
-    let exit (acc: 'a list) = List.rev acc |> Array.ofList
-    let rec takeRec (l2: 'a list) (acc: 'a list) index =
-      if index >= count then 
-        exit acc
-      else
-        match l2 with
-        | [] -> exit acc
-        | item::tail ->
-          let newAcc = item::acc
-          takeRec tail newAcc (index+1)
+module Array =
 
-    takeRec (Array.toList array) [] 0
+    /// <summary>
+    /// Take "count" many items from array if existing. if not enough items return as many as possible
+    /// </summary>
+    /// <param name="count"></param>
+    /// <param name="array"></param>
+    let takeSafe (count: int) (array: 'a []) =
+       let count = System.Math.Min(count, array.Length)
+       Array.take count array

--- a/src/Client/MainComponents/CellStyles.fs
+++ b/src/Client/MainComponents/CellStyles.fs
@@ -7,8 +7,10 @@ open Feliz.Bulma
 open Fable.Core
 
 let cellStyle (specificStyle: IStyleAttribute list) = prop.style [
-        style.minWidth 100
-        style.height 22
+        style.minWidth 200
+        style.maxWidth 600
+        style.height 35
+        style.minHeight(35)
         style.border(length.px 1, borderStyle.solid, "darkgrey")
         yield! specificStyle
     ]
@@ -17,15 +19,20 @@ let cellInnerContainerStyle (specificStyle: IStyleAttribute list) = prop.style [
         style.display.flex;
         style.justifyContent.spaceBetween;
         style.height(length.percent 100);
-        style.minHeight(35)
         style.width(length.percent 100)
-        style.alignItems.center
         yield! specificStyle
     ]
 
-let basicValueDisplayCell (v: string) =
+let basicValueDisplayCell (v: string) (isHeader: bool) =
     Html.span [
+        if v.Length > 60 then
+            prop.title v
         prop.style [
+            style.textOverflow.ellipsis
+            style.overflow.hidden
+            //style.whitespace.nowrap
+            if not isHeader then
+                style.maxHeight 35
             style.flexGrow 1
             style.padding(length.em 0.5,length.em 0.75)
         ]

--- a/src/Client/MainComponents/Cells.fs
+++ b/src/Client/MainComponents/Cells.fs
@@ -170,10 +170,13 @@ type Cell =
             prop.readOnly readonly
             cellStyle []
             prop.onContextMenu (CellAux.contextMenuController (columnIndex, -1) model dispatch)
-            if columnType.IsRefColumn then
-                prop.className "bg-gray-300 dark:bg-gray-700"
-            else
-                prop.className "bg-white dark:bg-black-800"
+            prop.className [
+                "w-[300px]" // horizontal resize property sets width, but cannot override style.width. Therefore we set width as class, which makes it overridable by resize property.
+                if columnType.IsRefColumn then
+                    "bg-gray-300 dark:bg-gray-700"
+                else
+                    "bg-white dark:bg-black-800"
+            ]
             prop.children [
                 Html.div [
                     cellInnerContainerStyle [style.custom("backgroundColor","inherit")]
@@ -191,7 +194,7 @@ type Cell =
                                 match columnType with
                                 | TSR | TAN -> $"{columnType} ({cellValue})" 
                                 | _ -> cellValue
-                            basicValueDisplayCell cellValue
+                            basicValueDisplayCell cellValue true
                         if columnType = Main && not header.IsSingleColumn then 
                             extendHeaderButton(state_extend, columnIndex, setState_extend)
                     ]
@@ -335,7 +338,7 @@ type Cell =
                             if columnType = Main && oasetter.IsSome then
                                 CellStyles.compositeCellDisplay oasetter.Value.oa displayValue
                             else
-                                basicValueDisplayCell displayValue
+                                basicValueDisplayCell displayValue false
                     ]
                 ]
             ]

--- a/src/Client/MainComponents/ContextMenu.fs
+++ b/src/Client/MainComponents/ContextMenu.fs
@@ -61,7 +61,7 @@ module Table =
         TransformCell   : (Browser.Types.MouseEvent -> unit) -> Browser.Types.MouseEvent -> unit
         UpdateAllCells  : (Browser.Types.MouseEvent -> unit) -> Browser.Types.MouseEvent -> unit
         GetTermDetails  : OntologyAnnotation -> (Browser.Types.MouseEvent -> unit) -> Browser.Types.MouseEvent -> unit
-        //EditColumn      : (Browser.Types.MouseEvent -> unit) -> Browser.Types.MouseEvent -> unit
+        EditColumn      : (Browser.Types.MouseEvent -> unit) -> Browser.Types.MouseEvent -> unit
         RowIndex        : int
         ColumnIndex     : int
     }
@@ -70,11 +70,11 @@ module Table =
         /// This element will remove the contextmenu when clicking anywhere else
         let isHeader = Shared.isHeader funcs.RowIndex
         let buttonList = [
+            Shared.button ("Edit Column", "fa-solid fa-table-columns", funcs.EditColumn rmv, [])
             if (isHeader && header.IsTermColumn) || Shared.isUnitOrTermCell contextCell then
                 let oa = if isHeader then header.ToTerm() else contextCell.Value.ToOA()
                 if oa.TermAccessionShort <> "" then
                     Shared.button ("Details", "fa-solid fa-magnifying-glass", funcs.GetTermDetails oa rmv, [])
-                //Shared.button ("Edit Column", "fa-solid fa-table-columns", funcs.EditColumn rmv, [])
             if not isHeader then
                 Shared.button ("Fill Column", "fa-solid fa-pen", funcs.FillColumn rmv, [])
                 if Shared.isUnitOrTermCell contextCell then
@@ -128,7 +128,7 @@ module Table =
         let cell = model.SpreadsheetModel.ActiveTable.TryGetCellAt(ci, ri)
         let header = model.SpreadsheetModel.ActiveTable.Headers.[ci]
         let isSelectedCell = model.SpreadsheetModel.SelectedCells.Contains index
-        //let editColumnEvent _ = Modals.Controller.renderModal("EditColumn_Modal", Modals.EditColumn.Main (fst index) model dispatch)
+        let editColumnEvent _ = Modals.Controller.renderModal("EditColumn_Modal", Modals.EditColumn.Main (fst index) model dispatch)
         let triggerMoveColumnModal _ = Modals.Controller.renderModal("MoveColumn_Modal", Modals.MoveColumn.Main(ci, model, dispatch))
         let triggerUpdateColumnModal _ = 
             let columnIndex = fst index
@@ -168,7 +168,7 @@ module Table =
                         
             UpdateAllCells = fun rmv e -> rmv e; triggerUpdateColumnModal e
             GetTermDetails = fun oa rmv e -> rmv e; triggerTermModal oa e
-            //EditColumn      = fun rmv e -> rmv e; editColumnEvent e
+            EditColumn      = fun rmv e -> rmv e; editColumnEvent e
             RowIndex        = snd index
             ColumnIndex     = fst index
         }

--- a/src/Client/MainComponents/MainViewContainer.fs
+++ b/src/Client/MainComponents/MainViewContainer.fs
@@ -1,4 +1,4 @@
-﻿module MainComponents.MainViewContainer
+module MainComponents.MainViewContainer
 
 
 open Feliz

--- a/src/Client/Modals/TermModal.fs
+++ b/src/Client/Modals/TermModal.fs
@@ -5,32 +5,10 @@ open Feliz
 open Feliz.Bulma
 open ARCtrl
 
-let private l = 200
-
-let private isTooLong (str:string) = str.Length > l
-
 type private State =
     | Loading
     | Found of Term
     | NotFound
-
-//type private UI = {
-//    DescriptionTooLong: bool
-//    IsExpanded: bool
-//    DescriptionShort: string
-//    DescriptionLong: string
-//} with
-//    static member init(description: string) =
-//        let isTooLong = isTooLong description
-//        let descriptionShort =
-//            if isTooLong then description.Substring(0,l).Trim() + ".. " else description
-//        {
-//            IsExpanded = false
-//            DescriptionTooLong = isTooLong
-//            DescriptionShort = descriptionShort
-//            DescriptionLong = description
-//        }
-
 
 [<ReactComponent>]
 let Main (oa: OntologyAnnotation, dispatch) (rmv: _ -> unit) =
@@ -55,22 +33,20 @@ let Main (oa: OntologyAnnotation, dispatch) (rmv: _ -> unit) =
                 prop.style [style.backgroundColor.transparent]
             ]
             Bulma.modalCard [
-                prop.style [style.maxWidth 300; style.border (1,borderStyle.solid,NFDIColors.black); style.borderRadius 0]
+                prop.className "shadow"
                 prop.children [
                     Bulma.modalCardHead [
-                        prop.className "p-2"
-                        prop.children [
-                            Bulma.modalCardTitle [
-                                prop.textf "%s - %s" oa.NameText oa.TermAccessionShort 
-                            ]
-                            Bulma.delete [
-                                Bulma.delete.isSmall
-                                prop.onClick rmv
-                            ]
+                        Bulma.modalCardTitle [
+                            Bulma.title.h4 oa.NameText
+                            Bulma.subtitle.h6 oa.TermAccessionShort
+                        ]
+                        Bulma.delete [
+                            Bulma.delete.isSmall
+                            prop.onClick rmv
                         ]
                     ]
                     Bulma.modalCardBody [
-                        prop.className "p-2 has-text-justified"
+                        prop.className "has-text-justified"
                         prop.children [
                             Bulma.content [
                                 match state with

--- a/src/Client/Modals/UpdateColumn.fs
+++ b/src/Client/Modals/UpdateColumn.fs
@@ -85,7 +85,7 @@ module private Components =
                     ]
                     Html.tbody [
                         let previewCount = 5
-                        let preview = takeFromArray previewCount cellValues 
+                        let preview = Array.takeSafe previewCount cellValues 
                         for i in 0 .. (preview.Length-1) do
                             let cell0 = column.Cells.[i].ToString()
                             let cell = preview.[i]

--- a/src/Client/Model.fs
+++ b/src/Client/Model.fs
@@ -182,7 +182,8 @@ module BuildingBlock =
 
     open ARCtrl
 
-    type [<RequireQualifiedAccess>] HeaderCellType =
+    [<RequireQualifiedAccess>]
+    type HeaderCellType =
     | Component
     | Characteristic
     | Factor
@@ -222,7 +223,26 @@ module BuildingBlock =
             | Output -> true
             | _ -> false
 
-    type [<RequireQualifiedAccess>] BodyCellType =
+        static member fromString(str: string) =
+            match str with
+            | "Component"           -> Component
+            | "Characteristic"      -> Characteristic
+            | "Factor"              -> Factor
+            | "Parameter"           -> Parameter
+            | "ProtocolType"        -> ProtocolType
+            | "ProtocolDescription" -> ProtocolDescription
+            | "ProtocolUri"         -> ProtocolUri
+            | "ProtocolVersion"     -> ProtocolVersion
+            | "ProtocolREF"         -> ProtocolREF
+            | "Performer"           -> Performer
+            | "Date"                -> Date
+            | "Input"               -> Input
+            | "Output"              -> Output
+            | anyElse -> failwithf "BuildingBlock.HeaderCellType.fromString: '%s' is not a valid HeaderCellType" anyElse
+
+
+    [<RequireQualifiedAccess>]
+    type BodyCellType =
     | Term
     | Unitized
     | Text

--- a/src/Client/Spreadsheet/Controller/Clipboard.fs
+++ b/src/Client/Spreadsheet/Controller/Clipboard.fs
@@ -103,7 +103,7 @@ let pasteCellsIntoSelected (state: Spreadsheet.Model) : JS.Promise<Spreadsheet.M
                 return state
             else
                 let rowCount = selectedSingleColumnCells.Count
-                let cellsTrimmed = cells |> takeFromArray rowCount
+                let cellsTrimmed = cells |> Array.takeSafe rowCount
                 let indicesTrimmed = (Set.toArray selectedSingleColumnCells).[0..cellsTrimmed.Length-1]
                 let indexedCellsTrimmed = Array.zip indicesTrimmed cellsTrimmed
                 Generic.setCells indexedCellsTrimmed state

--- a/src/Client/Views/SidebarView.fs
+++ b/src/Client/Views/SidebarView.fs
@@ -43,7 +43,6 @@ let private tabRow (model:Model) (tabs: seq<ReactElement>) =
     Bulma.tabs [
         Bulma.tabs.isCentered; Bulma.tabs.isFullWidth; Bulma.tabs.isBoxed
         prop.style [
-            //style.custom ("overflow","visible
             style.paddingTop(length.rem 1); style.borderBottom (2, borderStyle.solid, NFDIColors.Mint.Base)
         ]
         tabs
@@ -103,24 +102,6 @@ module private ResizeObserver =
         )
 
 
-let private viewContainer (model: Model) (dispatch: Msg -> unit) (state: SidebarStyle) (setState: SidebarStyle -> unit) (children: ReactElement list) =
-
-    Html.div [
-        prop.id Sidebar_Id
-        prop.onLoad(fun e ->
-            let ele = Browser.Dom.document.getElementById(Sidebar_Id)
-            ResizeObserver.observer(state, setState).observe(ele)
-        )
-        prop.style [
-            style.display.flex
-            style.flexGrow 1
-            style.flexDirection.column
-            style.position.relative
-            style.maxWidth (length.perc 100)
-            style.overflowY.auto
-        ]
-        prop.children children
-    ]
 
 type SidebarView =
 
@@ -187,33 +168,40 @@ type SidebarView =
     [<ReactComponent>]
     static member Main (model: Model, dispatch: Msg -> unit) =
         let state, setState = React.useState(SidebarStyle.init)
-        viewContainer model dispatch state setState [
-            SidebarComponents.Navbar.NavbarComponent model dispatch state.Size
+        Html.div [
+            prop.className "grow overflow-auto h-full"
+            prop.id Sidebar_Id
+            prop.onLoad(fun e ->
+                let ele = Browser.Dom.document.getElementById(Sidebar_Id)
+                ResizeObserver.observer(state, setState).observe(ele)
+            )
+            prop.children [
 
-            Bulma.container [
-                Bulma.container.isFluid
-                prop.className "pl-4 pr-4"
-                prop.children [
-                    tabs model dispatch state.Size
+                SidebarComponents.Navbar.NavbarComponent model dispatch state.Size
+                Html.div [
+                    prop.className "pl-4 pr-4 h-full"
+                    prop.children [
+                        tabs model dispatch state.Size
 
-                    //str <| state.Size.ToString()
+                        //str <| state.Size.ToString()
 
-                    //Button.button [
-                    //    Button.OnClick (fun _ ->
-                    //        //Spreadsheet.Controller.deleteRow 2 model.SpreadsheetModel
-                    //        //()
-                    //        //Spreadsheet.DeleteColumn 1 |> SpreadsheetMsg |> dispatch
-                    //        ()
-                    //    )
-                    //] [ str "Test button" ]
+                        //Button.button [
+                        //    Button.OnClick (fun _ ->
+                        //        //Spreadsheet.Controller.deleteRow 2 model.SpreadsheetModel
+                        //        //()
+                        //        //Spreadsheet.DeleteColumn 1 |> SpreadsheetMsg |> dispatch
+                        //        ()
+                        //    )
+                        //] [ str "Test button" ]
 
-                    match model.PersistentStorageState.Host, not model.ExcelState.HasAnnotationTable with
-                    | Some Swatehost.Excel, true ->
-                        SidebarComponents.AnnotationTableMissingWarning.annotationTableMissingWarningComponent model dispatch
-                    | _ -> ()
+                        match model.PersistentStorageState.Host, not model.ExcelState.HasAnnotationTable with
+                        | Some Swatehost.Excel, true ->
+                            SidebarComponents.AnnotationTableMissingWarning.annotationTableMissingWarningComponent model dispatch
+                        | _ -> ()
 
-                    SidebarView.content model dispatch
+                        SidebarView.content model dispatch
+                    ]
                 ]
+                SidebarView.footer (model, dispatch)
             ]
-            SidebarView.footer (model, dispatch)
         ]

--- a/src/Client/Views/SplitWindowView.fs
+++ b/src/Client/Views/SplitWindowView.fs
@@ -106,7 +106,8 @@ let Main (left:seq<ReactElement>) (right:seq<ReactElement>) (mainModel:Model) (d
     React.useEffect(model.WriteToLocalStorage, [|box model|])
     React.useEffectOnce(fun _ -> Browser.Dom.window.addEventListener("resize", onResize_event model setModel))
     Html.div [
-        prop.className "flex grow"
+        prop.id "SplitWindowView"
+        prop.className "flex overflow-auto grow"
         prop.children [
             MainComponents.MainViewContainer.Main(minWidth, left)
             if mainModel.SpreadsheetModel.TableViewIsActive() && mainModel.PersistentStorageState.ShowSideBar then

--- a/src/Client/Views/SplitWindowView.fs
+++ b/src/Client/Views/SplitWindowView.fs
@@ -106,9 +106,7 @@ let Main (left:seq<ReactElement>) (right:seq<ReactElement>) (mainModel:Model) (d
     React.useEffect(model.WriteToLocalStorage, [|box model|])
     React.useEffectOnce(fun _ -> Browser.Dom.window.addEventListener("resize", onResize_event model setModel))
     Html.div [
-        prop.style [
-            style.display.flex
-        ]
+        prop.className "flex grow"
         prop.children [
             MainComponents.MainViewContainer.Main(minWidth, left)
             if mainModel.SpreadsheetModel.TableViewIsActive() && mainModel.PersistentStorageState.ShowSideBar then

--- a/src/Client/index.html
+++ b/src/Client/index.html
@@ -61,7 +61,7 @@
     </style>
 </head>
 <body>
-    <div id="elmish-app" class="flex h-full"></div>
+    <div id="elmish-app" class="h-full overflow-auto"></div>
     <div id="modal-container"></div>
     <!-- Polyfill for remotedev -->
     <script type="text/javascript">

--- a/src/Server/Api/IOntologyAPI.fs
+++ b/src/Server/Api/IOntologyAPI.fs
@@ -65,6 +65,15 @@ module V3 =
                         |> Array.ofSeq
                     return dbSearchRes
                 }
+            getTermById = fun id  ->
+                async {
+                    let dbSearchRes = Term.Term(credentials).getByAccession id
+                    return 
+                        match Seq.length dbSearchRes with
+                        | 1 -> dbSearchRes |> Seq.head |> Some
+                        | 0 -> None
+                        | _ -> failwith $"Found multiple terms with the same accession: {id}" // must be multiples as negative cannot exist for length
+                }
         }
 
     let createIOntologyApi credentials =

--- a/src/Shared/Shared.fs
+++ b/src/Shared/Shared.fs
@@ -135,6 +135,8 @@ type IOntologyAPIv3 = {
     /// ontologies currently unused
     searchTermsByParent:
         {| limit: int; query: string; parentTAN: string |} -> Async<Term []>
+    getTermById:
+        string -> Async<Term option>
 }
 
 type ITemplateAPIv1 = {


### PR DESCRIPTION
Added:

* Edit Column
* Details
* Fix lazy load table handling cell width differences :bug: 🎨 

to context menu in swate table:

![image](https://github.com/user-attachments/assets/c4a1018a-0764-42ae-b9d3-dd8e5155b71a)


## Details modal

![image](https://github.com/user-attachments/assets/bd421b57-c40c-4a2c-ac50-c58f9dee1dec)

## Edit column modal

![image](https://github.com/user-attachments/assets/ce02db02-69b0-4817-9f0b-58cb93d0f138)

## lazy load table fix

I applied some fixes hopefully. I tried replicating excel logic for this now. width is iniatially set to 300, but can be resized between 200-600 (this manual resize will propagate through lazy load table). Large cell content will be hidden, but can be seen hovering over the cell. Cell editing should be unchanged. 

Let me know what you think/how it feels.

