### PR TITLE
Add Notes Editor components

### DIFF
--- a/src/Components/src/Notes/Editor/Actions.fs
+++ b/src/Components/src/Notes/Editor/Actions.fs
@@ -9,7 +9,8 @@ module Actions =
     let Main
         (
             isSubmitting: bool,
-            onAddToExisting: unit -> unit,
+            showExistingTargetSelector: bool,
+            onToggleExistingTargetSelector: unit -> unit,
             onCreateNew: unit -> unit,
             error: string option
         ) =
@@ -27,8 +28,13 @@ module Actions =
                                     "swt:btn-disabled"
                             ]
                             prop.disabled isSubmitting
-                            prop.onClick (fun _ -> onAddToExisting ())
-                            prop.text "Add to existing Assay/Study"
+                            prop.onClick (fun _ -> onToggleExistingTargetSelector ())
+                            prop.text (
+                                if showExistingTargetSelector then
+                                    "Close existing Assay/Study"
+                                else
+                                    "Add to existing Assay/Study"
+                            )
                         ]
                         Html.button [
                             prop.testId "notes-create-new-button"

--- a/src/Components/src/Notes/Editor/Actions.fs
+++ b/src/Components/src/Notes/Editor/Actions.fs
@@ -1,0 +1,55 @@
+namespace Swate.Components.Notes.Editor
+
+open Feliz
+
+[<RequireQualifiedAccess>]
+module Actions =
+
+    [<ReactComponent>]
+    let Main
+        (
+            isSubmitting: bool,
+            onAddToExisting: unit -> unit,
+            onCreateNew: unit -> unit,
+            error: string option
+        ) =
+        Html.div [
+            prop.className "swt:space-y-2"
+            prop.children [
+                Html.div [
+                    prop.className "swt:flex swt:flex-wrap swt:gap-3"
+                    prop.children [
+                        Html.button [
+                            prop.testId "notes-add-existing-button"
+                            prop.className [
+                                "swt:btn swt:btn-secondary"
+                                if isSubmitting then
+                                    "swt:btn-disabled"
+                            ]
+                            prop.disabled isSubmitting
+                            prop.onClick (fun _ -> onAddToExisting ())
+                            prop.text "Add to existing Assay/Study"
+                        ]
+                        Html.button [
+                            prop.testId "notes-create-new-button"
+                            prop.className [
+                                "swt:btn swt:btn-primary"
+                                if isSubmitting then
+                                    "swt:btn-disabled"
+                            ]
+                            prop.disabled isSubmitting
+                            prop.onClick (fun _ -> onCreateNew ())
+                            prop.text "Create new note"
+                        ]
+                    ]
+                ]
+                match error with
+                | Some message ->
+                    Html.span [
+                        prop.testId "notes-error-text"
+                        prop.className "swt:text-error"
+                        prop.text message
+                    ]
+                | None -> Html.none
+            ]
+        ]

--- a/src/Components/src/Notes/Editor/Conversion.fs
+++ b/src/Components/src/Notes/Editor/Conversion.fs
@@ -1,0 +1,95 @@
+namespace Swate.Components.Notes.Editor
+
+open System
+open ARCtrl
+
+[<RequireQualifiedAccess>]
+module Conversion =
+
+    let isSafePathSegment (value: string) =
+        not (String.IsNullOrWhiteSpace value)
+        && not (value.Contains "/")
+        && not (value.Contains "\\")
+        && not (value.Contains "..")
+
+    let formatDateFolder (dateCreated: DateTime) =
+        Validation.formatDateFolder dateCreated
+
+    let resolveProtocolName (draft: NotesDraft) =
+        Validation.sanitizeProtocolName draft.Title
+
+    let mkExistingTargetRelativePath (targetRef: ExistingTargetRef) (protocolName: string) =
+        let folder =
+            match targetRef.Kind with
+            | NotesTargetKind.Study -> "studies"
+            | NotesTargetKind.Assay -> "assays"
+
+        if isSafePathSegment targetRef.Name && isSafePathSegment protocolName then
+            Some $"{folder}/{targetRef.Name}/protocols/{protocolName}.md"
+        else
+            None
+
+    let mkNewRootNoteRelativePath (dateCreated: DateTime) (protocolName: string) =
+        let dateFolder = formatDateFolder dateCreated
+
+        if isSafePathSegment dateFolder && isSafePathSegment protocolName then
+            Some $"Notes/{dateFolder}/{protocolName}.md"
+        else
+            None
+
+    let private tryTagPart (value: string option) =
+        match value with
+        | Some v when not (String.IsNullOrWhiteSpace v) -> Some v
+        | _ -> None
+
+    let private tagToText (tag: OntologyAnnotation) =
+        let parts =
+            [
+                tryTagPart tag.Name
+                tryTagPart tag.TermSourceREF
+                tryTagPart tag.TermAccessionNumber
+            ]
+            |> List.choose id
+
+        if parts.IsEmpty then "Tag" else String.concat " | " parts
+
+    let formatMarkdown (draft: NotesDraft) =
+        let title = Validation.toOptionalString draft.Title |> Option.defaultValue "Untitled"
+
+        let dateCreated =
+            draft.DateCreated
+            |> Option.map formatDateFolder
+            |> Option.defaultValue ""
+
+        let tagsText =
+            draft.Tags
+            |> Seq.map tagToText
+            |> Seq.toList
+
+        let tagsLine =
+            if tagsText.IsEmpty then
+                None
+            else
+                let joinedTags = String.concat ", " tagsText
+                Some $"Tags: {joinedTags}"
+
+        let body = Validation.toOptionalString draft.MainText |> Option.defaultValue ""
+
+        let headerLines =
+            [
+                Some $"# {title}"
+                Some ""
+                Some $"Date Created: {dateCreated}"
+                tagsLine
+                Some ""
+                Some "---"
+                Some ""
+            ]
+            |> List.choose id
+
+        let header = String.concat "\n" headerLines
+
+        if String.IsNullOrWhiteSpace body then
+            $"{header}\n"
+        else
+            $"{header}\n{body}\n"

--- a/src/Components/src/Notes/Editor/Conversion.fs
+++ b/src/Components/src/Notes/Editor/Conversion.fs
@@ -13,7 +13,7 @@ module Conversion =
         && not (value.Contains "..")
 
     let formatDateFolder (dateCreated: DateTime) =
-        Validation.formatDateFolder dateCreated
+        sprintf "%02d_%02d_%04d" dateCreated.Day dateCreated.Month dateCreated.Year
 
     let resolveProtocolName (draft: NotesDraft) =
         Validation.sanitizeProtocolName draft.Title

--- a/src/Components/src/Notes/Editor/Conversion.fs
+++ b/src/Components/src/Notes/Editor/Conversion.fs
@@ -33,7 +33,7 @@ module Conversion =
         let dateFolder = formatDateFolder dateCreated
 
         if isSafePathSegment dateFolder && isSafePathSegment protocolName then
-            Some $"Notes/{dateFolder}/{protocolName}.md"
+            Some $"Notes/{dateFolder}/{protocolName}/{protocolName}.md"
         else
             None
 

--- a/src/Components/src/Notes/Editor/NoteFormFields.fs
+++ b/src/Components/src/Notes/Editor/NoteFormFields.fs
@@ -1,0 +1,70 @@
+namespace Swate.Components.Notes.Editor
+
+open Feliz
+open Swate.Components
+open Swate.Components.Metadata
+open Swate.Components.MarkdownText
+
+[<RequireQualifiedAccess>]
+module NoteFormFields =
+
+    [<ReactComponent>]
+    let Main (draft: NotesDraft, setDraft: NotesDraft -> unit) =
+        let dateInputValue =
+            draft.DateCreated
+            |> Option.map (fun dateValue -> dateValue.ToString("yyyy-MM-dd"))
+            |> Option.defaultValue ""
+
+        React.Fragment [
+            Html.div [
+                prop.testId "notes-title-field"
+                prop.className "swt:fieldset swt:grow"
+                prop.children [
+                    Generic.FieldTitle "Title (Required)"
+                    Html.input [
+                        prop.className "swt:input swt:input-bordered swt:w-full"
+                        prop.type'.text
+                        prop.valueOrDefault draft.Title
+                        prop.placeholder "Note title"
+                        prop.onChange (fun value -> setDraft { draft with Title = value })
+                    ]
+                ]
+            ]
+            Html.div [
+                prop.testId "notes-date-field"
+                prop.className "swt:fieldset swt:w-full swt:max-w-[9rem]"
+                prop.children [
+                    Generic.FieldTitle "Date Created (Required)"
+                    Html.input [
+                        prop.className "swt:input swt:input-bordered swt:w-full"
+                        prop.type'.date
+                        prop.valueOrDefault dateInputValue
+                        prop.onChange (fun value ->
+                            let parsedDate = Validation.tryParseDateCreated value
+                            setDraft { draft with DateCreated = parsedDate })
+                    ]
+                ]
+            ]
+            Html.div [
+                prop.testId "notes-tags-field"
+                prop.children [
+                    FormComponents.OntologyAnnotationsInput(
+                        draft.Tags,
+                        (fun tags -> setDraft { draft with Tags = tags }),
+                        label = "Tags (Optional)"
+                    )
+                ]
+            ]
+            Html.div [
+                prop.testId "notes-main-text-field"
+                prop.children [
+                    TextInputWithMarkdown.TextInputWithMarkdown(
+                        draft.MainText,
+                        (fun value -> setDraft { draft with MainText = value }),
+                        label = "Main Text",
+                        placeholder = "Write note markdown...",
+                        height = 360
+                    )
+                ]
+            ]
+        ]

--- a/src/Components/src/Notes/Editor/Notes.fs
+++ b/src/Components/src/Notes/Editor/Notes.fs
@@ -1,0 +1,157 @@
+namespace Swate.Components.Notes.Editor
+
+open Fable.Core
+open Feliz
+open Browser.Dom
+
+[<Erase; Mangle(false)>]
+type Notes =
+
+    static member private StartSubmit
+        (uiState: NotesUiState)
+        (setUiState: NotesUiState -> unit)
+        =
+        uiState
+        |> State.clearError
+        |> State.startSubmitting
+        |> setUiState
+
+    static member private StopSubmit
+        (uiState: NotesUiState)
+        (setUiState: NotesUiState -> unit)
+        =
+        uiState
+        |> State.stopSubmitting
+        |> setUiState
+
+    [<ReactComponent>]
+    static member Wizard
+        (
+            draft: NotesDraft,
+            setDraft: NotesDraft -> unit,
+            uiState: NotesUiState,
+            setUiState: NotesUiState -> unit,
+            onSubmit: NotesSubmitPayload -> unit,
+            availableExistingTargets: ResizeArray<ExistingTargetRef>
+        ) =
+
+        let setError (value: string option) =
+            setUiState (State.setError value uiState)
+
+        let createPayload (target: NotesTarget) (relativePath: string) =
+            match draft.DateCreated with
+            | None ->
+                setError (Some "Date Created is required.")
+            | Some dateCreated ->
+                let content = Conversion.formatMarkdown draft
+
+                let payload = {
+                    Intent = {
+                        RelativePath = relativePath
+                        Content = content
+                        Target = target
+                    }
+                    Title = draft.Title.Trim()
+                    DateCreated = dateCreated
+                    Tags = draft.Tags |> Seq.toList
+                }
+
+                Notes.StartSubmit uiState setUiState
+                onSubmit payload
+                Notes.StopSubmit uiState setUiState
+
+        let submitToExisting () =
+            if not uiState.ShowExistingTargetSelector then
+                uiState
+                |> State.showExistingTargetSelector
+                |> setUiState
+            else
+                if Validation.isRequiredDataValid draft |> not then
+                    setError (Some "Please enter a Title and a Date Created value before submitting.")
+                else
+                    match draft.SelectedExistingTarget with
+                    | None ->
+                        setError (Some "Select a Study or Assay target first.")
+                    | Some targetRef ->
+                        match Conversion.resolveProtocolName draft with
+                        | None ->
+                            setError (Some "Title is invalid for protocol naming. Choose a different title.")
+                        | Some protocolName ->
+                            match Conversion.mkExistingTargetRelativePath targetRef protocolName with
+                            | None ->
+                                setError (Some "Could not resolve a safe target path.")
+                            | Some relativePath ->
+                                createPayload (NotesTarget.ExistingTarget targetRef) relativePath
+
+        let submitNewRootNote () =
+            if Validation.isRequiredDataValid draft |> not then
+                setError (Some "Please enter a Title and a Date Created value before submitting.")
+            else
+                match draft.DateCreated with
+                | None ->
+                    setError (Some "Date Created is required.")
+                | Some dateCreated ->
+                    match Conversion.resolveProtocolName draft with
+                    | None ->
+                        setError (Some "Title is invalid for protocol naming. Choose a different title.")
+                    | Some protocolName ->
+                        match Conversion.mkNewRootNoteRelativePath dateCreated protocolName with
+                        | None ->
+                            setError (Some "Could not resolve a safe note path.")
+                        | Some relativePath ->
+                            createPayload NotesTarget.NewRootNote relativePath
+
+        Html.div [
+            prop.className "swt:p-8 swt:flex swt:justify-center"
+            prop.children [
+                Html.div [
+                    prop.className "swt:w-full swt:max-w-4xl swt:rounded-box swt:border swt:border-base-300 swt:bg-base-200 swt:p-6 swt:space-y-4"
+                    prop.children [
+                        Html.h2 [
+                            prop.className "swt:text-3xl swt:font-bold swt:text-primary"
+                            prop.text "Notes"
+                        ]
+                        NoteFormFields.Main(draft, setDraft)
+                        if uiState.ShowExistingTargetSelector then
+                            Html.div [
+                                prop.className "swt:mt-4 swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100 swt:p-4 swt:space-y-3"
+                                prop.children [
+                                    Html.h3 [
+                                        prop.className "swt:text-lg swt:font-semibold"
+                                        prop.text "Existing Target"
+                                    ]
+                                    TargetSelector.Main(
+                                        draft.SelectedExistingTarget,
+                                        (fun target -> setDraft { draft with SelectedExistingTarget = target }),
+                                        availableExistingTargets,
+                                        uiState.IsSubmitting
+                                    )
+                                ]
+                            ]
+                        Actions.Main(uiState.IsSubmitting, submitToExisting, submitNewRootNote, uiState.Error)
+                    ]
+                ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member Entry() =
+        let draft, setDraft = React.useState NotesDraft.init
+        let uiState, setUiState = React.useState NotesUiState.init
+
+        let onSubmit (payload: NotesSubmitPayload) =
+            console.log ("Notes submit payload", payload)
+
+        let availableTargets =
+            ResizeArray [
+                {
+                    Name = "DemoStudy"
+                    Kind = NotesTargetKind.Study
+                }
+                {
+                    Name = "DemoAssay"
+                    Kind = NotesTargetKind.Assay
+                }
+            ]
+
+        Notes.Wizard(draft, setDraft, uiState, setUiState, onSubmit, availableTargets)

--- a/src/Components/src/Notes/Editor/Notes.fs
+++ b/src/Components/src/Notes/Editor/Notes.fs
@@ -7,23 +7,6 @@ open Browser.Dom
 [<Erase; Mangle(false)>]
 type Notes =
 
-    static member private StartSubmit
-        (uiState: NotesUiState)
-        (setUiState: NotesUiState -> unit)
-        =
-        uiState
-        |> State.clearError
-        |> State.startSubmitting
-        |> setUiState
-
-    static member private StopSubmit
-        (uiState: NotesUiState)
-        (setUiState: NotesUiState -> unit)
-        =
-        uiState
-        |> State.stopSubmitting
-        |> setUiState
-
     [<ReactComponent>]
     static member Wizard
         (
@@ -56,32 +39,30 @@ type Notes =
                     Tags = draft.Tags |> Seq.toList
                 }
 
-                Notes.StartSubmit uiState setUiState
                 onSubmit payload
-                Notes.StopSubmit uiState setUiState
+
+        let toggleExistingTargetSelector () =
+            uiState
+            |> State.toggleExistingTargetSelector
+            |> setUiState
 
         let submitToExisting () =
-            if not uiState.ShowExistingTargetSelector then
-                uiState
-                |> State.showExistingTargetSelector
-                |> setUiState
+            if Validation.isRequiredDataValid draft |> not then
+                setError (Some "Please enter a Title and a Date Created value before submitting.")
             else
-                if Validation.isRequiredDataValid draft |> not then
-                    setError (Some "Please enter a Title and a Date Created value before submitting.")
-                else
-                    match draft.SelectedExistingTarget with
+                match draft.SelectedExistingTarget with
+                | None ->
+                    setError (Some "Select a Study or Assay target first.")
+                | Some targetRef ->
+                    match Conversion.resolveProtocolName draft with
                     | None ->
-                        setError (Some "Select a Study or Assay target first.")
-                    | Some targetRef ->
-                        match Conversion.resolveProtocolName draft with
+                        setError (Some "Title is invalid for protocol naming. Choose a different title.")
+                    | Some protocolName ->
+                        match Conversion.mkExistingTargetRelativePath targetRef protocolName with
                         | None ->
-                            setError (Some "Title is invalid for protocol naming. Choose a different title.")
-                        | Some protocolName ->
-                            match Conversion.mkExistingTargetRelativePath targetRef protocolName with
-                            | None ->
-                                setError (Some "Could not resolve a safe target path.")
-                            | Some relativePath ->
-                                createPayload (NotesTarget.ExistingTarget targetRef) relativePath
+                            setError (Some "Could not resolve a safe target path.")
+                        | Some relativePath ->
+                            createPayload (NotesTarget.ExistingTarget targetRef) relativePath
 
         let submitNewRootNote () =
             if Validation.isRequiredDataValid draft |> not then
@@ -112,7 +93,19 @@ type Notes =
                             prop.text "Notes"
                         ]
                         NoteFormFields.Main(draft, setDraft)
+                        Actions.Main(
+                            uiState.IsSubmitting,
+                            uiState.ShowExistingTargetSelector,
+                            toggleExistingTargetSelector,
+                            submitNewRootNote,
+                            uiState.Error
+                        )
                         if uiState.ShowExistingTargetSelector then
+                            let createInExistingText =
+                                match uiState.ActiveExistingTargetKind with
+                                | NotesTargetKind.Study -> "Create in Study"
+                                | NotesTargetKind.Assay -> "Create in Assay"
+
                             Html.div [
                                 prop.className "swt:mt-4 swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100 swt:p-4 swt:space-y-3"
                                 prop.children [
@@ -124,11 +117,23 @@ type Notes =
                                         draft.SelectedExistingTarget,
                                         (fun target -> setDraft { draft with SelectedExistingTarget = target }),
                                         availableExistingTargets,
-                                        uiState.IsSubmitting
+                                        uiState.IsSubmitting,
+                                        uiState.ActiveExistingTargetKind,
+                                        (fun kind -> setUiState (State.setActiveExistingTargetKind kind uiState))
                                     )
+                                    Html.button [
+                                        prop.testId "notes-create-existing-button"
+                                        prop.className [
+                                            "swt:btn swt:btn-primary"
+                                            if uiState.IsSubmitting || draft.SelectedExistingTarget.IsNone then
+                                                "swt:btn-disabled"
+                                        ]
+                                        prop.disabled (uiState.IsSubmitting || draft.SelectedExistingTarget.IsNone)
+                                        prop.onClick (fun _ -> submitToExisting ())
+                                        prop.text createInExistingText
+                                    ]
                                 ]
                             ]
-                        Actions.Main(uiState.IsSubmitting, submitToExisting, submitNewRootNote, uiState.Error)
                     ]
                 ]
             ]

--- a/src/Components/src/Notes/Editor/Notes.stories.tsx
+++ b/src/Components/src/Notes/Editor/Notes.stories.tsx
@@ -13,7 +13,7 @@ function renderWizard(args: any) {
     const next = createNotesDraft();
     next.Title = 'Watering plan';
     next.MainText = 'My markdown body';
-    next.DateCreated = new Date('2026-02-26T09:30:00');
+    next.DateCreated = new Date(2026, 1, 26);
     return next;
   });
   const [uiState, setUiState] = React.useState(createNotesUiState());
@@ -38,7 +38,7 @@ function createSeededPreviewDraft() {
   const next = createNotesDraft();
   next.Title = 'Preview title';
   next.MainText = 'Preview body content';
-  next.DateCreated = new Date('2026-02-26T09:30:00');
+  next.DateCreated = new Date(2026, 1, 26);
   return next;
 }
 
@@ -118,7 +118,7 @@ export const ExistingTargetSubmit: Story = {
     const targetSelect = canvas.getByTestId('notes-existing-target-select') as HTMLSelectElement;
     await userEvent.selectOptions(targetSelect, 'MyStudy');
 
-    await userEvent.click(canvas.getByTestId('notes-add-existing-button'));
+    await userEvent.click(canvas.getByTestId('notes-create-existing-button'));
 
     await waitFor(() => {
       expect(args.onSubmit).toHaveBeenCalledTimes(1);

--- a/src/Components/src/Notes/Editor/Notes.stories.tsx
+++ b/src/Components/src/Notes/Editor/Notes.stories.tsx
@@ -143,7 +143,7 @@ export const NewRootNoteSubmit: Story = {
     });
 
     const payload = args.onSubmit.mock.calls[0][0];
-    expect(payload.Intent.RelativePath).toBe('Notes/26_02_2026/Watering_plan.md');
+    expect(payload.Intent.RelativePath).toBe('Notes/26_02_2026/Watering_plan/Watering_plan.md');
   },
 };
 
@@ -161,7 +161,7 @@ export const PreviewGeneratedMarkdownAndPath: Story = {
 
     await waitFor(() => {
       expect(canvas.getByTestId('notes-preview-relative-path')).toHaveTextContent(
-        'Notes/26_02_2026/Preview_from_story.md'
+        'Notes/26_02_2026/Preview_from_story/Preview_from_story.md'
       );
     });
 

--- a/src/Components/src/Notes/Editor/Notes.stories.tsx
+++ b/src/Components/src/Notes/Editor/Notes.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect, userEvent, waitFor, fn } from 'storybook/test';
+import { Wizard as NotesWizard } from './Notes.fs.js';
+import {
+  Exports_createNotesDraft as createNotesDraft,
+  Exports_createNotesUiState as createNotesUiState,
+  Exports_createDemoExistingTargets as createDemoExistingTargets,
+} from './Types.fs.js';
+
+function renderWizard(args: any) {
+  const [draft, setDraft] = React.useState(() => {
+    const next = createNotesDraft();
+    next.Title = 'Watering plan';
+    next.MainText = 'My markdown body';
+    next.DateCreated = new Date('2026-02-26T09:30:00');
+    return next;
+  });
+  const [uiState, setUiState] = React.useState(createNotesUiState());
+
+  return (
+    <NotesWizard
+      draft={draft}
+      setDraft={setDraft}
+      uiState={uiState}
+      setUiState={setUiState}
+      onSubmit={args.onSubmit}
+      availableExistingTargets={createDemoExistingTargets()}
+    />
+  );
+}
+
+type PreviewHarnessProps = {
+  createInitialDraft: () => any;
+};
+
+function createSeededPreviewDraft() {
+  const next = createNotesDraft();
+  next.Title = 'Preview title';
+  next.MainText = 'Preview body content';
+  next.DateCreated = new Date('2026-02-26T09:30:00');
+  return next;
+}
+
+function createEmptyDraft() {
+  return createNotesDraft();
+}
+
+function PreviewHarness({ createInitialDraft }: PreviewHarnessProps) {
+  const [draft, setDraft] = React.useState(() => createInitialDraft());
+  const [uiState, setUiState] = React.useState(createNotesUiState());
+  const [previewPath, setPreviewPath] = React.useState<string | null>(null);
+  const [previewMarkdown, setPreviewMarkdown] = React.useState<string | null>(null);
+
+  return (
+    <div className="swt:flex swt:flex-col swt:gap-4">
+      <NotesWizard
+        draft={draft}
+        setDraft={setDraft}
+        uiState={uiState}
+        setUiState={setUiState}
+        onSubmit={(payload: any) => {
+          setPreviewPath(payload.Intent.RelativePath);
+          setPreviewMarkdown(payload.Intent.Content);
+        }}
+        availableExistingTargets={createDemoExistingTargets()}
+      />
+      <div
+        data-testid="notes-preview-panel"
+        className="swt:mx-auto swt:w-full swt:max-w-4xl swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100 swt:p-4 swt:space-y-2"
+      >
+        <h3 className="swt:text-lg swt:font-semibold">Generated Save Preview</h3>
+        <p className="swt:text-sm swt:font-semibold">Relative Path</p>
+        <pre
+          data-testid="notes-preview-relative-path"
+          className="swt:rounded swt:bg-base-200 swt:p-2 swt:text-xs swt:whitespace-pre-wrap"
+        >
+          {previewPath ?? 'No preview yet. Click a save-intent action above.'}
+        </pre>
+        <p className="swt:text-sm swt:font-semibold">Markdown Content</p>
+        <pre
+          data-testid="notes-preview-markdown"
+          className="swt:max-h-72 swt:overflow-auto swt:rounded swt:bg-base-200 swt:p-2 swt:text-xs swt:whitespace-pre-wrap"
+        >
+          {previewMarkdown ?? 'No preview yet. Click a save-intent action above.'}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Components/Notes/Editor',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  component: NotesWizard,
+} satisfies Meta<typeof NotesWizard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <PreviewHarness createInitialDraft={createEmptyDraft} />,
+};
+
+export const ExistingTargetSubmit: Story = {
+  render: renderWizard,
+  args: {
+    onSubmit: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByTestId('notes-add-existing-button'));
+
+    const targetSelect = canvas.getByTestId('notes-existing-target-select') as HTMLSelectElement;
+    await userEvent.selectOptions(targetSelect, 'MyStudy');
+
+    await userEvent.click(canvas.getByTestId('notes-add-existing-button'));
+
+    await waitFor(() => {
+      expect(args.onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = args.onSubmit.mock.calls[0][0];
+    expect(payload.Intent.RelativePath).toBe('studies/MyStudy/protocols/Watering_plan.md');
+  },
+};
+
+export const NewRootNoteSubmit: Story = {
+  render: renderWizard,
+  args: {
+    onSubmit: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId('notes-create-new-button'));
+
+    await waitFor(() => {
+      expect(args.onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = args.onSubmit.mock.calls[0][0];
+    expect(payload.Intent.RelativePath).toBe('Notes/26_02_2026/Watering_plan.md');
+  },
+};
+
+export const PreviewGeneratedMarkdownAndPath: Story = {
+  render: () => <PreviewHarness createInitialDraft={createSeededPreviewDraft} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const titleField = canvas.getByTestId('notes-title-field');
+    const titleInput = within(titleField).getByRole('textbox');
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, 'Preview from story');
+
+    await userEvent.click(canvas.getByTestId('notes-create-new-button'));
+
+    await waitFor(() => {
+      expect(canvas.getByTestId('notes-preview-relative-path')).toHaveTextContent(
+        'Notes/26_02_2026/Preview_from_story.md'
+      );
+    });
+
+    expect(canvas.getByTestId('notes-preview-markdown')).toHaveTextContent('# Preview from story');
+  },
+};

--- a/src/Components/src/Notes/Editor/State.fs
+++ b/src/Components/src/Notes/Editor/State.fs
@@ -23,8 +23,14 @@ module State =
             IsSubmitting = false
     }
 
-    let showExistingTargetSelector (state: NotesUiState) = {
+    let toggleExistingTargetSelector (state: NotesUiState) = {
         state with
-            ShowExistingTargetSelector = true
+            ShowExistingTargetSelector = not state.ShowExistingTargetSelector
+            Error = None
+    }
+
+    let setActiveExistingTargetKind (kind: NotesTargetKind) (state: NotesUiState) = {
+        state with
+            ActiveExistingTargetKind = kind
             Error = None
     }

--- a/src/Components/src/Notes/Editor/State.fs
+++ b/src/Components/src/Notes/Editor/State.fs
@@ -1,0 +1,30 @@
+namespace Swate.Components.Notes.Editor
+
+module State =
+
+    let setError (error: string option) (state: NotesUiState) = {
+        state with
+            Error = error
+    }
+
+    let clearError (state: NotesUiState) = {
+        state with
+            Error = None
+    }
+
+    let startSubmitting (state: NotesUiState) = {
+        state with
+            IsSubmitting = true
+            Error = None
+    }
+
+    let stopSubmitting (state: NotesUiState) = {
+        state with
+            IsSubmitting = false
+    }
+
+    let showExistingTargetSelector (state: NotesUiState) = {
+        state with
+            ShowExistingTargetSelector = true
+            Error = None
+    }

--- a/src/Components/src/Notes/Editor/TargetSelector.fs
+++ b/src/Components/src/Notes/Editor/TargetSelector.fs
@@ -11,18 +11,10 @@ module TargetSelector =
             selectedTarget: ExistingTargetRef option,
             setSelectedTarget: ExistingTargetRef option -> unit,
             availableTargets: ResizeArray<ExistingTargetRef>,
-            isSubmitting: bool
+            isSubmitting: bool,
+            activeKind: NotesTargetKind,
+            setActiveKind: NotesTargetKind -> unit
         ) =
-        let activeKind, setActiveKind =
-            React.useState (selectedTarget |> Option.map _.Kind |> Option.defaultValue NotesTargetKind.Study)
-
-        React.useEffect (
-            (fun () ->
-                selectedTarget
-                |> Option.iter (fun target -> setActiveKind target.Kind)),
-            [| box selectedTarget |]
-        )
-
         let setKind kind =
             setActiveKind kind
 

--- a/src/Components/src/Notes/Editor/TargetSelector.fs
+++ b/src/Components/src/Notes/Editor/TargetSelector.fs
@@ -1,0 +1,96 @@
+namespace Swate.Components.Notes.Editor
+
+open Feliz
+
+[<RequireQualifiedAccess>]
+module TargetSelector =
+
+    [<ReactComponent>]
+    let Main
+        (
+            selectedTarget: ExistingTargetRef option,
+            setSelectedTarget: ExistingTargetRef option -> unit,
+            availableTargets: ResizeArray<ExistingTargetRef>,
+            isSubmitting: bool
+        ) =
+        let activeKind, setActiveKind =
+            React.useState (selectedTarget |> Option.map _.Kind |> Option.defaultValue NotesTargetKind.Study)
+
+        React.useEffect (
+            (fun () ->
+                selectedTarget
+                |> Option.iter (fun target -> setActiveKind target.Kind)),
+            [| box selectedTarget |]
+        )
+
+        let setKind kind =
+            setActiveKind kind
+
+            match selectedTarget with
+            | Some target when target.Kind <> kind -> setSelectedTarget None
+            | _ -> ()
+
+        let filteredTargets =
+            availableTargets
+            |> Seq.filter (fun target -> target.Kind = activeKind)
+            |> Seq.toArray
+
+        let selectedValue =
+            selectedTarget
+            |> Option.filter (fun target -> target.Kind = activeKind)
+            |> Option.map _.Name
+            |> Option.defaultValue ""
+
+        let kindButton (label: string) (kind: NotesTargetKind) =
+            Html.button [
+                prop.className [
+                    "swt:btn swt:flex-1"
+                    if activeKind = kind then
+                        "swt:btn-primary"
+                    else
+                        "swt:btn-outline"
+                ]
+                prop.disabled isSubmitting
+                prop.onClick (fun _ -> setKind kind)
+                prop.text label
+            ]
+
+        Html.div [
+            prop.className "swt:space-y-2"
+            prop.children [
+                Html.div [
+                    prop.className "swt:flex swt:gap-3"
+                    prop.children [
+                        kindButton "Study" NotesTargetKind.Study
+                        kindButton "Assay" NotesTargetKind.Assay
+                    ]
+                ]
+                Html.select [
+                    prop.testId "notes-existing-target-select"
+                    prop.className "swt:select swt:select-bordered swt:w-full"
+                    prop.disabled (isSubmitting || filteredTargets.Length = 0)
+                    prop.valueOrDefault selectedValue
+                    prop.onChange (fun (value: string) ->
+                        filteredTargets
+                        |> Array.tryFind (fun target -> target.Name = value)
+                        |> setSelectedTarget)
+                    prop.children [
+                        Html.option [
+                            prop.value ""
+                            prop.text (
+                                if filteredTargets.Length = 0 then
+                                    "No targets available"
+                                else
+                                    "Select target"
+                            )
+                        ]
+                        for target in filteredTargets do
+                            Html.option [
+                                prop.key $"{target.Kind}-{target.Name}"
+                                prop.value target.Name
+                                prop.text target.Name
+                            ]
+                    ]
+                ]
+            ]
+        ]

--- a/src/Components/src/Notes/Editor/Types.fs
+++ b/src/Components/src/Notes/Editor/Types.fs
@@ -1,0 +1,82 @@
+namespace Swate.Components.Notes.Editor
+
+open ARCtrl
+open Fable.Core
+
+[<RequireQualifiedAccess>]
+type NotesTargetKind =
+    | Study
+    | Assay
+
+type ExistingTargetRef = {
+    Name: string
+    Kind: NotesTargetKind
+}
+
+[<RequireQualifiedAccess>]
+type NotesTarget =
+    | ExistingTarget of ExistingTargetRef
+    | NewRootNote
+
+type NotesDraft = {
+    Title: string
+    DateCreated: System.DateTime option
+    Tags: ResizeArray<OntologyAnnotation>
+    MainText: string
+    SelectedExistingTarget: ExistingTargetRef option
+} with
+    static member init = {
+        Title = ""
+        DateCreated = None
+        Tags = ResizeArray()
+        MainText = ""
+        SelectedExistingTarget = None
+    }
+
+type NotesUiState = {
+    Error: string option
+    IsSubmitting: bool
+    ShowExistingTargetSelector: bool
+} with
+    static member init = {
+        Error = None
+        IsSubmitting = false
+        ShowExistingTargetSelector = false
+    }
+
+type NotesProtocolIntent = {
+    RelativePath: string
+    Content: string
+    Target: NotesTarget
+}
+
+type NotesSubmitPayload = {
+    Intent: NotesProtocolIntent
+    Title: string
+    DateCreated: System.DateTime
+    Tags: OntologyAnnotation list
+}
+
+[<Mangle(false)>]
+module Exports =
+    let createNotesDraft () = NotesDraft.init
+    let createNotesUiState () = NotesUiState.init
+
+    let createExistingTargetRef (name: string) (kind: string) =
+        let normalizedKind = kind.Trim().ToLowerInvariant()
+
+        let targetKind =
+            match normalizedKind with
+            | "assay" -> NotesTargetKind.Assay
+            | _ -> NotesTargetKind.Study
+
+        {
+            Name = name
+            Kind = targetKind
+        }
+
+    let createDemoExistingTargets () =
+        ResizeArray [
+            createExistingTargetRef "MyStudy" "study"
+            createExistingTargetRef "MyAssay" "assay"
+        ]

--- a/src/Components/src/Notes/Editor/Types.fs
+++ b/src/Components/src/Notes/Editor/Types.fs
@@ -37,11 +37,13 @@ type NotesUiState = {
     Error: string option
     IsSubmitting: bool
     ShowExistingTargetSelector: bool
+    ActiveExistingTargetKind: NotesTargetKind
 } with
     static member init = {
         Error = None
         IsSubmitting = false
         ShowExistingTargetSelector = false
+        ActiveExistingTargetKind = NotesTargetKind.Study
     }
 
 type NotesProtocolIntent = {
@@ -62,21 +64,14 @@ module Exports =
     let createNotesDraft () = NotesDraft.init
     let createNotesUiState () = NotesUiState.init
 
-    let createExistingTargetRef (name: string) (kind: string) =
-        let normalizedKind = kind.Trim().ToLowerInvariant()
-
-        let targetKind =
-            match normalizedKind with
-            | "assay" -> NotesTargetKind.Assay
-            | _ -> NotesTargetKind.Study
-
-        {
-            Name = name
-            Kind = targetKind
-        }
-
     let createDemoExistingTargets () =
         ResizeArray [
-            createExistingTargetRef "MyStudy" "study"
-            createExistingTargetRef "MyAssay" "assay"
+            {
+                Name = "MyStudy"
+                Kind = NotesTargetKind.Study
+            }
+            {
+                Name = "MyAssay"
+                Kind = NotesTargetKind.Assay
+            }
         ]

--- a/src/Components/src/Notes/Editor/Validation.fs
+++ b/src/Components/src/Notes/Editor/Validation.fs
@@ -46,9 +46,6 @@ module Validation =
                 | true, parsed -> Some parsed
                 | false, _ -> None
 
-    let formatDateFolder (dateCreated: DateTime) =
-        dateCreated.ToString("dd_MM_yyyy")
-
     let private sanitizeProtocolNameCandidate (candidate: string) =
         let cleaned = Regex.Replace(candidate, @"[^a-zA-Z0-9_\- ]", " ").Trim()
         Regex.Replace(cleaned, @"\s+", " ").Trim()

--- a/src/Components/src/Notes/Editor/Validation.fs
+++ b/src/Components/src/Notes/Editor/Validation.fs
@@ -1,0 +1,60 @@
+namespace Swate.Components.Notes.Editor
+
+open System
+open System.Text.RegularExpressions
+
+[<RequireQualifiedAccess>]
+module Validation =
+
+    let toOptionalString (value: string) =
+        let trimmed = value.Trim()
+        if String.IsNullOrWhiteSpace trimmed then None else Some trimmed
+
+    let isRequiredDataValid (draft: NotesDraft) =
+        not (String.IsNullOrWhiteSpace draft.Title)
+        && draft.DateCreated.IsSome
+
+    let tryParseDateCreated (dateText: string) =
+        let trimmed = dateText.Trim()
+
+        if String.IsNullOrWhiteSpace trimmed then
+            None
+        else
+            let dateOnly = Regex.Match(trimmed, @"^(\d{4})-(\d{2})-(\d{2})$")
+            let dateTimeLocal = Regex.Match(trimmed, @"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$")
+
+            if dateOnly.Success then
+                try
+                    let year = int dateOnly.Groups.[1].Value
+                    let month = int dateOnly.Groups.[2].Value
+                    let day = int dateOnly.Groups.[3].Value
+                    Some(DateTime(year, month, day))
+                with _ ->
+                    None
+            elif dateTimeLocal.Success then
+                try
+                    let year = int dateTimeLocal.Groups.[1].Value
+                    let month = int dateTimeLocal.Groups.[2].Value
+                    let day = int dateTimeLocal.Groups.[3].Value
+                    let hour = int dateTimeLocal.Groups.[4].Value
+                    let minute = int dateTimeLocal.Groups.[5].Value
+                    Some(DateTime(year, month, day, hour, minute, 0))
+                with _ ->
+                    None
+            else
+                match DateTime.TryParse trimmed with
+                | true, parsed -> Some parsed
+                | false, _ -> None
+
+    let formatDateFolder (dateCreated: DateTime) =
+        dateCreated.ToString("dd_MM_yyyy")
+
+    let private sanitizeProtocolNameCandidate (candidate: string) =
+        let cleaned = Regex.Replace(candidate, @"[^a-zA-Z0-9_\- ]", " ").Trim()
+        Regex.Replace(cleaned, @"\s+", " ").Trim()
+
+    let sanitizeProtocolName (candidate: string) =
+        candidate
+        |> sanitizeProtocolNameCandidate
+        |> fun value -> Regex.Replace(value, @"\s+", "_").Trim([| '_'; '-' |])
+        |> toOptionalString

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -122,6 +122,14 @@
     <Compile Include="Widgets\Widgets.fs" />
     <Compile Include="Notes\Types.fs" />
     <Compile Include="Notes\NoteSearch\NoteSearchComponent.fs" />
+    <Compile Include="Notes\Editor\Types.fs" />
+    <Compile Include="Notes\Editor\State.fs" />
+    <Compile Include="Notes\Editor\Validation.fs" />
+    <Compile Include="Notes\Editor\Conversion.fs" />
+    <Compile Include="Notes\Editor\NoteFormFields.fs" />
+    <Compile Include="Notes\Editor\TargetSelector.fs" />
+    <Compile Include="Notes\Editor\Actions.fs" />
+    <Compile Include="Notes\Editor\Notes.fs" />
     <Compile Include="Style.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR introduces a new **Notes Editor** in `src/Components` to prepare note save intents for ARC workflows.
It follows the Landing-style structure (`Types`, `State`, `Validation`, `Conversion`, UI modules).

## Feature behavior
- Input flow:
  - required **Title**
  - required **Date Created** (date-only)
  - optional **Tags**
  - main markdown body editor
- Save-intent paths:
  - Existing target:  
    `studies/<study>/protocols/<protocol>.md` or `assays/<assay>/protocols/<protocol>.md`
  - New root note:  
    `Notes/<dd_MM_yyyy>/<protocol>/<protocol>.md`
- Existing-target UX:
  - `Add to existing Assay/Study` now toggles the selector block open/close.
  - Submit for existing target is a separate button inside that block:
    - `Create in Study` / `Create in Assay` (label follows active target kind).
- Markdown payload formatting includes title, date, optional tags, separator, and body.
- Validation/sanitization included for required fields and safe path segments.

## Storybook
- Added Notes stories covering:
  - default rendering
  - existing-target submit
  - new-root submit
  - interactive preview of generated relative path and markdown content

## Out of scope (intentional)
- No filesystem write logic in Components.
- No runtime target fetching or IPC integration.