### PR TITLE
Add Git diff services and comparison/merge resolution components

### DIFF
--- a/src/Components/src/GitComparison/GitComparisonView.fs
+++ b/src/Components/src/GitComparison/GitComparisonView.fs
@@ -1,0 +1,69 @@
+namespace Swate.Components
+
+open Feliz
+
+module internal GitComparisonView =
+
+    let private PanelShellClassName =
+        "swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100 swt:overflow-hidden swt:shadow-sm"
+
+    let TitleStack (title: ReactElement) (description: ReactElement option) (className: string option) =
+        Html.div [
+            prop.className [
+                "swt:flex swt:flex-col swt:gap-1"
+                if className.IsSome then
+                    className.Value
+            ]
+            prop.children [
+                title
+                if description.IsSome then
+                    description.Value
+            ]
+        ]
+
+    let HeaderRow (leading: ReactElement) (trailing: ReactElement) (className: string option) =
+        Html.div [
+            prop.className [
+                "swt:flex swt:flex-wrap swt:items-center swt:justify-between swt:gap-3 swt:px-4 swt:py-3"
+                if className.IsSome then
+                    className.Value
+            ]
+            prop.children [
+                leading
+                trailing
+            ]
+        ]
+
+    let PanelShell
+        (children: ReactElement)
+        (testId: string option)
+        (className: string option)
+        (styleAttributes: IStyleAttribute list option)
+        =
+        Html.div [
+            if testId.IsSome then
+                prop.testId testId.Value
+            prop.className [
+                PanelShellClassName
+                if className.IsSome then
+                    className.Value
+            ]
+            if styleAttributes.IsSome then
+                prop.style styleAttributes.Value
+            prop.children children
+        ]
+
+    let SectionCard (header: ReactElement) (body: ReactElement) (key: string option) (className: string option) =
+        Html.section [
+            if key.IsSome then
+                prop.key key.Value
+            prop.className [
+                "swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100"
+                if className.IsSome then
+                    className.Value
+            ]
+            prop.children [
+                header
+                body
+            ]
+        ]

--- a/src/Components/src/GitComparison/GitDiffViewer.fs
+++ b/src/Components/src/GitComparison/GitDiffViewer.fs
@@ -1,0 +1,88 @@
+namespace Swate.Components
+
+open System
+open Fable.Core
+open Feliz
+
+[<Erase; Mangle(false)>]
+type GitDiffViewer =
+
+    [<ReactComponent>]
+    static member Viewer
+        (
+            wordDiffText: string,
+            previousContent: string,
+            currentContent: string,
+            ?previousTitle: string,
+            ?currentTitle: string,
+            ?testIdPrefix: string
+        ) =
+        let previousHeaderLabel, currentHeaderLabel, rows, previousLineCount, currentLineCount =
+            React.useMemo (
+                (fun () ->
+                    let metadata = GitTextComparisonCore.Metadata.extractDiffMetadata wordDiffText
+
+                    let previousHeaderLabel =
+                        GitTextComparisonCore.Metadata.resolveHeaderLabel "Previous version" previousTitle metadata.PreviousPath
+
+                    let currentHeaderLabel =
+                        GitTextComparisonCore.Metadata.resolveHeaderLabel "Current version" currentTitle metadata.CurrentPath
+
+                    let rows =
+                        GitTextComparisonCore.WordDiff.buildRowsFromWordDiff wordDiffText previousContent currentContent
+
+                    let previousLineCount = (GitTextComparisonCore.Text.splitContentToLines previousContent).Length
+                    let currentLineCount = (GitTextComparisonCore.Text.splitContentToLines currentContent).Length
+
+                    previousHeaderLabel, currentHeaderLabel, rows, previousLineCount, currentLineCount
+                ),
+                [| box wordDiffText; box previousContent; box currentContent; box previousTitle; box currentTitle |]
+            )
+
+        let rootTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-root")
+
+        let previousHeaderTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-previous-header")
+
+        let currentHeaderTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-current-header")
+
+        let comparisonScrollTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-comparison-scroll")
+
+        let changeBadgeText =
+            if String.IsNullOrWhiteSpace wordDiffText then
+                "No changes"
+            else
+                "Changed"
+
+        GitComparisonView.PanelShell
+            (React.Fragment [
+                GitComparisonView.HeaderRow
+                    (GitComparisonView.TitleStack
+                        (Html.h3 [
+                            prop.className "swt:text-sm swt:font-semibold"
+                            prop.text "Git Diff"
+                        ])
+                        None
+                        None)
+                    (Html.span [
+                        prop.className "swt:badge swt:badge-outline swt:badge-sm"
+                        prop.text changeBadgeText
+                    ])
+                    (Some "swt:border-b swt:border-base-content/10 swt:bg-base-100")
+                GitTextComparisonRendering.Rendering.ComparisonGrid(
+                    rows,
+                    ("Previous", (previousHeaderLabel, previousLineCount)),
+                    ("Current", (currentHeaderLabel, currentLineCount)),
+                    previousHeaderTestId,
+                    currentHeaderTestId,
+                    comparisonScrollTestId,
+                    None,
+                    None
+                )
+            ])
+            rootTestId
+            None
+            None

--- a/src/Components/src/GitComparison/GitDiffViewer.stories.tsx
+++ b/src/Components/src/GitComparison/GitDiffViewer.stories.tsx
@@ -1,0 +1,212 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect, waitFor } from "storybook/test";
+import { Viewer as GitDiffViewerComponent } from "./GitDiffViewer.fs.js";
+
+const introLines = Array.from({ length: 14 }, (_, index) => `Context line ${index + 1}`);
+const checkpointLines = Array.from({ length: 16 }, (_, index) => `Checkpoint item ${index + 1}`);
+const followUpLines = Array.from({ length: 14 }, (_, index) => `Follow-up note ${index + 1}`);
+
+const previousLines = [
+  "# Protocol Overview",
+  ...introLines,
+  "Step A",
+  "Remove me",
+  ...checkpointLines,
+  "Temperature 20 C",
+  "Observation pending",
+  ...followUpLines,
+  "Tail note",
+  "Footer",
+];
+
+const currentLines = [
+  "# Protocol Overview",
+  ...introLines,
+  "Step A updated",
+  ...checkpointLines,
+  "Temperature 24 C",
+  "Observation pending",
+  "Added after shared",
+  ...followUpLines,
+  "Tail note refined",
+  "Footer",
+];
+
+const previousContent = `${previousLines.join("\n")}\n`;
+const currentContent = `${currentLines.join("\n")}\n`;
+
+const stepOldStart = previousLines.indexOf("Step A") + 1;
+const stepNewStart = currentLines.indexOf("Step A updated") + 1;
+const temperatureOldStart = previousLines.indexOf("Temperature 20 C") + 1;
+const temperatureNewStart = currentLines.indexOf("Temperature 24 C") + 1;
+const insertAnchor = previousLines.indexOf("Observation pending") + 1;
+const insertNewStart = currentLines.indexOf("Added after shared") + 1;
+const tailOldStart = previousLines.indexOf("Tail note") + 1;
+const tailNewStart = currentLines.indexOf("Tail note refined") + 1;
+
+const wordDiffText = `diff --git a/notes/protocol.md b/notes/protocol.md
+index 1111111..3333333 100644
+--- a/notes/protocol.md
++++ b/notes/protocol.md
+@@ -${stepOldStart},2 +${stepNewStart} @@
+ Step A 
+-Remove me
++updated
+~
+@@ -${temperatureOldStart} +${temperatureNewStart} @@
+-Temperature 20
++Temperature 24
+ C
+~
+@@ -${insertAnchor},0 +${insertNewStart} @@ Observation pending
++Added after shared
+~
+@@ -${tailOldStart} +${tailNewStart} @@
+-Tail note
++Tail note refined
+~
+`;
+
+const meta = {
+  title: "Components/GitComparison/GitDiffViewer",
+  component: GitDiffViewerComponent,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "This component expects the machine-readable word diff string together with the full previous/current file contents, because the diff alone still omits unchanged regions outside the hunks.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="swt:p-6 swt:bg-base-200">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GitDiffViewerComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    wordDiffText,
+    previousContent,
+    currentContent,
+    testIdPrefix: "git-diff-story",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = canvas.getByTestId("git-diff-story-root");
+    const comparisonScroll = canvas.getByTestId("git-diff-story-comparison-scroll");
+
+    await expect(canvas.getByTestId("git-diff-story-previous-header")).toHaveTextContent("notes/protocol.md");
+    await expect(canvas.getByTestId("git-diff-story-current-header")).toHaveTextContent("notes/protocol.md");
+    await expect(root).toHaveTextContent("Protocol Overview");
+    await expect(root).toHaveTextContent("Context line 14");
+    await expect(root).toHaveTextContent("Checkpoint item 16");
+    await expect(root).toHaveTextContent("Temperature 24 C");
+    await expect(root).toHaveTextContent("Step A updated");
+    await expect(root).toHaveTextContent("Remove me");
+    await expect(root).toHaveTextContent("Added after shared");
+    await expect(root).toHaveTextContent("Tail note refined");
+
+    await waitFor(() => {
+      expect(comparisonScroll.scrollHeight).toBeGreaterThan(comparisonScroll.clientHeight);
+    });
+  },
+};
+
+const quotedPath = "notes/my protocol.md";
+const quotedPreviousContent = "Quoted previous line\n";
+const quotedCurrentContent = "Quoted current line\n";
+const quotedPathWordDiffText = `diff --git "a/${quotedPath}" "b/${quotedPath}"
+index 2222222..3333333 100644
+--- "a/${quotedPath}"
++++ "b/${quotedPath}"
+@@ -1 +1 @@
+-Quoted previous line
++Quoted current line
+~
+`;
+
+const createdFilePath = "notes/new file.md";
+const createdFileWordDiffText = `new file mode 100644
+--- /dev/null
++++ b/${createdFilePath}
+@@ -0,0 +1 @@
++Fresh content
+~
+`;
+
+const deletedFilePath = "notes/obsolete file.md";
+const deletedFileWordDiffText = `deleted file mode 100644
+--- a/${deletedFilePath}
++++ /dev/null
+@@ -1 +0,0 @@
+-Remove obsolete content
+~
+`;
+
+const renamedPreviousPath = "notes/old name.md";
+const renamedCurrentPath = "notes/new name.md";
+const renamedFileWordDiffText = `diff --git "a/${renamedPreviousPath}" "b/${renamedCurrentPath}"
+similarity index 100%
+rename from ${renamedPreviousPath}
+rename to ${renamedCurrentPath}
+`;
+
+function MetadataVariants() {
+  return (
+    <div className="swt:flex swt:flex-col swt:gap-6">
+      <GitDiffViewerComponent
+        wordDiffText={quotedPathWordDiffText}
+        previousContent={quotedPreviousContent}
+        currentContent={quotedCurrentContent}
+        testIdPrefix="git-diff-quoted"
+      />
+      <GitDiffViewerComponent
+        wordDiffText={createdFileWordDiffText}
+        previousContent=""
+        currentContent={"Fresh content\n"}
+        testIdPrefix="git-diff-created"
+      />
+      <GitDiffViewerComponent
+        wordDiffText={deletedFileWordDiffText}
+        previousContent={"Remove obsolete content\n"}
+        currentContent=""
+        testIdPrefix="git-diff-deleted"
+      />
+      <GitDiffViewerComponent
+        wordDiffText={renamedFileWordDiffText}
+        previousContent={"Rename only content\n"}
+        currentContent={"Rename only content\n"}
+        testIdPrefix="git-diff-renamed"
+      />
+    </div>
+  );
+}
+
+export const MetadataEdgeCases: Story = {
+  render: () => <MetadataVariants />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId("git-diff-quoted-previous-header")).toHaveTextContent(quotedPath);
+    await expect(canvas.getByTestId("git-diff-quoted-current-header")).toHaveTextContent(quotedPath);
+
+    await expect(canvas.getByTestId("git-diff-created-previous-header")).toHaveTextContent("Previous version");
+    await expect(canvas.getByTestId("git-diff-created-current-header")).toHaveTextContent(createdFilePath);
+
+    await expect(canvas.getByTestId("git-diff-deleted-previous-header")).toHaveTextContent(deletedFilePath);
+    await expect(canvas.getByTestId("git-diff-deleted-current-header")).toHaveTextContent("Current version");
+
+    await expect(canvas.getByTestId("git-diff-renamed-previous-header")).toHaveTextContent(renamedPreviousPath);
+    await expect(canvas.getByTestId("git-diff-renamed-current-header")).toHaveTextContent(renamedCurrentPath);
+  },
+};

--- a/src/Components/src/GitComparison/GitMergeConflictViewer.fs
+++ b/src/Components/src/GitComparison/GitMergeConflictViewer.fs
@@ -1,0 +1,675 @@
+namespace Swate.Components
+
+open System.Globalization
+open Browser.Dom
+open Fable.Core
+open Feliz
+
+module private GitMergeConflictViewerInternal =
+
+    type ConflictResolutionChoice =
+        | Incoming
+        | Current
+
+    type ConflictResolutionState = {
+        Choice: ConflictResolutionChoice
+        AppliedText: string
+        StartIndex: int
+    }
+
+    type ConflictPaneState =
+        | Unresolved of GitTextComparisonCore.MergeConflictBlock
+        | Resolved of GitTextComparisonCore.MergeConflictBlock * ConflictResolutionState
+
+    type ConflictPaneEntry = {
+        EntryId: int
+        State: ConflictPaneState
+    }
+
+    let parseConflictBlocks (content: string) =
+        GitTextComparisonCore.MergeConflicts.parseMergeConflictFragments content
+        |> List.choose (function
+            | GitTextComparisonCore.ConflictBlock block -> Some block
+            | GitTextComparisonCore.PlainText _ -> None
+        )
+
+    let parsePaneEntries (content: string) =
+        parseConflictBlocks content
+        |> List.mapi (fun index block ->
+            {
+                EntryId = index + 1
+                State = Unresolved block
+            }
+        )
+
+    let countUnresolvedEntries (entries: ConflictPaneEntry list) =
+        entries
+        |> List.sumBy (fun entry ->
+            match entry.State with
+            | Unresolved _ -> 1
+            | Resolved _ -> 0
+        )
+
+    let shiftResolvedEntryOffsetsAfter cutoffIndex delta (entries: ConflictPaneEntry list) =
+        if delta = 0 then
+            entries
+        else
+            entries
+            |> List.map (fun entry ->
+                match entry.State with
+                | Resolved(block, resolution) when resolution.StartIndex > cutoffIndex ->
+                    {
+                        entry with
+                            State =
+                                Resolved(
+                                    block,
+                                    {
+                                        resolution with
+                                            StartIndex = resolution.StartIndex + delta
+                                    }
+                                )
+                    }
+                | _ ->
+                    entry
+            )
+
+    let refreshPaneEntries (content: string) (entries: ConflictPaneEntry list) =
+        let unresolvedBlocks = parseConflictBlocks content
+        let expectedUnresolvedCount = countUnresolvedEntries entries
+
+        if unresolvedBlocks.Length <> expectedUnresolvedCount then
+            parsePaneEntries content
+        else
+            let mutable unresolvedIndex = 0
+
+            entries
+            |> List.map (fun entry ->
+                match entry.State with
+                | Resolved _ ->
+                    entry
+                | Unresolved _ ->
+                    let nextBlock = unresolvedBlocks.[unresolvedIndex]
+                    unresolvedIndex <- unresolvedIndex + 1
+
+                    {
+                        entry with
+                            State = Unresolved nextBlock
+                    }
+            )
+
+    [<ReactComponent>]
+    let VerticalSplitHandle
+        (
+            onPointerDown: Browser.Types.PointerEvent -> unit,
+            testId: string option
+        ) =
+        Html.div [
+            if testId.IsSome then
+                prop.testId testId.Value
+            prop.className
+                "swt:group swt:flex swt:items-center swt:justify-center swt:cursor-row-resize swt:bg-base-200 hover:swt:bg-base-300"
+            prop.onPointerDown onPointerDown
+            prop.style [ style.custom ("touch-action", "none") ]
+            prop.children [
+                Html.div [
+                    prop.className "swt:h-1 swt:w-20 swt:rounded-full swt:bg-base-content/20 group-hover:swt:bg-base-content/35"
+                ]
+                ]
+            ]
+
+    [<ReactComponent>]
+    let VerticalSplitPane
+        (
+            topPane: ReactElement,
+            bottomPane: ReactElement,
+            splitHandleTestId: string option
+        ) =
+        let splitPaneRef = React.useElementRef ()
+        let splitPercent, setSplitPercent = React.useState 50
+        let splitPercentRef = React.useRef 50
+        let isDragging = React.useRef false
+
+        let commitSplitPercent nextSplitPercent =
+            if splitPercentRef.current <> nextSplitPercent then
+                splitPercentRef.current <- nextSplitPercent
+                setSplitPercent nextSplitPercent
+
+        let updateSplitPercentFromClientY (clientY: float) =
+            match splitPaneRef.current with
+            | Some container ->
+                let rect = container.getBoundingClientRect()
+                let relativeY = clientY - rect.top
+
+                let rawPercent =
+                    if rect.height <= 0. then
+                        float splitPercentRef.current
+                    else
+                        (relativeY / rect.height) * 100.
+
+                let clampedPercent =
+                    rawPercent
+                    |> max 25.
+                    |> min 75.
+                    |> round
+                    |> int
+
+                commitSplitPercent clampedPercent
+            | None ->
+                ()
+
+        React.useEffectOnce (fun () ->
+            let onMove =
+                fun (moveEvent: Browser.Types.PointerEvent) ->
+                    if isDragging.current then
+                        updateSplitPercentFromClientY moveEvent.clientY
+                    else
+                        ()
+
+            let stopDragging =
+                fun (_: Browser.Types.PointerEvent) ->
+                    isDragging.current <- false
+
+            document.addEventListener ("pointermove", unbox onMove)
+            document.addEventListener ("pointerup", unbox stopDragging)
+            document.addEventListener ("pointercancel", unbox stopDragging)
+
+            FsReact.createDisposable (fun () ->
+                document.removeEventListener ("pointermove", unbox onMove)
+                document.removeEventListener ("pointerup", unbox stopDragging)
+                document.removeEventListener ("pointercancel", unbox stopDragging)
+            )
+        )
+
+        let startSplitDrag (event: Browser.Types.PointerEvent) =
+            event.preventDefault ()
+            isDragging.current <- true
+            updateSplitPercentFromClientY event.clientY
+
+        let topFractionText = splitPercent.ToString(CultureInfo.InvariantCulture)
+        let bottomFractionText = (100 - splitPercent).ToString(CultureInfo.InvariantCulture)
+
+        Html.div [
+            prop.ref splitPaneRef
+            prop.className "swt:grid swt:min-h-0 swt:flex-1"
+            prop.style [
+                style.custom (
+                    "grid-template-rows",
+                    $"minmax(0, {topFractionText}fr) 0.75rem minmax(0, {bottomFractionText}fr)"
+                )
+            ]
+            prop.children [
+                topPane
+                VerticalSplitHandle(startSplitDrag, splitHandleTestId)
+                bottomPane
+            ]
+        ]
+
+    [<ReactComponent>]
+    let RenderConflictBlock
+        (
+            entryId: int,
+            block: GitTextComparisonCore.MergeConflictBlock,
+            incomingTitle: string option,
+            currentTitle: string option,
+            applyResolution: ConflictResolutionChoice -> int -> GitTextComparisonCore.MergeConflictBlock -> string -> unit,
+            comparisonScrollTestId: string option
+        ) =
+        let incomingHeaderLabel, currentHeaderLabel, rows, incomingLineCount, currentLineCount =
+            React.useMemo (
+                (fun () ->
+                    let incomingHeaderLabel =
+                        GitTextComparisonCore.Metadata.resolveHeaderLabel "Incoming" incomingTitle block.IncomingLabel
+
+                    let currentHeaderLabel =
+                        GitTextComparisonCore.Metadata.resolveHeaderLabel "Current" currentTitle block.CurrentLabel
+
+                    let rows = GitTextComparisonCore.Rows.buildRows block.IncomingContent block.CurrentContent
+                    let incomingLineCount = (GitTextComparisonCore.Text.splitContentToLines block.IncomingContent).Length
+                    let currentLineCount = (GitTextComparisonCore.Text.splitContentToLines block.CurrentContent).Length
+
+                    incomingHeaderLabel, currentHeaderLabel, rows, incomingLineCount, currentLineCount
+                ),
+                [| box block; box incomingTitle; box currentTitle |]
+            )
+
+        let header =
+            GitComparisonView.HeaderRow
+                (GitComparisonView.TitleStack
+                    (Html.h4 [
+                        prop.className "swt:text-sm swt:font-semibold"
+                        prop.text $"Merge conflict {entryId}"
+                    ])
+                    None
+                    None)
+                (Html.div [
+                    prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
+                    prop.children [
+                        Html.button [
+                            prop.className "swt:btn swt:btn-sm swt:btn-outline"
+                            prop.text "Take incoming"
+                            prop.onClick (fun _ ->
+                                applyResolution ConflictResolutionChoice.Incoming entryId block block.IncomingContent
+                            )
+                        ]
+                        Html.button [
+                            prop.className "swt:btn swt:btn-sm swt:btn-outline"
+                            prop.text "Take current"
+                            prop.onClick (fun _ ->
+                                applyResolution ConflictResolutionChoice.Current entryId block block.CurrentContent
+                            )
+                        ]
+                    ]
+                ])
+                (Some "swt:border-b swt:border-base-content/10 swt:bg-base-100")
+
+        let body =
+            GitTextComparisonRendering.Rendering.ComparisonGrid(
+                rows,
+                ("Incoming", (incomingHeaderLabel, incomingLineCount)),
+                ("Current", (currentHeaderLabel, currentLineCount)),
+                None,
+                None,
+                comparisonScrollTestId,
+                Some 260,
+                Some GitTextComparisonRendering.Rendering.ChoiceTheme
+            )
+
+        GitComparisonView.SectionCard
+            header
+            body
+            (Some $"merge-conflict-{entryId}")
+            (Some "swt:overflow-hidden")
+
+    [<ReactComponent>]
+    let ResolvedConflictSummary
+        (
+            entryId: int,
+            block: GitTextComparisonCore.MergeConflictBlock,
+            resolution: ConflictResolutionState,
+            undoResolution: int -> GitTextComparisonCore.MergeConflictBlock -> ConflictResolutionState -> unit
+        ) =
+        let resolutionLabel =
+            match resolution.Choice with
+            | ConflictResolutionChoice.Incoming -> "incoming"
+            | ConflictResolutionChoice.Current -> "current"
+
+        let header =
+            GitComparisonView.HeaderRow
+                (GitComparisonView.TitleStack
+                    (Html.h4 [
+                        prop.className "swt:text-sm swt:font-semibold"
+                        prop.text $"Merge conflict {entryId}"
+                    ])
+                    (Some(
+                        Html.p [
+                            prop.className "swt:text-xs swt:text-base-content/60"
+                            prop.text $"Resolved with {resolutionLabel}. Expand again with Undo if you want to choose differently."
+                        ]
+                    ))
+                    None)
+                (Html.div [
+                    prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
+                    prop.children [
+                        Html.span [
+                            prop.className "swt:badge swt:badge-ghost swt:badge-sm"
+                            prop.text $"Using {resolutionLabel}"
+                        ]
+                        Html.button [
+                            prop.className "swt:btn swt:btn-sm"
+                            prop.text "Undo"
+                            prop.onClick (fun _ -> undoResolution entryId block resolution)
+                        ]
+                    ]
+                ])
+                None
+
+        GitComparisonView.SectionCard
+            header
+            Html.none
+            (Some $"merge-conflict-{entryId}")
+            None
+
+[<Erase; Mangle(false)>]
+type GitMergeConflictViewer =
+
+    [<ReactComponent>]
+    static member Viewer
+        (
+            mergeConflictContent: string,
+            ?resolvedContent: string,
+            ?defaultResolvedContent: string,
+            ?onResolvedContentChange: (string -> unit),
+            ?onConfirmMerge: (string -> unit),
+            ?incomingTitle: string,
+            ?currentTitle: string,
+            ?resolvedTitle: string,
+            ?heightPx: int,
+            ?minHeightPx: int,
+            ?className: string,
+            ?testIdPrefix: string
+        ) =
+        let normalizedConflictContent = GitTextComparisonCore.Text.normalizeLineEndings mergeConflictContent
+        let normalizedControlledResolvedText = resolvedContent |> Option.map GitTextComparisonCore.Text.normalizeLineEndings
+        let normalizedDefaultResolvedText = defaultResolvedContent |> Option.map GitTextComparisonCore.Text.normalizeLineEndings
+
+        match normalizedControlledResolvedText, normalizedDefaultResolvedText, onResolvedContentChange with
+        | Some _, Some _, _ ->
+            failwith
+                "GitMergeConflictViewer: `resolvedContent` and `defaultResolvedContent` cannot be used together."
+        | Some _, None, None ->
+            failwith
+                "GitMergeConflictViewer: `resolvedContent` requires `onResolvedContentChange`."
+        | _ ->
+            ()
+
+        let isControlled = normalizedControlledResolvedText.IsSome
+
+        let initialUncontrolledResolvedText =
+            normalizedDefaultResolvedText
+            |> Option.defaultValue normalizedConflictContent
+
+        let internalResolvedText, setInternalResolvedText = React.useState initialUncontrolledResolvedText
+
+        let initialActiveResolvedText =
+            normalizedControlledResolvedText
+            |> Option.defaultValue initialUncontrolledResolvedText
+
+        let paneEntries, setPaneEntries =
+            React.useState (GitMergeConflictViewerInternal.parsePaneEntries initialActiveResolvedText)
+
+        let skipPaneSync = React.useRef false
+
+        React.useEffect (
+            (fun () ->
+                if not isControlled then
+                    let nextResolvedText =
+                        normalizedDefaultResolvedText
+                        |> Option.defaultValue normalizedConflictContent
+
+                    setInternalResolvedText nextResolvedText),
+            [| box normalizedConflictContent; box normalizedDefaultResolvedText; box isControlled |]
+        )
+
+        let activeResolvedText =
+            normalizedControlledResolvedText
+            |> Option.defaultValue internalResolvedText
+
+        React.useEffect (
+            (fun () ->
+                if skipPaneSync.current then
+                    skipPaneSync.current <- false
+                else
+                    setPaneEntries (GitMergeConflictViewerInternal.parsePaneEntries activeResolvedText)),
+            [| box activeResolvedText |]
+        )
+
+        let updateResolvedText nextValue =
+            let normalizedValue = GitTextComparisonCore.Text.normalizeLineEndings nextValue
+
+            if isControlled then
+                onResolvedContentChange.Value normalizedValue
+            else
+                setInternalResolvedText normalizedValue
+                onResolvedContentChange |> Option.iter (fun notifyResolvedTextChanged -> notifyResolvedTextChanged normalizedValue)
+
+        let handleResolvedTextChange nextValue =
+            skipPaneSync.current <- false
+            updateResolvedText nextValue
+
+        let rootTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-root")
+
+        let resolvedEditorTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-resolved-editor")
+
+        let confirmMergeButtonTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-confirm-merge")
+
+        let conflictsPaneTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-conflicts-pane")
+
+        let splitHandleTestId =
+            testIdPrefix |> Option.map (fun prefix -> prefix + "-split-handle")
+
+        let resetPaneEntriesFromActiveText () =
+            setPaneEntries (GitMergeConflictViewerInternal.parsePaneEntries activeResolvedText)
+
+        let applyResolution
+            (choice: GitMergeConflictViewerInternal.ConflictResolutionChoice)
+            (entryId: int)
+            (block: GitTextComparisonCore.MergeConflictBlock)
+            (replacementText: string)
+            =
+            let normalizedReplacementText = GitTextComparisonCore.Text.normalizeLineEndings replacementText
+
+            match
+                GitTextComparisonCore.MergeConflicts.tryReplaceExactTextAt
+                    block.StartIndex
+                    block.RawContent
+                    normalizedReplacementText
+                    activeResolvedText
+            with
+            | Some nextResolvedText ->
+                let resolution: GitMergeConflictViewerInternal.ConflictResolutionState = {
+                    Choice = choice
+                    AppliedText = normalizedReplacementText
+                    StartIndex = block.StartIndex
+                }
+
+                let delta = normalizedReplacementText.Length - block.RawContent.Length
+
+                let nextPaneEntries =
+                    paneEntries
+                    |> List.map (fun entry ->
+                        if entry.EntryId = entryId then
+                            {
+                                entry with
+                                    State = GitMergeConflictViewerInternal.Resolved(block, resolution)
+                            }
+                        else
+                            entry
+                    )
+                    |> GitMergeConflictViewerInternal.shiftResolvedEntryOffsetsAfter block.StartIndex delta
+                    |> GitMergeConflictViewerInternal.refreshPaneEntries nextResolvedText
+
+                skipPaneSync.current <- true
+                setPaneEntries nextPaneEntries
+                updateResolvedText nextResolvedText
+            | None ->
+                skipPaneSync.current <- false
+                resetPaneEntriesFromActiveText ()
+
+        let undoResolution
+            (entryId: int)
+            (block: GitTextComparisonCore.MergeConflictBlock)
+            (resolution: GitMergeConflictViewerInternal.ConflictResolutionState)
+            =
+            match
+                GitTextComparisonCore.MergeConflicts.tryReplaceExactTextAt
+                    resolution.StartIndex
+                    resolution.AppliedText
+                    block.RawContent
+                    activeResolvedText
+            with
+            | Some nextResolvedText ->
+                let delta = block.RawContent.Length - resolution.AppliedText.Length
+
+                let nextPaneEntries =
+                    paneEntries
+                    |> List.map (fun entry ->
+                        if entry.EntryId = entryId then
+                            {
+                                entry with
+                                    State = GitMergeConflictViewerInternal.Unresolved block
+                            }
+                        else
+                            entry
+                    )
+                    |> GitMergeConflictViewerInternal.shiftResolvedEntryOffsetsAfter resolution.StartIndex delta
+                    |> GitMergeConflictViewerInternal.refreshPaneEntries nextResolvedText
+
+                skipPaneSync.current <- true
+                setPaneEntries nextPaneEntries
+                updateResolvedText nextResolvedText
+            | None ->
+                skipPaneSync.current <- false
+                resetPaneEntriesFromActiveText ()
+
+        let hasRemainingConflictMarkers =
+            React.useMemo (
+                (fun () -> GitTextComparisonCore.MergeConflicts.containsConflictMarkers activeResolvedText),
+                [| box activeResolvedText |]
+            )
+
+        let unresolvedConflictCount =
+            React.useMemo (
+                (fun () -> GitMergeConflictViewerInternal.countUnresolvedEntries paneEntries),
+                [| box paneEntries |]
+            )
+
+        let resolvedLineCount =
+            React.useMemo (
+                (fun () -> (GitTextComparisonCore.Text.splitContentToLines activeResolvedText).Length),
+                [| box activeResolvedText |]
+            )
+
+        let canConfirmMerge =
+            onConfirmMerge.IsSome && not hasRemainingConflictMarkers
+
+        let header =
+            GitComparisonView.HeaderRow
+                (GitComparisonView.TitleStack
+                    (Html.h3 [
+                        prop.className "swt:text-sm swt:font-semibold"
+                        prop.text "Merge Conflicts"
+                    ])
+                    None
+                    None)
+                (Html.span [
+                    prop.className "swt:badge swt:badge-outline swt:badge-sm"
+                    prop.text $"{unresolvedConflictCount} conflicts"
+                ])
+                (Some "swt:border-b swt:border-base-content/10 swt:bg-base-100")
+
+        let resolvedEditorHeader =
+            GitComparisonView.HeaderRow
+                (GitComparisonView.TitleStack
+                    (Html.h4 [
+                        prop.className "swt:text-sm swt:font-semibold"
+                        prop.text (defaultArg resolvedTitle "Resolved file view")
+                    ])
+                    None
+                    (Some "swt:gap-0.5"))
+                (Html.span [
+                    prop.className "swt:badge swt:badge-ghost swt:badge-sm"
+                    prop.text $"{resolvedLineCount} lines"
+                ])
+                None
+
+        let conflictsPane =
+            Html.div [
+                if conflictsPaneTestId.IsSome then
+                    prop.testId conflictsPaneTestId.Value
+                prop.className "swt:min-h-0 swt:border-b swt:border-base-content/10"
+                prop.children [
+                    if List.isEmpty paneEntries then
+                        Html.div [
+                            prop.className "swt:px-4 swt:py-3 swt:text-sm swt:text-base-content/70"
+                            prop.text "No merge conflict markers were detected in the supplied content."
+                        ]
+                    else
+                        Html.div [
+                            prop.className "swt:flex swt:h-full swt:min-h-0 swt:flex-col"
+                            prop.children [
+                                Html.div [
+                                    prop.className
+                                        "swt:min-h-0 swt:flex-1 swt:overflow-y-auto swt:scrollbar-fade swt:p-4 swt:space-y-4"
+                                    prop.children (
+                                        paneEntries
+                                        |> List.map (fun entry ->
+                                            match entry.State with
+                                            | GitMergeConflictViewerInternal.Resolved(block, resolution) ->
+                                                GitMergeConflictViewerInternal.ResolvedConflictSummary(
+                                                    entry.EntryId,
+                                                    block,
+                                                    resolution,
+                                                    undoResolution
+                                                )
+                                            | GitMergeConflictViewerInternal.Unresolved block ->
+                                                let comparisonScrollTestId =
+                                                    testIdPrefix
+                                                    |> Option.map (fun prefix -> $"{prefix}-conflict-{entry.EntryId}-scroll")
+
+                                                GitMergeConflictViewerInternal.RenderConflictBlock(
+                                                    entry.EntryId,
+                                                    block,
+                                                    incomingTitle,
+                                                    currentTitle,
+                                                    applyResolution,
+                                                    comparisonScrollTestId
+                                                )
+                                        )
+                                    )
+                                ]
+                            ]
+                        ]
+                ]
+            ]
+
+        let resolvedEditorPane =
+            Html.div [
+                prop.className "swt:flex swt:min-h-0 swt:flex-col swt:px-4 swt:py-3"
+                prop.children [
+                    resolvedEditorHeader
+                    Html.textarea [
+                        if resolvedEditorTestId.IsSome then
+                            prop.testId resolvedEditorTestId.Value
+                        prop.className
+                            "swt:mt-2 swt:min-h-0 swt:flex-1 swt:w-full swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100 swt:px-4 swt:py-3 swt:font-mono swt:text-xs swt:leading-6 swt:resize-none swt:focus:outline-hidden"
+                        prop.value activeResolvedText
+                        prop.onChange handleResolvedTextChange
+                    ]
+                    Html.div [
+                        prop.className "swt:mt-3 swt:flex swt:justify-end"
+                        prop.children [
+                            Html.button [
+                                if confirmMergeButtonTestId.IsSome then
+                                    prop.testId confirmMergeButtonTestId.Value
+                                prop.className "swt:btn swt:btn-primary"
+                                prop.disabled (not canConfirmMerge)
+                                prop.text "Confirm Merge"
+                                prop.onClick (fun _ ->
+                                    if canConfirmMerge then
+                                        onConfirmMerge
+                                        |> Option.iter (fun confirm -> confirm activeResolvedText)
+                                )
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+
+        let splitPane =
+            GitMergeConflictViewerInternal.VerticalSplitPane(conflictsPane, resolvedEditorPane, splitHandleTestId)
+
+        GitComparisonView.PanelShell
+            (React.Fragment [
+                header
+                splitPane
+            ])
+            rootTestId
+            (Some(
+                match className with
+                | Some value -> $"swt:flex swt:h-full swt:min-h-0 swt:flex-col {value}"
+                | None -> "swt:flex swt:h-full swt:min-h-0 swt:flex-col"
+            ))
+            (Some [
+                style.minHeight 0
+
+                if heightPx.IsSome then
+                    style.height heightPx.Value
+
+                if minHeightPx.IsSome then
+                    style.minHeight minHeightPx.Value
+            ])
+        

--- a/src/Components/src/GitComparison/GitMergeConflictViewer.stories.tsx
+++ b/src/Components/src/GitComparison/GitMergeConflictViewer.stories.tsx
@@ -1,0 +1,329 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect, userEvent, waitFor, fn } from "storybook/test";
+import { Viewer as GitMergeConflictViewerComponent } from "./GitMergeConflictViewer.fs.js";
+
+const introLines = Array.from({ length: 10 }, (_, index) => `Shared intro line ${index + 1}`);
+const currentExperimentLines = Array.from({ length: 32 }, (_, index) => `Current experiment note ${index + 1}`);
+const incomingExperimentLines = Array.from({ length: 32 }, (_, index) => `Incoming experiment note ${index + 1}`);
+const middleLines = Array.from({ length: 8 }, (_, index) => `Shared middle line ${index + 1}`);
+const currentTemperatureLines = Array.from({ length: 10 }, (_, index) =>
+  index === 4 ? "Current temperature 24 C" : `Current measurement note ${index + 1}`
+);
+const incomingTemperatureLines = Array.from({ length: 10 }, (_, index) =>
+  index === 4 ? "Incoming temperature 20 C" : `Incoming measurement note ${index + 1}`
+);
+const checklistLines = Array.from({ length: 6 }, (_, index) => `Checklist line ${index + 1}`);
+const currentClosingLines = ["Current closing summary", ...Array.from({ length: 8 }, (_, index) => `Current closing note ${index + 1}`)];
+const incomingClosingLines = [
+  "Incoming closing summary",
+  "Incoming extra context",
+  ...Array.from({ length: 8 }, (_, index) => `Incoming closing note ${index + 1}`),
+];
+
+const mergeConflictContent = [
+  "# Merge plan",
+  ...introLines,
+  "<<<<<<< HEAD",
+  ...currentExperimentLines,
+  "=======",
+  ...incomingExperimentLines,
+  ">>>>>>> origin/main",
+  ...middleLines,
+  "<<<<<<< HEAD",
+  ...currentTemperatureLines,
+  "=======",
+  ...incomingTemperatureLines,
+  ">>>>>>> lab/main",
+  ...checklistLines,
+  "<<<<<<< HEAD",
+  ...currentClosingLines,
+  "=======",
+  ...incomingClosingLines,
+  ">>>>>>> feature/review",
+  "Shared outro",
+].join("\n") + "\n";
+
+const fullyResolvedContent = [
+  "# Merge plan",
+  ...introLines,
+  ...incomingExperimentLines,
+  ...middleLines,
+  ...currentTemperatureLines,
+  ...checklistLines,
+  ...incomingClosingLines,
+  "Shared outro",
+].join("\n") + "\n";
+
+const duplicateConflictContent = [
+  "Before duplicate block",
+  "<<<<<<< HEAD",
+  "Current duplicate line",
+  "=======",
+  "Incoming duplicate line",
+  ">>>>>>> origin/main",
+  "Between duplicate blocks",
+  "<<<<<<< HEAD",
+  "Current duplicate line",
+  "=======",
+  "Incoming duplicate line",
+  ">>>>>>> origin/main",
+  "After duplicate block",
+].join("\n") + "\n";
+
+type ControlledMergeHarnessProps = Omit<
+  React.ComponentProps<typeof GitMergeConflictViewerComponent>,
+  "resolvedContent" | "defaultResolvedContent"
+> & {
+  initialResolvedContent?: string;
+};
+
+function ControlledMergeHarness({
+  initialResolvedContent,
+  onResolvedContentChange,
+  ...viewerProps
+}: ControlledMergeHarnessProps) {
+  const [resolvedContent, setResolvedContent] = React.useState(
+    initialResolvedContent ?? viewerProps.mergeConflictContent
+  );
+
+  return (
+    <GitMergeConflictViewerComponent
+      {...viewerProps}
+      resolvedContent={resolvedContent}
+      onResolvedContentChange={(nextResolvedContent: string) => {
+        setResolvedContent(nextResolvedContent);
+        onResolvedContentChange?.(nextResolvedContent);
+      }}
+    />
+  );
+}
+
+const meta = {
+  title: "Components/GitComparison/GitMergeConflictViewer",
+  component: GitMergeConflictViewerComponent,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="swt:h-[80vh] swt:min-h-[48rem] swt:bg-base-200 swt:p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GitMergeConflictViewerComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: { isolated: true },
+  args: {
+    mergeConflictContent,
+    onConfirmMerge: fn(),
+    testIdPrefix: "git-merge-story",
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const hasExactText = (value: string) => (_content: string, element: Element | null) =>
+      element?.textContent === value;
+    const root = canvas.getByTestId("git-merge-story-root");
+    const firstConflictScroll = canvas.getByTestId("git-merge-story-conflict-1-scroll");
+    const conflictsPane = canvas.getByTestId("git-merge-story-conflicts-pane");
+    const splitHandle = canvas.getByTestId("git-merge-story-split-handle");
+    const confirmMergeButton = canvas.getByTestId("git-merge-story-confirm-merge");
+
+    await expect(canvas.getByText("Merge conflict 1")).toBeInTheDocument();
+    await expect(canvas.getByText("Merge conflict 2")).toBeInTheDocument();
+    await expect(canvas.getByText("Merge conflict 3")).toBeInTheDocument();
+    await expect(canvas.getByText(hasExactText("Incoming experiment note 1"))).toBeInTheDocument();
+    await expect(canvas.getByText(hasExactText("Current experiment note 32"))).toBeInTheDocument();
+    await expect(root).toHaveTextContent("3 conflicts");
+    await expect(confirmMergeButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(firstConflictScroll.scrollHeight).toBeGreaterThan(firstConflictScroll.clientHeight);
+    });
+
+    const handleRect = splitHandle.getBoundingClientRect();
+    const pointerX = handleRect.left + handleRect.width / 2;
+    const pointerY = handleRect.top + handleRect.height / 2;
+
+    splitHandle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: pointerX, clientY: pointerY }));
+    document.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: pointerX, clientY: pointerY + 120 }));
+    document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, clientX: pointerX, clientY: pointerY + 120 }));
+
+    await expect(conflictsPane).toBeInTheDocument();
+
+    const takeIncomingButtons = canvas.getAllByRole("button", { name: "Take incoming" });
+
+    await userEvent.click(takeIncomingButtons[0]);
+
+    await waitFor(() => {
+      expect(canvas.getAllByRole("button", { name: "Undo" })).toHaveLength(1);
+    });
+
+    const remainingTakeCurrentButtons = canvas.getAllByRole("button", { name: "Take current" });
+    await userEvent.click(remainingTakeCurrentButtons[0]);
+
+    await expect(canvas.getAllByRole("button", { name: "Undo" })).toHaveLength(2);
+    await expect(root).toHaveTextContent("Using incoming");
+    await expect(root).toHaveTextContent("Using current");
+
+    const resolvedEditor = canvas.getByTestId("git-merge-story-resolved-editor") as HTMLTextAreaElement;
+
+    await waitFor(() => {
+      expect(resolvedEditor.value).toContain("Incoming experiment note 1");
+      expect(resolvedEditor.value).toContain("Current temperature 24 C");
+      expect(resolvedEditor.value).toContain("<<<<<<< HEAD");
+    });
+
+    await expect(confirmMergeButton).toBeDisabled();
+
+    const undoButtonsBeforeManualEdit = canvas.getAllByRole("button", { name: "Undo" });
+    await userEvent.click(undoButtonsBeforeManualEdit[0]);
+
+    await waitFor(() => {
+      expect(canvas.getByText("Merge conflict 1")).toBeInTheDocument();
+      expect(canvas.getAllByRole("button", { name: "Undo" })).toHaveLength(1);
+      expect(root).toHaveTextContent("2 conflicts");
+      expect(resolvedEditor.value).toContain("<<<<<<< HEAD");
+    });
+
+    await userEvent.type(resolvedEditor, "\nManual final line");
+
+    await waitFor(() => {
+      expect(resolvedEditor.value).toContain("Manual final line");
+      expect(resolvedEditor.value).toContain("Incoming extra context");
+      expect(canvas.queryByRole("button", { name: "Undo" })).not.toBeInTheDocument();
+    });
+
+    await expect(confirmMergeButton).toBeDisabled();
+
+    const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+    if (!valueSetter) {
+      throw new Error("Textarea value setter is unavailable.");
+    }
+
+    valueSetter.call(resolvedEditor, fullyResolvedContent);
+    resolvedEditor.dispatchEvent(new Event("input", { bubbles: true }));
+
+    await waitFor(() => {
+      expect(confirmMergeButton).toBeEnabled();
+      expect(resolvedEditor.value).toBe(fullyResolvedContent);
+    });
+
+    await expect(root).toHaveTextContent("0 conflicts");
+    await expect(canvas.queryByText("Merge conflict 1")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Merge conflict 2")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Merge conflict 3")).not.toBeInTheDocument();
+
+    await userEvent.click(confirmMergeButton);
+
+    await waitFor(() => {
+      expect(args.onConfirmMerge).toHaveBeenCalledTimes(1);
+    });
+
+    expect(args.onConfirmMerge.mock.calls[0][0]).toBe(fullyResolvedContent);
+  },
+};
+
+export const DuplicateConflictBodies: Story = {
+  parameters: { isolated: true },
+  args: {
+    mergeConflictContent: duplicateConflictContent,
+    testIdPrefix: "git-merge-duplicate-story",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const resolvedEditor = canvas.getByTestId("git-merge-duplicate-story-resolved-editor") as HTMLTextAreaElement;
+    const takeIncomingButtons = canvas.getAllByRole("button", { name: "Take incoming" });
+
+    await userEvent.click(takeIncomingButtons[1]);
+
+    await waitFor(() => {
+      expect(resolvedEditor.value).toContain("Between duplicate blocks\nIncoming duplicate line\nAfter duplicate block");
+      expect(resolvedEditor.value).toContain("Before duplicate block\n<<<<<<< HEAD");
+      expect(resolvedEditor.value).toContain("Between duplicate blocks\nIncoming duplicate line");
+    });
+  },
+};
+
+export const DefaultResolvedContentRemainsEditable: Story = {
+  parameters: { isolated: true },
+  args: {
+    mergeConflictContent,
+    defaultResolvedContent: fullyResolvedContent,
+    onResolvedContentChange: fn(),
+    onConfirmMerge: fn(),
+    testIdPrefix: "git-merge-default-resolved-story",
+  },
+  play: async ({ canvasElement, args }: { canvasElement: HTMLElement; args: any }) => {
+    const canvas = within(canvasElement);
+    const root = canvas.getByTestId("git-merge-default-resolved-story-root");
+    const resolvedEditor = canvas.getByTestId("git-merge-default-resolved-story-resolved-editor") as HTMLTextAreaElement;
+    const confirmMergeButton = canvas.getByTestId("git-merge-default-resolved-story-confirm-merge");
+
+    await expect(root).toHaveTextContent("0 conflicts");
+    await expect(confirmMergeButton).toBeEnabled();
+
+    await userEvent.type(resolvedEditor, "\nEdited from default value");
+
+    await waitFor(() => {
+      expect(resolvedEditor.value).toContain("Edited from default value");
+      expect(root).toHaveTextContent("0 conflicts");
+      expect(args.onResolvedContentChange).toHaveBeenCalled();
+    });
+
+    await userEvent.click(confirmMergeButton);
+
+    await waitFor(() => {
+      expect(args.onConfirmMerge).toHaveBeenCalledTimes(1);
+    });
+
+    expect(args.onConfirmMerge.mock.calls[0][0]).toContain("Edited from default value");
+  },
+};
+
+export const ControlledResolvedContentRemainsEditable: Story = {
+  parameters: { isolated: true },
+  render: (args: any) => (
+    <ControlledMergeHarness
+      {...args}
+      initialResolvedContent={fullyResolvedContent}
+    />
+  ),
+  args: {
+    mergeConflictContent,
+    onResolvedContentChange: fn(),
+    onConfirmMerge: fn(),
+    testIdPrefix: "git-merge-controlled-story",
+  },
+  play: async ({ canvasElement, args }: { canvasElement: HTMLElement; args: any }) => {
+    const canvas = within(canvasElement);
+    const root = canvas.getByTestId("git-merge-controlled-story-root");
+    const resolvedEditor = canvas.getByTestId("git-merge-controlled-story-resolved-editor") as HTMLTextAreaElement;
+    const confirmMergeButton = canvas.getByTestId("git-merge-controlled-story-confirm-merge");
+
+    await expect(root).toHaveTextContent("0 conflicts");
+    await expect(confirmMergeButton).toBeEnabled();
+
+    await userEvent.type(resolvedEditor, "\nEdited in controlled mode");
+
+    await waitFor(() => {
+      expect(resolvedEditor.value).toContain("Edited in controlled mode");
+      expect(root).toHaveTextContent("0 conflicts");
+      expect(args.onResolvedContentChange).toHaveBeenCalled();
+    });
+
+    await userEvent.click(confirmMergeButton);
+
+    await waitFor(() => {
+      expect(args.onConfirmMerge).toHaveBeenCalledTimes(1);
+    });
+
+    expect(args.onConfirmMerge.mock.calls[0][0]).toContain("Edited in controlled mode");
+  },
+};

--- a/src/Components/src/GitComparison/GitTextComparison.Core.fs
+++ b/src/Components/src/GitComparison/GitTextComparison.Core.fs
@@ -1,0 +1,603 @@
+namespace Swate.Components
+
+open System
+
+module internal GitTextComparisonCore =
+
+    [<RequireQualifiedAccess>]
+    type LineChangeKind =
+        | Neutral
+        | Added
+        | Removed
+
+    type InlineSegment = {
+        Text: string
+        Kind: LineChangeKind
+    }
+
+    type SideLine = {
+        Number: int option
+        Text: string
+        Segments: InlineSegment list
+        Kind: LineChangeKind
+    }
+
+    type DiffRow = {
+        Left: SideLine
+        Right: SideLine
+    }
+
+    type DiffMetadata = {
+        PreviousPath: string option
+        CurrentPath: string option
+    }
+
+    type MergeConflictBlock = {
+        Id: int
+        CurrentLabel: string option
+        CurrentContent: string
+        IncomingLabel: string option
+        IncomingContent: string
+        RawContent: string
+        StartIndex: int
+    }
+
+    type MergeConflictFragment =
+        | PlainText of string
+        | ConflictBlock of MergeConflictBlock
+
+    module Text =
+
+        let normalizeLineEndings (content: string) =
+            content.Replace("\r\n", "\n").Replace("\r", "\n")
+
+        let splitContentToLines (content: string) =
+            let normalized = normalizeLineEndings content
+
+            if String.IsNullOrEmpty normalized then
+                [||]
+            else
+                let lines = normalized.Split('\n')
+
+                if normalized.EndsWith("\n", StringComparison.Ordinal) then
+                    lines.[0 .. lines.Length - 2]
+                else
+                    lines
+
+        let sliceLines (lines: string[]) (startLineNumber: int) (lineCount: int) =
+            if lineCount > 0 then
+                Array.sub lines (startLineNumber - 1) lineCount
+            else
+                [||]
+
+    module Metadata =
+
+        let private diffGitHeaderPattern =
+            Text.RegularExpressions.Regex(
+                @"^diff --git (?<old>""(?:\\.|[^""])+""|\S+) (?<new>""(?:\\.|[^""])+""|\S+)$",
+                Text.RegularExpressions.RegexOptions.Compiled
+            )
+
+        let private unquotePathToken (pathText: string) =
+            let trimmed = pathText.Trim()
+
+            if trimmed.Length >= 2 && trimmed.StartsWith("\"", StringComparison.Ordinal) && trimmed.EndsWith("\"", StringComparison.Ordinal) then
+                let quotedValue = trimmed.Substring(1, trimmed.Length - 2)
+
+                try
+                    Text.RegularExpressions.Regex.Unescape quotedValue
+                with _ ->
+                    quotedValue
+            else
+                trimmed.Trim('"')
+
+        let private normalizeDiffPath (pathText: string) =
+            let trimmed = pathText |> unquotePathToken |> fun value -> value.Trim()
+
+            if String.IsNullOrWhiteSpace trimmed || trimmed = "/dev/null" then
+                None
+            elif trimmed.StartsWith("a/", StringComparison.Ordinal) || trimmed.StartsWith("b/", StringComparison.Ordinal) then
+                Some(trimmed.Substring(2))
+            else
+                Some trimmed
+
+        let private extractFromPatchHeaders (lines: string[]) =
+            let previousPath =
+                lines
+                |> Array.tryFind (fun line -> line.StartsWith("--- ", StringComparison.Ordinal))
+                |> Option.bind (fun line -> normalizeDiffPath (line.Substring(4)))
+
+            let currentPath =
+                lines
+                |> Array.tryFind (fun line -> line.StartsWith("+++ ", StringComparison.Ordinal))
+                |> Option.bind (fun line -> normalizeDiffPath (line.Substring(4)))
+
+            {
+                PreviousPath = previousPath
+                CurrentPath = currentPath
+            }
+
+        let private extractFromDiffLine (diffLine: string) =
+            let matched = diffGitHeaderPattern.Match diffLine
+
+            if matched.Success then
+                Some {
+                    PreviousPath = normalizeDiffPath matched.Groups.["old"].Value
+                    CurrentPath = normalizeDiffPath matched.Groups.["new"].Value
+                }
+            else
+                None
+
+        let extractDiffMetadata (diffText: string) =
+            let lines =
+                diffText
+                |> Text.normalizeLineEndings
+                |> Text.splitContentToLines
+
+            match lines |> Array.tryFind (fun line -> line.StartsWith("diff --git ", StringComparison.Ordinal)) with
+            | Some diffLine ->
+                extractFromDiffLine diffLine
+                |> Option.defaultValue (extractFromPatchHeaders lines)
+            | None ->
+                extractFromPatchHeaders lines
+
+        let resolveHeaderLabel (fallbackLabel: string) (explicitLabel: string option) (pathLabel: string option) =
+            explicitLabel
+            |> Option.filter (String.IsNullOrWhiteSpace >> not)
+            |> Option.orElse pathLabel
+            |> Option.defaultValue fallbackLabel
+
+    module InlineDiff =
+
+        type private DiffOperation =
+            | Keep of string
+            | Delete of string
+            | Insert of string
+
+        let private buildTokenLcsMatrix (leftTokens: string[]) (rightTokens: string[]) =
+            let matrix =
+                Array.init (leftTokens.Length + 1) (fun _ -> Array.zeroCreate<int> (rightTokens.Length + 1))
+
+            for leftIndex = leftTokens.Length - 1 downto 0 do
+                for rightIndex = rightTokens.Length - 1 downto 0 do
+                    matrix.[leftIndex].[rightIndex] <-
+                        if leftTokens.[leftIndex] = rightTokens.[rightIndex] then
+                            matrix.[leftIndex + 1].[rightIndex + 1] + 1
+                        else
+                            max matrix.[leftIndex + 1].[rightIndex] matrix.[leftIndex].[rightIndex + 1]
+
+            matrix
+
+        let private buildTokenDiffOperations (leftTokens: string[]) (rightTokens: string[]) =
+            let matrix = buildTokenLcsMatrix leftTokens rightTokens
+
+            let rec loop leftIndex rightIndex acc =
+                if leftIndex >= leftTokens.Length && rightIndex >= rightTokens.Length then
+                    List.rev acc
+                elif leftIndex >= leftTokens.Length then
+                    loop leftIndex (rightIndex + 1) (Insert rightTokens.[rightIndex] :: acc)
+                elif rightIndex >= rightTokens.Length then
+                    loop (leftIndex + 1) rightIndex (Delete leftTokens.[leftIndex] :: acc)
+                elif leftTokens.[leftIndex] = rightTokens.[rightIndex] then
+                    loop (leftIndex + 1) (rightIndex + 1) (Keep leftTokens.[leftIndex] :: acc)
+                elif matrix.[leftIndex + 1].[rightIndex] >= matrix.[leftIndex].[rightIndex + 1] then
+                    loop (leftIndex + 1) rightIndex (Delete leftTokens.[leftIndex] :: acc)
+                else
+                    loop leftIndex (rightIndex + 1) (Insert rightTokens.[rightIndex] :: acc)
+
+            loop 0 0 []
+
+        let private tokenize (text: string) =
+            let tokens = ResizeArray<string>()
+            let buffer = Text.StringBuilder()
+            let mutable currentIsWhitespace: bool option = None
+
+            let flushBuffer () =
+                if buffer.Length > 0 then
+                    tokens.Add(buffer.ToString())
+                    buffer.Clear() |> ignore
+
+            for character in text do
+                let isWhitespace = Char.IsWhiteSpace character
+
+                match currentIsWhitespace with
+                | Some currentKind when currentKind <> isWhitespace ->
+                    flushBuffer ()
+                    buffer.Append(character) |> ignore
+                    currentIsWhitespace <- Some isWhitespace
+                | Some _ ->
+                    buffer.Append(character) |> ignore
+                | None ->
+                    buffer.Append(character) |> ignore
+                    currentIsWhitespace <- Some isWhitespace
+
+            flushBuffer ()
+            tokens |> Seq.toArray
+
+        let private appendSegment kind text (segments: ResizeArray<InlineSegment>) =
+            if not (String.IsNullOrEmpty text) then
+                match segments.Count with
+                | count when count > 0 && segments.[count - 1].Kind = kind ->
+                    let previous = segments.[count - 1]
+                    segments.[count - 1] <- { previous with Text = previous.Text + text }
+                | _ ->
+                    segments.Add({ Text = text; Kind = kind })
+
+        let buildInlineSegments (leftText: string) (rightText: string) =
+            let leftSegments = ResizeArray<InlineSegment>()
+            let rightSegments = ResizeArray<InlineSegment>()
+
+            buildTokenDiffOperations (tokenize leftText) (tokenize rightText)
+            |> List.iter (function
+                | Keep text ->
+                    appendSegment LineChangeKind.Neutral text leftSegments
+                    appendSegment LineChangeKind.Neutral text rightSegments
+                | Delete text ->
+                    appendSegment LineChangeKind.Removed text leftSegments
+                | Insert text ->
+                    appendSegment LineChangeKind.Added text rightSegments
+            )
+
+            leftSegments |> Seq.toList, rightSegments |> Seq.toList
+
+    module Rows =
+
+        let private createSideLine (number: int option) (text: string) (kind: LineChangeKind) (segments: InlineSegment list) = {
+            Number = number
+            Text = text
+            Segments = segments
+            Kind = kind
+        }
+
+        let private createNeutralLine number text =
+            createSideLine
+                (Some number)
+                text
+                LineChangeKind.Neutral
+                [
+                    {
+                        Text = text
+                        Kind = LineChangeKind.Neutral
+                    }
+                ]
+
+        let private createRemovedLine number text =
+            createSideLine
+                (Some number)
+                text
+                LineChangeKind.Removed
+                [
+                    {
+                        Text = text
+                        Kind = LineChangeKind.Removed
+                    }
+                ]
+
+        let private createAddedLine number text =
+            createSideLine
+                (Some number)
+                text
+                LineChangeKind.Added
+                [
+                    {
+                        Text = text
+                        Kind = LineChangeKind.Added
+                    }
+                ]
+
+        let emptyRow () = {
+            Left = createSideLine None "" LineChangeKind.Neutral []
+            Right = createSideLine None "" LineChangeKind.Neutral []
+        }
+
+        let buildIndexedRows
+            (leftLineNumberStart: int)
+            (rightLineNumberStart: int)
+            (leftLines: string[])
+            (rightLines: string[])
+            =
+            let rowCount = max leftLines.Length rightLines.Length
+
+            [
+                for rowIndex in 0 .. rowCount - 1 do
+                    let leftLine =
+                        if rowIndex < leftLines.Length then
+                            Some leftLines.[rowIndex]
+                        else
+                            None
+
+                    let rightLine =
+                        if rowIndex < rightLines.Length then
+                            Some rightLines.[rowIndex]
+                        else
+                            None
+
+                    yield
+                        match leftLine, rightLine with
+                        | Some leftText, Some rightText when leftText = rightText ->
+                            {
+                                Left = createNeutralLine (leftLineNumberStart + rowIndex) leftText
+                                Right = createNeutralLine (rightLineNumberStart + rowIndex) rightText
+                            }
+                        | Some leftText, Some rightText ->
+                            let leftSegments, rightSegments = InlineDiff.buildInlineSegments leftText rightText
+
+                            {
+                                Left =
+                                    createSideLine
+                                        (Some(leftLineNumberStart + rowIndex))
+                                        leftText
+                                        LineChangeKind.Removed
+                                        leftSegments
+                                Right =
+                                    createSideLine
+                                        (Some(rightLineNumberStart + rowIndex))
+                                        rightText
+                                        LineChangeKind.Added
+                                        rightSegments
+                            }
+                        | Some leftText, None ->
+                            {
+                                Left = createRemovedLine (leftLineNumberStart + rowIndex) leftText
+                                Right = (emptyRow ()).Right
+                            }
+                        | None, Some rightText ->
+                            {
+                                Left = (emptyRow ()).Left
+                                Right = createAddedLine (rightLineNumberStart + rowIndex) rightText
+                            }
+                        | None, None ->
+                            emptyRow ()
+            ]
+
+        let buildRows (leftContent: string) (rightContent: string) =
+            buildIndexedRows 1 1 (Text.splitContentToLines leftContent) (Text.splitContentToLines rightContent)
+
+    module WordDiff =
+
+        type DiffHunk = {
+            OldStart: int
+            OldCount: int
+            NewStart: int
+            NewCount: int
+        }
+
+        let private unchangedBoundary (startLine: int) (lineCount: int) =
+            if lineCount = 0 then startLine + 1 else startLine
+
+        let private buildUnchangedRows
+            (leftLines: string[])
+            (rightLines: string[])
+            (leftLineNumberStart: int)
+            (rightLineNumberStart: int)
+            (leftLineNumberEndExclusive: int)
+            (rightLineNumberEndExclusive: int)
+            =
+            let leftCount = max 0 (leftLineNumberEndExclusive - leftLineNumberStart)
+            let rightCount = max 0 (rightLineNumberEndExclusive - rightLineNumberStart)
+
+            let leftSlice = Text.sliceLines leftLines leftLineNumberStart leftCount
+            let rightSlice = Text.sliceLines rightLines rightLineNumberStart rightCount
+
+            if leftCount = rightCount && Array.forall2 (=) leftSlice rightSlice then
+                [
+                    for rowIndex in 0 .. leftCount - 1 do
+                        yield {
+                            Left = {
+                                Number = Some(leftLineNumberStart + rowIndex)
+                                Text = leftSlice.[rowIndex]
+                                Segments = [ { Text = leftSlice.[rowIndex]; Kind = LineChangeKind.Neutral } ]
+                                Kind = LineChangeKind.Neutral
+                            }
+                            Right = {
+                                Number = Some(rightLineNumberStart + rowIndex)
+                                Text = rightSlice.[rowIndex]
+                                Segments = [ { Text = rightSlice.[rowIndex]; Kind = LineChangeKind.Neutral } ]
+                                Kind = LineChangeKind.Neutral
+                            }
+                        }
+                ]
+            else
+                // If the supplied contents do not line up with the word-diff hunk boundaries,
+                // fall back to the generic row pairing so the UI still renders a sane comparison.
+                Rows.buildIndexedRows leftLineNumberStart rightLineNumberStart leftSlice rightSlice
+
+        let parseWordDiffHunks (wordDiffText: string) =
+            let hunkHeaderPattern =
+                Text.RegularExpressions.Regex(
+                    @"^@@ -(?<oldStart>\d+)(,(?<oldCount>\d+))? \+(?<newStart>\d+)(,(?<newCount>\d+))? @@",
+                    Text.RegularExpressions.RegexOptions.Compiled
+                )
+
+            wordDiffText
+            |> Text.normalizeLineEndings
+            |> Text.splitContentToLines
+            |> Array.choose (fun line ->
+                let matched = hunkHeaderPattern.Match line
+
+                if matched.Success then
+                    let parseCount (groupName: string) =
+                        let group = matched.Groups.[groupName]
+
+                        if group.Success then
+                            Int32.Parse group.Value
+                        else
+                            1
+
+                    Some {
+                        OldStart = Int32.Parse matched.Groups.["oldStart"].Value
+                        OldCount = parseCount "oldCount"
+                        NewStart = Int32.Parse matched.Groups.["newStart"].Value
+                        NewCount = parseCount "newCount"
+                    }
+                else
+                    None
+            )
+            |> Array.toList
+
+        let buildRowsFromWordDiff (wordDiffText: string) (leftContent: string) (rightContent: string) =
+            let leftLines = Text.splitContentToLines leftContent
+            let rightLines = Text.splitContentToLines rightContent
+            let hunks = parseWordDiffHunks wordDiffText
+
+            let rec loop leftCursor rightCursor remainingHunks =
+                match remainingHunks with
+                | hunk :: rest ->
+                    let leftBoundary = unchangedBoundary hunk.OldStart hunk.OldCount
+                    let rightBoundary = unchangedBoundary hunk.NewStart hunk.NewCount
+
+                    let unchangedRows =
+                        buildUnchangedRows leftLines rightLines leftCursor rightCursor leftBoundary rightBoundary
+
+                    let changedRows =
+                        Rows.buildIndexedRows
+                            leftBoundary
+                            rightBoundary
+                            (Text.sliceLines leftLines leftBoundary hunk.OldCount)
+                            (Text.sliceLines rightLines rightBoundary hunk.NewCount)
+
+                    [
+                        yield! unchangedRows
+                        yield! changedRows
+                        yield! loop (leftBoundary + hunk.OldCount) (rightBoundary + hunk.NewCount) rest
+                    ]
+                | [] ->
+                    buildUnchangedRows
+                        leftLines
+                        rightLines
+                        leftCursor
+                        rightCursor
+                        (leftLines.Length + 1)
+                        (rightLines.Length + 1)
+
+            loop 1 1 hunks
+
+    module MergeConflicts =
+
+        let containsConflictMarkers (content: string) =
+            content
+            |> Text.normalizeLineEndings
+            |> Text.splitContentToLines
+            |> Array.exists (fun line ->
+                line.StartsWith("<<<<<<<", StringComparison.Ordinal)
+                || line.StartsWith("=======", StringComparison.Ordinal)
+                || line.StartsWith(">>>>>>>", StringComparison.Ordinal)
+                || line.StartsWith("|||||||", StringComparison.Ordinal)
+            )
+
+        let private normalizeConflictLabel (markerLine: string) =
+            if markerLine.Length <= 7 then
+                None
+            else
+                markerLine.Substring(7).Trim()
+                |> Option.ofObj
+                |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
+        let parseMergeConflictFragments (mergeConflictContent: string) =
+            let normalized = Text.normalizeLineEndings mergeConflictContent
+            let lines = normalized.Split('\n')
+            let lineStartIndices = Array.zeroCreate<int> lines.Length
+
+            do
+                let mutable nextStartIndex = 0
+
+                for lineIndex in 0 .. lines.Length - 1 do
+                    lineStartIndices.[lineIndex] <- nextStartIndex
+                    nextStartIndex <- nextStartIndex + lines.[lineIndex].Length
+
+                    if lineIndex < lines.Length - 1 then
+                        nextStartIndex <- nextStartIndex + 1
+
+            let isMarker marker (line: string) =
+                line.StartsWith(marker, StringComparison.Ordinal)
+
+            let flushPlainFragment plainLinesRev fragmentsRev =
+                match plainLinesRev with
+                | [] -> fragmentsRev
+                | _ -> PlainText(String.concat "\n" (List.rev plainLinesRev)) :: fragmentsRev
+
+            let sliceToText startIndex endIndexInclusive =
+                let startOffset = lineStartIndices.[startIndex]
+                let endExclusive = lineStartIndices.[endIndexInclusive] + lines.[endIndexInclusive].Length
+                normalized.Substring(startOffset, endExclusive - startOffset)
+
+            let sliceToTextToEnd startIndex =
+                normalized.Substring(lineStartIndices.[startIndex])
+
+            let rec collectCurrent currentRev index =
+                if index >= lines.Length then
+                    Error()
+                else
+                    match lines.[index] with
+                    | line when isMarker "|||||||" line -> skipBase currentRev (index + 1)
+                    | line when isMarker "=======" line -> collectIncoming currentRev [] (index + 1)
+                    | line -> collectCurrent (line :: currentRev) (index + 1)
+
+            and skipBase currentRev index =
+                if index >= lines.Length then
+                    Error()
+                else
+                    match lines.[index] with
+                    | line when isMarker "=======" line -> collectIncoming currentRev [] (index + 1)
+                    | _ -> skipBase currentRev (index + 1)
+
+            and collectIncoming currentRev incomingRev index =
+                if index >= lines.Length then
+                    Error()
+                else
+                    match lines.[index] with
+                    | line when isMarker ">>>>>>>" line ->
+                        Ok(List.rev currentRev, normalizeConflictLabel line, List.rev incomingRev, index + 1, index)
+                    | line ->
+                        collectIncoming currentRev (line :: incomingRev) (index + 1)
+
+            let tryParseConflict conflictId startIndex =
+                let currentLabel = normalizeConflictLabel lines.[startIndex]
+
+                match collectCurrent [] (startIndex + 1) with
+                | Error() ->
+                    None
+                | Ok(currentLines, incomingLabel, incomingLines, nextIndex, endIndex) ->
+                    Some(
+                        {
+                            Id = conflictId
+                            CurrentLabel = currentLabel
+                            CurrentContent = String.concat "\n" currentLines
+                            IncomingLabel = incomingLabel
+                            IncomingContent = String.concat "\n" incomingLines
+                            RawContent = sliceToText startIndex endIndex
+                            StartIndex = lineStartIndices.[startIndex]
+                        },
+                        nextIndex
+                    )
+
+            let rec loop plainRev fragmentsRev nextConflictId index =
+                if index >= lines.Length then
+                    flushPlainFragment plainRev fragmentsRev |> List.rev
+                else
+                    match lines.[index] with
+                    | line when isMarker "<<<<<<<" line ->
+                        match tryParseConflict nextConflictId index with
+                        | Some(block, nextIndex) ->
+                            let fragmentsRev = flushPlainFragment plainRev fragmentsRev
+                            loop [] (ConflictBlock block :: fragmentsRev) (nextConflictId + 1) nextIndex
+                        | None ->
+                            let fragmentsRev = flushPlainFragment plainRev fragmentsRev
+                            List.rev (PlainText(sliceToTextToEnd index) :: fragmentsRev)
+                    | line ->
+                        loop (line :: plainRev) fragmentsRev nextConflictId (index + 1)
+
+            loop [] [] 1 0
+
+        let tryReplaceExactTextAt (startIndex: int) (expectedText: string) (replacementText: string) (sourceText: string) =
+            if String.IsNullOrEmpty expectedText then
+                Some sourceText
+            elif startIndex < 0 || startIndex + expectedText.Length > sourceText.Length then
+                None
+            else
+                let actualText = sourceText.Substring(startIndex, expectedText.Length)
+
+                if actualText = expectedText then
+                    Some(sourceText.Substring(0, startIndex) + replacementText + sourceText.Substring(startIndex + expectedText.Length))
+                else
+                    None

--- a/src/Components/src/GitComparison/GitTextComparison.fs
+++ b/src/Components/src/GitComparison/GitTextComparison.fs
@@ -1,0 +1,180 @@
+namespace Swate.Components
+
+open Feliz
+
+module internal GitTextComparisonRendering =
+
+    open GitTextComparisonCore
+
+    module Rendering =
+
+        type ComparisonSideStyle = {
+            ChangedLineNumberClass: string
+            ChangedLineClass: string
+            ChangedSegmentClass: string
+        }
+
+        type ComparisonTheme = {
+            LeftChanged: ComparisonSideStyle
+            RightChanged: ComparisonSideStyle
+        }
+
+        let DiffTheme = {
+            LeftChanged = {
+                ChangedLineNumberClass = "swt:text-base-content/60 swt:bg-error/8"
+                ChangedLineClass = "swt:bg-error/12"
+                ChangedSegmentClass = "swt:bg-error/22"
+            }
+            RightChanged = {
+                ChangedLineNumberClass = "swt:text-base-content/60 swt:bg-success/8"
+                ChangedLineClass = "swt:bg-success/12"
+                ChangedSegmentClass = "swt:bg-success/22"
+            }
+        }
+
+        let ChoiceTheme = {
+            LeftChanged = {
+                ChangedLineNumberClass = "swt:text-base-content/60 swt:bg-info/10"
+                ChangedLineClass = "swt:bg-info/12"
+                ChangedSegmentClass = "swt:bg-info/22"
+            }
+            RightChanged = {
+                ChangedLineNumberClass = "swt:text-base-content/60 swt:bg-secondary/12"
+                ChangedLineClass = "swt:bg-secondary/12"
+                ChangedSegmentClass = "swt:bg-secondary/20"
+            }
+        }
+
+        [<ReactComponent>]
+        let private ComparisonSegments (segments: InlineSegment list, changedSegmentClass: string) =
+            if List.isEmpty segments then
+                Html.span [ prop.text " " ]
+            else
+                segments
+                |> List.mapi (fun index segment ->
+                    Html.span [
+                        prop.key $"segment-{index}-{segment.Kind}"
+
+                        match segment.Kind with
+                        | LineChangeKind.Neutral -> ()
+                        | _ -> prop.className changedSegmentClass
+
+                        prop.text segment.Text
+                    ]
+                )
+                |> React.Fragment
+
+        [<ReactComponent>]
+        let private ComparisonSide (side: SideLine, changedStyle: ComparisonSideStyle) =
+            let lineNumberClassName =
+                match side.Kind with
+                | LineChangeKind.Neutral -> "swt:text-base-content/45 swt:bg-base-100"
+                | _ -> changedStyle.ChangedLineNumberClass
+
+            let lineClassName =
+                match side.Kind with
+                | LineChangeKind.Neutral -> "swt:bg-base-100"
+                | _ -> changedStyle.ChangedLineClass
+
+            Html.div [
+                prop.className "swt:grid swt:grid-cols-[3.5rem_minmax(0,1fr)] swt:min-w-0"
+                prop.children [
+                    Html.div [
+                        prop.className [
+                            "swt:px-3 swt:py-1 swt:text-right swt:text-xs swt:leading-5 swt:select-none swt:border-r swt:border-base-content/10"
+                            lineNumberClassName
+                        ]
+                        prop.text (side.Number |> Option.map string |> Option.defaultValue "")
+                    ]
+                    Html.div [
+                        prop.className [
+                            "swt:px-3 swt:py-1 swt:min-w-0 swt:font-mono swt:text-xs swt:leading-5"
+                            lineClassName
+                        ]
+                        prop.style [
+                            style.whitespace.pre
+                            style.overflowWrap.anywhere
+                        ]
+                        prop.children [ ComparisonSegments(side.Segments, changedStyle.ChangedSegmentClass) ]
+                    ]
+                ]
+            ]
+
+        [<ReactComponent>]
+        let private ComparisonHeader (sideLabel: string, title: string, lineCount: int, testId: string option) =
+            Html.div [
+                if testId.IsSome then
+                    prop.testId testId.Value
+                prop.className "swt:flex swt:items-start swt:justify-between swt:gap-3 swt:px-4 swt:py-3 swt:bg-base-200 swt:border-b swt:border-base-content/10"
+                prop.children [
+                    Html.div [
+                        prop.className "swt:min-w-0 swt:flex swt:flex-col swt:gap-0.5"
+                        prop.children [
+                            Html.span [
+                                prop.className "swt:text-[11px] swt:uppercase swt:tracking-wide swt:text-base-content/60"
+                                prop.text sideLabel
+                            ]
+                            Html.span [
+                                prop.className "swt:truncate swt:text-sm swt:font-semibold"
+                                prop.text title
+                            ]
+                        ]
+                    ]
+                    Html.span [
+                        prop.className "swt:badge swt:badge-ghost swt:badge-sm swt:shrink-0"
+                        prop.text $"{lineCount} lines"
+                    ]
+                ]
+            ]
+
+        [<ReactMemoComponent(AreEqualFn.FsEquals)>]
+        let ComparisonGrid
+            (
+                rows: DiffRow list,
+                leftHeader: string * (string * int),
+                rightHeader: string * (string * int),
+                leftHeaderTestId: string option,
+                rightHeaderTestId: string option,
+                scrollTestId: string option,
+                maxHeightPx: int option,
+                theme: ComparisonTheme option
+            ) =
+            let rows = if List.isEmpty rows then [ Rows.emptyRow () ] else rows
+            let maxHeightPx = defaultArg maxHeightPx 640
+            let theme = defaultArg theme DiffTheme
+
+            Html.div [
+                if scrollTestId.IsSome then
+                    prop.testId scrollTestId.Value
+                prop.className "swt:overflow-auto swt:scrollbar-fade"
+                prop.style [ style.maxHeight maxHeightPx ]
+                prop.children [
+                    Html.div [
+                        prop.className "swt:min-w-[58rem]"
+                        prop.children [
+                            Html.div [
+                                prop.className "swt:sticky swt:top-0 swt:z-10 swt:grid swt:grid-cols-2 swt:divide-x swt:divide-base-content/10"
+                                prop.children [
+                                    ComparisonHeader(fst leftHeader, (snd leftHeader |> fst), (snd leftHeader |> snd), leftHeaderTestId)
+                                    ComparisonHeader(fst rightHeader, (snd rightHeader |> fst), (snd rightHeader |> snd), rightHeaderTestId)
+                                ]
+                            ]
+                            Html.div [
+                                prop.children (
+                                    rows
+                                    |> List.mapi (fun index row ->
+                                        Html.div [
+                                            prop.key $"comparison-row-{index}"
+                                            prop.className "swt:grid swt:grid-cols-2 swt:divide-x swt:divide-base-content/10"
+                                            prop.children [
+                                                ComparisonSide(row.Left, theme.LeftChanged)
+                                                ComparisonSide(row.Right, theme.RightChanged)
+                                            ]
+                                        ]
+                                    )
+                                )
+                            ]
+                        ]
+                    ]
+                ]
+            ]

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -83,6 +83,11 @@
     <Compile Include="FileExplorer\FileExplorerGitLfsHelper.fs" />
     <Compile Include="FileExplorer\FileExplorerBreadcrumbs.fs" />
     <Compile Include="FileExplorer\FileExplorer.fs" />
+    <Compile Include="GitComparison\GitTextComparison.Core.fs" />
+    <Compile Include="GitComparison\GitTextComparison.fs" />
+    <Compile Include="GitComparison\GitComparisonView.fs" />
+    <Compile Include="GitComparison\GitDiffViewer.fs" />
+    <Compile Include="GitComparison\GitMergeConflictViewer.fs" />
     <Compile Include="ThemeProvider\ThemeProvider.fs" />
     <Compile Include="QuickAccessButton\QuickAccessButton.fs" />
     <Compile Include="TermSearch\TermSearchConfigProvider.fs" />

--- a/src/Components/src/index.js
+++ b/src/Components/src/index.js
@@ -4,5 +4,7 @@ export * as Icons from './output/GenericComponents/Icons.fs.ts';
 export { default as ThemeProvider } from './output/ThemeProvider/ThemeProvider.fs.ts';
 export { default as AnnotationTable } from './output/AnnotationTable/AnnotationTable.fs.ts';
 export { default as DataMapTable } from './output/DataMapTable/DataMapTable.fs.ts';
+export { Viewer as GitDiffViewer } from './output/GitComparison/GitDiffViewer.fs.ts';
+export { Viewer as GitMergeConflictViewer } from './output/GitComparison/GitMergeConflictViewer.fs.ts';
 export { SwateApi, TIBApi } from './output/Util/Api.fs.ts'
 import '../tailwind.css'

--- a/src/Electron/src/Main/Bindings/SimpleGit.fs
+++ b/src/Electron/src/Main/Bindings/SimpleGit.fs
@@ -26,7 +26,7 @@ type IAbortController =
 
 [<AllowNullLiteral>]
 type SimpleGitTimeoutOptions
-    [<ParamObject>]
+    [<ParamObject; Emit("$0")>]
     (
         ?block: int,
         ?stdOut: bool,
@@ -38,7 +38,7 @@ type SimpleGitTimeoutOptions
 
 [<AllowNullLiteral>]
 type SimpleGitUnsafeOptions
-    [<ParamObject>]
+    [<ParamObject; Emit("$0")>]
     (
         ?allowUnsafeCustomBinary: bool,
         ?allowUnsafeProtocolOverride: bool,
@@ -431,7 +431,7 @@ type CwdDirectory =
 
 [<AllowNullLiteral>]
 type SimpleGitCompletionOptions
-    [<ParamObject>]
+    [<ParamObject; Emit("$0")>]
     (
         ?onClose: U2<bool, int>,
         ?onExit: U2<bool, int>
@@ -441,7 +441,7 @@ type SimpleGitCompletionOptions
 
 [<AllowNullLiteral>]
 type SimpleGitSpawnOptions
-    [<ParamObject>]
+    [<ParamObject; Emit("$0")>]
     (
         ?uid: int,
         ?gid: int
@@ -451,7 +451,7 @@ type SimpleGitSpawnOptions
 
 [<AllowNullLiteral>]
 type SimpleGitOptions
-    [<ParamObject>]
+    [<ParamObject; Emit("$0")>]
     (
         ?baseDir: string,
         ?binary: SimpleGitBinary,

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -335,6 +335,27 @@ let getDiff (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<strin
                 })
 }
 
+let getWordDiff (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<string>> = promise {
+    match validatePathspecs pathSpecs with
+    | Error validationError -> return errorResult validationError
+    | Ok safePathSpecs ->
+        return!
+            withLocalGit
+                arcPath
+                (fun git -> promise {
+                    let diffArgs = [|
+                        "diff"
+                        "--word-diff=porcelain"
+                        "-U0"
+                        "--"
+                        yield! safePathSpecs
+                    |]
+
+                    let! diff = git.raw diffArgs
+                    return diff
+                })
+}
+
 let fetch
     (arcPath: string)
     (remoteName: string option)

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -321,6 +321,20 @@ let getDiffSummary (arcPath: string) : JS.Promise<GitResult<GitDiffSummaryDto>> 
             }
         })
 
+let getDiff (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<string>> = promise {
+    match validatePathspecs pathSpecs with
+    | Error validationError -> return errorResult validationError
+    | Ok safePathSpecs ->
+        return!
+            withLocalGit
+                arcPath
+                (fun git -> promise {
+                    let diffArgs = [| "diff"; "--"; yield! safePathSpecs |]
+                    let! diff = git.raw diffArgs
+                    return diff
+                })
+}
+
 let fetch
     (arcPath: string)
     (remoteName: string option)

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -102,6 +102,17 @@ let api: IGitApi = {
                 | Ok diffDto -> return Ok(toDiffSummaryDto diffDto)
                 | Error failure -> return Error(exn $"git diff summary failed ({failure.Kind}): {failure.Message}")
         }
+    getGitWordDiff =
+        fun (event: IpcMainEvent) (request: GitPathspecRequest) -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(_, arcPath) ->
+                let! result = GitService.getWordDiff arcPath request.Pathspecs
+
+                match result with
+                | Ok diffText -> return Ok diffText
+                | Error failure -> return Error(exn $"git word diff failed ({failure.Kind}): {failure.Message}")
+        }
     gitFetch =
         fun (event: IpcMainEvent) (request: GitRemoteOperationRequest) -> promise {
             match tryGetVaultAndArcPath event with

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -66,6 +66,7 @@ type IGitLfsApi = {
 type IGitApi = {
     getGitStatus: IpcMainEvent -> JS.Promise<Result<GitStatusDto, exn>>
     getGitDiffSummary: IpcMainEvent -> JS.Promise<Result<GitDiffSummaryDto, exn>>
+    getGitWordDiff: IpcMainEvent -> GitPathspecRequest -> JS.Promise<Result<string, exn>>
     gitFetch: IpcMainEvent -> GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitPull: IpcMainEvent -> GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitPush: IpcMainEvent -> GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>

--- a/tests/Electron.Core/Electron.Core.Tests.fsproj
+++ b/tests/Electron.Core/Electron.Core.Tests.fsproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GitService.test.fs" />
     <Compile Include="SecureAuthStore.test.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -1,0 +1,312 @@
+module ElectronCore.GitServiceTests
+
+open System
+open Fable.Core
+open Fable.Core.JS
+open Fable.Core.JsInterop
+open Main.Bindings.Path
+open Main.Bindings.SimpleGit
+open Vitest
+
+module GitService = Main.Git.GitService
+module GitProvisioningService = Main.Git.GitProvisioningService
+module GitAuthAdapter = Main.Git.GitAuthAdapter
+
+let private fsPromisesDynamic: obj = importAll "fs/promises"
+let private osDynamic: obj = importAll "os"
+
+type private TempRepositoryContext = {
+    RootPath: string
+    RepoPath: string
+    Git: ISimpleGit
+}
+
+let private createSimpleGit (repoPath: string) =
+    let options =
+        SimpleGitOptions(
+            baseDir = repoPath,
+            binary = U3.Case1 "git",
+            maxConcurrentProcesses = 1
+        )
+
+    SimpleGit.create options |> GitAuthAdapter.applyNonInteractiveEnv
+
+let private createTempDirectoryAsync () : JS.Promise<string> =
+    let prefix =
+        join [|
+            osDynamic?tmpdir() |> unbox<string>
+            "swate-electron-git-tests-"
+        |]
+
+    fsPromisesDynamic?mkdtemp(prefix) |> unbox<JS.Promise<string>>
+
+let private removeDirectoryAsync (path: string) : JS.Promise<unit> = promise {
+    let! _ =
+        fsPromisesDynamic?rm(path, createObj [ "recursive" ==> true; "force" ==> true ])
+        |> unbox<JS.Promise<obj>>
+
+    return ()
+}
+
+let private configureRepositoryAsync (git: ISimpleGit) : JS.Promise<unit> = promise {
+    let! _ = git.raw [| "config"; "user.name"; "Swate Electron Tests" |]
+    let! _ = git.raw [| "config"; "user.email"; "swate-electron-tests@example.org" |]
+    let! _ = git.raw [| "config"; "core.autocrlf"; "false" |]
+    return ()
+}
+
+let private ensureDirectoryAsync (path: string) : JS.Promise<unit> = promise {
+    let! _ =
+        fsPromisesDynamic?mkdir(path, createObj [ "recursive" ==> true ])
+        |> unbox<JS.Promise<obj>>
+
+    return ()
+}
+
+let private writeUtf8FileAsync (path: string) (content: string) : JS.Promise<unit> = promise {
+    let! _ = fsPromisesDynamic?writeFile(path, content, "utf8") |> unbox<JS.Promise<obj>>
+    return ()
+}
+
+let private expectOk<'T> (operationName: string) (result: GitService.GitResult<'T>) : 'T =
+    match result with
+    | Ok value -> value
+    | Error failure -> failwith $"{operationName} failed ({failure.Kind}): {failure.Message}"
+
+let private expectError<'T> (result: GitService.GitResult<'T>) : GitService.GitFailure =
+    match result with
+    | Ok _ -> failwith "Expected operation to fail."
+    | Error failure -> failure
+
+let private unwrapResultAsync
+    (resultPromise: JS.Promise<GitService.GitResult<'T>>)
+    (unwrap: GitService.GitResult<'T> -> 'U)
+    : JS.Promise<'U> =
+    promise {
+        let! result = resultPromise
+        return unwrap result
+    }
+
+let private splitNonEmptyLines (text: string) =
+    text.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
+
+let private withTempRepository (testBody: TempRepositoryContext -> JS.Promise<unit>) : JS.Promise<unit> = promise {
+    let! rootPath = createTempDirectoryAsync ()
+
+    try
+        let repoPath = join [| rootPath; "repo" |]
+        let! initResult = GitProvisioningService.initRepository repoPath
+        let normalizedRepoPath = expectOk "git init" initResult
+        let git = createSimpleGit normalizedRepoPath
+        do! configureRepositoryAsync git
+
+        do!
+            testBody {
+                RootPath = rootPath
+                RepoPath = normalizedRepoPath
+                Git = git
+            }
+
+        do! removeDirectoryAsync rootPath
+    with error ->
+        do! removeDirectoryAsync rootPath
+        return raise error
+}
+
+let private commitWorkflowFilePath = "notes/workflow.txt"
+let private featureBranchName = "feature/local-workflow"
+let private initialCommitMessage = "test: initial commit"
+let private secondCommitMessage = "test: second commit"
+
+Vitest.describe("GitService local repository workflow", fun () ->
+    Vitest.test("initializes, commits, diffs, recommits, and switches branches locally", fun () -> promise {
+        do!
+            withTempRepository (fun context -> promise {
+                let notesDirectory = join [| context.RepoPath; "notes" |]
+                let filePath = join [| context.RepoPath; "notes"; "workflow.txt" |]
+
+                do! ensureDirectoryAsync notesDirectory
+                do! writeUtf8FileAsync filePath "alpha\nbeta\ngamma\n"
+
+                let! stageResult = GitService.stagePaths context.RepoPath [| commitWorkflowFilePath |]
+                expectOk "git add" stageResult |> ignore
+
+                let! stagedStatus =
+                    unwrapResultAsync (GitService.getStatus context.RepoPath) (expectOk "git status after staging")
+
+                let stagedFile =
+                    stagedStatus.Files
+                    |> Microsoft.FSharp.Collections.Array.find (fun file -> file.Path = commitWorkflowFilePath)
+
+                Vitest.expect(stagedStatus.IsClean).toBe(false)
+                Vitest.expect(stagedFile.Index).toBe("A")
+
+                let! firstCommitHash =
+                    unwrapResultAsync (GitService.commit context.RepoPath initialCommitMessage) (expectOk "first commit")
+
+                Vitest.expect(firstCommitHash.Length).toBeGreaterThan(6)
+
+                let! cleanStatus =
+                    unwrapResultAsync (GitService.getStatus context.RepoPath) (expectOk "git status after first commit")
+
+                let initialBranch =
+                    cleanStatus.Current
+                    |> Option.defaultWith (fun () -> failwith "Expected initialized repository to have a current branch.")
+
+                Vitest.expect(cleanStatus.IsClean).toBe(true)
+
+                do! writeUtf8FileAsync filePath "alpha\nbeta updated\ndelta\n"
+
+                let! modifiedStatus =
+                    unwrapResultAsync (GitService.getStatus context.RepoPath) (expectOk "git status after file change")
+
+                let modifiedFile =
+                    modifiedStatus.Files
+                    |> Microsoft.FSharp.Collections.Array.find (fun file -> file.Path = commitWorkflowFilePath)
+
+                Vitest.expect(modifiedStatus.IsClean).toBe(false)
+                Vitest.expect(modifiedFile.WorkingDir).toBe("M")
+
+                let! diffSummary =
+                    unwrapResultAsync (GitService.getDiffSummary context.RepoPath) (expectOk "git diff summary")
+
+                Vitest.expect(diffSummary.Changed).toBe(1)
+                Vitest.expect(diffSummary.Insertions).toBe(2)
+                Vitest.expect(diffSummary.Deletions).toBe(2)
+
+                let! diffText =
+                    unwrapResultAsync (GitService.getDiff context.RepoPath [| commitWorkflowFilePath |]) (expectOk "git diff")
+
+                Vitest.expect(diffText.Contains("diff --git")).toBe(true)
+                Vitest.expect(diffText.Contains("@@")).toBe(true)
+                Vitest.expect(diffText.Contains("-beta")).toBe(true)
+                Vitest.expect(diffText.Contains("+beta updated")).toBe(true)
+                Vitest.expect(diffText.Contains("-gamma")).toBe(true)
+                Vitest.expect(diffText.Contains("+delta")).toBe(true)
+
+                let! secondStageResult = GitService.stagePaths context.RepoPath [| commitWorkflowFilePath |]
+                expectOk "git add after edit" secondStageResult |> ignore
+
+                let! secondCommitHash =
+                    unwrapResultAsync (GitService.commit context.RepoPath secondCommitMessage) (expectOk "second commit")
+
+                Vitest.expect(secondCommitHash.Length).toBeGreaterThan(6)
+
+                let! logOutput = context.Git.raw [| "log"; "-2"; "--pretty=%s" |]
+                let logMessages = splitNonEmptyLines logOutput
+                Vitest.expect(logMessages.Length).toBe(2)
+                Vitest.expect(logMessages.[0]).toBe(secondCommitMessage)
+                Vitest.expect(logMessages.[1]).toBe(initialCommitMessage)
+
+                let! createBranchResult = GitService.createBranch context.RepoPath featureBranchName None
+                expectOk "create branch" createBranchResult |> ignore
+
+                let! createdBranchStatus =
+                    unwrapResultAsync (GitService.getStatus context.RepoPath) (expectOk "git status after create branch")
+
+                Vitest.expect(createdBranchStatus.Current |> Option.defaultValue "").toBe(featureBranchName)
+
+                let! checkoutBaseBranchResult = GitService.checkoutBranch context.RepoPath initialBranch
+                expectOk "checkout initial branch" checkoutBaseBranchResult |> ignore
+
+                let! baseBranchStatus =
+                    unwrapResultAsync (GitService.getStatus context.RepoPath) (expectOk "git status after checkout")
+
+                Vitest.expect(baseBranchStatus.Current |> Option.defaultValue "").toBe(initialBranch)
+
+                let! checkoutFeatureBranchResult = GitService.checkoutBranch context.RepoPath featureBranchName
+                expectOk "checkout feature branch" checkoutFeatureBranchResult |> ignore
+
+                let! featureBranchStatus =
+                    unwrapResultAsync (GitService.getStatus context.RepoPath) (expectOk "git status on feature branch")
+
+                Vitest.expect(featureBranchStatus.Current |> Option.defaultValue "").toBe(featureBranchName)
+            })
+    })
+
+    Vitest.test("unstagePaths keeps working tree changes but removes staged state", fun () -> promise {
+        do!
+            withTempRepository (fun context -> promise {
+                let filePath = join [| context.RepoPath; "tracked.txt" |]
+
+                do! writeUtf8FileAsync filePath "first\nsecond\n"
+
+                let! initialStageResult = GitService.stagePaths context.RepoPath [| "tracked.txt" |]
+                expectOk "stage tracked file" initialStageResult |> ignore
+
+                let! initialCommitResult = GitService.commit context.RepoPath "test: track file"
+                expectOk "commit tracked file" initialCommitResult |> ignore
+
+                do! writeUtf8FileAsync filePath "first\nsecond updated\nthird\n"
+
+                let! modifiedStageResult = GitService.stagePaths context.RepoPath [| "tracked.txt" |]
+                expectOk "stage modified file" modifiedStageResult |> ignore
+
+                let! unstageResult = GitService.unstagePaths context.RepoPath [| "tracked.txt" |]
+                expectOk "unstage modified file" unstageResult |> ignore
+
+                let! status =
+                    unwrapResultAsync (GitService.getStatus context.RepoPath) (expectOk "git status after unstage")
+
+                let fileStatus =
+                    status.Files
+                    |> Microsoft.FSharp.Collections.Array.find (fun file -> file.Path = "tracked.txt")
+
+                Vitest.expect(status.IsClean).toBe(false)
+                Vitest.expect(fileStatus.WorkingDir).toBe("M")
+                Vitest.expect(fileStatus.Index = "M").toBe(false)
+            })
+    })
+
+    Vitest.test("rejects invalid diff pathspecs before invoking git", fun () -> promise {
+        do!
+            withTempRepository (fun context -> promise {
+                let! failure =
+                    unwrapResultAsync (GitService.getDiff context.RepoPath [| "../outside.txt" |]) expectError
+
+                Vitest.expect(failure.Message.Contains("traversal")).toBe(true)
+            })
+    })
+
+    Vitest.test("fails when initializing a repository twice at the same target path", fun () -> promise {
+        let! rootPath = createTempDirectoryAsync ()
+
+        try
+            let repoPath = join [| rootPath; "repo" |]
+
+            let! firstInitResult = GitProvisioningService.initRepository repoPath
+            let normalizedRepoPath = expectOk "first init" firstInitResult
+            Vitest.expect(normalizedRepoPath.Length).toBeGreaterThan(0)
+
+            let! secondInitResult = GitProvisioningService.initRepository repoPath
+            let failure = expectError secondInitResult
+
+            Vitest.expect(failure.Message.Contains("already a git repository")).toBe(true)
+            do! removeDirectoryAsync rootPath
+        with error ->
+            do! removeDirectoryAsync rootPath
+            return raise error
+    })
+
+    Vitest.test("fails when checking out a branch that does not exist locally", fun () -> promise {
+        do!
+            withTempRepository (fun context -> promise {
+                let filePath = join [| context.RepoPath; "tracked.txt" |]
+
+                do! writeUtf8FileAsync filePath "content\n"
+
+                let! stageResult = GitService.stagePaths context.RepoPath [| "tracked.txt" |]
+                expectOk "stage tracked file" stageResult |> ignore
+
+                let! commitResult = GitService.commit context.RepoPath "test: base commit"
+                expectOk "commit tracked file" commitResult |> ignore
+
+                let! failure =
+                    unwrapResultAsync
+                        (GitService.checkoutBranch context.RepoPath "missing/local-branch")
+                        expectError
+
+                Vitest.expect(failure.Message.Contains("does not exist in the local repository")).toBe(true)
+            })
+    })
+)

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -184,6 +184,17 @@ Vitest.describe("GitService local repository workflow", fun () ->
                 Vitest.expect(diffText.Contains("-gamma")).toBe(true)
                 Vitest.expect(diffText.Contains("+delta")).toBe(true)
 
+                let! wordDiffText =
+                    unwrapResultAsync (GitService.getWordDiff context.RepoPath [| commitWorkflowFilePath |]) (expectOk "git word diff")
+
+                Vitest.expect(wordDiffText.Contains("diff --git")).toBe(true)
+                Vitest.expect(wordDiffText.Contains("@@ -2,2 +2,2 @@")).toBe(true)
+                Vitest.expect(wordDiffText.Contains("-beta")).toBe(false)
+                Vitest.expect(wordDiffText.Contains("-gamma")).toBe(true)
+                Vitest.expect(wordDiffText.Contains("+updated")).toBe(true)
+                Vitest.expect(wordDiffText.Contains("+delta")).toBe(true)
+                Vitest.expect(wordDiffText.Contains("~")).toBe(true)
+
                 let! secondStageResult = GitService.stagePaths context.RepoPath [| commitWorkflowFilePath |]
                 expectOk "git add after edit" secondStageResult |> ignore
 
@@ -263,6 +274,16 @@ Vitest.describe("GitService local repository workflow", fun () ->
             withTempRepository (fun context -> promise {
                 let! failure =
                     unwrapResultAsync (GitService.getDiff context.RepoPath [| "../outside.txt" |]) expectError
+
+                Vitest.expect(failure.Message.Contains("traversal")).toBe(true)
+            })
+    })
+
+    Vitest.test("rejects invalid word diff pathspecs before invoking git", fun () -> promise {
+        do!
+            withTempRepository (fun context -> promise {
+                let! failure =
+                    unwrapResultAsync (GitService.getWordDiff context.RepoPath [| "../outside.txt" |]) expectError
 
                 Vitest.expect(failure.Message.Contains("traversal")).toBe(true)
             })


### PR DESCRIPTION
This PR expands Swate’s Git comparison support on both the Electron and component-library sides. It adds local Git diff retrieval in the Electron service layer, exposes word-diff data over IPC, fixes `simple-git` option emission so repository directory settings propagate correctly, and adds local repository tests covering diff/commit/branch workflows plus pathspec validation.

On the UI side, it introduces reusable `GitDiffViewer` and `GitMergeConflictViewer` components with shared comparison rendering. These components support side-by-side diff display, interactive merge conflict resolution with incoming/current selection and undo, editable resolved content, and Storybook coverage.