### PR TITLE
Adjusted horizontal (x) scroll bar

### DIFF
--- a/src/Components/src/Table/Table.fs
+++ b/src/Components/src/Table/Table.fs
@@ -89,6 +89,35 @@ swt:p-0"""
         let defaultStyleSelect = defaultArg defaultStyleSelect true
 
         let scrollContainerRef = React.useElementRef ()
+        let stickyScrollbarRef = React.useElementRef ()
+
+        // Sync scroll positions between main container and sticky scrollbar
+        React.useEffect (
+            (fun () ->
+                match scrollContainerRef.current, stickyScrollbarRef.current with
+                | Some mainScroll, Some stickyScroll ->
+                    let syncMainToSticky =
+                        fun (_: Browser.Types.Event) -> stickyScroll?scrollLeft <- mainScroll?scrollLeft
+
+                    let syncStickyToMain =
+                        fun (_: Browser.Types.Event) -> mainScroll?scrollLeft <- stickyScroll?scrollLeft
+
+                    mainScroll.addEventListener ("scroll", syncMainToSticky)
+                    stickyScroll.addEventListener ("scroll", syncStickyToMain)
+
+                    // Return cleanup function
+                    { new IDisposable with
+                        member _.Dispose() =
+                            mainScroll.removeEventListener ("scroll", syncMainToSticky)
+                            stickyScroll.removeEventListener ("scroll", syncStickyToMain)
+                    }
+                | _ ->
+                    { new IDisposable with
+                        member _.Dispose() = ()
+                    }
+            ),
+            [||]
+        )
 
         let rowVirtualizer =
             Virtual.useVirtualizer (
@@ -252,202 +281,265 @@ swt:p-0"""
         Contexts.Table.TableStateCtx.Provider(
             ctx,
             React.Fragment [
-
                 Html.div [
-                    prop.key "scroll-container"
-                    prop.ref scrollContainerRef
-                    prop.onKeyDown (fun e ->
-                        TableHelper.keyDownController e GridSelect (activeCellIndex, setActiveCellIndex) onKeydown
-                    )
-                    prop.tabIndex 0
-                    prop.style [
-                        if height.IsSome then
-                            style.height height.Value
-                        if width.IsSome then
-                            style.width width.Value
+                    prop.className "swt:relative swt:h-full swt:w-full swt:flex swt:flex-col swt:overflow-hidden"
+                    prop.children[Html.div [
+                                      prop.key "scroll-container"
+                                      prop.ref scrollContainerRef
+                                      prop.onKeyDown (fun e ->
+                                          TableHelper.keyDownController
+                                              e
+                                              GridSelect
+                                              (activeCellIndex, setActiveCellIndex)
+                                              onKeydown
+                                      )
+                                      prop.tabIndex 0
+                                      prop.style [
+                                          if height.IsSome then
+                                              style.height height.Value
+                                          if width.IsSome then
+                                              style.width width.Value
 
-                        style.minHeight 0
-                        style.minWidth 0
-                    ]
-                    prop.className
-                        "swt:overflow-auto swt:h-full swt:w-full swt:border swt:border-primary swt:rounded-sm swt:bg-base-100"
-                    if debug then
-                        prop.testId "virtualized-table"
-                    prop.children [
-                        Html.div [
-                            prop.key "table-container"
-                            prop.style [
-                                if isSafari then
-                                    style.custom ("willChange", "transform")
-                                    style.custom ("minHeight", $"{rowVirtualizer.getTotalSize ()}px")
-                                    style.minWidth (columnVirtualizer.getTotalSize () + 800)
-                                    style.custom ("contain", "size layout paint")
-                                else
-                                    style.height (rowVirtualizer.getTotalSize ())
-                                    style.width (columnVirtualizer.getTotalSize () + 800) // extra space to improve UX with rightmost columns
+                                          style.minHeight 0
+                                          style.minWidth 0
+                                      ]
+                                      prop.className
+                                          "swt:overflow-x-hidden swt:overflow-y-auto swt:flex-1 swt:w-full swt:border swt:border-primary swt:rounded-t-sm swt:bg-base-100"
+                                      if debug then
+                                          prop.testId "virtualized-table"
+                                      prop.children [
+                                          Html.div [
+                                              prop.key "table-container"
+                                              prop.style [
+                                                  if isSafari then
+                                                      style.custom ("willChange", "transform")
+                                                      style.custom ("minHeight", $"{rowVirtualizer.getTotalSize ()}px")
+                                                      style.minWidth (columnVirtualizer.getTotalSize () + 800)
+                                                      style.custom ("contain", "size layout paint")
+                                                  else
+                                                      style.height (rowVirtualizer.getTotalSize ())
+                                                      style.width (columnVirtualizer.getTotalSize () + 800) // extra space to improve UX with rightmost columns
 
-                                style.position.relative
-                            ]
-                            prop.children [
-                                Html.table [
-                                    prop.key "table"
-                                    prop.className "swt:w-full swt:h-full"
-                                    prop.children [
-                                        Html.thead [
-                                            prop.key "table-thead"
-                                            prop.children [
-                                                Html.tr [
-                                                    prop.key "virtualHeaderRow"
-                                                    prop.className
-                                                        "swt:sticky swt:top-0 swt:left-0 swt:z-10 swt:bg-base-100 swt:text-left"
-                                                    prop.style [ style.height Constants.Table.DefaultRowHeight ]
-                                                    prop.children [
-                                                        for virtualColumn in columnVirtualizer.getVirtualItems () do
-                                                            let index = {| x = virtualColumn.index; y = 0 |}
+                                                  style.position.relative
+                                              ]
+                                              prop.children [
+                                                  Html.table [
+                                                      prop.key "table"
+                                                      prop.className "swt:w-full swt:h-full"
+                                                      prop.children [
+                                                          Html.thead [
+                                                              prop.key "table-thead"
+                                                              prop.children [
+                                                                  Html.tr [
+                                                                      prop.key "virtualHeaderRow"
+                                                                      prop.className
+                                                                          "swt:sticky swt:top-0 swt:left-0 swt:z-10 swt:bg-base-100 swt:text-left"
+                                                                      prop.style [
+                                                                          style.height Constants.Table.DefaultRowHeight
+                                                                      ]
+                                                                      prop.children [
+                                                                          for virtualColumn in
+                                                                              columnVirtualizer.getVirtualItems () do
+                                                                              let index = {|
+                                                                                  x = virtualColumn.index
+                                                                                  y = 0
+                                                                              |}
 
-                                                            let isActive = isActive index
+                                                                              let isActive = isActive index
 
-                                                            Html.th [
+                                                                              Html.th [
 
-                                                                prop.ref columnVirtualizer.measureElement
+                                                                                  prop.ref
+                                                                                      columnVirtualizer.measureElement
 
-                                                                prop.custom ("data-index", virtualColumn.index)
-                                                                prop.key $"virtualHeaderCell-{virtualColumn.key}--1"
-                                                                prop.className [
-                                                                    if virtualColumn.index <> 0 then
-                                                                        "swt:min-w-32"
-                                                                    else
-                                                                        "swt:min-w-min"
-                                                                    "swt:h-full swt:resize-x swt:overflow-hidden"
-                                                                    if defaultStyleSelect then
-                                                                        Table.TableCellStyle
-                                                                ]
-                                                                prop.dataRow 0
-                                                                prop.dataColumn virtualColumn.index
-                                                                prop.style [
-                                                                    style.position.absolute
-                                                                    style.top 0
-                                                                    style.left 0
-                                                                    style.custom (
-                                                                        "transform",
-                                                                        $"translateX({virtualColumn.start}px)"
-                                                                    )
-                                                                ]
-                                                                if isActive then
-                                                                    prop.custom ("data-active", true)
-                                                                if isSelected (index) then
-                                                                    prop.custom ("data-selected", true)
-                                                                if isOrigin (index) then
-                                                                    prop.custom ("data-is-append-origin", true)
-                                                                prop.children [
-                                                                    if virtualColumn.index = 0 then
-                                                                        TableCell.BaseCell(
-                                                                            index.y,
-                                                                            index.x,
-                                                                            Html.text (
-                                                                                let i =
-                                                                                    rowVirtualizer.getVirtualIndexes ()
+                                                                                  prop.custom (
+                                                                                      "data-index",
+                                                                                      virtualColumn.index
+                                                                                  )
+                                                                                  prop.key
+                                                                                      $"virtualHeaderCell-{virtualColumn.key}--1"
+                                                                                  prop.className [
+                                                                                      if virtualColumn.index <> 0 then
+                                                                                          "swt:min-w-32"
+                                                                                      else
+                                                                                          "swt:min-w-min"
+                                                                                      "swt:h-full swt:resize-x swt:overflow-hidden"
+                                                                                      if defaultStyleSelect then
+                                                                                          Table.TableCellStyle
+                                                                                  ]
+                                                                                  prop.dataRow 0
+                                                                                  prop.dataColumn virtualColumn.index
+                                                                                  prop.style [
+                                                                                      style.position.absolute
+                                                                                      style.top 0
+                                                                                      style.left 0
+                                                                                      style.custom (
+                                                                                          "transform",
+                                                                                          $"translateX({virtualColumn.start}px)"
+                                                                                      )
+                                                                                  ]
+                                                                                  if isActive then
+                                                                                      prop.custom ("data-active", true)
+                                                                                  if isSelected (index) then
+                                                                                      prop.custom (
+                                                                                          "data-selected",
+                                                                                          true
+                                                                                      )
+                                                                                  if isOrigin (index) then
+                                                                                      prop.custom (
+                                                                                          "data-is-append-origin",
+                                                                                          true
+                                                                                      )
+                                                                                  prop.children [
+                                                                                      if virtualColumn.index = 0 then
+                                                                                          TableCell.BaseCell(
+                                                                                              index.y,
+                                                                                              index.x,
+                                                                                              Html.text (
+                                                                                                  let i =
+                                                                                                      rowVirtualizer
+                                                                                                          .getVirtualIndexes ()
 
-                                                                                if i.Length > 0 then
-                                                                                    i |> Seq.last
-                                                                                else
-                                                                                    0
-                                                                            ),
-                                                                            className =
-                                                                                "swt:px-2 swt:py-2 swt:flex swt:items-center swt:cursor-not-allowed swt:w-full swt:h-full swt:min-w-8 swt:bg-base-200 swt:text-transparent",
-                                                                            debug = debug
-                                                                        )
-                                                                    elif isActive then
-                                                                        renderActiveCell index
-                                                                    else
-                                                                        renderCell index
-                                                                ]
-                                                            ]
-                                                    ]
-                                                ]
-                                            ]
-                                        ]
-                                        Html.tbody [
-                                            prop.key "body"
-                                            prop.style [ style.marginTop Constants.Table.DefaultRowHeight ]
-                                            prop.children [
-                                                for virtualRow in rowVirtualizer.getVirtualItems () do
-                                                    let rowStart =
-                                                        if annotator then virtualRow.``end`` else virtualRow.start
+                                                                                                  if i.Length > 0 then
+                                                                                                      i |> Seq.last
+                                                                                                  else
+                                                                                                      0
+                                                                                              ),
+                                                                                              className =
+                                                                                                  "swt:px-2 swt:py-2 swt:flex swt:items-center swt:cursor-not-allowed swt:w-full swt:h-full swt:min-w-8 swt:bg-base-200 swt:text-transparent",
+                                                                                              debug = debug
+                                                                                          )
+                                                                                      elif isActive then
+                                                                                          renderActiveCell index
+                                                                                      else
+                                                                                          renderCell index
+                                                                                  ]
+                                                                              ]
+                                                                      ]
+                                                                  ]
+                                                              ]
+                                                          ]
+                                                          Html.tbody [
+                                                              prop.key "body"
+                                                              prop.style [
+                                                                  style.marginTop Constants.Table.DefaultRowHeight
+                                                              ]
+                                                              prop.children [
+                                                                  for virtualRow in rowVirtualizer.getVirtualItems () do
+                                                                      let rowStart =
+                                                                          if annotator then
+                                                                              virtualRow.``end``
+                                                                          else
+                                                                              virtualRow.start
 
-                                                    if virtualRow.index = 0 && not annotator then
-                                                        Html.none // skip header row, is part of thead
-                                                    else
-                                                        Html.tr [
-                                                            prop.key (sprintf "virtualRow-%s" virtualRow.key)
-                                                            prop.style [
-                                                                style.position.absolute
-                                                                style.top 0
-                                                                style.left 0
-                                                                style.custom ("transform", $"translateY({rowStart}px)")
-                                                                style.height virtualRow.size
-                                                            ]
-                                                            prop.className "swt:w-full"
-                                                            prop.children [
-                                                                for virtualColumn in
-                                                                    columnVirtualizer.getVirtualItems () do
-                                                                    let index = {|
-                                                                        x = virtualColumn.index
-                                                                        y = virtualRow.index
-                                                                    |}
+                                                                      if virtualRow.index = 0 && not annotator then
+                                                                          Html.none // skip header row, is part of thead
+                                                                      else
+                                                                          Html.tr [
+                                                                              prop.key (
+                                                                                  sprintf "virtualRow-%s" virtualRow.key
+                                                                              )
+                                                                              prop.style [
+                                                                                  style.position.absolute
+                                                                                  style.top 0
+                                                                                  style.left 0
+                                                                                  style.custom (
+                                                                                      "transform",
+                                                                                      $"translateY({rowStart}px)"
+                                                                                  )
+                                                                                  style.height virtualRow.size
+                                                                              ]
+                                                                              prop.className "swt:w-full"
+                                                                              prop.children [
+                                                                                  for virtualColumn in
+                                                                                      columnVirtualizer.getVirtualItems () do
+                                                                                      let index = {|
+                                                                                          x = virtualColumn.index
+                                                                                          y = virtualRow.index
+                                                                                      |}
 
-                                                                    let isActive = isActive index
+                                                                                      let isActive = isActive index
 
-                                                                    Html.td [
-                                                                        prop.key (
-                                                                            sprintf
-                                                                                "virtualCell-%s-%s"
-                                                                                virtualRow.key
-                                                                                virtualColumn.key
-                                                                        )
-                                                                        prop.dataRow virtualRow.index
-                                                                        prop.dataColumn virtualColumn.index
-                                                                        prop.className [
-                                                                            if defaultStyleSelect then
-                                                                                Table.TableCellStyle
-                                                                        ]
-                                                                        if isActive then
-                                                                            prop.custom ("data-active", true)
-                                                                        if isSelected index then
-                                                                            prop.custom ("data-selected", true)
-                                                                        if isOrigin index then
-                                                                            prop.custom ("data-is-append-origin", true)
-                                                                        prop.style [
-                                                                            // if virtualColumn.index = 0 then
-                                                                            //     style.position.sticky
-                                                                            //     style.zIndex 10
-                                                                            // else
-                                                                            style.position.absolute
-                                                                            style.width virtualColumn.size
-                                                                            style.height virtualRow.size
-                                                                            style.top 0
-                                                                            style.left 0
-                                                                            style.custom (
-                                                                                "transform",
-                                                                                $"translateX({virtualColumn.start}px)"
-                                                                            )
-                                                                        ]
-                                                                        prop.children [
-                                                                            if isActive then
-                                                                                renderActiveCell index
-                                                                            else
-                                                                                renderCell index
-                                                                        ]
-                                                                    ]
-                                                            ]
-                                                        ]
-                                            ]
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
+                                                                                      Html.td [
+                                                                                          prop.key (
+                                                                                              sprintf
+                                                                                                  "virtualCell-%s-%s"
+                                                                                                  virtualRow.key
+                                                                                                  virtualColumn.key
+                                                                                          )
+                                                                                          prop.dataRow virtualRow.index
+                                                                                          prop.dataColumn
+                                                                                              virtualColumn.index
+                                                                                          prop.className [
+                                                                                              if defaultStyleSelect then
+                                                                                                  Table.TableCellStyle
+                                                                                          ]
+                                                                                          if isActive then
+                                                                                              prop.custom (
+                                                                                                  "data-active",
+                                                                                                  true
+                                                                                              )
+                                                                                          if isSelected index then
+                                                                                              prop.custom (
+                                                                                                  "data-selected",
+                                                                                                  true
+                                                                                              )
+                                                                                          if isOrigin index then
+                                                                                              prop.custom (
+                                                                                                  "data-is-append-origin",
+                                                                                                  true
+                                                                                              )
+                                                                                          prop.style [
+                                                                                              // if virtualColumn.index = 0 then
+                                                                                              //     style.position.sticky
+                                                                                              //     style.zIndex 10
+                                                                                              // else
+                                                                                              style.position.absolute
+                                                                                              style.width
+                                                                                                  virtualColumn.size
+                                                                                              style.height
+                                                                                                  virtualRow.size
+                                                                                              style.top 0
+                                                                                              style.left 0
+                                                                                              style.custom (
+                                                                                                  "transform",
+                                                                                                  $"translateX({virtualColumn.start}px)"
+                                                                                              )
+                                                                                          ]
+                                                                                          prop.children [
+                                                                                              if isActive then
+                                                                                                  renderActiveCell index
+                                                                                              else
+                                                                                                  renderCell index
+                                                                                          ]
+                                                                                      ]
+                                                                              ]
+                                                                          ]
+                                                              ]
+                                                          ]
+                                                      ]
+                                                  ]
+                                              ]
+                                          ]
+                                      ]
+                                  ]
+                                  // Sticky horizontal scrollbar at the bottom
+                                  Html.div[prop.key "sticky-scrollbar-container"
+                                           prop.ref stickyScrollbarRef
+                                           prop.className
+                                               "swt:fixed swt:bottom-11 swt:overflow-x-auto swt:overflow-y-hidden swt:bg-base-100 swt:w-[-webkit-fill-available]"
+                                           prop.children [
+                                               Html.div [
+                                                   prop.style [
+                                                       style.height 1
+                                                       if isSafari then
+                                                           style.minWidth (columnVirtualizer.getTotalSize () + 800)
+                                                       else
+                                                           style.width (columnVirtualizer.getTotalSize () + 800)
+                                                   ]
+                                               ]
+                                           ]]]
+
                 ]
             ]
         )

--- a/src/Components/src/Table/Table.fs
+++ b/src/Components/src/Table/Table.fs
@@ -283,263 +283,238 @@ swt:p-0"""
             React.Fragment [
                 Html.div [
                     prop.className "swt:relative swt:h-full swt:w-full swt:flex swt:flex-col swt:overflow-hidden"
-                    prop.children[Html.div [
-                                      prop.key "scroll-container"
-                                      prop.ref scrollContainerRef
-                                      prop.onKeyDown (fun e ->
-                                          TableHelper.keyDownController
-                                              e
-                                              GridSelect
-                                              (activeCellIndex, setActiveCellIndex)
-                                              onKeydown
-                                      )
-                                      prop.tabIndex 0
-                                      prop.style [
-                                          if height.IsSome then
-                                              style.height height.Value
-                                          if width.IsSome then
-                                              style.width width.Value
+                    prop.children [
+                        Html.div [
+                            prop.key "scroll-container"
+                            prop.ref scrollContainerRef
+                            prop.onKeyDown (fun e ->
+                                TableHelper.keyDownController
+                                    e
+                                    GridSelect
+                                    (activeCellIndex, setActiveCellIndex)
+                                    onKeydown
+                            )
+                            prop.tabIndex 0
+                            prop.style [
+                                if height.IsSome then
+                                    style.height height.Value
+                                if width.IsSome then
+                                    style.width width.Value
 
-                                          style.minHeight 0
-                                          style.minWidth 0
-                                      ]
-                                      prop.className
-                                          "swt:overflow-x-hidden swt:overflow-y-auto swt:flex-1 swt:w-full swt:border swt:border-primary swt:rounded-t-sm swt:bg-base-100"
-                                      if debug then
-                                          prop.testId "virtualized-table"
-                                      prop.children [
-                                          Html.div [
-                                              prop.key "table-container"
-                                              prop.style [
-                                                  if isSafari then
-                                                      style.custom ("willChange", "transform")
-                                                      style.custom ("minHeight", $"{rowVirtualizer.getTotalSize ()}px")
-                                                      style.minWidth (columnVirtualizer.getTotalSize () + 800)
-                                                      style.custom ("contain", "size layout paint")
-                                                  else
-                                                      style.height (rowVirtualizer.getTotalSize ())
-                                                      style.width (columnVirtualizer.getTotalSize () + 800) // extra space to improve UX with rightmost columns
+                                style.minHeight 0
+                                style.minWidth 0
+                            ]
+                            prop.className
+                                "swt:relative swt:overflow-x-hidden swt:overflow-y-auto swt:flex-1 swt:w-full swt:border swt:border-primary swt:rounded-sm swt:bg-base-100"
+                            if debug then
+                                prop.testId "virtualized-table"
+                            prop.children [
+                                Html.div [
+                                    prop.key "table-container"
+                                    prop.style [
+                                        if isSafari then
+                                            style.custom ("willChange", "transform")
+                                            style.custom ("minHeight", $"{rowVirtualizer.getTotalSize ()}px")
+                                            style.minWidth (columnVirtualizer.getTotalSize () + 800)
+                                            style.custom ("contain", "size layout paint")
+                                        else
+                                            style.height (rowVirtualizer.getTotalSize ())
+                                            style.width (columnVirtualizer.getTotalSize () + 800) // extra space to improve UX with rightmost columns
 
-                                                  style.position.relative
-                                              ]
-                                              prop.children [
-                                                  Html.table [
-                                                      prop.key "table"
-                                                      prop.className "swt:w-full swt:h-full"
-                                                      prop.children [
-                                                          Html.thead [
-                                                              prop.key "table-thead"
-                                                              prop.children [
-                                                                  Html.tr [
-                                                                      prop.key "virtualHeaderRow"
-                                                                      prop.className
-                                                                          "swt:sticky swt:top-0 swt:left-0 swt:z-10 swt:bg-base-100 swt:text-left"
-                                                                      prop.style [
-                                                                          style.height Constants.Table.DefaultRowHeight
-                                                                      ]
-                                                                      prop.children [
-                                                                          for virtualColumn in
-                                                                              columnVirtualizer.getVirtualItems () do
-                                                                              let index = {|
-                                                                                  x = virtualColumn.index
-                                                                                  y = 0
-                                                                              |}
+                                        style.position.relative
+                                    ]
+                                    prop.children [
+                                        Html.table [
+                                            prop.key "table"
+                                            prop.className "swt:w-full swt:h-full"
+                                            prop.children [
+                                                Html.thead [
+                                                    prop.key "table-thead"
+                                                    prop.children [
+                                                        Html.tr [
+                                                            prop.key "virtualHeaderRow"
+                                                            prop.className
+                                                                "swt:sticky swt:top-0 swt:left-0 swt:z-10 swt:bg-base-100 swt:text-left"
+                                                            prop.style [ style.height Constants.Table.DefaultRowHeight ]
+                                                            prop.children [
+                                                                for virtualColumn in
+                                                                    columnVirtualizer.getVirtualItems () do
+                                                                    let index = {| x = virtualColumn.index; y = 0 |}
 
-                                                                              let isActive = isActive index
+                                                                    let isActive = isActive index
 
-                                                                              Html.th [
+                                                                    Html.th [
 
-                                                                                  prop.ref
-                                                                                      columnVirtualizer.measureElement
+                                                                        prop.ref columnVirtualizer.measureElement
 
-                                                                                  prop.custom (
-                                                                                      "data-index",
-                                                                                      virtualColumn.index
-                                                                                  )
-                                                                                  prop.key
-                                                                                      $"virtualHeaderCell-{virtualColumn.key}--1"
-                                                                                  prop.className [
-                                                                                      if virtualColumn.index <> 0 then
-                                                                                          "swt:min-w-32"
-                                                                                      else
-                                                                                          "swt:min-w-min"
-                                                                                      "swt:h-full swt:resize-x swt:overflow-hidden"
-                                                                                      if defaultStyleSelect then
-                                                                                          Table.TableCellStyle
-                                                                                  ]
-                                                                                  prop.dataRow 0
-                                                                                  prop.dataColumn virtualColumn.index
-                                                                                  prop.style [
-                                                                                      style.position.absolute
-                                                                                      style.top 0
-                                                                                      style.left 0
-                                                                                      style.custom (
-                                                                                          "transform",
-                                                                                          $"translateX({virtualColumn.start}px)"
-                                                                                      )
-                                                                                  ]
-                                                                                  if isActive then
-                                                                                      prop.custom ("data-active", true)
-                                                                                  if isSelected (index) then
-                                                                                      prop.custom (
-                                                                                          "data-selected",
-                                                                                          true
-                                                                                      )
-                                                                                  if isOrigin (index) then
-                                                                                      prop.custom (
-                                                                                          "data-is-append-origin",
-                                                                                          true
-                                                                                      )
-                                                                                  prop.children [
-                                                                                      if virtualColumn.index = 0 then
-                                                                                          TableCell.BaseCell(
-                                                                                              index.y,
-                                                                                              index.x,
-                                                                                              Html.text (
-                                                                                                  let i =
-                                                                                                      rowVirtualizer
-                                                                                                          .getVirtualIndexes ()
+                                                                        prop.custom ("data-index", virtualColumn.index)
+                                                                        prop.key
+                                                                            $"virtualHeaderCell-{virtualColumn.key}--1"
+                                                                        prop.className [
+                                                                            if virtualColumn.index <> 0 then
+                                                                                "swt:min-w-32"
+                                                                            else
+                                                                                "swt:min-w-min"
+                                                                            "swt:h-full swt:resize-x swt:overflow-hidden"
+                                                                            if defaultStyleSelect then
+                                                                                Table.TableCellStyle
+                                                                        ]
+                                                                        prop.dataRow 0
+                                                                        prop.dataColumn virtualColumn.index
+                                                                        prop.style [
+                                                                            style.position.absolute
+                                                                            style.top 0
+                                                                            style.left 0
+                                                                            style.custom (
+                                                                                "transform",
+                                                                                $"translateX({virtualColumn.start}px)"
+                                                                            )
+                                                                        ]
+                                                                        if isActive then
+                                                                            prop.custom ("data-active", true)
+                                                                        if isSelected (index) then
+                                                                            prop.custom ("data-selected", true)
+                                                                        if isOrigin (index) then
+                                                                            prop.custom ("data-is-append-origin", true)
+                                                                        prop.children [
+                                                                            if virtualColumn.index = 0 then
+                                                                                TableCell.BaseCell(
+                                                                                    index.y,
+                                                                                    index.x,
+                                                                                    Html.text (
+                                                                                        let i =
+                                                                                            rowVirtualizer
+                                                                                                .getVirtualIndexes ()
 
-                                                                                                  if i.Length > 0 then
-                                                                                                      i |> Seq.last
-                                                                                                  else
-                                                                                                      0
-                                                                                              ),
-                                                                                              className =
-                                                                                                  "swt:px-2 swt:py-2 swt:flex swt:items-center swt:cursor-not-allowed swt:w-full swt:h-full swt:min-w-8 swt:bg-base-200 swt:text-transparent",
-                                                                                              debug = debug
-                                                                                          )
-                                                                                      elif isActive then
-                                                                                          renderActiveCell index
-                                                                                      else
-                                                                                          renderCell index
-                                                                                  ]
-                                                                              ]
-                                                                      ]
-                                                                  ]
-                                                              ]
-                                                          ]
-                                                          Html.tbody [
-                                                              prop.key "body"
-                                                              prop.style [
-                                                                  style.marginTop Constants.Table.DefaultRowHeight
-                                                              ]
-                                                              prop.children [
-                                                                  for virtualRow in rowVirtualizer.getVirtualItems () do
-                                                                      let rowStart =
-                                                                          if annotator then
-                                                                              virtualRow.``end``
-                                                                          else
-                                                                              virtualRow.start
+                                                                                        if i.Length > 0 then
+                                                                                            i |> Seq.last
+                                                                                        else
+                                                                                            0
+                                                                                    ),
+                                                                                    className =
+                                                                                        "swt:px-2 swt:py-2 swt:flex swt:items-center swt:cursor-not-allowed swt:w-full swt:h-full swt:min-w-8 swt:bg-base-200 swt:text-transparent",
+                                                                                    debug = debug
+                                                                                )
+                                                                            elif isActive then
+                                                                                renderActiveCell index
+                                                                            else
+                                                                                renderCell index
+                                                                        ]
+                                                                    ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                                Html.tbody [
+                                                    prop.key "body"
+                                                    prop.style [ style.marginTop Constants.Table.DefaultRowHeight ]
+                                                    prop.children [
+                                                        for virtualRow in rowVirtualizer.getVirtualItems () do
+                                                            let rowStart =
+                                                                if annotator then
+                                                                    virtualRow.``end``
+                                                                else
+                                                                    virtualRow.start
 
-                                                                      if virtualRow.index = 0 && not annotator then
-                                                                          Html.none // skip header row, is part of thead
-                                                                      else
-                                                                          Html.tr [
-                                                                              prop.key (
-                                                                                  sprintf "virtualRow-%s" virtualRow.key
-                                                                              )
-                                                                              prop.style [
-                                                                                  style.position.absolute
-                                                                                  style.top 0
-                                                                                  style.left 0
-                                                                                  style.custom (
-                                                                                      "transform",
-                                                                                      $"translateY({rowStart}px)"
-                                                                                  )
-                                                                                  style.height virtualRow.size
-                                                                              ]
-                                                                              prop.className "swt:w-full"
-                                                                              prop.children [
-                                                                                  for virtualColumn in
-                                                                                      columnVirtualizer.getVirtualItems () do
-                                                                                      let index = {|
-                                                                                          x = virtualColumn.index
-                                                                                          y = virtualRow.index
-                                                                                      |}
+                                                            if virtualRow.index = 0 && not annotator then
+                                                                Html.none // skip header row, is part of thead
+                                                            else
+                                                                Html.tr [
+                                                                    prop.key (sprintf "virtualRow-%s" virtualRow.key)
+                                                                    prop.style [
+                                                                        style.position.absolute
+                                                                        style.top 0
+                                                                        style.left 0
+                                                                        style.custom (
+                                                                            "transform",
+                                                                            $"translateY({rowStart}px)"
+                                                                        )
+                                                                        style.height virtualRow.size
+                                                                    ]
+                                                                    prop.className "swt:w-full"
+                                                                    prop.children [
+                                                                        for virtualColumn in
+                                                                            columnVirtualizer.getVirtualItems () do
+                                                                            let index = {|
+                                                                                x = virtualColumn.index
+                                                                                y = virtualRow.index
+                                                                            |}
 
-                                                                                      let isActive = isActive index
+                                                                            let isActive = isActive index
 
-                                                                                      Html.td [
-                                                                                          prop.key (
-                                                                                              sprintf
-                                                                                                  "virtualCell-%s-%s"
-                                                                                                  virtualRow.key
-                                                                                                  virtualColumn.key
-                                                                                          )
-                                                                                          prop.dataRow virtualRow.index
-                                                                                          prop.dataColumn
-                                                                                              virtualColumn.index
-                                                                                          prop.className [
-                                                                                              if defaultStyleSelect then
-                                                                                                  Table.TableCellStyle
-                                                                                          ]
-                                                                                          if isActive then
-                                                                                              prop.custom (
-                                                                                                  "data-active",
-                                                                                                  true
-                                                                                              )
-                                                                                          if isSelected index then
-                                                                                              prop.custom (
-                                                                                                  "data-selected",
-                                                                                                  true
-                                                                                              )
-                                                                                          if isOrigin index then
-                                                                                              prop.custom (
-                                                                                                  "data-is-append-origin",
-                                                                                                  true
-                                                                                              )
-                                                                                          prop.style [
-                                                                                              // if virtualColumn.index = 0 then
-                                                                                              //     style.position.sticky
-                                                                                              //     style.zIndex 10
-                                                                                              // else
-                                                                                              style.position.absolute
-                                                                                              style.width
-                                                                                                  virtualColumn.size
-                                                                                              style.height
-                                                                                                  virtualRow.size
-                                                                                              style.top 0
-                                                                                              style.left 0
-                                                                                              style.custom (
-                                                                                                  "transform",
-                                                                                                  $"translateX({virtualColumn.start}px)"
-                                                                                              )
-                                                                                          ]
-                                                                                          prop.children [
-                                                                                              if isActive then
-                                                                                                  renderActiveCell index
-                                                                                              else
-                                                                                                  renderCell index
-                                                                                          ]
-                                                                                      ]
-                                                                              ]
-                                                                          ]
-                                                              ]
-                                                          ]
-                                                      ]
-                                                  ]
-                                              ]
-                                          ]
-                                      ]
-                                  ]
-                                  // Sticky horizontal scrollbar at the bottom
-                                  Html.div[prop.key "sticky-scrollbar-container"
-                                           prop.ref stickyScrollbarRef
-                                           prop.className
-                                               "swt:fixed swt:bottom-11 swt:overflow-x-auto swt:overflow-y-hidden swt:bg-base-100 swt:w-[-webkit-fill-available]"
-                                           prop.children [
-                                               Html.div [
-                                                   prop.style [
-                                                       style.height 1
-                                                       if isSafari then
-                                                           style.minWidth (columnVirtualizer.getTotalSize () + 800)
-                                                       else
-                                                           style.width (columnVirtualizer.getTotalSize () + 800)
-                                                   ]
-                                               ]
-                                           ]]]
-
+                                                                            Html.td [
+                                                                                prop.key (
+                                                                                    sprintf
+                                                                                        "virtualCell-%s-%s"
+                                                                                        virtualRow.key
+                                                                                        virtualColumn.key
+                                                                                )
+                                                                                prop.dataRow virtualRow.index
+                                                                                prop.dataColumn virtualColumn.index
+                                                                                prop.className [
+                                                                                    if defaultStyleSelect then
+                                                                                        Table.TableCellStyle
+                                                                                ]
+                                                                                if isActive then
+                                                                                    prop.custom ("data-active", true)
+                                                                                if isSelected index then
+                                                                                    prop.custom ("data-selected", true)
+                                                                                if isOrigin index then
+                                                                                    prop.custom (
+                                                                                        "data-is-append-origin",
+                                                                                        true
+                                                                                    )
+                                                                                prop.style [
+                                                                                    // if virtualColumn.index = 0 then
+                                                                                    //     style.position.sticky
+                                                                                    //     style.zIndex 10
+                                                                                    // else
+                                                                                    style.position.absolute
+                                                                                    style.width virtualColumn.size
+                                                                                    style.height virtualRow.size
+                                                                                    style.top 0
+                                                                                    style.left 0
+                                                                                    style.custom (
+                                                                                        "transform",
+                                                                                        $"translateX({virtualColumn.start}px)"
+                                                                                    )
+                                                                                ]
+                                                                                prop.children [
+                                                                                    if isActive then
+                                                                                        renderActiveCell index
+                                                                                    else
+                                                                                        renderCell index
+                                                                                ]
+                                                                            ]
+                                                                    ]
+                                                                ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                        // Sticky horizontal scrollbar at the bottom
+                        Html.div [
+                            prop.key "sticky-scrollbar-container"
+                            prop.ref stickyScrollbarRef
+                            prop.className
+                                "swt:fixed swt:bottom-11 swt:overflow-x-auto swt:overflow-y-hidden swt:bg-base-100 swt:w-[-webkit-fill-available]"
+                            prop.children [
+                                Html.div [
+                                    prop.style [
+                                        style.height 1
+                                        if isSafari then
+                                            style.minWidth (columnVirtualizer.getTotalSize () + 800)
+                                        else
+                                            style.width (columnVirtualizer.getTotalSize () + 800)
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
                 ]
             ]
         )

--- a/src/Electron/src/Renderer/App.fs
+++ b/src/Electron/src/Renderer/App.fs
@@ -42,7 +42,7 @@ let CreateARCPreview (arcFile: ArcFiles) (setArcFileState: ArcFiles option -> un
         prop.className "swt:flex swt:flex-col swt:h-full"
         prop.children [|
             Html.div [
-                prop.className "swt:flex-1 swt:overflow-auto"
+                prop.className "swt:flex-1 swt:overflow-x-hidden swt:overflow-y-auto"
                 prop.children [
                     CreateTableView activeView arcFile setArcFile
                 ]

--- a/src/Electron/src/Renderer/components/MainElement.fs
+++ b/src/Electron/src/Renderer/components/MainElement.fs
@@ -32,7 +32,7 @@ let CreateTablePreview (table: ARCtrl.ArcTable) =
     AnnotationTableContextProvider.AnnotationTableContextProvider(
         Html.div [
             //It works but not as clean as we want it
-            prop.className "swt:w-screen"
+            prop.className "swt:w-screen swt:pb-4"
             prop.children [
                 AnnotationTable.AnnotationTable(tableState, setTableState)
             ]


### PR DESCRIPTION
Removed weird empty horizontal scrollbar and added functioning floating x-scroll bar in overflowing tables to scroll sideways any time, without scrolling all the way down to the end of the table. 

before
<img width="3826" height="2117" alt="image" src="https://github.com/user-attachments/assets/13f6ebfc-d50d-4d08-aa22-f607e04009cc" />

after
<img width="1926" height="961" alt="image" src="https://github.com/user-attachments/assets/566f8c8f-6e2e-469b-841c-e650048c00b2" />
