### PR TITLE
Remove filename from navbar because it is always truncated

### DIFF
--- a/src/Client/MainComponents/Navbar.fs
+++ b/src/Client/MainComponents/Navbar.fs
@@ -174,7 +174,9 @@ let Main (model: Model, dispatch, widgets, setWidgets) =
             add widget widgets
 
     Components.BaseNavbar.Main [
-        Html.div [ prop.className "swt:grow-0"; prop.children [ FileName model ] ]
+        Html.div [
+            prop.className "swt:grow-0"
+        ]
         Html.div [
             prop.className "swt:navbar-center swt:overflow-x-auto swt:min-w-0 swt:shrink swt:grow"
             prop.children [

--- a/src/Client/MainComponents/NoFileElement.fs
+++ b/src/Client/MainComponents/NoFileElement.fs
@@ -117,7 +117,6 @@ module private Helper =
         ]
 
     let createNewFile (dispatch: Messages.Msg -> unit) =
-        //Daisy.dropdown
         Html.div  [
             prop.className "swt:dropdown"
             prop.children [


### PR DESCRIPTION
Closes Issue #758 