### PR TITLE
Widget bugs fixed 🐛 

### DIFF
--- a/src/Client/MainComponents/Widgets.fs
+++ b/src/Client/MainComponents/Widgets.fs
@@ -245,7 +245,10 @@ type Widget =
 
     static member DataAnnotator (model, dispatch, rmv) =
         let content = Html.div [
-            Pages.DataAnnotator.Main(model, dispatch)
+            prop.className "min-w-80"
+            prop.children [
+                Pages.DataAnnotator.Main(model, dispatch)
+            ]
         ]
         let prefix = WidgetLiterals.DataAnnotator
         Widget.Base(content, prefix, rmv, prefix)

--- a/src/Client/MainComponents/Widgets.fs
+++ b/src/Client/MainComponents/Widgets.fs
@@ -6,7 +6,7 @@ open Browser.Types
 open LocalStorage.Widgets
 open Swate
 open Modals
-open Types.JsonImport
+open Types.FileImport
 open Swate.Components
 
 module private InitExtensions =
@@ -220,15 +220,14 @@ type Widget =
         Widget.Base(content, prefix, rmv, prefix)
 
     [<ReactComponent>]
-    static member Templates (model: Model, importTypeStateData, dispatch, rmv: MouseEvent -> unit) =
-        let isProtocolSearch, setProtocolSearch = React.useState(true)
+    static member Templates (model: Model, dispatch, rmv: MouseEvent -> unit) =
         React.useEffectOnce(fun _ -> Messages.Protocol.GetAllProtocolsRequest |> Messages.ProtocolMsg |> dispatch)
 
         let content =
-            if isProtocolSearch then
-                Protocol.SearchContainer.Main(model, setProtocolSearch, importTypeStateData, dispatch)
+            if model.ProtocolState.ShowSearch then
+                Protocol.SearchContainer.Main(model, dispatch)
             else
-                SelectiveTemplateFromDB.Main(model, true, setProtocolSearch, importTypeStateData, dispatch)
+                SelectiveTemplateFromDB.Main(model, dispatch)
 
         let prefix = WidgetLiterals.Templates
         Widget.Base(content, prefix, rmv, prefix)

--- a/src/Client/MainComponents/Widgets.fs
+++ b/src/Client/MainComponents/Widgets.fs
@@ -206,7 +206,7 @@ type Widget =
                     ]
                 ]
                 Html.div [
-                    prop.className "p-2 max-h-[80vh] overflow-visible"
+                    prop.className "p-2 max-h-[80vh] overflow-visible flex flex-col"
                     prop.children [
                         content
                     ]
@@ -223,24 +223,12 @@ type Widget =
     static member Templates (model: Model, importTypeStateData, dispatch, rmv: MouseEvent -> unit) =
         let isProtocolSearch, setProtocolSearch = React.useState(true)
         React.useEffectOnce(fun _ -> Messages.Protocol.GetAllProtocolsRequest |> Messages.ProtocolMsg |> dispatch)
-        let selectContent() =
-            Protocol.SearchContainer.Main(model, setProtocolSearch, importTypeStateData, dispatch)
-        let insertContent() =
-            Html.div [
-                prop.style [style.maxHeight (length.px 350); style.overflow.auto]
-                prop.className "flex flex-col gap-2"
-                prop.children (SelectiveTemplateFromDB.Main(model, true, setProtocolSearch, importTypeStateData, dispatch))
-            ]
 
         let content =
-            Html.div [
-                prop.children [
-                    if isProtocolSearch then
-                        selectContent ()
-                    else
-                        insertContent ()
-                ]
-            ]
+            if isProtocolSearch then
+                Protocol.SearchContainer.Main(model, setProtocolSearch, importTypeStateData, dispatch)
+            else
+                SelectiveTemplateFromDB.Main(model, true, setProtocolSearch, importTypeStateData, dispatch)
 
         let prefix = WidgetLiterals.Templates
         Widget.Base(content, prefix, rmv, prefix)

--- a/src/Client/Messages.fs
+++ b/src/Client/Messages.fs
@@ -81,16 +81,19 @@ module BuildingBlock =
 module Protocol =
 
     type Msg =
-        // Client
-        | UpdateTemplates               of Template []
+        // UI
+        | UpdateShowSearch              of bool
+        | UpdateImportConfig            of Types.FileImport.SelectiveImportConfig
         | UpdateLoading                 of bool
+        //
+        | UpdateTemplates               of Template []
+        | SelectProtocols               of Template list
+        | AddProtocol                   of Template
         | RemoveSelectedProtocols
         // // ------ Protocol from Database ------
         | GetAllProtocolsForceRequest
         | GetAllProtocolsRequest
         | GetAllProtocolsResponse       of string
-        | SelectProtocols               of Template list
-        | AddProtocol                   of Template
         | ProtocolIncreaseTimesUsed     of protocolName:string
 
 type SettingsDataStewardMsg =

--- a/src/Client/Modals/ModalElements.fs
+++ b/src/Client/Modals/ModalElements.fs
@@ -7,18 +7,19 @@ open Messages
 open Swate.Components.Shared
 
 open ARCtrl
-open JsonImport
+open FileImport
 open Fable.React.Helpers
 
 type ModalElements =
 
-    static member Button(text: string, onClickAction, buttonInput, ?isDisabled: bool) =
+    static member Button(text: string, onClickAction, buttonInput, ?isDisabled: bool, ?className: string) =
         let isDisabled = defaultArg isDisabled false
         Daisy.button.a [
             button.primary
-            button.wide
             if isDisabled then
                 button.error
+            if className.IsSome then
+                prop.className className.Value
             prop.disabled isDisabled
             prop.onClick (fun _ -> onClickAction buttonInput)
             prop.text text

--- a/src/Client/Modals/ModalProvider.fs
+++ b/src/Client/Modals/ModalProvider.fs
@@ -23,7 +23,7 @@ type ModalProvider =
         | TableModals.TermDetails term ->
             Modals.TermModal.Main (term, dispatch)
         | TableModals.SelectiveFileImport arcfile ->
-            Modals.SelectiveImportModal.Main (arcfile, dispatch)
+            Modals.SelectiveImportModal.Main (arcfile, model, dispatch)
         | TableModals.BatchUpdateColumnValues (columnIndex, column) ->
             Modals.UpdateColumn.Main (columnIndex, column, dispatch)
         | TableModals.TableCellContext (mouseX, mouseY, ci, ri) ->

--- a/src/Client/Modals/SelectiveImportModal.fs
+++ b/src/Client/Modals/SelectiveImportModal.fs
@@ -144,7 +144,10 @@ type SelectiveImportModal =
                 Html.input [prop.type'.checkbox; prop.className "min-h-0 h-5"]
 
                 Daisy.collapseTitle [
-                    prop.className "p-1 min-h-0 h-5 text-success text-sm font-bold space-x-2"
+                    prop.className [
+                        "p-1 min-h-0 h-5 text-sm font-bold space-x-2"
+                        if isActive then "text-primary-content" else "text-success"
+                    ]
                     prop.children [
                         Html.span (if isActive then "Select Columns" else "Preview Table")
                         Html.i [prop.className "fa-solid fa-magnifying-glass"]

--- a/src/Client/Modals/SelectiveImportModal.fs
+++ b/src/Client/Modals/SelectiveImportModal.fs
@@ -7,7 +7,7 @@ open Messages
 open Swate.Components.Shared
 
 open ARCtrl
-open JsonImport
+open FileImport
 open Swate.Components
 
 type SelectiveImportModal =
@@ -27,30 +27,30 @@ type SelectiveImportModal =
             ]
         ])
 
-    static member CheckBoxForTableColumnSelection(columns: CompositeColumn [], tableIndex, columnIndex, selectionInformation: SelectiveImportModalState, setSelectedColumns: SelectiveImportModalState -> unit) =
+    static member CheckBoxForTableColumnSelection(columns: CompositeColumn [], tableIndex, columnIndex, isActive: bool, model: Model.Model, dispatch) =
+        let importConfig = model.ProtocolState.ImportConfig
+        let isChecked = importConfig.DeselectedColumns |> Set.contains (tableIndex, columnIndex) |> not
         Html.div [
-            prop.style [style.display.flex; style.justifyContent.center]
+            prop.className "flex justify-center"
             prop.children [
                 Daisy.checkbox [
                     prop.type'.checkbox
+                    prop.disabled (not isActive)
                     prop.style [
                         style.height(length.perc 100)
                     ]
-                    prop.isChecked (not (Set.contains (tableIndex, columnIndex) selectionInformation.DeselectedColumns))
+                    prop.isChecked isChecked
                     prop.onChange (fun (b: bool) ->
                         if columns.Length > 0 then
-                            let selectedData = selectionInformation.toggleDeselectedColumns(tableIndex, columnIndex)
-                            {selectionInformation with DeselectedColumns = selectedData} |> setSelectedColumns)
+                            let nextImportConfig = importConfig.toggleDeselectColumn(tableIndex, columnIndex)
+                            nextImportConfig |> Protocol.UpdateImportConfig |> ProtocolMsg |> dispatch
+                    )
                 ]
             ]
         ]
 
-    static member TableWithImportColumnCheckboxes(table: ArcTable, ?tableIndex, ?selectionInformation: SelectiveImportModalState, ?setDeselectedColumns: SelectiveImportModalState -> unit) =
+    static member TableWithImportColumnCheckboxes(table: ArcTable, tableIndex, isActive: bool, model: Model.Model, dispatch: Messages.Msg -> unit) =
         let columns = table.Columns
-        let tableIndex = defaultArg tableIndex 0
-        let displayCheckBox =
-            //Determine whether to display checkboxes or not
-            selectionInformation.IsSome && setDeselectedColumns.IsSome
         Daisy.table [
             prop.children [
                 Html.thead [
@@ -60,8 +60,7 @@ type SelectiveImportModal =
                                 Html.label [
                                     prop.className "join flex flex-row centered gap-2"
                                     prop.children [
-                                        if displayCheckBox then
-                                            SelectiveImportModal.CheckBoxForTableColumnSelection(columns, tableIndex, columnIndex, selectionInformation.Value, setDeselectedColumns.Value)
+                                        SelectiveImportModal.CheckBoxForTableColumnSelection(columns, tableIndex, columnIndex, isActive, model, dispatch)
                                         Html.text (columns.[columnIndex].Header.ToString())
                                     ]
                                 ]
@@ -109,13 +108,20 @@ type SelectiveImportModal =
     )
 
     [<ReactComponent>]
-    static member TableImport(tableIndex: int, table0: ArcTable, state: SelectiveImportModalState, addTableImport: int -> bool -> unit, rmvTableImport: int -> unit, deselectedColumns, setSelectedColumns, ?templateName) =
+    static member TableImport(tableIndex: int, table0: ArcTable, model: Model.Model, dispatch, ?templateName) =
+        let importConfig = model.ProtocolState.ImportConfig
         let name = defaultArg templateName table0.Name
-        let guid = React.useMemo(fun () -> System.Guid.NewGuid().ToString())
-        let radioGroup = "radioGroup_" + guid
-        let import = state.ImportTables |> List.tryFind (fun it -> it.Index = tableIndex)
+        let radioGroup = "RADIO_GROUP" + table0.Name + string tableIndex
+        let import = importConfig.ImportTables |> List.tryFind (fun it -> it.Index = tableIndex)
         let isActive = import.IsSome
-        let isDisabled = state.ImportMetadata
+        let isDisabled = importConfig.ImportMetadata
+        let addTableImport = fun (i: int) (fullImport: bool) ->
+            let newImportTable: ImportTable = {Index = i; FullImport = fullImport}
+            let newImportTables = newImportTable::importConfig.ImportTables |> List.distinct
+            {importConfig with ImportTables = newImportTables} |> Protocol.UpdateImportConfig |> ProtocolMsg |> dispatch
+        let rmvTableImport = fun i ->
+            let tableRemoved = importConfig.ImportTables |> List.filter (fun it -> it.Index <> i)
+            {importConfig with ImportTables = tableRemoved} |> Protocol.UpdateImportConfig |> ProtocolMsg |> dispatch
         ModalElements.Box (name, "fa-solid fa-table", React.fragment [
             Html.div [
                 ModalElements.RadioPlugin (radioGroup, "Import",
@@ -136,7 +142,7 @@ type SelectiveImportModal =
             ]
             Daisy.collapse [
                 Html.input [prop.type'.checkbox; prop.className "min-h-0 h-5"]
-                
+
                 Daisy.collapseTitle [
                     prop.className "p-1 min-h-0 h-5 text-success text-sm font-bold space-x-2"
                     prop.children [
@@ -147,10 +153,7 @@ type SelectiveImportModal =
                 Daisy.collapseContent [
                     prop.className "overflow-x-auto"
                     prop.children [
-                        if isActive then
-                            SelectiveImportModal.TableWithImportColumnCheckboxes(table0, tableIndex, deselectedColumns, setSelectedColumns)
-                        else
-                            SelectiveImportModal.TableWithImportColumnCheckboxes(table0)
+                        SelectiveImportModal.TableWithImportColumnCheckboxes(table0, tableIndex, isActive, model, dispatch)
                     ]
                 ]
             ]
@@ -158,14 +161,14 @@ type SelectiveImportModal =
         className = [if isActive then "!bg-primary !text-primary-content"])
 
     [<ReactComponent>]
-    static member Main (import: ArcFiles, dispatch, rmv) =
+    static member Main (import: ArcFiles, model, dispatch, rmv) =
         let tables, disArcfile =
             match import with
             | Assay a -> a.Tables, ArcFilesDiscriminate.Assay
             | Study (s,_) -> s.Tables, ArcFilesDiscriminate.Study
             | Template t -> ResizeArray([t.Table]), ArcFilesDiscriminate.Template
             | Investigation _ -> ResizeArray(), ArcFilesDiscriminate.Investigation
-        let importDataState, setImportDataState = React.useState(SelectiveImportModalState.init())
+        let importDataState, setImportDataState = React.useState(SelectiveImportConfig.init())
         let setMetadataImport = fun b ->
             if b then
                 {
@@ -174,7 +177,7 @@ type SelectiveImportModal =
                         ImportTables    = [for ti in 0 .. tables.Count-1 do {ImportTable.Index = ti; ImportTable.FullImport = true}]
                 } |> setImportDataState
             else
-                SelectiveImportModalState.init() |> setImportDataState
+                SelectiveImportConfig.init() |> setImportDataState
         let addTableImport = fun (i: int) (fullImport: bool) ->
             let newImportTable: ImportTable = {Index = i; FullImport = fullImport}
             let newImportTables = newImportTable::importDataState.ImportTables |> List.distinct
@@ -209,7 +212,7 @@ type SelectiveImportModal =
                         SelectiveImportModal.MetadataImport(importDataState.ImportMetadata, setMetadataImport, disArcfile)
                         for ti in 0 .. (tables.Count-1) do
                             let t = tables.[ti]
-                            SelectiveImportModal.TableImport(ti, t, importDataState, addTableImport, rmvTableImport, importDataState, setImportDataState)
+                            SelectiveImportModal.TableImport(ti, t, model, dispatch)
                         Daisy.cardActions [
                             Daisy.button.button [
                                 button.info
@@ -226,6 +229,6 @@ type SelectiveImportModal =
             ]
         ]
 
-    static member Main(import: ArcFiles, dispatch: Messages.Msg -> unit) =
+    static member Main(import: ArcFiles, model, dispatch: Messages.Msg -> unit) =
         let rmv = Util.RMV_MODAL dispatch
-        SelectiveImportModal.Main (import, dispatch, rmv = rmv)
+        SelectiveImportModal.Main (import, model, dispatch, rmv = rmv)

--- a/src/Client/Modals/UpdateColumn.fs
+++ b/src/Client/Modals/UpdateColumn.fs
@@ -76,24 +76,27 @@ module private Components =
 
     let PreviewTable(column: CompositeColumn, cellValues: string [], regex) =
         Html.div [
-            Daisy.label [
-                Daisy.labelText "Preview"
-            ]
-            Html.div [
-                prop.className "overflow-x-auto grow"
-                prop.children [
-                    Daisy.table [
-                        Html.thead [
-                            Html.tr [Html.th "";Html.th "Before"; Html.th "After"]
-                        ]
-                        Html.tbody [
-                            let previewCount = 5
-                            let preview = Array.takeSafe previewCount cellValues
-                            for i in 0 .. (preview.Length-1) do
-                                let cell0 = column.Cells.[i].ToString()
-                                let cell = preview.[i]
-                                let regexMarkedIndex = calculateRegex regex cell0
-                                PreviewRow(i,cell0,cell,regexMarkedIndex)
+            prop.className "shrink-1 overflow-y-auto"
+            prop.children [
+                Daisy.label [
+                    Daisy.labelText "Preview"
+                ]
+                Html.div [
+                    prop.className "overflow-x-auto grow"
+                    prop.children [
+                        Daisy.table [
+                            Html.thead [
+                                Html.tr [Html.th "";Html.th "Before"; Html.th "After"]
+                            ]
+                            Html.tbody [
+                                let previewCount = 5
+                                let preview = Array.takeSafe previewCount cellValues
+                                for i in 0 .. (preview.Length-1) do
+                                    let cell0 = column.Cells.[i].ToString()
+                                    let cell = preview.[i]
+                                    let regexMarkedIndex = calculateRegex regex cell0
+                                    PreviewRow(i,cell0,cell,regexMarkedIndex)
+                            ]
                         ]
                     ]
                 ]
@@ -121,6 +124,7 @@ type UpdateColumn =
                 ]
                 Daisy.input [
                     input.bordered
+                    prop.className "input-xs sm:input-sm md:input-md"
                     prop.autoFocus true
                     prop.valueOrDefault baseStr
                     prop.onChange(fun s ->
@@ -178,6 +182,7 @@ type UpdateColumn =
                     Daisy.input [
                         prop.autoFocus true
                         input.bordered
+                        prop.className "input-xs sm:input-sm md:input-md"
                         prop.valueOrDefault regex
                         prop.onChange (fun s ->
                             setRegex s;
@@ -191,6 +196,7 @@ type UpdateColumn =
                     ]
                     Daisy.input [
                         input.bordered
+                        prop.className "input-xs sm:input-sm md:input-md"
                         prop.valueOrDefault replacement
                         prop.onChange (fun s ->
                             setReplacement s;
@@ -226,32 +232,37 @@ type UpdateColumn =
             prop.children [
                 Daisy.modalBackdrop [ prop.onClick rmv ]
                 Daisy.modalBox.div [
-                    prop.style [style.maxHeight(length.percent 70); style.maxWidth(length.px 900); style.overflowY.hidden]
+                    prop.className "max-h-screen max-w-4xl flex"
                     prop.children [
                         Daisy.card [
+                            prop.className "flex"
+                            card.compact
                             prop.children [
                                 Daisy.cardBody [
-                                    Daisy.cardTitle [
-                                        prop.className "flex flex-row justify-between"
-                                        prop.children [
-                                            Html.p "Update Column"
-                                            Components.DeleteButton(props=[prop.onClick rmv])
+                                    prop.className "overflow-y-hidden"
+                                    prop.children [
+                                        Daisy.cardTitle [
+                                            prop.className "flex flex-row justify-between"
+                                            prop.children [
+                                                Html.p "Update Column"
+                                                Components.DeleteButton(props=[prop.onClick rmv])
+                                            ]
                                         ]
-                                    ]
-                                    Components.TabNavigation(currentPage, setPage)
-                                    match currentPage with
-                                    | FunctionPage.Create -> UpdateColumn.CreateForm(getCellStrings(), setPreview)
-                                    | FunctionPage.Update -> UpdateColumn.UpdateForm(getCellStrings(), setPreview, regex, setRegex)
-                                    Components.PreviewTable(column, preview, regex)
-                                    Daisy.cardActions [
-                                        Daisy.button.button [
-                                            button.info
-                                            prop.style [style.marginLeft length.auto]
-                                            prop.text "Submit"
-                                            prop.onClick(fun e ->
-                                                submit()
-                                                rmv e
-                                            )
+                                        Components.TabNavigation(currentPage, setPage)
+                                        match currentPage with
+                                        | FunctionPage.Create -> UpdateColumn.CreateForm(getCellStrings(), setPreview)
+                                        | FunctionPage.Update -> UpdateColumn.UpdateForm(getCellStrings(), setPreview, regex, setRegex)
+                                        Components.PreviewTable(column, preview, regex)
+                                        Daisy.cardActions [
+                                            Daisy.button.button [
+                                                button.info
+                                                prop.style [style.marginLeft length.auto]
+                                                prop.text "Submit"
+                                                prop.onClick(fun e ->
+                                                    submit()
+                                                    rmv e
+                                                )
+                                            ]
                                         ]
                                     ]
                                 ]

--- a/src/Client/Model.fs
+++ b/src/Client/Model.fs
@@ -248,14 +248,18 @@ module Protocol =
         // Client
         Loading             : bool
         LastUpdated         : System.DateTime option
-        // ------ Protocol from Database ------
+        ShowSearch          : bool
+        ImportConfig        : FileImport.SelectiveImportConfig
         TemplatesSelected   : ARCtrl.Template list
+        // ------ Protocol from Database ------
         Templates           : ARCtrl.Template []
     } with
         static member init () = {
             // Client
             Loading             = false
             LastUpdated         = None
+            ShowSearch          = false
+            ImportConfig        = FileImport.SelectiveImportConfig.init()
             TemplatesSelected   = []
             // ------ Protocol from Database ------
             Templates           = [||]

--- a/src/Client/OfficeInterop/OfficeInterop.fs
+++ b/src/Client/OfficeInterop/OfficeInterop.fs
@@ -205,7 +205,7 @@ module GetHandler =
     /// <param name="tablesToAdd"></param>
     /// <param name="selectedColumnsCollection"></param>
     /// <param name="importTables"></param>
-    let selectTablesToAdd (tablesToAdd: ArcTable []) (importTables: JsonImport.ImportTable list) =
+    let selectTablesToAdd (tablesToAdd: ArcTable []) (importTables: FileImport.ImportTable list) =
 
         let importData =
             importTables
@@ -1178,7 +1178,7 @@ type Main =
     /// <param name="tableToAdd"></param>
     /// <param name="index"></param>
     /// <param name="options"></param>
-    static member joinTables (tablesToAdd: ArcTable [], deselectedColumnsCollection: Set<int*int>, options: TableJoinOptions option, importTables: JsonImport.ImportTable list, ?context0) =
+    static member joinTables (tablesToAdd: ArcTable [], deselectedColumnsCollection: Set<int*int>, options: TableJoinOptions option, importTables: FileImport.ImportTable list, ?context0) =
         excelRunWith context0 <| fun context ->
             promise {
                 //When a name is available get the annotation and arctable for easy access of indices and value adaption

--- a/src/Client/Pages/DataAnnotator/DataAnnotator.fs
+++ b/src/Client/Pages/DataAnnotator/DataAnnotator.fs
@@ -113,7 +113,7 @@ module private DataAnnotatorHelper =
                     ]
                     Html.input [
                         prop.title fileName
-                        prop.className "input input-bordered input-disabled join-item grow"
+                        prop.className "input input-bordered input-disabled join-item grow w-full"
                         prop.value fileName
                         prop.readOnly true
                     ]

--- a/src/Client/Pages/ProtocolTemplates/ProtocolSearch.fs
+++ b/src/Client/Pages/ProtocolTemplates/ProtocolSearch.fs
@@ -15,7 +15,7 @@ module private HelperProtocolSearch =
         Html.button [
             prop.className "btn btn-outline btn-sm"
             prop.onClick (fun _ ->
-                setIsProtocolSearch false
+                Messages.Protocol.UpdateShowSearch false |> Messages.ProtocolMsg |> setIsProtocolSearch
             )
             prop.children [
                 Html.i [ prop.className "fa-solid fa-chevron-left" ]
@@ -29,11 +29,11 @@ open Fable.Core
 
 type SearchContainer =
 
-    static member HeaderElement(toggleShowFilter, setProtocolSearch) =
+    static member HeaderElement(toggleShowFilter, dispatch: Messages.Msg -> unit) =
         Html.div [
             prop.className [ "flex" ]
             prop.children [
-                HelperProtocolSearch.breadcrumbEle setProtocolSearch
+                HelperProtocolSearch.breadcrumbEle dispatch
                 Html.div [
                     prop.className "flex flex-row gap-2 ml-auto"
                     prop.children [
@@ -69,7 +69,7 @@ type SearchContainer =
         ]
 
     [<ReactComponent>]
-    static member Main(model:Model, setProtocolSearch, importTypeStateData, dispatch, ?hasBreadCrumps) =
+    static member Main(model:Model, dispatch) =
         let config, setConfig = React.useState(TemplateFilterConfig.init)
         let showTemplatesFilter, setShowTemplatesFilter = React.useState(false)
         let filteredTemplates =
@@ -85,13 +85,13 @@ type SearchContainer =
         Html.div [
             prop.className "flex flex-col gap-2 lg:gap-4 overflow-hidden"
             prop.children [
-                SearchContainer.HeaderElement((fun _ -> setShowTemplatesFilter (not showTemplatesFilter)), setProtocolSearch)
+                SearchContainer.HeaderElement((fun _ -> setShowTemplatesFilter (not showTemplatesFilter)), dispatch)
                 if showTemplatesFilter then
                     Protocol.Search.FileSortElement(model, config, setConfig)
                 if isEmpty && not isLoading then
                     Html.p [prop.className "text-error text-sm"; prop.text "No templates were found. This can happen if connection to the server was lost. You can try reload this site or contact a developer."]
                 else
-                    Search.SelectTemplatesButton(model, setProtocolSearch, importTypeStateData, dispatch)
+                    Search.SelectTemplatesButton(model, dispatch)
                     Protocol.Search.Component (filteredTemplates, model, dispatch)
             ]
         ]

--- a/src/Client/Pages/ProtocolTemplates/ProtocolSearch.fs
+++ b/src/Client/Pages/ProtocolTemplates/ProtocolSearch.fs
@@ -11,12 +11,12 @@ open Swate.Components.Shared
 
 module private HelperProtocolSearch =
 
-    let breadcrumbEle (model: Model) setIsProtocolSearch dispatch =
+    let breadcrumbEle setIsProtocolSearch =
         Html.button [
             prop.className "btn btn-outline btn-sm"
             prop.onClick (fun _ ->
                 setIsProtocolSearch false
-                UpdateModel {model with Model.PageState.SidebarPage = Routing.SidebarPage.Protocol} |> dispatch)
+            )
             prop.children [
                 Html.i [ prop.className "fa-solid fa-chevron-left" ]
                 Html.span [
@@ -29,72 +29,69 @@ open Fable.Core
 
 type SearchContainer =
 
-    [<ReactComponent>]
-    static member Main(model:Model, setProtocolSearch, importTypeStateData, dispatch, ?hasBreadCrumps) =
-        let hasBreadCrumps = defaultArg hasBreadCrumps false
-        let templates, setTemplates = React.useState(model.ProtocolState.Templates)
-        let config, setConfig = React.useState(TemplateFilterConfig.init)
-        let showTemplatesFilter, setShowTemplatesFilter = React.useState(false)
-        let filteredTemplates = Protocol.Search.filterTemplates (templates, config)
-        React.useEffectOnce(fun _ -> Messages.Protocol.GetAllProtocolsRequest |> Messages.ProtocolMsg |> dispatch)
-        React.useEffect((fun _ -> setTemplates model.ProtocolState.Templates), [|box model.ProtocolState.Templates|])
-        let isEmpty = model.ProtocolState.Templates |> isNull || model.ProtocolState.Templates |> Array.isEmpty
-        let isLoading = model.ProtocolState.Loading
+    static member HeaderElement(toggleShowFilter, setProtocolSearch) =
         Html.div [
-            prop.onSubmit (fun e -> e.preventDefault())
-            // https://keycode.info/
-            prop.onKeyDown (fun k -> if k.key = "Enter" then k.preventDefault())
-            prop.className "flex flex-col gap-2"
+            prop.className [ "flex" ]
             prop.children [
+                HelperProtocolSearch.breadcrumbEle setProtocolSearch
                 Html.div [
-                    prop.className [ if hasBreadCrumps then "flex flex-row justify-between" else "flex justify-end" ]
+                    prop.className "flex flex-row gap-2 ml-auto"
                     prop.children [
-                        if hasBreadCrumps then
-                            HelperProtocolSearch.breadcrumbEle model setProtocolSearch dispatch
-                        Html.div [
-                            prop.className "flex flex-row gap-2"
+                        Daisy.dropdown [
+                            prop.className "dropdown dropdown-bottom dropdown-end group relative z-[9999]"
                             prop.children [
-                                Daisy.dropdown [
-                                    prop.className "dropdown dropdown-bottom dropdown-end group relative z-[9999]"
-                                    prop.children [
-                                        Daisy.button.a [
-                                            button.sm
-                                            button.info
-                                            prop.className "btn fa-solid fa-info"
-                                            prop.tabIndex 0
-                                        ]
-                                        Daisy.dropdownContent [
-                                            Html.ul [
-                                                prop.tabIndex 0
-                                                prop.className "relative left-1/2 -translate-x-1/2 mt-2 w-64 p-3 bg-gray-800 text-white text-sm rounded-lg shadow-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-[100]"
-                                                prop.children [
-                                                    Html.li [ Search.InfoField() ]
-                                                ]
-                                            ]
+                                Daisy.button.a [
+                                    button.sm
+                                    button.info
+                                    prop.className "btn fa-solid fa-info"
+                                    prop.tabIndex 0
+                                ]
+                                Daisy.dropdownContent [
+                                    Html.ul [
+                                        prop.tabIndex 0
+                                        prop.className "relative left-1/2 -translate-x-1/2 mt-2 w-64 p-3 bg-gray-800 text-white text-sm rounded-lg shadow-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-[100]"
+                                        prop.children [
+                                            Html.li [ Search.InfoField() ]
                                         ]
                                     ]
                                 ]
-                                Daisy.button.a [
-                                    button.sm
-                                    prop.className "fa-solid fa-cog"
-                                    button.success
-                                    prop.onClick(fun _ -> not showTemplatesFilter |> setShowTemplatesFilter)
-                                ]
                             ]
+                        ]
+                        Daisy.button.a [
+                            button.sm
+                            prop.className "fa-solid fa-cog"
+                            button.success
+                            prop.onClick(fun _ -> toggleShowFilter())
                         ]
                     ]
                 ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member Main(model:Model, setProtocolSearch, importTypeStateData, dispatch, ?hasBreadCrumps) =
+        let config, setConfig = React.useState(TemplateFilterConfig.init)
+        let showTemplatesFilter, setShowTemplatesFilter = React.useState(false)
+        let filteredTemplates =
+            React.useMemo(
+                (fun _ ->
+                    Protocol.Search.filterTemplates (model.ProtocolState.Templates, config)
+                ),
+                [|box model.ProtocolState.Templates; box config|]
+            )
+        React.useEffectOnce(fun _ -> Messages.Protocol.GetAllProtocolsRequest |> Messages.ProtocolMsg |> dispatch)
+        let isEmpty = model.ProtocolState.Templates |> isNull || model.ProtocolState.Templates |> Array.isEmpty
+        let isLoading = model.ProtocolState.Loading
+        Html.div [
+            prop.className "flex flex-col gap-2 lg:gap-4 overflow-hidden"
+            prop.children [
+                SearchContainer.HeaderElement((fun _ -> setShowTemplatesFilter (not showTemplatesFilter)), setProtocolSearch)
+                if showTemplatesFilter then
+                    Protocol.Search.FileSortElement(model, config, setConfig)
                 if isEmpty && not isLoading then
                     Html.p [prop.className "text-error text-sm"; prop.text "No templates were found. This can happen if connection to the server was lost. You can try reload this site or contact a developer."]
-
-                Html.div [
-                    prop.className "relative flex shadow-md gap-4 flex-col !m-0 !p-0"
-                    prop.children [
-                        if showTemplatesFilter then
-                            Protocol.Search.FileSortElement(model, config, setConfig)
-                        Search.SelectTemplatesButton(model, setProtocolSearch, importTypeStateData, dispatch)
-                        Protocol.Search.Component (filteredTemplates, model, dispatch)
-                    ]
-                ]
+                else
+                    Search.SelectTemplatesButton(model, setProtocolSearch, importTypeStateData, dispatch)
+                    Protocol.Search.Component (filteredTemplates, model, dispatch)
             ]
         ]

--- a/src/Client/Pages/ProtocolTemplates/ProtocolSearchViewComponent.fs
+++ b/src/Client/Pages/ProtocolTemplates/ProtocolSearchViewComponent.fs
@@ -10,7 +10,7 @@ open Feliz.DaisyUI
 
 open Modals
 
-open JsonImport
+open FileImport
 
 /// Fields of Template that can be searched
 [<RequireQualifiedAccess>]
@@ -555,15 +555,13 @@ type Search =
                 ]
         ]
 
-    static member SelectTemplatesButton(model, setProtocolSearch, importTypeStateData, dispatch) =
-        let importTypeState, setImportTypeState = importTypeStateData
+    static member SelectTemplatesButton(model: Model.Model, dispatch) =
         Html.div [
             prop.className "flex justify-center gap-2"
             prop.children [
                 Daisy.button.a [
                     button.wide
                     prop.onClick (fun _ ->
-                        setProtocolSearch false
                         SelectProtocols model.ProtocolState.TemplatesSelected |> ProtocolMsg |> dispatch
                     )
                     if model.ProtocolState.TemplatesSelected.Length > 0 then

--- a/src/Client/Pages/ProtocolTemplates/ProtocolSearchViewComponent.fs
+++ b/src/Client/Pages/ProtocolTemplates/ProtocolSearchViewComponent.fs
@@ -391,7 +391,7 @@ module ComponentAux =
                             prop.children [
                                 if List.contains template model.ProtocolState.TemplatesSelected then
                                     let templates = model.ProtocolState.TemplatesSelected |> Array.ofSeq
-                                    let templateIndex = Array.findIndex (fun selectedTemplate -> selectedTemplate = template) templates                                    
+                                    let templateIndex = Array.findIndex (fun selectedTemplate -> selectedTemplate = template) templates
                                     Daisy.button.a [
                                         button.sm
                                         prop.onClick (fun _ ->
@@ -580,7 +580,8 @@ type Search =
         let maxheight = defaultArg maxheight (length.px 600)
         let showIds, setShowIds = React.useState(fun _ -> [])
         Html.div [
-            prop.style [style.overflow.auto; style.maxHeight maxheight]
+            prop.style [style.maxHeight maxheight]
+            prop.className "shrink overflow-y-auto"
             prop.children [
                 Daisy.table [
                     table.zebra

--- a/src/Client/Pages/ProtocolTemplates/ProtocolView.fs
+++ b/src/Client/Pages/ProtocolTemplates/ProtocolView.fs
@@ -21,14 +21,12 @@ open Feliz
 open Feliz.DaisyUI
 open ARCtrl
 
-open JsonImport
+open FileImport
 
 type Templates =
 
     [<ReactComponent>]
     static member Main (model: Model, dispatch) =
-        let isProtocolSearch, setProtocolSearch = React.useState(false)
-        let importTypeStateData = React.useState(SelectiveImportModalState.init())
         SidebarComponents.SidebarLayout.Container [
             SidebarComponents.SidebarLayout.Header "Templates"
 
@@ -41,12 +39,12 @@ type Templates =
                 ]
             ])
 
-            if isProtocolSearch then
-                Protocol.SearchContainer.Main(model, setProtocolSearch, importTypeStateData, dispatch, true)
-            else
-                SidebarComponents.SidebarLayout.LogicContainer [
-                    Modals.SelectiveTemplateFromDB.Main(model, false, setProtocolSearch, importTypeStateData, dispatch)
-                ]
+            SidebarComponents.SidebarLayout.LogicContainer [
+                if model.ProtocolState.ShowSearch then
+                    Protocol.SearchContainer.Main(model, dispatch)
+                else
+                    Modals.SelectiveTemplateFromDB.Main(model, dispatch)
+            ]
 
             // Box 2
             SidebarComponents.SidebarLayout.Description (Html.p [

--- a/src/Client/Pages/ProtocolTemplates/SelectiveTemplateFromDB.fs
+++ b/src/Client/Pages/ProtocolTemplates/SelectiveTemplateFromDB.fs
@@ -11,7 +11,7 @@ open OfficeInterop.Core
 type SelectiveTemplateFromDB =
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="adaptTableName"></param>
     /// <param name="setAdaptTableName"></param>
@@ -31,7 +31,7 @@ type SelectiveTemplateFromDB =
         ]
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="model"></param>
     /// <param name="dispatch"></param>
@@ -50,7 +50,7 @@ type SelectiveTemplateFromDB =
         ]
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="selectedTemplate"></param>
     /// <param name="templateIndex"></param>
@@ -73,7 +73,7 @@ type SelectiveTemplateFromDB =
         ]
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="importState"></param>
     /// <param name="activeTableIndex"></param>
@@ -96,7 +96,7 @@ type SelectiveTemplateFromDB =
         |> ResizeArray
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="name"></param>
     /// <param name="model"></param>
@@ -123,7 +123,7 @@ type SelectiveTemplateFromDB =
         ]
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="model"></param>
     /// <param name="dispatch"></param>
@@ -136,32 +136,40 @@ type SelectiveTemplateFromDB =
             {importTypeState with ImportTables = newImportTables} |> setImportTypeState
         let rmvTableImport = fun index ->
             {importTypeState with ImportTables = importTypeState.ImportTables |> List.filter (fun it -> it.Index <> index)} |> setImportTypeState
-        React.fragment [
-            Html.div [
-                SelectiveTemplateFromDB.ToProtocolSearchElement(model, setProtocolSearch, dispatch)
-            ]
-            if model.ProtocolState.TemplatesSelected.Length > 0 then
-                SelectiveImportModal.RadioPluginsBox(
-                    "Import Type",
-                    "fa-solid fa-cog",
-                    importTypeState.ImportType,
-                    "importType",
-                    [|
-                        ARCtrl.TableJoinOptions.Headers, " Column Headers";
-                        ARCtrl.TableJoinOptions.WithUnit, " ..With Units";
-                        ARCtrl.TableJoinOptions.WithValues, " ..With Values";
-                    |],
-                    fun importType -> {importTypeState with ImportType = importType} |> setImportTypeState
-                )
+        Html.div [
+            prop.className "flex flex-col gap-2 lg:gap-4 overflow-hidden"
+            prop.children [
 
-            if model.ProtocolState.TemplatesSelected.Length > 0 then
-                let templates = model.ProtocolState.TemplatesSelected
-                for templateIndex in 0..templates.Length-1 do
-                    let template = templates.[templateIndex]
-                    SelectiveImportModal.TableImport(
-                        templateIndex, template.Table, importTypeState, addTableImport, rmvTableImport, importTypeState, setImportTypeState, template.Name)
                 Html.div [
-                    SelectiveTemplateFromDB.AddTemplatesFromDBToTableButton(
-                        "Import", model, importTypeState, setImportTypeState, protocolSearchState, setProtocolSearch, dispatch)
+                    SelectiveTemplateFromDB.ToProtocolSearchElement(model, setProtocolSearch, dispatch)
                 ]
+                if model.ProtocolState.TemplatesSelected.Length > 0 then
+                    Html.div [
+                        prop.className "flex gap-2 flex-col shrink overflow-y-auto"
+                        prop.children [
+
+                            SelectiveImportModal.RadioPluginsBox(
+                                "Import Type",
+                                "fa-solid fa-cog",
+                                importTypeState.ImportType,
+                                "importType",
+                                [|
+                                    ARCtrl.TableJoinOptions.Headers, " Column Headers";
+                                    ARCtrl.TableJoinOptions.WithUnit, " ..With Units";
+                                    ARCtrl.TableJoinOptions.WithValues, " ..With Values";
+                                |],
+                                fun importType -> {importTypeState with ImportType = importType} |> setImportTypeState
+                            )
+
+                            for templateIndex in 0..model.ProtocolState.TemplatesSelected.Length-1 do
+                                let template = model.ProtocolState.TemplatesSelected.[templateIndex]
+                                SelectiveImportModal.TableImport(
+                                    templateIndex, template.Table, importTypeState, addTableImport, rmvTableImport, importTypeState, setImportTypeState, template.Name)
+                            Html.div [
+                                SelectiveTemplateFromDB.AddTemplatesFromDBToTableButton(
+                                    "Import", model, importTypeState, setImportTypeState, protocolSearchState, setProtocolSearch, dispatch)
+                            ]
+                        ]
+                    ]
+            ]
         ]

--- a/src/Client/Pages/ProtocolTemplates/SelectiveTemplateFromDB.fs
+++ b/src/Client/Pages/ProtocolTemplates/SelectiveTemplateFromDB.fs
@@ -5,95 +5,98 @@ open Feliz.DaisyUI
 open Model
 open Messages
 open ARCtrl
-open JsonImport
+open FileImport
 open OfficeInterop.Core
 
 type SelectiveTemplateFromDB =
 
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="adaptTableName"></param>
-    /// <param name="setAdaptTableName"></param>
-    /// <param name="templateName"></param>
-    static member CheckBoxForTakeOverTemplateName(adaptTableName: SelectiveImportModalState, setAdaptTableName: SelectiveImportModalState -> unit, templateName) =
-        Html.label [
-            prop.className "join flex flex-row centered gap-2"
-            prop.children [
-                Daisy.checkbox [
-                    prop.type'.checkbox
-                    prop.isChecked adaptTableName.TemplateName.IsSome
-                    prop.onChange (fun (b: bool) ->
-                        { adaptTableName with TemplateName = if b then Some templateName else None} |> setAdaptTableName)
-                ]
-                Html.text $"Use Template name: {templateName}"
-            ]
-        ]
+    // /// <summary>
+    // ///
+    // /// </summary>
+    // /// <param name="adaptTableName"></param>
+    // /// <param name="setAdaptTableName"></param>
+    // /// <param name="templateName"></param>
+    // static member CheckBoxForTakeOverTemplateName(adaptTableName: SelectiveImportConfig, setAdaptTableName: SelectiveImportConfig -> unit, templateName) =
+    //     Html.label [
+    //         prop.className "join flex flex-row centered gap-2"
+    //         prop.children [
+    //             Daisy.checkbox [
+    //                 prop.type'.checkbox
+    //                 prop.isChecked adaptTableName.TemplateName.IsSome
+    //                 prop.onChange (fun (b: bool) ->
+    //                     { adaptTableName with TemplateName = if b then Some templateName else None} |> setAdaptTableName)
+    //             ]
+    //             Html.text $"Use Template name: {templateName}"
+    //         ]
+    //     ]
 
     /// <summary>
     ///
     /// </summary>
     /// <param name="model"></param>
     /// <param name="dispatch"></param>
-    static member ToProtocolSearchElement (model: Model, setProtocolSearch, dispatch) =
+    static member ToProtocolSearchElement (model: Model, dispatch, ?className: Fable.Core.U2<string, string list>) =
         Daisy.button.button [
             prop.onClick(fun _ ->
-                setProtocolSearch true
-                if model.ProtocolState.TemplatesSelected.Length > 0 then
-                    Protocol.RemoveSelectedProtocols |> ProtocolMsg |> dispatch
-                    //{importTypeState with DeSelectedColumns = Array.empty} |> setImportTypeState
-                else
-                    UpdateModel model |> dispatch)
+                    Protocol.UpdateShowSearch true |> ProtocolMsg |> dispatch
+                    if model.ProtocolState.TemplatesSelected.Length > 0 then
+                        Protocol.RemoveSelectedProtocols |> ProtocolMsg |> dispatch
+                )
             button.primary
-            button.block
+            if className.IsSome then
+                match className.Value with // this can also be done with !^ , but i was too lazy to open Fable.Core
+                | Fable.Core.Case1 className ->
+                    prop.className className
+                | Fable.Core.U2.Case2 className ->
+                    prop.className className
             prop.text "Browse database"
         ]
 
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="selectedTemplate"></param>
-    /// <param name="templateIndex"></param>
-    /// <param name="selectionInformation"></param>
-    /// <param name="setSelectedColumns"></param>
-    /// <param name="dispatch"></param>
-    /// <param name="hasIcon"></param>
-    static member DisplaySelectedProtocolElements(selectedTemplate: Template option, templateIndex, selectedInformation, setSelectedInformation, dispatch, ?hasIcon: bool) =
-        let hasIcon = defaultArg hasIcon true
-        Html.div [
-            prop.style [style.overflowX.auto; style.marginBottom (length.rem 1)]
-            prop.children [
-                if selectedTemplate.IsSome then
-                    if hasIcon then
-                        Html.i [prop.className "fa-solid fa-cog"]
-                    Html.span $"Template: {selectedTemplate.Value.Name}"
-                if selectedTemplate.IsSome then
-                    SelectiveImportModal.TableWithImportColumnCheckboxes(selectedTemplate.Value.Table, templateIndex, selectedInformation, setSelectedInformation)
-            ]
-        ]
+    // /// <summary>
+    // ///
+    // /// </summary>
+    // /// <param name="selectedTemplate"></param>
+    // /// <param name="templateIndex"></param>
+    // /// <param name="selectionInformation"></param>
+    // /// <param name="setSelectedColumns"></param>
+    // /// <param name="dispatch"></param>
+    // /// <param name="hasIcon"></param>
+    // static member DisplaySelectedProtocolElements(selectedTemplate: Template option, templateIndex, selectedInformation, setSelectedInformation, dispatch, ?hasIcon: bool) =
+    //     let hasIcon = defaultArg hasIcon true
+    //     Html.div [
+    //         prop.style [style.overflowX.auto; style.marginBottom (length.rem 1)]
+    //         prop.children [
+    //             if selectedTemplate.IsSome then
+    //                 if hasIcon then
+    //                     Html.i [prop.className "fa-solid fa-cog"]
+    //                 Html.span $"Template: {selectedTemplate.Value.Name}"
+    //             if selectedTemplate.IsSome then
+    //                 SelectiveImportModal.TableWithImportColumnCheckboxes(selectedTemplate.Value.Table, templateIndex, true, selectedInformation, setSelectedInformation)
+    //         ]
+    //     ]
 
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="importState"></param>
-    /// <param name="activeTableIndex"></param>
-    /// <param name="existingOpt"></param>
-    /// <param name="appendTables"></param>
-    /// <param name="joinTables"></param>
-    static member CreateUpdatedTables (arcTables: ResizeArray<ArcTable>) (state: SelectiveImportModalState) (deselectedColumns: Set<int*int>) fullImport =
-        [
-            for importTable in state.ImportTables do
-                let fullImport = defaultArg fullImport importTable.FullImport
-                if importTable.FullImport = fullImport then
-                    let deselectedColumnIndices = getDeselectedTableColumnIndices deselectedColumns importTable.Index
-                    let sourceTable = arcTables.[importTable.Index]
-                    let appliedTable = ArcTable.init(sourceTable.Name)
+    // /// <summary>
+    // ///
+    // /// </summary>
+    // /// <param name="importState"></param>
+    // /// <param name="activeTableIndex"></param>
+    // /// <param name="existingOpt"></param>
+    // /// <param name="appendTables"></param>
+    // /// <param name="joinTables"></param>
+    // static member CreateUpdatedTables (arcTables: ResizeArray<ArcTable>) (state: SelectiveImportConfig) (deselectedColumns: Set<int*int>) fullImport =
+    //     [
+    //         for importTable in state.ImportTables do
+    //             let fullImport = defaultArg fullImport importTable.FullImport
+    //             if importTable.FullImport = fullImport then
+    //                 let deselectedColumnIndices = getDeselectedTableColumnIndices deselectedColumns importTable.Index
+    //                 let sourceTable = arcTables.[importTable.Index]
+    //                 let appliedTable = ArcTable.init(sourceTable.Name)
 
-                    let finalTable = Table.selectiveTablePrepare appliedTable sourceTable deselectedColumnIndices
-                    appliedTable.Join(finalTable, joinOptions=state.ImportType)
-                    appliedTable
-        ]
-        |> ResizeArray
+    //                 let finalTable = Table.selectiveTablePrepare appliedTable sourceTable deselectedColumnIndices
+    //                 appliedTable.Join(finalTable, joinOptions=state.ImportType)
+    //                 appliedTable
+    //     ]
+    //     |> ResizeArray
 
     /// <summary>
     ///
@@ -102,25 +105,17 @@ type SelectiveTemplateFromDB =
     /// <param name="model"></param>
     /// <param name="importType"></param>
     /// <param name="dispatch"></param>
-    static member AddTemplatesFromDBToTableButton(name, model: Model, importType, setImportType, protocolSearchState, setProtocolSearch, dispatch) =
-        let addTemplates (model: Model, deselectedColumns) =
+    static member AddTemplatesFromDBToTableButton(label: string, model: Model, dispatch) =
+        let addTemplates () =
             let templates = model.ProtocolState.TemplatesSelected
             if templates.Length = 0 then
                 failwith "No template selected!"
             if model.ProtocolState.TemplatesSelected.Length > 0 then
                 let importTables = templates |> List.map (fun item -> item.Table) |> Array.ofList
-                SpreadsheetInterface.AddTemplates(importTables, deselectedColumns, importType) |> InterfaceMsg |> dispatch
-                Protocol.RemoveSelectedProtocols |> ProtocolMsg |> dispatch
-                setProtocolSearch protocolSearchState
-                { importType with DeselectedColumns = Set.empty } |> setImportType
+                SpreadsheetInterface.AddTemplates(importTables, model.ProtocolState.ImportConfig) |> InterfaceMsg |> dispatch
 
-        Html.div [
-            prop.className "join flex flex-row justify-center gap-2"
-            prop.children [
-                let isDisabled = model.ProtocolState.TemplatesSelected.Length = 0
-                ModalElements.Button(name, addTemplates, (model, importType.DeselectedColumns), isDisabled)
-            ]
-        ]
+        let isDisabled = model.ProtocolState.TemplatesSelected.Length = 0
+        ModalElements.Button(label, addTemplates, (), isDisabled, "grow")
 
     /// <summary>
     ///
@@ -128,20 +123,25 @@ type SelectiveTemplateFromDB =
     /// <param name="model"></param>
     /// <param name="dispatch"></param>
     [<ReactComponent>]
-    static member Main (model: Model, protocolSearchState, setProtocolSearch, importTypeStateData, dispatch) =
-        let importTypeState, setImportTypeState = importTypeStateData
-        let addTableImport = fun (i: int) (fullImport: bool) ->
-            let newImportTable: ImportTable = {Index = i; FullImport = fullImport}
-            let newImportTables = newImportTable::importTypeState.ImportTables |> List.distinctBy (fun table -> table.Index)
-            {importTypeState with ImportTables = newImportTables} |> setImportTypeState
-        let rmvTableImport = fun index ->
-            {importTypeState with ImportTables = importTypeState.ImportTables |> List.filter (fun it -> it.Index <> index)} |> setImportTypeState
+    static member Main (model: Model, dispatch) =
         Html.div [
             prop.className "flex flex-col gap-2 lg:gap-4 overflow-hidden"
             prop.children [
 
                 Html.div [
-                    SelectiveTemplateFromDB.ToProtocolSearchElement(model, setProtocolSearch, dispatch)
+                    prop.className "grid grid-cols-2 gap-2"
+                    prop.children [
+                        SelectiveTemplateFromDB.ToProtocolSearchElement(
+                            model,
+                            dispatch,
+                            Fable.Core.U2.Case2 ["grow"; if model.ProtocolState.TemplatesSelected.Length > 0 then "btn-outline"]
+                        )
+                        SelectiveTemplateFromDB.AddTemplatesFromDBToTableButton(
+                            "Import",
+                            model,
+                            dispatch
+                        )
+                    ]
                 ]
                 if model.ProtocolState.TemplatesSelected.Length > 0 then
                     Html.div [
@@ -151,24 +151,27 @@ type SelectiveTemplateFromDB =
                             SelectiveImportModal.RadioPluginsBox(
                                 "Import Type",
                                 "fa-solid fa-cog",
-                                importTypeState.ImportType,
+                                model.ProtocolState.ImportConfig.ImportType,
                                 "importType",
                                 [|
                                     ARCtrl.TableJoinOptions.Headers, " Column Headers";
                                     ARCtrl.TableJoinOptions.WithUnit, " ..With Units";
                                     ARCtrl.TableJoinOptions.WithValues, " ..With Values";
                                 |],
-                                fun importType -> {importTypeState with ImportType = importType} |> setImportTypeState
+                                fun importType ->
+                                    {model.ProtocolState.ImportConfig with ImportType = importType}
+                                    |> Protocol.UpdateImportConfig |> ProtocolMsg |> dispatch
                             )
 
                             for templateIndex in 0..model.ProtocolState.TemplatesSelected.Length-1 do
                                 let template = model.ProtocolState.TemplatesSelected.[templateIndex]
                                 SelectiveImportModal.TableImport(
-                                    templateIndex, template.Table, importTypeState, addTableImport, rmvTableImport, importTypeState, setImportTypeState, template.Name)
-                            Html.div [
-                                SelectiveTemplateFromDB.AddTemplatesFromDBToTableButton(
-                                    "Import", model, importTypeState, setImportTypeState, protocolSearchState, setProtocolSearch, dispatch)
-                            ]
+                                    templateIndex,
+                                    template.Table,
+                                    model,
+                                    dispatch,
+                                    template.Name
+                                )
                         ]
                     ]
             ]

--- a/src/Client/Pages/ProtocolTemplates/SelectiveTemplateFromDB.fs
+++ b/src/Client/Pages/ProtocolTemplates/SelectiveTemplateFromDB.fs
@@ -110,7 +110,7 @@ type SelectiveTemplateFromDB =
             let templates = model.ProtocolState.TemplatesSelected
             if templates.Length = 0 then
                 failwith "No template selected!"
-            if model.ProtocolState.TemplatesSelected.Length > 0 then
+            else
                 let importTables = templates |> List.map (fun item -> item.Table) |> Array.ofList
                 SpreadsheetInterface.AddTemplates(importTables, model.ProtocolState.ImportConfig) |> InterfaceMsg |> dispatch
 

--- a/src/Client/Pages/ProtocolTemplates/TemplateFromFile.fs
+++ b/src/Client/Pages/ProtocolTemplates/TemplateFromFile.fs
@@ -103,7 +103,7 @@ type TemplateFromFile =
             // modal!
             match state.UploadedFile with
             | Some af ->
-                Modals.SelectiveImportModal.Main (af, dispatch, rmv = (fun _ -> TemplateFromFileState.init() |> setState))
+                Modals.SelectiveImportModal.Main (af, model, dispatch)
             | None -> Html.none
             Html.div [
                 Daisy.join [

--- a/src/Client/Pages/ProtocolTemplates/TemplateFromFile.fs
+++ b/src/Client/Pages/ProtocolTemplates/TemplateFromFile.fs
@@ -103,7 +103,12 @@ type TemplateFromFile =
             // modal!
             match state.UploadedFile with
             | Some af ->
-                Modals.SelectiveImportModal.Main (af, model, dispatch)
+                Modals.SelectiveImportModal.Main (
+                    af,
+                    model,
+                    dispatch,
+                    fun _ -> setState {state with UploadedFile = None}
+                )
             | None -> Html.none
             Html.div [
                 Daisy.join [

--- a/src/Client/States/OfficeInteropState.fs
+++ b/src/Client/States/OfficeInteropState.fs
@@ -2,7 +2,7 @@ namespace OfficeInterop
 
 open Swate.Components.Shared
 open ARCtrl
-open JsonImport
+open FileImport
 
 type FillHiddenColsState =
 | Inactive
@@ -31,7 +31,7 @@ type Msg =
     | ValidateBuildingBlock
     | AddAnnotationBlock                    of CompositeColumn
     | AddAnnotationBlocks                   of CompositeColumn [] //* OfficeInterop.Types.Xml.ValidationTypes.TableValidation option
-    | AddTemplates                          of ArcTable[] * Set<int*int> * SelectiveImportModalState
+    | AddTemplates                          of ArcTable[] * SelectiveImportConfig
     | JoinTable                             of ArcTable * options: TableJoinOptions option
     | RemoveBuildingBlock
     | UpdateUnitForCells

--- a/src/Client/States/Spreadsheet.fs
+++ b/src/Client/States/Spreadsheet.fs
@@ -3,7 +3,7 @@ namespace Spreadsheet
 open Swate.Components.Shared
 open ARCtrl
 open Fable.Core
-open JsonImport
+open FileImport
 
 type ColumnType =
 | Main
@@ -200,7 +200,7 @@ type Msg =
 | AddAnnotationBlock of CompositeColumn
 | AddAnnotationBlocks of CompositeColumn []
 | AddDataAnnotation of {| fragmentSelectors: string []; fileName: string; fileType: string; targetColumn: DataAnnotator.TargetColumn |}
-| AddTemplates of ArcTable[] * Set<int*int> * SelectiveImportModalState
+| AddTemplates of ArcTable[] * SelectiveImportConfig
 | JoinTable of ArcTable * index: int option * options: TableJoinOptions option * string option
 | UpdateArcFile of ArcFiles
 | InitFromArcFile of ArcFiles

--- a/src/Client/States/SpreadsheetInterface.fs
+++ b/src/Client/States/SpreadsheetInterface.fs
@@ -2,7 +2,7 @@ namespace SpreadsheetInterface
 
 open Swate.Components.Shared
 open ARCtrl
-open JsonImport
+open FileImport
 
 ///<summary>This type is used to interface between standalone, electron and excel logic and will forward the command to the correct logic.</summary>
 type Msg =
@@ -17,14 +17,14 @@ type Msg =
 | AddAnnotationBlocks of CompositeColumn []
 | AddDataAnnotation of {| fragmentSelectors: string []; fileName: string; fileType: string; targetColumn: DataAnnotator.TargetColumn |}
 /// This function will do preprocessing on the tables to join
-| AddTemplates          of ArcTable[] * Set<int*int> * SelectiveImportModalState
+| AddTemplates          of ArcTable[] * SelectiveImportConfig
 | JoinTable             of ArcTable * columnIndex: int option * options: TableJoinOptions option
 | UpdateArcFile         of ArcFiles
 /// Inserts TermMinimal to selected fields of one column
 | InsertOntologyAnnotation of OntologyAnnotation
 | InsertFileNames of string list
 | ImportXlsx of byte []
-| ImportJson of {| importState: SelectiveImportModalState; importedFile: ArcFiles; deselectedColumns: Set<int*int> |}
+| ImportJson of {| importState: SelectiveImportConfig; importedFile: ArcFiles; deselectedColumns: Set<int*int> |}
 /// Starts chain to export active table to isa json
 | ExportJson of ArcFiles * JsonExportFormat
 | UpdateUnitForCells

--- a/src/Client/Types.fs
+++ b/src/Client/Types.fs
@@ -12,7 +12,7 @@ module Feliz =
     | Ok of 's
     | Error of exn
 
-module JsonImport =
+module FileImport =
 
     [<RequireQualifiedAccess>]
     type ImportTable = {
@@ -21,7 +21,7 @@ module JsonImport =
         FullImport: bool
     }
 
-    type SelectiveImportModalState = {
+    type SelectiveImportConfig = {
         ImportType: ARCtrl.TableJoinOptions
         ImportMetadata: bool
         ImportTables: ImportTable list
@@ -37,11 +37,14 @@ module JsonImport =
                 TemplateName = None
             }
 
-        member this.toggleDeselectedColumns(tableIndex: int, columnIndex: int) =
-            if Set.contains (tableIndex, columnIndex) this.DeselectedColumns then
-                Set.remove (tableIndex, columnIndex) this.DeselectedColumns
-            else
-                Set.add (tableIndex, columnIndex) this.DeselectedColumns
+        member this.toggleDeselectColumn(tableIndex: int, columnIndex: int) : SelectiveImportConfig =
+            { this with
+                DeselectedColumns =
+                    if Set.contains (tableIndex, columnIndex) this.DeselectedColumns then
+                        Set.remove (tableIndex, columnIndex) this.DeselectedColumns
+                    else
+                        Set.add (tableIndex, columnIndex) this.DeselectedColumns
+            }
 
 open Fable.Core
 

--- a/src/Client/Update.fs
+++ b/src/Client/Update.fs
@@ -299,12 +299,12 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
             nextModel, nextCmd
 
         | ProtocolMsg fileUploadJsonMsg ->
-            let nextFileUploadJsonState, nextCmd =
+            let nextState, model, nextCmd =
                 Protocol.update fileUploadJsonMsg currentModel.ProtocolState model
 
             let nextModel = {
-                currentModel with
-                    ProtocolState = nextFileUploadJsonState
+                model with
+                    ProtocolState = nextState
                 }
             nextModel, nextCmd
 

--- a/src/Client/Update/ARCitectUpdate.fs
+++ b/src/Client/Update/ARCitectUpdate.fs
@@ -19,6 +19,7 @@ module ARCitect =
         | ARCitect.Init msg ->
             match msg with
             | Start () ->
+                log "ARCitect.Init.Start"
                 let cmd =
                     Cmd.OfPromise.either
                         api.Init

--- a/src/Client/Update/InterfaceUpdate.fs
+++ b/src/Client/Update/InterfaceUpdate.fs
@@ -173,13 +173,13 @@ module Interface =
                     let cmd = Spreadsheet.AddAnnotationBlocks compositeColumns |> SpreadsheetMsg |> Cmd.ofMsg
                     model, cmd
                 | _ -> failwith "not implemented"
-            | AddTemplates (tables, deselectedColumns, importType) ->
+            | AddTemplates (tables, importType) ->
                 match host with
                 | Some Swatehost.Excel ->
-                    let cmd = OfficeInterop.AddTemplates (tables, deselectedColumns, importType) |> OfficeInteropMsg |> Cmd.ofMsg
+                    let cmd = OfficeInterop.AddTemplates (tables, importType) |> OfficeInteropMsg |> Cmd.ofMsg
                     model, cmd
                 | Some Swatehost.Browser | Some Swatehost.ARCitect ->
-                    let cmd = Spreadsheet.AddTemplates (tables, deselectedColumns, importType) |> SpreadsheetMsg |> Cmd.ofMsg
+                    let cmd = Spreadsheet.AddTemplates (tables, importType) |> SpreadsheetMsg |> Cmd.ofMsg
                     model, cmd
                 | _ -> failwith "not implemented"
             | JoinTable (table, index, options) ->
@@ -229,7 +229,7 @@ module Interface =
                                     match arcfileOpt, activeTable with
                                     | Some arcfile, Ok activeTable -> arcfile.Tables() |> Seq.tryFindIndex (fun table -> table = activeTable)
                                     | _ -> None
-                                return UpdateUtil.JsonImportHelper.updateArcFileTables data.importedFile data.importState activeTableIndex arcfileOpt deselectedColumns
+                                return UpdateUtil.JsonImportHelper.updateArcFileTables data.importedFile data.importState activeTableIndex arcfileOpt
                         }
                     let updateArcFile (arcFile: ArcFiles) = SpreadsheetInterface.UpdateArcFile arcFile |> InterfaceMsg
                     let cmd =
@@ -243,7 +243,7 @@ module Interface =
                     let cmd =
                         match data.importState.ImportMetadata with
                         | true -> UpdateUtil.JsonImportHelper.updateWithMetadata data.importedFile data.importState deselectedColumns
-                        | false -> UpdateUtil.JsonImportHelper.updateArcFileTables data.importedFile data.importState model.SpreadsheetModel.ActiveView.TryTableIndex model.SpreadsheetModel.ArcFile deselectedColumns
+                        | false -> UpdateUtil.JsonImportHelper.updateArcFileTables data.importedFile data.importState model.SpreadsheetModel.ActiveView.TryTableIndex model.SpreadsheetModel.ArcFile
                         |> SpreadsheetInterface.UpdateArcFile |> InterfaceMsg |> Cmd.ofMsg
                     model, cmd
                 | _ -> failwith "not implemented"

--- a/src/Client/Update/InterfaceUpdate.fs
+++ b/src/Client/Update/InterfaceUpdate.fs
@@ -107,7 +107,6 @@ module Interface =
                         Cmd.none
                     | Swatehost.ARCitect ->
                         LocalHistory.Model.ResetHistoryWebStorage()
-                        Spreadsheet.Model.initHistoryIndexedDB() |> Promise.start
                         Start() |> ARCitect.Init |> ARCitectMsg |> Cmd.ofMsg
                 /// Updates from local storage if standalone in browser
                 let nextModel = model.UpdateFromLocalStorage()

--- a/src/Client/Update/OfficeInteropUpdate.fs
+++ b/src/Client/Update/OfficeInteropUpdate.fs
@@ -74,11 +74,11 @@ module OfficeInterop =
                 let jsonExport = UpdateUtil.JsonExportHelper.parseToJsonString(arcfile, jef)
                 UpdateUtil.downloadFromString (jsonExport)
                 state, model, Cmd.none
-            | AddTemplates (tables, deselectedColumns, importType) ->
+            | AddTemplates (tables, importType) ->
                 let cmd =
                     Cmd.OfPromise.either
                         Main.joinTables
-                        (tables, deselectedColumns, Some importType.ImportType, importType.ImportTables)
+                        (tables, importType.DeselectedColumns, Some importType.ImportType, importType.ImportTables)
                         (curry GenericInteropLogs Cmd.none >> DevMsg)
                         (curry GenericError Cmd.none >> DevMsg)
                 state, model, cmd

--- a/src/Client/Update/SpreadsheetUpdate.fs
+++ b/src/Client/Update/SpreadsheetUpdate.fs
@@ -116,9 +116,9 @@ module Spreadsheet =
                     | IsTable -> Controller.BuildingBlocks.addDataAnnotation data state
                     | IsMetadata -> failwith "Unable to add data annotation in metadata view"
                 nextState, model, Cmd.none
-            | AddTemplates (tables, deselectedColumns, importType) ->
+            | AddTemplates (tables, importType) ->
                 let arcFile = model.SpreadsheetModel.ArcFile
-                let updatedArcFile = UpdateUtil.JsonImportHelper.updateTables (tables |> ResizeArray) importType model.SpreadsheetModel.ActiveView.TryTableIndex arcFile deselectedColumns
+                let updatedArcFile = UpdateUtil.JsonImportHelper.updateTables (tables |> ResizeArray) importType model.SpreadsheetModel.ActiveView.TryTableIndex arcFile
                 let nextState = {state with ArcFile = Some updatedArcFile}
                 nextState, model, Cmd.none
             | JoinTable (table, index, options, templateName) ->

--- a/src/Client/Views/SpreadsheetView.fs
+++ b/src/Client/Views/SpreadsheetView.fs
@@ -31,12 +31,11 @@ let private ModalDisplay (widgets: Widget list, displayWidget: Widget -> ReactEl
 
 
 open Swate.Components.Shared
-open JsonImport
+open FileImport
 
 [<ReactComponent>]
 let Main (model: Model, dispatch) =
     let widgets, setWidgets = React.useState([])
-    let importTypeStateData = React.useState(SelectiveImportModalState.init())
     let rmvWidget (widget: Widget) = widgets |> List.except [widget] |> setWidgets
     let bringWidgetToFront (widget: Widget) =
         let newList = widgets |> List.except [widget] |> fun x -> widget::x |> List.rev
@@ -46,7 +45,7 @@ let Main (model: Model, dispatch) =
         let bringWidgetToFront = fun _ -> bringWidgetToFront widget
         match widget with
         | Widget._BuildingBlock -> Widget.BuildingBlock (model, dispatch, rmv widget)
-        | Widget._Template -> Widget.Templates (model, importTypeStateData, dispatch, rmv widget)
+        | Widget._Template -> Widget.Templates (model, dispatch, rmv widget)
         | Widget._FilePicker -> Widget.FilePicker (model, dispatch, rmv widget)
         | Widget._DataAnnotator -> Widget.DataAnnotator(model, dispatch, rmv widget)
         |> WidgetOrderContainer bringWidgetToFront

--- a/src/Components/src/TermSearch/TermSearch.fs
+++ b/src/Components/src/TermSearch/TermSearch.fs
@@ -696,6 +696,17 @@ type TermSearch =
 
         let (modal: Modals option), setModal = React.useState None
 
+        let inputText = term |> Option.bind _.name |> Option.defaultValue ""
+
+        React.useLayoutEffect(
+            (fun () ->
+                if inputRef.current.IsSome then
+                    inputRef.current.Value.value <- inputText
+                ()
+            ),
+            [|box term|]
+        )
+
         /// Close term search result window when opening a modal
         let setModal =
             fun (modal: Modals option) ->
@@ -959,11 +970,11 @@ type TermSearch =
                                     ]
                                 ]
                                 Html.input [
-                                    prop.className "grow"
+                                    prop.className "grow shrink min-w-[50px] w-full"
                                     if debug then
                                         prop.testid "term-search-input"
                                     prop.ref(inputRef)
-                                    prop.defaultValue (term |> Option.bind _.name |> Option.defaultValue "")
+                                    prop.defaultValue inputText
                                     prop.placeholder "..."
                                     prop.autoFocus autoFocus
                                     prop.onChange (fun (e: string) ->

--- a/src/Server/Version.fs
+++ b/src/Server/Version.fs
@@ -4,12 +4,12 @@ open System.Reflection
 
 [<assembly: AssemblyTitleAttribute("Swate")>]
 [<assembly: AssemblyVersionAttribute("1.0.0")>]
-[<assembly: AssemblyMetadataAttribute("Version","v1.0.0-beta.25")>]
-[<assembly: AssemblyMetadataAttribute("ReleaseDate","12.02.2025")>]
+[<assembly: AssemblyMetadataAttribute("Version","v1.0.0-beta.26")>]
+[<assembly: AssemblyMetadataAttribute("ReleaseDate","24.02.2025")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "Swate"
     let [<Literal>] AssemblyVersion = "1.0.0"
-    let [<Literal>] AssemblyMetadata_Version = "v1.0.0-beta.25"
-    let [<Literal>] AssemblyMetadata_ReleaseDate = "12.02.2025"
+    let [<Literal>] AssemblyMetadata_Version = "v1.0.0-beta.26"
+    let [<Literal>] AssemblyMetadata_ReleaseDate = "24.02.2025"


### PR DESCRIPTION
Fixes 3 bugs with widgets:

- Bug 1: Widgets jump to 0 on x-axis as soon as the right screen window border touches them, like scared little kitties 🐈
- Bug 2: overflow for term search was set to scrollable
- Bug 3: Opening all widgets with the same params (Building Block, FilePicker, DataAnnotator), then clicking on them to get them in front made react not understand that they switched and reused their states (typical missing key issue). So i added a key to base widget and now they stay where they are supposed to stay.