### PR TITLE
make filetree async and filter .git from filetree

### DIFF
--- a/src/Electron/src/Main/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault.fs
@@ -49,15 +49,16 @@ module ArcVaultHelper =
         let ignoreFn =
             fun (path: string) ->
                 let normalizedPath = path.Replace("\\", "/")
+                let segments =
+                    normalizedPath.Trim('/').Split('/', System.StringSplitOptions.RemoveEmptyEntries)
 
                 let tempXlsxPattern = """\.~\$.*\.xlsx$"""
-                let dotFolders = """(^|\/)\.[^/]+\/.+"""
 
                 // skip temporary Excel files (created when editing an xlsx file)
                 if System.Text.RegularExpressions.Regex.IsMatch(normalizedPath, tempXlsxPattern) then
                     true
-                // skip dot-folders (e.g., .git/, .vscode/, .idea/, etc.). This will also match if a subfolder is a dot-folder
-                elif System.Text.RegularExpressions.Regex.IsMatch(normalizedPath, dotFolders) then
+                // skip git folder itself (and its contents) to avoid expensive scans
+                elif segments |> Array.exists (fun segment -> segment = ".git") then
                     true
                 else
                     false
@@ -166,7 +167,8 @@ module ArcVaultExtensions =
                                             this.SetFileTree(newFileTree)
                                     | _ ->
                                         if this.path.IsSome then
-                                            let fileTree = getFileEntries this.path.Value |> createFileEntryTree
+                                            let! fileEntries = getFileEntries this.path.Value
+                                            let fileTree = createFileEntryTree fileEntries
                                             this.SetFileTree(fileTree)
                                 }
                                 |> Promise.start

--- a/src/Electron/src/Main/FileTreeCreator.fs
+++ b/src/Electron/src/Main/FileTreeCreator.fs
@@ -2,23 +2,127 @@
 module Main.FileTreeCreator
 
 open Swate.Electron.Shared
+open System.Collections.Generic
 open Fable.Core.JsInterop
 open Swate.Electron.Shared.IPCTypes
 
 let fs: obj = importAll "fs"
 let pathMod: obj = importAll "path"
-let gitLfs: IPC.GitLfs.IGitLfs = IPC.GitLfs.gitLfs
+let childProcessDynamic: obj = importAll "node:child_process"
 
-let private isLfsTracked (repoRoot: string) (absolutePath: string) =
+let private normalizePath (path: string) = path.Replace("\\", "/")
+
+let private normalizeRootPath (path: string) =
+    pathMod?resolve(path) |> unbox<string> |> normalizePath
+
+let private shouldIgnoreDirName (name: string) =
+    name = ".git"
+
+let private shouldIgnorePath (path: string) =
+    let normalizedPath = normalizePath path
+    let tempXlsxPattern = """\.~\$.*\.xlsx$"""
+    System.Text.RegularExpressions.Regex.IsMatch(normalizedPath, tempXlsxPattern)
+
+let private tryGetRepoRelativePath (repoRoot: string) (absolutePath: string) =
     let relativePath =
         pathMod?relative (repoRoot, absolutePath)
         |> unbox<string>
-        |> fun p -> p.Replace("\\", "/")
+        |> normalizePath
 
     if System.String.IsNullOrWhiteSpace relativePath || relativePath = "." then
-        false
+        None
     else
-        gitLfs.IsTrackedByAttributes repoRoot relativePath
+        Some relativePath
+
+let private tryGetLfsTrackedByAttributes
+    (repoRoot: string)
+    (repoRelativePaths: string[])
+    : Fable.Core.JS.Promise<Dictionary<string, bool>> =
+    promise {
+        let results = Dictionary<string, bool>()
+
+        if repoRelativePaths.Length = 0 then
+            return results
+        else
+            let gitDir = pathMod?join(repoRoot, ".git") |> unbox<string>
+            let isGitRepo =
+                try
+                    fs?existsSync(gitDir) |> unbox<bool>
+                with _ ->
+                    false
+
+            if not isGitRepo then
+                return results
+            else
+                return!
+                    Fable.Core.JS.Constructors.Promise.Create(fun resolve _reject ->
+                        try
+                            let proc: obj =
+                                childProcessDynamic?spawn (
+                                    "git",
+                                    [| "check-attr"; "-z"; "filter"; "--stdin" |],
+                                    createObj [
+                                        "cwd" ==> repoRoot
+                                        "shell" ==> false
+                                        "windowsHide" ==> true
+                                    ]
+                                )
+
+                            let stdoutChunks = ResizeArray<string>()
+
+                            proc?stdout?on (
+                                "data",
+                                fun d ->
+                                    let msg = d?toString("utf8") |> unbox<string>
+                                    stdoutChunks.Add(msg)
+                            )
+                            |> ignore
+
+                            proc?on (
+                                "close",
+                                fun code ->
+                                    let success =
+                                        if isNull code then
+                                            false
+                                        else
+                                            (unbox<float> code) = 0.
+
+                                    if success then
+                                        let stdout = System.String.Concat(stdoutChunks.ToArray())
+                                        let segments = stdout.Split('\u0000')
+
+                                        let lastIndex =
+                                            if segments.Length > 0 && segments.[segments.Length - 1] = "" then
+                                                segments.Length - 1
+                                            else
+                                                segments.Length
+
+                                        let mutable i = 0
+
+                                        while i + 2 < lastIndex do
+                                            let path = segments.[i]
+                                            let attr = segments.[i + 1]
+                                            let value = segments.[i + 2]
+
+                                            if attr = "filter" then
+                                                results.[path] <- value = "lfs"
+
+                                            i <- i + 3
+
+                                    resolve results
+                            )
+                            |> ignore
+
+                            proc?on ("error", fun _ -> resolve results) |> ignore
+
+                            repoRelativePaths
+                            |> Array.iter (fun relativePath -> proc?stdin?write(relativePath + "\u0000") |> ignore)
+
+                            proc?stdin?``end`` () |> ignore
+                        with _ ->
+                            resolve results
+                    )
+    }
 
 let getFileEntry (path: string) = promise {
     let! stats = fs?promises?stat (path)
@@ -26,35 +130,75 @@ let getFileEntry (path: string) = promise {
 }
 
 /// Finds all files and subfolders of the given filepath
-let getFileEntries (path: string) =
-    let repoRoot = path.Replace("\\", "/")
+let getFileEntries (path: string) : Fable.Core.JS.Promise<FileEntry[]> =
+    promise {
+        let repoRoot = normalizeRootPath path
 
-    let rec loop (currentPath: string) =
-        let stat = fs?statSync (currentPath)
-        let isDir = stat?isDirectory ()
-        let name = pathMod?basename (currentPath)
-        let normalizedPath = currentPath.Replace("\\", "/")
+        let! rootStats = fs?promises?stat (repoRoot)
+        let rootIsDir = rootStats?isDirectory () |> unbox<bool>
 
-        let isLfs =
-            if isDir then
-                None
-            else
-                Some(isLfsTracked repoRoot normalizedPath)
+        let rootName = pathMod?basename (repoRoot) |> unbox<string>
+        let rootEntry = IPCTypes.FileEntry.create (rootName, repoRoot, rootIsDir, None)
 
-        let currentEntry = IPCTypes.FileEntry.create (name, normalizedPath, isDir, isLfs)
+        if not rootIsDir then
+            return [| rootEntry |]
+        else
+            let stack = ResizeArray<string>()
+            stack.Add(repoRoot)
 
-        if isDir then
-            let entries: string[] = fs?readdirSync (normalizedPath)
+            let entries = ResizeArray<FileEntry>()
+            entries.Add(rootEntry)
 
-            let children =
-                entries
-                |> Array.collect (fun entry ->
-                    let fullPath = pathMod?join (normalizedPath, entry)
-                    loop fullPath
+            while stack.Count > 0 do
+                let currentDir = stack.[stack.Count - 1]
+                stack.RemoveAt(stack.Count - 1)
+
+                let! dirents =
+                    fs?promises?readdir (currentDir, createObj [ "withFileTypes" ==> true ])
+                    |> unbox<Fable.Core.JS.Promise<obj[]>>
+
+                dirents
+                |> Array.iter (fun dirent ->
+                    let name = dirent?name |> unbox<string>
+                    let isDir = dirent?isDirectory () |> unbox<bool>
+
+                    if isDir then
+                        if not (shouldIgnoreDirName name) then
+                            let fullPath = pathMod?join (currentDir, name) |> unbox<string> |> normalizePath
+                            entries.Add(IPCTypes.FileEntry.create (name, fullPath, true, None))
+                            stack.Add(fullPath)
+                    else
+                        let fullPath = pathMod?join (currentDir, name) |> unbox<string> |> normalizePath
+
+                        if not (shouldIgnorePath fullPath) then
+                            entries.Add(IPCTypes.FileEntry.create (name, fullPath, false, Some false))
                 )
 
-            Array.append [| currentEntry |] children
-        else
-            [| currentEntry |]
+            let repoRelativeFilePaths =
+                entries.ToArray()
+                |> Array.choose (fun entry ->
+                    if entry.isDirectory then
+                        None
+                    else
+                        tryGetRepoRelativePath repoRoot entry.path
+                )
 
-    loop repoRoot
+            let! lfsTracked = tryGetLfsTrackedByAttributes repoRoot repoRelativeFilePaths
+
+            return
+                entries.ToArray()
+                |> Array.map (fun entry ->
+                    if entry.isDirectory then
+                        entry
+                    else
+                        match tryGetRepoRelativePath repoRoot entry.path with
+                        | None -> entry
+                        | Some relativePath ->
+                            let tracked =
+                                match lfsTracked.TryGetValue(relativePath) with
+                                | true, value -> value
+                                | _ -> false
+
+                            { entry with isLfs = Some tracked }
+                )
+    }

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -140,7 +140,8 @@ let private persistArcChangesAndRefreshVault
             afterArcPersist ()
             do! vault.LoadArc()
 
-            let fileTree = getFileEntries arcPath |> IPCTypes.FileEntryExtensions.createFileEntryTree
+            let! fileEntries = getFileEntries arcPath
+            let fileTree = createFileEntryTree fileEntries
             vault.SetFileTree(fileTree)
         finally
             vault.isBusyWriting <- false
@@ -170,7 +171,8 @@ let api: IPCTypes.IArcVaultsApi = {
                 let recentARCs = ARCHolder.updateRecentARCs arcPath maxNumberRecentARCs
                 ARC_VAULTS.BroadcastRecentARCs(recentARCs)
 
-                let fileTree = getFileEntries arcPath |> IPCTypes.FileEntryExtensions.createFileEntryTree
+                let! fileEntries = getFileEntries arcPath
+                let fileTree = createFileEntryTree fileEntries
 
                 ARC_VAULTS.SetFileTree(windowId, fileTree)
 
@@ -198,7 +200,8 @@ let api: IPCTypes.IArcVaultsApi = {
                 let recentARCs = ARCHolder.updateRecentARCs arcPath maxNumberRecentARCs
                 ARC_VAULTS.BroadcastRecentARCs(recentARCs)
 
-                let fileTree = getFileEntries arcPath |> IPCTypes.FileEntryExtensions.createFileEntryTree
+                let! fileEntries = getFileEntries arcPath
+                let fileTree = createFileEntryTree fileEntries
 
                 ARC_VAULTS.SetFileTree(windowId, fileTree)
                 return Ok arcPath
@@ -252,7 +255,8 @@ let api: IPCTypes.IArcVaultsApi = {
                     let! windowId = ARC_VAULTS.RegisterVaultWithArc(arcPath)
                     ARC_VAULTS.BroadcastRecentARCs(recentARCs)
 
-                    let fileTree = getFileEntries arcPath |> IPCTypes.FileEntryExtensions.createFileEntryTree
+                    let! fileEntries = getFileEntries arcPath
+                    let fileTree = createFileEntryTree fileEntries
                     ARC_VAULTS.SetFileTree(windowId, fileTree)
 
                     return Ok()
@@ -360,7 +364,8 @@ let api: IPCTypes.IArcVaultsApi = {
                                 do! mkdirRecursiveAsync directoryPath
                                 do! writeUtf8FileAsync absolutePath request.Content
 
-                                let fileTree = getFileEntries arcPath |> IPCTypes.FileEntryExtensions.createFileEntryTree
+                                let! fileEntries = getFileEntries arcPath
+                                let fileTree = createFileEntryTree fileEntries
                                 vault.SetFileTree(fileTree)
                                 return Ok()
                             finally
@@ -535,7 +540,8 @@ let api: IPCTypes.IArcVaultsApi = {
                         match enforcedRequest.Command with
                         | Track
                         | Untrack ->
-                            let fileTree = getFileEntries arcPath |> createFileEntryTree
+                            let! fileEntries = getFileEntries arcPath
+                            let fileTree = createFileEntryTree fileEntries
                             vault.SetFileTree(fileTree)
                         | _ -> ()
 


### PR DESCRIPTION
Make ARC file tree generation faster by switching to async traversal, batching Git LFS checks, and excluding `.git` from scans.

## Changes
- Refactor `getFileEntries` to use `fs.promises` + iterative traversal (no sync IO / deep recursion).
- Batch LFS detection via `git check-attr -z filter --stdin` instead of per-file checks.
- Filter `.git` from both the file tree and file watcher ignore rules; skip temp Excel lock files (`.~$*.xlsx`).
- Update vault/IPC call sites to `await` file entry collection before building the tree.
