### PR TITLE
Reinclude data annotation match case for updating client interface

### DIFF
--- a/src/Client/Update/InterfaceUpdate.fs
+++ b/src/Client/Update/InterfaceUpdate.fs
@@ -224,6 +224,16 @@ module Interface =
                             Spreadsheet.DeleteColumn (distinct.[0]) |> SpreadsheetMsg |> Cmd.ofMsg
                     model, cmd
                 | _ -> failwith "not implemented"
+            | AddDataAnnotation data ->
+                match host with
+                | Some Swatehost.Excel ->
+                    //let cmd = OfficeInterop.AddDataAnnotation data |> OfficeInteropMsg |> Cmd.ofMsg
+                    failwith "AddDataAnnotation is not implemented" 
+                    model, Cmd.none
+                | Some Swatehost.Browser | Some Swatehost.ARCitect ->
+                    let cmd = Spreadsheet.AddDataAnnotation data |> SpreadsheetMsg |> Cmd.ofMsg
+                    model, cmd
+                | _ -> failwith "not implemented"
             | ExportJson (arcfile, jef) ->
                 match host with
                 | Some Swatehost.Excel ->


### PR DESCRIPTION
Reincluded match case lost in some merge.  Now data annotator works again.

closes #512 