### PR TITLE
Feature/add images plugin

### DIFF
--- a/src/Components/src/MarkdownText/Plugins/AddImage.fs
+++ b/src/Components/src/MarkdownText/Plugins/AddImage.fs
@@ -1,0 +1,79 @@
+namespace Swate.Components.MarkdownText.Plugins
+
+open System
+open Fable.Core.JsInterop
+open Feliz
+open Swate.Components.MarkdownText.JsBindings
+
+[<RequireQualifiedAccess>]
+module AddImage =
+
+    [<Literal>]
+    let keyCommand = "add-image"
+
+    let private toMarkdownImageLink ((file: MarkdownPromptFile), (path: string)) =
+        let fallbackPath = if String.IsNullOrWhiteSpace path then file.Name else path
+        let normalizedPath = fallbackPath.Replace("\\", "/")
+        let altText = if String.IsNullOrWhiteSpace file.Name then "image" else file.Name
+
+        $"![{altText}]({normalizedPath})"
+
+    let private insertAtSelection (source: string) (startIndex: int) (endIndex: int) (links: string list) =
+        let boundedStart = min (max startIndex 0) source.Length
+        let boundedEnd = min (max endIndex boundedStart) source.Length
+        let content = links |> String.concat "\n"
+
+        let requiresLeadingNewLine = boundedStart > 0 && source.[boundedStart - 1] <> '\n'
+
+        let requiresTrailingNewLine =
+            boundedEnd < source.Length && source.[boundedEnd] <> '\n'
+
+        let prefix = if requiresLeadingNewLine then "\n" else ""
+        let suffix = if requiresTrailingNewLine then "\n" else ""
+        let insertion = $"{prefix}{content}{suffix}"
+
+        let nextValue =
+            $"{source.Substring(0, boundedStart)}{insertion}{source.Substring boundedEnd}"
+
+        let caretIndex = boundedStart + insertion.Length
+        nextValue, (caretIndex, caretIndex)
+
+    let command: ICommand =
+        { new ICommand with
+            member _.name = "Add Image"
+            member _.keyCommand = keyCommand
+            member _.icon = Html.span [ prop.className "swt:text-xs"; prop.text "Add Image" ]
+            member _.buttonProps = createObj [ "aria-label" ==> "Add Image" ]
+            member _.execute _ _ = ()
+        }
+
+    let private prompt: MarkdownPromptPlugin = {
+        Title = "Add Image"
+        Description = Some "Drop image files or choose them to insert markdown image links."
+        Placeholder = "Choose image files"
+        SubmitButtonText = "Insert"
+        // Not used in File mode; required by MarkdownPromptPlugin shape.
+        Validate = (fun _ -> Ok())
+        // Not used in File mode; required by MarkdownPromptPlugin shape.
+        Apply = (fun source selectionStart selectionEnd _ -> source, (selectionStart, selectionEnd))
+        InputMode = Some MarkdownPromptInputMode.File
+        Accept = Some "image/*"
+        AllowMultiple = Some true
+        ApplyFiles =
+            Some(
+                fun source selectionStart selectionEnd filesWithPaths ->
+                    let links = filesWithPaths |> List.map toMarkdownImageLink
+
+                    if List.isEmpty links then
+                        source, (selectionStart, selectionEnd)
+                    else
+                        insertAtSelection source selectionStart selectionEnd links
+            )
+    }
+
+    let plugin: MarkdownToolbarPlugin = {
+        Id = keyCommand
+        Command = command
+        Enabled = true
+        Prompt = Some prompt
+    }

--- a/src/Components/src/MarkdownText/Plugins/AddOntologyReference.fs
+++ b/src/Components/src/MarkdownText/Plugins/AddOntologyReference.fs
@@ -97,6 +97,10 @@ module AddOntologyReference =
                         insertAtSelection source selectionStart selectionEnd reference
                     | Error _ ->
                         source, (selectionStart, selectionEnd))
+            InputMode = None
+            Accept = None
+            AllowMultiple = None
+            ApplyFiles = None
         }
 
     let plugin: MarkdownToolbarPlugin =

--- a/src/Components/src/MarkdownText/Plugins/AddStep.fs
+++ b/src/Components/src/MarkdownText/Plugins/AddStep.fs
@@ -78,6 +78,10 @@ module AddStep =
 
                 nextValue, (caretIndex, caretIndex)
             )
+        InputMode = None
+        Accept = None
+        AllowMultiple = None
+        ApplyFiles = None
     }
 
     let plugin: MarkdownToolbarPlugin = {

--- a/src/Components/src/MarkdownText/Plugins/PluginRegistry.fs
+++ b/src/Components/src/MarkdownText/Plugins/PluginRegistry.fs
@@ -5,6 +5,7 @@ module PluginRegistry =
 
     let defaultPlugins: MarkdownToolbarPlugin list = [
         AddStep.plugin
+        AddImage.plugin
         AddOntologyReference.plugin
     ]
 

--- a/src/Components/src/MarkdownText/Plugins/PluginTypes.fs
+++ b/src/Components/src/MarkdownText/Plugins/PluginTypes.fs
@@ -1,6 +1,27 @@
 namespace Swate.Components.MarkdownText.Plugins
 
+open Browser.Types
+open Fable.Core
 open Swate.Components.MarkdownText.JsBindings
+
+[<RequireQualifiedAccess>]
+type MarkdownPromptInputMode =
+    | Text
+    | File
+
+type MarkdownPromptFile = {
+    Name: string
+    MimeType: string option
+    HostPath: string option
+    BrowserFile: File option
+}
+
+// Host/runtime extension point for dialog picking and markdown path resolution.
+// When provided, "Choose file" uses the adapter, while built-in drag/drop input remains available.
+type MarkdownFilePickerAdapter = {
+    PickFiles: unit -> JS.Promise<MarkdownPromptFile list>
+    ResolveMarkdownPath: MarkdownPromptFile -> JS.Promise<string>
+}
 
 type MarkdownPromptPlugin =
     {
@@ -10,6 +31,13 @@ type MarkdownPromptPlugin =
         SubmitButtonText: string
         Validate: string -> Result<unit, string>
         Apply: string -> int -> int -> string -> string * (int * int)
+        // None defaults to text prompt mode for backwards compatibility.
+        InputMode: MarkdownPromptInputMode option
+        // Applies to file mode only.
+        Accept: string option
+        AllowMultiple: bool option
+        // Applies to file mode only.
+        ApplyFiles: (string -> int -> int -> (MarkdownPromptFile * string) list -> string * (int * int)) option
     }
 
 type MarkdownToolbarPlugin =

--- a/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
@@ -181,12 +181,75 @@ type TextInputWithMarkdown =
             |> Option.bind (fun prompt -> prompt.AllowMultiple)
             |> Option.defaultValue false
 
+        let activePromptAcceptTypes () =
+            activePrompt
+            |> Option.bind (fun prompt -> prompt.Accept)
+            |> Option.filter (fun accept -> not (String.IsNullOrWhiteSpace accept))
+
         let normalizePromptFiles (files: MarkdownPromptFile list) =
             if activePromptAllowsMultipleFiles () then
                 files
             else
                 // In single-file mode, always keep the most recently selected file.
                 files |> List.rev |> List.truncate 1 |> List.rev
+
+        let acceptedTypeTokens () =
+            activePromptAcceptTypes ()
+            |> Option.defaultValue ""
+            |> fun accept ->
+                accept.Split(',')
+                |> Array.toList
+                |> List.map (fun token -> token.Trim().ToLowerInvariant())
+                |> List.filter (fun token -> not (String.IsNullOrWhiteSpace token))
+
+        let fileMatchesAcceptToken (file: MarkdownPromptFile) (token: string) =
+            let fileNameLower =
+                if String.IsNullOrWhiteSpace file.Name then
+                    ""
+                else
+                    file.Name.ToLowerInvariant()
+
+            let mimeLower =
+                file.MimeType
+                |> Option.defaultValue ""
+                |> fun mime -> mime.ToLowerInvariant()
+
+            if token.StartsWith "." then
+                not (String.IsNullOrWhiteSpace fileNameLower) && fileNameLower.EndsWith token
+            elif token.EndsWith "/*" then
+                let mimePrefix = token.Substring(0, token.Length - 1)
+                not (String.IsNullOrWhiteSpace mimeLower) && mimeLower.StartsWith mimePrefix
+            else
+                not (String.IsNullOrWhiteSpace mimeLower) && mimeLower = token
+
+        let partitionFilesByAccept (files: MarkdownPromptFile list) =
+            let tokens = acceptedTypeTokens ()
+
+            if List.isEmpty tokens then
+                files, []
+            else
+                files
+                |> List.partition (fun file -> tokens |> List.exists (fileMatchesAcceptToken file))
+
+        let rejectedFilesMessage (files: MarkdownPromptFile list) =
+            let rejectedNames =
+                files
+                |> List.map (fun file ->
+                    if String.IsNullOrWhiteSpace file.Name then
+                        "(unnamed file)"
+                    else
+                        file.Name
+                )
+                |> String.concat ", "
+
+            let allowed =
+                activePromptAcceptTypes ()
+                |> Option.defaultValue "configured accepted types"
+
+            if List.length files = 1 then
+                $"File not allowed: {rejectedNames}. Allowed: {allowed}."
+            else
+                $"Files not allowed: {rejectedNames}. Allowed: {allowed}."
 
         let normalizePath (path: string) = path.Replace("\\", "/")
 
@@ -211,6 +274,15 @@ type TextInputWithMarkdown =
                 )
                 if promptError.IsSome then
                     setPromptError None
+
+        let applyPickedPromptFiles (files: MarkdownPromptFile list) =
+            let accepted, rejected = partitionFilesByAccept files
+
+            if not (List.isEmpty accepted) then
+                appendPromptFilesAndClearError accepted
+
+            if not (List.isEmpty rejected) && isMountedRef.current then
+                setPromptError (Some(rejectedFilesMessage rejected))
 
         let removePromptFileAtIndex (indexToRemove: int) =
             setPromptFiles (fun currentFiles ->
@@ -250,7 +322,7 @@ type TextInputWithMarkdown =
                 | Some adapter ->
                     // Preferred substitution point for runtime-specific file pickers.
                     let! files = adapter.PickFiles()
-                    appendPromptFilesAndClearError files
+                    applyPickedPromptFiles files
                 | None ->
                     // Built-in fallback: standard browser file input dialog.
                     promptFileInputRef.current
@@ -265,7 +337,7 @@ type TextInputWithMarkdown =
         let handlePromptFileChange =
             fun (files: File list) ->
                 let selected = files |> List.map toPromptFile
-                appendPromptFilesAndClearError selected
+                applyPickedPromptFiles selected
 
                 // Reset the input value so selecting the same file triggers onChange.
                 promptFileInputRef.current
@@ -293,7 +365,7 @@ type TextInputWithMarkdown =
                 if List.isEmpty files then
                     setPromptError (Some "No files were dropped.")
                 else
-                    appendPromptFilesAndClearError files
+                    applyPickedPromptFiles files
 
         let openPromptDialog (prompt: MarkdownPromptPlugin) =
             let startIndex, endIndex = getSelectionOrEnd ()
@@ -480,8 +552,7 @@ type TextInputWithMarkdown =
         let isFilePrompt = promptInputMode = MarkdownPromptInputMode.File
 
         let promptAcceptedTypes =
-            activePrompt
-            |> Option.bind (fun prompt -> prompt.Accept)
+            activePromptAcceptTypes ()
 
         let promptAllowMultipleFiles = activePromptAllowsMultipleFiles ()
 

--- a/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
@@ -185,7 +185,8 @@ type TextInputWithMarkdown =
             if activePromptAllowsMultipleFiles () then
                 files
             else
-                files |> List.truncate 1
+                // In single-file mode, always keep the most recently selected file.
+                files |> List.rev |> List.truncate 1 |> List.rev
 
         let normalizePath (path: string) = path.Replace("\\", "/")
 

--- a/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
@@ -58,7 +58,8 @@ type TextInputWithMarkdown =
             ?height: int,
             ?mode: PreviewMode,
             ?previewClassName: string,
-            ?plugins: MarkdownToolbarPlugin list
+            ?plugins: MarkdownToolbarPlugin list,
+            ?filePickerAdapter: MarkdownFilePickerAdapter
         ) =
         let disabled = defaultArg disabled false
         let isJoin = defaultArg isJoin false
@@ -82,11 +83,21 @@ type TextInputWithMarkdown =
         let activePrompt, setActivePrompt = React.useState (None: MarkdownPromptPlugin option)
         let promptInput, setPromptInput = React.useState ""
         let promptError, setPromptError = React.useState (None: string option)
+        let promptFiles, setPromptFiles = React.useStateWithUpdater ([]: MarkdownPromptFile list)
+        let promptFileDropActive, setPromptFileDropActive = React.useState false
 
         let textareaRef = React.useElementRef ()
         let promptInputRef = React.useInputRef ()
+        let promptFileInputRef = React.useInputRef ()
         let commandOrchestratorRef = React.useRef<TextAreaCommandOrchestrator option> None
         let promptSelectionRef = React.useRef (None: (int * int) option)
+        let isMountedRef = React.useRef true
+
+        React.useEffectOnce (fun _ ->
+            { new System.IDisposable with
+                member _.Dispose() = isMountedRef.current <- false
+            }
+        )
 
         React.useEffect (
             (fun () ->
@@ -160,39 +171,211 @@ type TextInputWithMarkdown =
             | Some textarea -> textarea.selectionStart, textarea.selectionEnd
             | None -> tempValue.Length, tempValue.Length
 
+        let activePromptInputMode () =
+            activePrompt
+            |> Option.bind (fun prompt -> prompt.InputMode)
+            |> Option.defaultValue MarkdownPromptInputMode.Text
+
+        let activePromptAllowsMultipleFiles () =
+            activePrompt
+            |> Option.bind (fun prompt -> prompt.AllowMultiple)
+            |> Option.defaultValue false
+
+        let normalizePromptFiles (files: MarkdownPromptFile list) =
+            if activePromptAllowsMultipleFiles () then
+                files
+            else
+                files |> List.truncate 1
+
+        let normalizePath (path: string) = path.Replace("\\", "/")
+
+        let toPromptFile (file: File) : MarkdownPromptFile =
+            {
+                Name = file.name
+                MimeType =
+                    if String.IsNullOrWhiteSpace file.``type`` then
+                        None
+                    else
+                        Some file.``type``
+                // Browser fallback cannot reliably resolve host filesystem paths.
+                HostPath = None
+                BrowserFile = Some file
+            }
+
+        let appendPromptFilesAndClearError (files: MarkdownPromptFile list) =
+            if isMountedRef.current then
+                setPromptFiles (fun currentFiles ->
+                    let combined = currentFiles @ files
+                    normalizePromptFiles combined
+                )
+                if promptError.IsSome then
+                    setPromptError None
+
+        let removePromptFileAtIndex (indexToRemove: int) =
+            setPromptFiles (fun currentFiles ->
+                currentFiles
+                |> List.indexed
+                |> List.choose (fun (index, file) ->
+                    if index = indexToRemove then
+                        None
+                    else
+                        Some file
+                )
+            )
+
+        let resolvePromptFilePath (file: MarkdownPromptFile) =
+            promise {
+                // Fallback path strategy when no host resolver is provided.
+                let fallbackPath =
+                    match file.HostPath with
+                    | Some hostPath when not (String.IsNullOrWhiteSpace hostPath) -> normalizePath hostPath
+                    | _ -> file.Name
+
+                match filePickerAdapter with
+                | Some adapter ->
+                    // Preferred substitution point for runtime-specific link/path mapping.
+                    let! resolvedPath = adapter.ResolveMarkdownPath file
+
+                    if String.IsNullOrWhiteSpace resolvedPath then
+                        return fallbackPath
+                    else
+                        return normalizePath resolvedPath
+                | None -> return fallbackPath
+            }
+
+        let triggerPromptFileSelection () =
+            promise {
+                match filePickerAdapter with
+                | Some adapter ->
+                    // Preferred substitution point for runtime-specific file pickers.
+                    let! files = adapter.PickFiles()
+                    appendPromptFilesAndClearError files
+                | None ->
+                    // Built-in fallback: standard browser file input dialog.
+                    promptFileInputRef.current
+                    |> Option.iter (fun input -> input.click ())
+            }
+            |> Promise.catch (fun err ->
+                if isMountedRef.current then
+                    setPromptError (Some $"File selection failed: {string err}")
+            )
+            |> Promise.start
+
+        let handlePromptFileChange =
+            fun (files: File list) ->
+                let selected = files |> List.map toPromptFile
+                appendPromptFilesAndClearError selected
+
+                // Reset the input value so selecting the same file triggers onChange.
+                promptFileInputRef.current
+                |> Option.iter (fun input -> input.value <- "")
+
+        let handlePromptDrop =
+            fun (e: DragEvent) ->
+                e.preventDefault ()
+                e.stopPropagation ()
+                setPromptFileDropActive false
+
+                // Built-in fallback: use dropped browser File objects directly.
+                let files =
+                    if isNull e.dataTransfer || isNull e.dataTransfer.files then
+                        []
+                    else
+                        [
+                            for i in 0 .. int e.dataTransfer.files.length - 1 do
+                                let file = e.dataTransfer.files.item i
+
+                                if not (isNull file) then
+                                    yield toPromptFile file
+                        ]
+
+                if List.isEmpty files then
+                    setPromptError (Some "No files were dropped.")
+                else
+                    appendPromptFilesAndClearError files
+
         let openPromptDialog (prompt: MarkdownPromptPlugin) =
             let startIndex, endIndex = getSelectionOrEnd ()
             promptSelectionRef.current <- Some(startIndex, endIndex)
             setPromptInput ""
             setPromptError None
+            setPromptFiles (fun _ -> [])
+            setPromptFileDropActive false
             setActivePrompt (Some prompt)
 
         let submitPromptDialog () =
             match activePrompt with
             | None -> ()
             | Some prompt ->
-                match prompt.Validate promptInput with
-                | Error message -> setPromptError (Some message)
-                | Ok() ->
-                    let startIndex, endIndex =
-                        match promptSelectionRef.current with
-                        | Some(startIndex, endIndex) -> startIndex, endIndex
-                        | None -> getSelectionOrEnd ()
+                let applyPromptResult (nextValue: string) ((nextSelectionStart, nextSelectionEnd): int * int) =
+                    if isMountedRef.current then
+                        setTempValue nextValue
+                        startedChange.current <- true
+                        promptSelectionRef.current <- Some(nextSelectionStart, nextSelectionEnd)
+                        setActivePrompt None
+                        setPromptInput ""
+                        setPromptError None
+                        setPromptFiles (fun _ -> [])
+                        setPromptFileDropActive false
 
-                    let nextValue, (nextSelectionStart, nextSelectionEnd) =
-                        prompt.Apply tempValue startIndex endIndex promptInput
+                match activePromptInputMode () with
+                | MarkdownPromptInputMode.Text ->
+                    match prompt.Validate promptInput with
+                    | Error message -> setPromptError (Some message)
+                    | Ok() ->
+                        let startIndex, endIndex =
+                            match promptSelectionRef.current with
+                            | Some(startIndex, endIndex) -> startIndex, endIndex
+                            | None -> getSelectionOrEnd ()
 
-                    setTempValue nextValue
-                    startedChange.current <- true
-                    promptSelectionRef.current <- Some(nextSelectionStart, nextSelectionEnd)
-                    setActivePrompt None
-                    setPromptInput ""
-                    setPromptError None
+                        let nextValue, selection =
+                            prompt.Apply tempValue startIndex endIndex promptInput
+
+                        applyPromptResult nextValue selection
+
+                | MarkdownPromptInputMode.File ->
+                    let selectedFiles = promptFiles |> normalizePromptFiles
+
+                    if List.isEmpty selectedFiles then
+                        setPromptError (Some "Select at least one file.")
+                    else
+                        match prompt.ApplyFiles with
+                        | None ->
+                            setPromptError (Some "This plugin does not support file input.")
+                        | Some applyFiles ->
+                            promise {
+                                let mutable resolvedFiles: (MarkdownPromptFile * string) list = []
+
+                                for file in selectedFiles do
+                                    let! resolvedPath = resolvePromptFilePath file
+                                    resolvedFiles <- (file, resolvedPath) :: resolvedFiles
+
+                                return List.rev resolvedFiles
+                            }
+                            |> Promise.map (fun resolvedFiles ->
+                                if isMountedRef.current then
+                                    let startIndex, endIndex =
+                                        match promptSelectionRef.current with
+                                        | Some(startIndex, endIndex) -> startIndex, endIndex
+                                        | None -> getSelectionOrEnd ()
+
+                                    let nextValue, selection =
+                                        applyFiles tempValue startIndex endIndex resolvedFiles
+
+                                    applyPromptResult nextValue selection
+                            )
+                            |> Promise.catch (fun err ->
+                                if isMountedRef.current then
+                                    setPromptError (Some $"Could not resolve file paths: {string err}")
+                            )
+                            |> Promise.start
 
         let closePromptDialog (_: bool) =
             setActivePrompt None
             setPromptError None
             setPromptInput ""
+            setPromptFiles (fun _ -> [])
+            setPromptFileDropActive false
 
         let activePlugins = PluginRegistry.activePlugins plugins
         let pluginCommands = activePlugins |> List.map (fun plugin -> plugin.Command) |> List.toArray
@@ -291,6 +474,15 @@ type TextInputWithMarkdown =
             activePrompt
             |> Option.map (fun prompt -> prompt.SubmitButtonText)
             |> Option.defaultValue "Apply"
+
+        let promptInputMode = activePromptInputMode ()
+        let isFilePrompt = promptInputMode = MarkdownPromptInputMode.File
+
+        let promptAcceptedTypes =
+            activePrompt
+            |> Option.bind (fun prompt -> prompt.Accept)
+
+        let promptAllowMultipleFiles = activePromptAllowsMultipleFiles ()
 
         Html.div [
             prop.className (
@@ -431,26 +623,104 @@ type TextInputWithMarkdown =
                         Html.div [
                             prop.className "swt:flex swt:flex-col swt:gap-2"
                             prop.children [
-                                Html.input [
-                                    prop.ref promptInputRef
-                                    prop.className [
-                                        "swt:input swt:input-bordered swt:w-full"
-                                        if promptError.IsSome then
-                                            "swt:input-error"
+                                if isFilePrompt then
+                                    Html.input [
+                                        prop.testId "markdown-plugin-file-input"
+                                        prop.ref promptFileInputRef
+                                        prop.type'.file
+                                        prop.className "swt:hidden"
+                                        prop.multiple promptAllowMultipleFiles
+                                        if promptAcceptedTypes.IsSome then
+                                            prop.accept promptAcceptedTypes.Value
+                                        prop.onChange handlePromptFileChange
                                     ]
-                                    prop.placeholder promptPlaceholder
-                                    prop.value promptInput
-                                    prop.onChange (fun text ->
-                                        setPromptInput text
-                                        if promptError.IsSome then
-                                            setPromptError None
-                                    )
-                                    prop.onKeyDown (fun (e: KeyboardEvent) ->
-                                        if e.key = "Enter" then
+
+                                    Html.button [
+                                        prop.type'.button
+                                        prop.className "swt:btn swt:btn-outline swt:w-full"
+                                        prop.text "Choose file"
+                                        prop.onClick (fun _ -> triggerPromptFileSelection ())
+                                    ]
+
+                                    Html.div [
+                                        prop.testId "markdown-plugin-file-dropzone"
+                                        prop.className [
+                                            "swt:border-2 swt:border-dashed swt:rounded-box swt:p-3 swt:text-sm swt:text-center"
+                                            if promptFileDropActive then
+                                                "swt:border-primary swt:bg-primary/10"
+                                            else
+                                                "swt:border-base-300"
+                                        ]
+                                        prop.onDragEnter (fun (e: DragEvent) ->
                                             e.preventDefault ()
-                                            submitPromptDialog ()
-                                    )
-                                ]
+                                            e.stopPropagation ()
+                                            setPromptFileDropActive true
+                                        )
+                                        prop.onDragLeave (fun (e: DragEvent) ->
+                                            e.preventDefault ()
+                                            e.stopPropagation ()
+                                            setPromptFileDropActive false
+                                        )
+                                        prop.onDragOver (fun (e: DragEvent) ->
+                                            e.preventDefault ()
+                                            e.stopPropagation ()
+                                        )
+                                        prop.onDrop handlePromptDrop
+                                        prop.text "Drop files here"
+                                    ]
+
+                                    if List.isEmpty promptFiles then
+                                        Html.div [
+                                            prop.className "swt:text-xs swt:opacity-70"
+                                            prop.text "No files selected."
+                                        ]
+                                    else
+                                        Html.ul [
+                                            prop.className "swt:flex swt:flex-col swt:gap-1"
+                                            prop.children [
+                                                for index, file in promptFiles |> List.indexed do
+                                                    Html.li [
+                                                        prop.key $"prompt-file-{index}-{file.Name}"
+                                                        prop.className "swt:flex swt:items-center swt:gap-2"
+                                                        prop.children [
+                                                            Html.span [
+                                                                prop.className
+                                                                    "swt:grow swt:text-sm swt:truncate swt:text-left"
+                                                                prop.title file.Name
+                                                                prop.text file.Name
+                                                            ]
+                                                            Html.button [
+                                                                prop.type'.button
+                                                                prop.className "swt:btn swt:btn-xs swt:btn-ghost"
+                                                                prop.ariaLabel $"Remove {file.Name}"
+                                                                prop.text "x"
+                                                                prop.onClick (fun _ -> removePromptFileAtIndex index)
+                                                            ]
+                                                        ]
+                                                    ]
+                                            ]
+                                        ]
+                                else
+                                    Html.input [
+                                        prop.ref promptInputRef
+                                        prop.className [
+                                            "swt:input swt:input-bordered swt:w-full"
+                                            if promptError.IsSome then
+                                                "swt:input-error"
+                                        ]
+                                        prop.placeholder promptPlaceholder
+                                        prop.value promptInput
+                                        prop.onChange (fun text ->
+                                            setPromptInput text
+                                            if promptError.IsSome then
+                                                setPromptError None
+                                        )
+                                        prop.onKeyDown (fun (e: KeyboardEvent) ->
+                                            if e.key = "Enter" then
+                                                e.preventDefault ()
+                                                submitPromptDialog ()
+                                        )
+                                    ]
                                 if promptError.IsSome then
                                     Html.p [
                                         prop.className "swt:text-error swt:text-sm"

--- a/src/Components/src/MarkdownText/TextInputWithMarkdown.stories.tsx
+++ b/src/Components/src/MarkdownText/TextInputWithMarkdown.stories.tsx
@@ -88,3 +88,39 @@ export const AddOntologyPluginFlow: Story = {
     });
   },
 };
+
+export const AddImagePluginFlow: Story = {
+  parameters: { isolated: true },
+  render: () => <TextInputWithMarkdownEntry />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const editor = canvas.getByPlaceholderText('Write markdown...') as HTMLTextAreaElement;
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add Image' }));
+
+    const fileInput = await screen.findByTestId('markdown-plugin-file-input');
+    expect(fileInput).toBeTruthy();
+
+    const firstImage = new File(['fake-image-a'], 'diagram-a.png', { type: 'image/png' });
+    const secondImage = new File(['fake-image-b'], 'diagram-b.png', { type: 'image/png' });
+
+    await userEvent.upload(fileInput as HTMLInputElement, firstImage);
+    await userEvent.upload(fileInput as HTMLInputElement, secondImage);
+
+    expect(screen.getByText('diagram-a.png')).toBeInTheDocument();
+    expect(screen.getByText('diagram-b.png')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove diagram-a.png' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('diagram-a.png')).not.toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Insert' }));
+
+    await waitFor(() => {
+      expect(editor.value).toContain('![diagram-b.png](diagram-b.png)');
+      expect(editor.value).not.toContain('![diagram-a.png](diagram-a.png)');
+    });
+  },
+};

--- a/src/Components/src/MarkdownText/TextInputWithMarkdown.stories.tsx
+++ b/src/Components/src/MarkdownText/TextInputWithMarkdown.stories.tsx
@@ -124,3 +124,23 @@ export const AddImagePluginFlow: Story = {
     });
   },
 };
+
+export const AddImageRejectsInvalidSelection: Story = {
+  parameters: { isolated: true },
+  render: () => <TextInputWithMarkdownEntry />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Add Image' }));
+
+    const fileInput = await screen.findByTestId('markdown-plugin-file-input');
+    const invalidFile = new File(['fake-text'], 'notes.txt', { type: 'text/plain' });
+
+    await userEvent.upload(fileInput as HTMLInputElement, invalidFile, { applyAccept: false });
+
+    await waitFor(() => {
+      expect(screen.getByText(/File not allowed: notes\.txt\./)).toBeInTheDocument();
+      expect(screen.getByText(/Allowed: image\/\*/)).toBeInTheDocument();
+      expect(screen.getByText('No files selected.')).toBeInTheDocument();
+    });
+  },
+};

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -95,6 +95,7 @@
     <Compile Include="MarkdownText\JsBindings\Mermaid.fs" />
     <Compile Include="MarkdownText\Plugins\PluginTypes.fs" />
     <Compile Include="MarkdownText\Plugins\AddStep.fs" />
+    <Compile Include="MarkdownText\Plugins\AddImage.fs" />
     <Compile Include="MarkdownText\Plugins\AddOntologyReference.fs" />
     <Compile Include="MarkdownText\Plugins\PluginRegistry.fs" />
     <Compile Include="MarkdownText\Preview.fs" />


### PR DESCRIPTION
Adds image file insertion support to the Markdown editor and extends plugin prompts to handle file-based input.

## What changed
- Added an **Add Image** toolbar plugin and included it in default plugins.
- Extended plugin prompt options to support file mode (accepted types, multi-select, file apply handler).
- Updated the Markdown prompt modal for file workflows:
  - **Choose file** action
  - **Drop zone**
  - **Selected files list** with per-file **remove (x)** action
- Selection behavior keeps files across repeated select/drop actions and clears when the dialog is reopened.
- Existing text plugins were updated to explicitly keep file-mode options disabled (`None`), so their behavior stays unchanged.
- Added Storybook coverage for the Add Image flow (multi-select, remove, insert).

## Adapter behavior (host-provided)
When a host provides `filePickerAdapter`:
- **Choose file** uses the host picker (`PickFiles`).
- Markdown path resolution uses host logic (`ResolveMarkdownPath`) before insertion.
- Built-in **drag & drop** remains available; resolved paths still go through adapter logic at insert time.

When no adapter is provided:
- Browser file input/drop is used.
- Markdown links fall back to filename-based paths.