### PR TITLE
Feature excel: Adapt warning messages

### DIFF
--- a/src/Client/OfficeInterop/OfficeInterop.fs
+++ b/src/Client/OfficeInterop/OfficeInterop.fs
@@ -1954,8 +1954,8 @@ let validateAnnotationTable () =
                     indexedErrors
                     |> List.ofArray
                     |> List.collect (fun (ex, header ) ->
-                        [InteropLogging.Msg.create InteropLogging.Warning $"Table is not a valid ARC table / ISA table: {ex.Message}";
-                         InteropLogging.Msg.create InteropLogging.Warning $"The column {header} is not valid! It needs further inspection what causes the error"])
+                        [InteropLogging.Msg.create InteropLogging.Warning $"Table is not a valid ARC table / ISA table: {ex.Message}. The column {header} is not valid! It needs further inspection what causes the error.";
+                        ])
                 else
                     [InteropLogging.Msg.create InteropLogging.Warning $"The annotation table {excelTable.name} is valid"]
 


### PR DESCRIPTION
Currently two warning messages are displayed for each building block that causes problem.
With the fix of this pull request only one warning message will be displayed.