### PR TITLE
Refactor usage of relative and absolute paths

### DIFF
--- a/src/Client/MainComponents/Widgets.fs
+++ b/src/Client/MainComponents/Widgets.fs
@@ -297,10 +297,9 @@ type Widget =
     [<ReactComponent>]
     static member DataAnnotator(model: Model, dispatch, rmv) =
         let inputRef = React.useInputRef ()
-        let selectedFilesRef = React.useRef (Map.empty<string, Browser.Types.File>)
 
         let pendingPickResolve =
-            React.useRef (None: (Result<string[], string> -> unit) option)
+            React.useRef (None: (Result<ImportedTextFile[], string> -> unit) option)
 
         let activeView =
             match model.SpreadsheetModel.ActiveView with
@@ -316,7 +315,7 @@ type Widget =
         let services =
             React.useMemo (
                 (fun _ -> {
-                    pickPaths =
+                    pickTextFiles =
                         fun () ->
                             Promise.create (fun resolve _ ->
                                 pendingPickResolve.current <- Some resolve
@@ -329,15 +328,6 @@ type Widget =
                                     pendingPickResolve.current <- None
                                     resolve (Result.Error "Browser file input is unavailable.")
                             )
-                    loadTextFile =
-                        fun path -> promise {
-                            match selectedFilesRef.current |> Map.tryFind path with
-                            | Some file ->
-                                let! content = file.text ()
-                                return Result.Ok content
-                            | None ->
-                                return Result.Error "Selected file is no longer available. Choose the file again."
-                        }
                 }),
                 [||]
             )
@@ -352,12 +342,17 @@ type Widget =
                         prop.accept ".csv,.tsv,.txt,text/csv,text/tab-separated-values,text/plain"
                         prop.ref inputRef
                         prop.onChange (fun (file: Browser.Types.File) ->
-                            selectedFilesRef.current <- selectedFilesRef.current.Add(file.name, file)
+                            promise {
+                                let! content = file.text ()
 
-                            pendingPickResolve.current
-                            |> Option.iter (fun resolve -> resolve (Result.Ok [| file.name |]))
+                                pendingPickResolve.current
+                                |> Option.iter (fun resolve ->
+                                    resolve (Result.Ok [| { Name = file.name; Content = content } |])
+                                )
 
-                            pendingPickResolve.current <- None
+                                pendingPickResolve.current <- None
+                            }
+                            |> Promise.start
                         )
                     ]
                     if model.SpreadsheetModel.ArcFile.IsSome then

--- a/src/Components/src/FileExplorer/FileExplorer.fs
+++ b/src/Components/src/FileExplorer/FileExplorer.fs
@@ -87,13 +87,13 @@ type FileExplorer =
                         Disabled = None
                     }
                 match item.Path with
-                | Some path -> {
+                | Some path when not (System.String.IsNullOrWhiteSpace path) -> {
                     Label = "Copy Path"
                     Icon = "swt:fluent--copy-24-regular"
                     OnClick = fun () -> copyPathToClipboard path
                     Disabled = None
                   }
-                | None -> ()
+                | _ -> ()
                 if item.IsDirectory then
                     let isExpanded = model.ExpandedIds.Contains item.Id
 

--- a/src/Components/src/FileExplorer/FileExplorerGitLfsHelper.fs
+++ b/src/Components/src/FileExplorer/FileExplorerGitLfsHelper.fs
@@ -5,37 +5,20 @@ open Fable.Core
 [<RequireQualifiedAccess>]
 type FileExplorerGitLfsHelper =
 
-    static member private NormalizePath(path: string) = path.Replace("\\", "/").TrimEnd('/')
-
-    static member private TryToRepoRelativePath(rootRepoPath: string, filePath: string) =
-        let normalizedRepoPath = FileExplorerGitLfsHelper.NormalizePath rootRepoPath
-        let normalizedFilePath = FileExplorerGitLfsHelper.NormalizePath filePath
-        let prefix = normalizedRepoPath + "/"
-
-        if normalizedFilePath = normalizedRepoPath then
-            Some(normalizedRepoPath, "")
-        elif normalizedFilePath.StartsWith(prefix, System.StringComparison.OrdinalIgnoreCase) then
-            Some(normalizedRepoPath, normalizedFilePath.Substring(prefix.Length))
-        else
-            None
-
     static member ToggleLfsMark
         (
-            rootRepoPath: string,
             setError: string option -> unit,
-            runToggle: string -> string -> bool -> JS.Promise<Result<unit, string>>
+            runToggle: string -> bool -> JS.Promise<Result<unit, string>>
         ) : (FileItem -> bool -> unit) =
         fun item markAsLfs ->
             promise {
                 match item.Path with
                 | None -> ()
-                | Some itemPath ->
-                    match FileExplorerGitLfsHelper.TryToRepoRelativePath(rootRepoPath, itemPath) with
-                    | None -> setError (Some $"Could not resolve repository-relative path for '{item.Name}'.")
-                    | Some(_, relativePath) when System.String.IsNullOrWhiteSpace relativePath ->
+                | Some relativePath ->
+                    if System.String.IsNullOrWhiteSpace relativePath then
                         setError (Some "Cannot mark ARC root as a Git LFS file.")
-                    | Some(repoPath, relativePath) ->
-                        let! result = runToggle repoPath relativePath markAsLfs
+                    else
+                        let! result = runToggle relativePath markAsLfs
 
                         match result with
                         | Ok _ -> setError None

--- a/src/Components/src/Widgets/DataAnnotatorWidget.fs
+++ b/src/Components/src/Widgets/DataAnnotatorWidget.fs
@@ -231,9 +231,6 @@ type DataAnnotatorWidget =
     static member private WidgetContainerClass =
         "swt:flex swt:flex-col swt:gap-3 swt:p-2 swt:w-fit swt:max-w-[95vw]"
 
-    static member private fileNameFromPath(path: string) =
-        path.Replace("\\", "/").Split('/') |> Array.last
-
     static member private fileTypeFromName(fileName: string) =
         if fileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase) then
             "text/csv"
@@ -374,7 +371,7 @@ type DataAnnotatorWidget =
         (
             pickFile: unit -> JS.Promise<unit>,
             loading: bool,
-            selectedPath: string option,
+            selectedFileName: string option,
             dataFile: DataAnnotatorWidgetModel.DataFile option,
             reset: unit -> unit
         ) =
@@ -391,11 +388,7 @@ type DataAnnotatorWidget =
                     prop.className "swt:input swt:input-sm swt:grow"
                     prop.readOnly true
                     prop.placeholder "No file selected"
-                    prop.value (
-                        selectedPath
-                        |> Option.map DataAnnotatorWidget.fileNameFromPath
-                        |> Option.defaultValue ""
-                    )
+                    prop.value (selectedFileName |> Option.defaultValue "")
                 ]
                 Html.button [
                     prop.className "swt:btn swt:btn-outline swt:btn-sm"
@@ -426,7 +419,7 @@ type DataAnnotatorWidget =
             React.useStateWithUpdater (Set.empty<DataAnnotatorWidgetModel.DataTarget>)
 
         let separatorInput, setSeparatorInput = React.useState ""
-        let selectedPath, setSelectedPath = React.useState (None: string option)
+        let selectedFileName, setSelectedFileName = React.useState (None: string option)
 
         let targetColumn, setTargetColumn =
             React.useState DataAnnotatorWidgetModel.TargetColumn.Autodetect
@@ -444,52 +437,45 @@ type DataAnnotatorWidget =
             setParsedFile None
             setSelectedTargets (fun _ -> Set.empty)
             setSeparatorInput ""
-            setSelectedPath None
+            setSelectedFileName None
             setTargetColumn DataAnnotatorWidgetModel.TargetColumn.Autodetect
             setStatusMessage None
             setErrorMessage None
 
         let setLoadedFile
-            (path: string)
+            (fileName: string)
             (nextDataFile: DataAnnotatorWidgetModel.DataFile)
             (nextParsedFile: DataAnnotatorWidgetModel.ParsedDataFile option)
             =
-            setSelectedPath (Some path)
+            setSelectedFileName (Some fileName)
             setDataFile (Some nextDataFile)
             setParsedFile nextParsedFile
             setSeparatorInput (DataAnnotatorWidget.separatorToInput nextDataFile.ExpectedSeparator)
             setSelectedTargets (fun _ -> Set.empty)
 
-        let loadFileFromPath (path: string) = promise {
+        let loadImportedFile (importedFile: ImportedTextFile) = promise {
             setLoading true
             setStatusMessage None
             setErrorMessage None
 
             try
-                let! fileResult = services.loadTextFile path
+                let loadedDataFile =
+                    DataAnnotatorWidgetModel.DataFile.create (
+                        importedFile.Name,
+                        DataAnnotatorWidget.fileTypeFromName importedFile.Name,
+                        importedFile.Content,
+                        float importedFile.Content.Length
+                    )
 
-                match fileResult with
-                | Error message -> setErrorMessage (Some $"Failed to open file: {message}")
-                | Ok content ->
-                    let fileName = DataAnnotatorWidget.fileNameFromPath path
-
-                    let loadedDataFile =
-                        DataAnnotatorWidgetModel.DataFile.create (
-                            fileName,
-                            DataAnnotatorWidget.fileTypeFromName fileName,
-                            content,
-                            float content.Length
-                        )
-
-                    match
-                        DataAnnotatorWidget.parseDataFileBySeparator loadedDataFile.ExpectedSeparator loadedDataFile
-                    with
-                    | Ok parsed ->
-                        setLoadedFile path loadedDataFile (Some parsed)
-                        setStatusMessage (Some $"Loaded {fileName} ({parsed.BodyRows.Length} rows).")
-                    | Error message ->
-                        setLoadedFile path loadedDataFile None
-                        setErrorMessage (Some message)
+                match
+                    DataAnnotatorWidget.parseDataFileBySeparator loadedDataFile.ExpectedSeparator loadedDataFile
+                with
+                | Ok parsed ->
+                    setLoadedFile importedFile.Name loadedDataFile (Some parsed)
+                    setStatusMessage (Some $"Loaded {importedFile.Name} ({parsed.BodyRows.Length} rows).")
+                | Error message ->
+                    setLoadedFile importedFile.Name loadedDataFile None
+                    setErrorMessage (Some message)
             finally
                 setLoading false
         }
@@ -498,17 +484,17 @@ type DataAnnotatorWidget =
             setStatusMessage None
             setErrorMessage None
 
-            let! pathResult = services.pickPaths ()
+            let! importResult = services.pickTextFiles ()
 
-            match pathResult with
+            match importResult with
             | Error message when message <> "Cancelled" -> setErrorMessage (Some $"Failed to pick file: {message}")
             | Error _ -> ()
-            | Ok paths when paths.Length = 0 -> setStatusMessage (Some "No file selected.")
-            | Ok paths ->
-                if paths.Length > 1 then
+            | Ok importedFiles when importedFiles.Length = 0 -> setStatusMessage (Some "No file selected.")
+            | Ok importedFiles ->
+                if importedFiles.Length > 1 then
                     setStatusMessage (Some "Multiple files selected. Using the first one.")
 
-                do! loadFileFromPath paths.[0]
+                do! loadImportedFile importedFiles.[0]
         }
 
         let applySeparator () =
@@ -663,7 +649,13 @@ type DataAnnotatorWidget =
                             ]
                         ]
                     ]
-                    DataAnnotatorWidget.FileControllerElements(pickFile, loading, selectedPath, dataFile, reset)
+                    DataAnnotatorWidget.FileControllerElements(
+                        pickFile,
+                        loading,
+                        selectedFileName,
+                        dataFile,
+                        reset
+                    )
                     if dataFile.IsSome then
                         Html.div [
                             prop.className "swt:flex swt:flex-wrap swt:gap-2 swt:items-center"

--- a/src/Components/src/Widgets/WidgetSupport.fs
+++ b/src/Components/src/Widgets/WidgetSupport.fs
@@ -42,9 +42,13 @@ type FilePickerWidgetServices = {
     pickPaths: unit -> JS.Promise<Result<string[], string>>
 }
 
+type ImportedTextFile = {
+    Name: string
+    Content: string
+}
+
 type DataAnnotatorWidgetServices = {
-    pickPaths: unit -> JS.Promise<Result<string[], string>>
-    loadTextFile: string -> JS.Promise<Result<string, string>>
+    pickTextFiles: unit -> JS.Promise<Result<ImportedTextFile[], string>>
 }
 
 type TemplateWidgetServices = {

--- a/src/Electron/src/Main/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault.fs
@@ -204,7 +204,12 @@ module ArcVaultExtensions =
                 |> Remoting.withWindow this.window
                 |> Remoting.buildClient<IMainUpdateRendererApi>
 
-            sendMsg.fileTreeUpdate fileTree
+            let rendererFileTree =
+                match this.path with
+                | Some arcPath -> toRendererFileTree arcPath fileTree.Values
+                | None -> Dictionary<string, FileEntry>()
+
+            sendMsg.fileTreeUpdate rendererFileTree
 
         member this.LoadArc() = promise {
             if this.path.IsSome then

--- a/src/Electron/src/Main/FileTreeCreator.fs
+++ b/src/Electron/src/Main/FileTreeCreator.fs
@@ -12,8 +12,12 @@ let childProcessDynamic: obj = importAll "node:child_process"
 
 let private normalizePath (path: string) = path.Replace("\\", "/")
 
-let private normalizeRootPath (path: string) =
+let normalizeRootPath (path: string) =
     pathMod?resolve (path) |> unbox<string> |> normalizePath
+
+let private containsTraversalSegments (path: string) =
+    path.Split('/')
+    |> Array.exists (fun segment -> segment = "." || segment = "..")
 
 let private shouldIgnoreDirName (name: string) = name = ".git"
 
@@ -22,14 +26,38 @@ let private shouldIgnorePath (path: string) =
     let tempXlsxPattern = """\.~\$.*\.xlsx$"""
     System.Text.RegularExpressions.Regex.IsMatch(normalizedPath, tempXlsxPattern)
 
-let private tryGetRepoRelativePath (repoRoot: string) (absolutePath: string) =
+let private tryGetRepoRelativePathCore (repoRoot: string) (absolutePath: string) (allowRoot: bool) =
     let relativePath =
-        pathMod?relative (repoRoot, absolutePath) |> unbox<string> |> normalizePath
+        pathMod?relative (normalizeRootPath repoRoot, normalizeRootPath absolutePath)
+        |> unbox<string>
+        |> normalizePath
 
     if System.String.IsNullOrWhiteSpace relativePath || relativePath = "." then
+        if allowRoot then Some "" else None
+    elif containsTraversalSegments relativePath then
         None
     else
         Some relativePath
+
+let tryGetRepoRelativePath (repoRoot: string) (absolutePath: string) =
+    tryGetRepoRelativePathCore repoRoot absolutePath false
+
+let tryGetRepoRelativePathOrRoot (repoRoot: string) (absolutePath: string) =
+    tryGetRepoRelativePathCore repoRoot absolutePath true
+
+/// Build the renderer snapshot using ARC-relative dictionary keys and FileEntry paths.
+let toRendererFileTree (repoRoot: string) (entries: seq<FileEntry>) : Dictionary<string, FileEntry> =
+    let rendererFileTree = Dictionary<string, FileEntry>()
+
+    entries
+    |> Seq.iter (fun entry ->
+        match tryGetRepoRelativePathOrRoot repoRoot entry.path with
+        | Some relativePath ->
+            rendererFileTree.[relativePath] <- { entry with path = relativePath }
+        | None -> ()
+    )
+
+    rendererFileTree
 
 let private tryGetLfsTrackedByAttributes
     (repoRoot: string)

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -1,6 +1,7 @@
 module Main.IPC.ArcVaultsApi
 
 open System
+open Swate.Components
 open Swate.Electron.Shared
 open Swate.Electron.Shared.IPCTypes
 open Swate.Electron.Shared.GitTypes
@@ -19,12 +20,37 @@ open ARCtrl.Json
 let private fsPromisesDynamic: obj = importAll "fs/promises"
 let private pathDynamic: obj = importAll "path"
 
-let private normalizePathForComparison (pathValue: string) =
-    pathValue.Replace("\\", "/").Trim().TrimEnd('/').ToLowerInvariant()
+[<RequireQualifiedAccess>]
+module ArcPathValidation =
 
-let private containsTraversalSegments (relativePath: string) =
-    relativePath.Split('/')
-    |> Array.exists (fun segment -> segment = "." || segment = "..")
+    let normalizePathForComparison (pathValue: string) =
+        pathValue.Replace("\\", "/").Trim().TrimEnd('/').ToLowerInvariant()
+
+    let containsTraversalSegments (pathValue: string) =
+        pathValue.Split('/')
+        |> Array.exists (fun segment -> segment = "." || segment = "..")
+
+    let isSafeRelativePathCandidate (pathValue: string) =
+        let normalizedPath = FileIOHelper.normalizePath pathValue
+
+        not (String.IsNullOrWhiteSpace normalizedPath)
+        && normalizedPath <> "."
+        && not (pathDynamic?isAbsolute (normalizedPath) |> unbox<bool>)
+        && not (containsTraversalSegments normalizedPath)
+
+    let isWithinRootPath (rootPath: string) (candidatePath: string) =
+        let normalizedRootPath =
+            pathDynamic?resolve (rootPath)
+            |> unbox<string>
+            |> normalizePathForComparison
+
+        let normalizedCandidatePath =
+            pathDynamic?resolve (candidatePath)
+            |> unbox<string>
+            |> normalizePathForComparison
+
+        normalizedCandidatePath = normalizedRootPath
+        || normalizedCandidatePath.StartsWith(normalizedRootPath + "/")
 
 let private tryGetArcRelativePath (arcPath: string) (requestedAbsolutePath: string) =
     let arcRoot = pathDynamic?resolve (arcPath) |> unbox<string>
@@ -37,7 +63,9 @@ let private tryGetArcRelativePath (arcPath: string) (requestedAbsolutePath: stri
 
     if String.IsNullOrWhiteSpace relativePath || relativePath = "." then
         Ok ""
-    elif containsTraversalSegments relativePath then
+    elif not (ArcPathValidation.isSafeRelativePathCandidate relativePath) then
+        Error(exn $"Path '{requestedAbsolutePath}' is outside the active ARC root.")
+    elif not (ArcPathValidation.isWithinRootPath arcRoot absolutePath) then
         Error(exn $"Path '{requestedAbsolutePath}' is outside the active ARC root.")
     else
         Ok relativePath
@@ -48,22 +76,16 @@ let private tryResolveArcRelativePath (arcPath: string) (requestedRelativePath: 
 
     if String.IsNullOrWhiteSpace relativePath then
         Error(exn "RelativePath must not be empty.")
-    elif pathDynamic?isAbsolute (relativePath) |> unbox<bool> then
-        Error(exn "RelativePath must not be absolute.")
-    elif containsTraversalSegments relativePath then
-        Error(exn "RelativePath must not contain path traversal segments.")
+    elif not (ArcPathValidation.isSafeRelativePathCandidate relativePath) then
+        if pathDynamic?isAbsolute (relativePath) |> unbox<bool> then
+            Error(exn "RelativePath must not be absolute.")
+        else
+            Error(exn "RelativePath must not contain path traversal segments.")
     else
         let arcRoot = pathDynamic?resolve (arcPath) |> unbox<string>
         let absolutePath = pathDynamic?resolve (arcRoot, relativePath) |> unbox<string>
 
-        let normalizedArcRoot = normalizePathForComparison arcRoot
-        let normalizedAbsolutePath = normalizePathForComparison absolutePath
-
-        let isWithinArcRoot =
-            normalizedAbsolutePath = normalizedArcRoot
-            || normalizedAbsolutePath.StartsWith(normalizedArcRoot + "/")
-
-        if isWithinArcRoot then
+        if ArcPathValidation.isWithinRootPath arcRoot absolutePath then
             Ok absolutePath
         else
             Error(exn "RelativePath resolves outside the ARC root.")
@@ -85,6 +107,10 @@ let private writeUtf8FileAsync (absolutePath: string) (content: string) : JS.Pro
     let! _ = writePromise
     return ()
 }
+
+let private readUtf8FileAsync (absolutePath: string) : JS.Promise<string> =
+    fsPromisesDynamic?readFile (absolutePath, "utf8")
+    |> unbox<JS.Promise<string>>
 
 open ARCtrl.Contract
 
@@ -331,19 +357,52 @@ let api: IPCTypes.IArcVaultsApi = {
             with e ->
                 return Error e
         }
-    pickPaths =
+    pickAbsolutePaths =
         fun _ -> promise {
-            let properties = [|
-                Enums.Dialog.ShowOpenDialog.Options.Properties.OpenFile
-                Enums.Dialog.ShowOpenDialog.Options.Properties.MultiSelections
-            |]
+            try
+                let properties = [|
+                    Enums.Dialog.ShowOpenDialog.Options.Properties.OpenFile
+                    Enums.Dialog.ShowOpenDialog.Options.Properties.MultiSelections
+                |]
 
-            let! result = dialog.showOpenDialog (properties = properties)
+                let! result = dialog.showOpenDialog (properties = properties)
 
-            if result.canceled then
-                return Error(exn "Cancelled")
-            else
-                return Ok result.filePaths
+                if result.canceled then
+                    return Error(exn "Cancelled")
+                else
+                    return Ok result.filePaths
+            with e ->
+                return Error(exn $"Could not pick files: {e.Message}")
+        }
+    pickExternalTextFiles =
+        fun _ -> promise {
+            try
+                let properties = [|
+                    Enums.Dialog.ShowOpenDialog.Options.Properties.OpenFile
+                    Enums.Dialog.ShowOpenDialog.Options.Properties.MultiSelections
+                |]
+
+                let filters = [| FileFilter("Delimited text files", [| "csv"; "tsv"; "txt" |]) |]
+
+                let! result = dialog.showOpenDialog (properties = properties, filters = filters)
+
+                if result.canceled then
+                    return Error(exn "Cancelled")
+                else
+                    let importedFiles = ResizeArray<ImportedTextFile>()
+
+                    for filePath in result.filePaths do
+                        let absolutePath = pathDynamic?resolve (filePath) |> unbox<string>
+                        let! content = readUtf8FileAsync absolutePath
+
+                        importedFiles.Add {
+                            Name = path.basename absolutePath
+                            Content = content
+                        }
+
+                    return Ok(importedFiles.ToArray())
+            with e ->
+                return Error(exn $"Could not import external text files: {e.Message}")
         }
     readNotes =
         fun event -> promise {
@@ -448,18 +507,6 @@ let api: IPCTypes.IArcVaultsApi = {
                     with e ->
                         return Error(exn $"Could not read file {relativePath}: {e.Message}")
             | _ -> return Error(exn "ARC is not loaded.")
-        }
-    readExternalTextFile =
-        fun _ (path: string) -> promise {
-            try
-                if String.IsNullOrWhiteSpace path then
-                    return Error(exn "Path must not be empty.")
-                else
-                    let absolutePath = pathDynamic?resolve (path) |> unbox<string>
-                    let content = fs.readFileSync (absolutePath, "utf8")
-                    return Ok content
-            with e ->
-                return Error(exn $"Could not read external file: {e.Message}")
         }
     runGitLfs =
         fun (event: IpcMainEvent) (request: GitLfsRequest) -> promise {

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -26,12 +26,30 @@ let private containsTraversalSegments (relativePath: string) =
     relativePath.Split('/')
     |> Array.exists (fun segment -> segment = "." || segment = "..")
 
+let private tryGetArcRelativePath (arcPath: string) (requestedAbsolutePath: string) =
+    let arcRoot = pathDynamic?resolve (arcPath) |> unbox<string>
+    let absolutePath = pathDynamic?resolve (requestedAbsolutePath) |> unbox<string>
+
+    let relativePath =
+        pathDynamic?relative (arcRoot, absolutePath)
+        |> unbox<string>
+        |> FileIOHelper.normalizePath
+
+    if String.IsNullOrWhiteSpace relativePath || relativePath = "." then
+        Ok ""
+    elif containsTraversalSegments relativePath then
+        Error(exn $"Path '{requestedAbsolutePath}' is outside the active ARC root.")
+    else
+        Ok relativePath
+
 /// This function resolves a given relative path against the ARC root path and ensures that the resolved absolute path is within the ARC root directory to prevent unauthorized file system access.
 let private tryResolveArcRelativePath (arcPath: string) (requestedRelativePath: string) =
     let relativePath = FileIOHelper.normalizePath requestedRelativePath
 
     if String.IsNullOrWhiteSpace relativePath then
         Error(exn "RelativePath must not be empty.")
+    elif pathDynamic?isAbsolute (relativePath) |> unbox<bool> then
+        Error(exn "RelativePath must not be absolute.")
     elif containsTraversalSegments relativePath then
         Error(exn "RelativePath must not contain path traversal segments.")
     else
@@ -274,6 +292,45 @@ let api: IPCTypes.IArcVaultsApi = {
             with e ->
                 return Error e
         }
+    pickArcPaths =
+        fun event -> promise {
+            try
+                let windowId = windowIdFromIpcEvent event
+
+                match ARC_VAULTS.TryGetVault(windowId) with
+                | None -> return Error(exn $"The ARC for window id {windowId} should exist")
+                | Some vault ->
+                    match vault.path with
+                    | None -> return Error(exn "ARC is not loaded.")
+                    | Some arcPath ->
+                        let properties = [|
+                            Enums.Dialog.ShowOpenDialog.Options.Properties.OpenFile
+                            Enums.Dialog.ShowOpenDialog.Options.Properties.MultiSelections
+                        |]
+
+                        let! result = dialog.showOpenDialog (properties = properties, defaultPath = arcPath)
+
+                        if result.canceled then
+                            return Error(exn "Cancelled")
+                        else
+                            let relativePaths =
+                                result.filePaths
+                                |> Array.map (tryGetArcRelativePath arcPath)
+
+                            match relativePaths |> Array.tryFind Result.isError with
+                            | Some(Error pathError) -> return Error pathError
+                            | _ ->
+                                return
+                                    relativePaths
+                                    |> Array.choose (function
+                                        | Ok path when String.IsNullOrWhiteSpace path -> None
+                                        | Ok path -> Some path
+                                        | Error _ -> None
+                                    )
+                                    |> Ok
+            with e ->
+                return Error e
+        }
     pickPaths =
         fun _ -> promise {
             let properties = [|
@@ -386,11 +443,23 @@ let api: IPCTypes.IArcVaultsApi = {
                         | Error pathError -> return Error pathError
                         | Ok path ->
                             let content = fs.readFileSync (path, "utf8")
-                            let dto = FileContentDTO.create ARCtrl.Contract.DTOType.PlainText content path
+                            let dto = FileContentDTO.create ARCtrl.Contract.DTOType.PlainText content relativePath
                             return Ok dto
                     with e ->
-                        return Error(exn $"Could not read file {path}: {e.Message}")
+                        return Error(exn $"Could not read file {relativePath}: {e.Message}")
             | _ -> return Error(exn "ARC is not loaded.")
+        }
+    readExternalTextFile =
+        fun _ (path: string) -> promise {
+            try
+                if String.IsNullOrWhiteSpace path then
+                    return Error(exn "Path must not be empty.")
+                else
+                    let absolutePath = pathDynamic?resolve (path) |> unbox<string>
+                    let content = fs.readFileSync (absolutePath, "utf8")
+                    return Ok content
+            with e ->
+                return Error(exn $"Could not read external file: {e.Message}")
         }
     runGitLfs =
         fun (event: IpcMainEvent) (request: GitLfsRequest) -> promise {

--- a/src/Electron/src/Renderer/Components/FileExplorer.fs
+++ b/src/Electron/src/Renderer/Components/FileExplorer.fs
@@ -4,53 +4,13 @@ open System
 open Browser.Dom
 open Renderer
 open Swate.Components.FileExplorerTypes
+open Swate.Electron.Shared.FileIOHelper
 open Swate.Electron.Shared.FileIOTypes
 open Swate.Electron.Shared.GitTypes
 open Feliz
 
 
 module private FileExplorerHelper =
-
-    let normalizePath (path: string) = path.Replace("\\", "/").TrimEnd('/')
-
-    let splitPath (path: string) =
-        normalizePath path
-        |> fun normalizedPath -> normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries)
-
-    let resolvePreviewPath (path: string) =
-        let normalized = normalizePath path
-        let lowered = normalized.ToLowerInvariant()
-
-        let isAssayDatamapFile =
-            lowered.Contains("/assays/") && lowered.EndsWith("/isa.datamap.xlsx")
-
-        let isStudyDatamapFile =
-            lowered.Contains("/studies/") && lowered.EndsWith("/isa.datamap.xlsx")
-
-        let isRunDatamapFile =
-            lowered.Contains("/runs/") && lowered.EndsWith("/isa.datamap.xlsx")
-
-        if isAssayDatamapFile then
-            let folderPath = normalized.Substring(0, normalized.LastIndexOf('/'))
-            $"{folderPath}/isa.assay.xlsx"
-        elif isStudyDatamapFile then
-            let folderPath = normalized.Substring(0, normalized.LastIndexOf('/'))
-            $"{folderPath}/isa.study.xlsx"
-        elif isRunDatamapFile then
-            let folderPath = normalized.Substring(0, normalized.LastIndexOf('/'))
-            $"{folderPath}/isa.run.xlsx"
-        else
-            normalized
-
-    let isFocusedPathOrAncestor (selectedTreeItemPath) (nodePath: string) =
-        match selectedTreeItemPath with
-        | Some focusedPath ->
-            let normalizedNode = normalizePath nodePath
-            let normalizedFocused = normalizePath focusedPath
-
-            normalizedFocused = normalizedNode
-            || normalizedFocused.StartsWith(normalizedNode + "/", StringComparison.OrdinalIgnoreCase)
-        | None -> false
 
     let rec loopPaths (selectedTreeItemPath: string option) (parent: FileTreeNode) =
         match parent.isDirectory with
@@ -66,7 +26,9 @@ module private FileExplorerHelper =
             Some {
                 FileTree.createFolder parent.name (Some parent.path) "swt:fluent--folder-24-regular" with
                     Id = parent.path
-                    IsExpanded = isFocusedPathOrAncestor selectedTreeItemPath parent.path
+                    IsExpanded =
+                        selectedTreeItemPath
+                        |> Option.exists (fun focusedPath -> isSameOrDescendantPath focusedPath parent.path)
                     IsLFS = parent.isLfs
                     Children = Some tmp
             }
@@ -76,84 +38,6 @@ module private FileExplorerHelper =
                     Id = parent.path
                     IsLFS = parent.isLfs
             }
-
-    let private insertEntry (root: FileTreeNode) (rootPath: string) (entry: FileEntry) =
-        let parts = splitPath entry.path
-        let rootParts = splitPath rootPath
-
-        if parts.Length > rootParts.Length then
-            let rec loop (node: FileTreeNode) index =
-                let part = parts[index]
-                let isLast = index = parts.Length - 1
-
-                let child =
-                    match node.children.TryGetValue(part) with
-                    | true, existing when ((not isLast) || entry.isDirectory) && not existing.isDirectory ->
-                        // A node may first appear via a file path segment; upgrade it to a directory when needed.
-                        let upgraded = { existing with isDirectory = true }
-                        node.children.[part] <- upgraded
-                        upgraded
-                    | true, existing -> existing
-                    | false, _ ->
-                        let newPath = parts.[0..index] |> String.concat "/"
-
-                        let newNode =
-                            FileTreeNode.create (
-                                part,
-                                (if isLast then entry.isDirectory else true),
-                                newPath,
-                                System.Collections.Generic.Dictionary(),
-                                entry.isLfs
-                            )
-
-                        node.children.Add(part, newNode)
-                        newNode
-
-                if not isLast then
-                    loop child (index + 1)
-
-            loop root rootParts.Length
-
-    let getFileTree (fileEntries: FileEntry[]) =
-
-        if fileEntries.Length = 0 then
-            failwith "getFileTree requires at least one file entry to determine the root path."
-
-        let normalizedPaths =
-            fileEntries |> Array.map (fun fileEntry -> normalizePath fileEntry.path)
-
-        let rootPath =
-            normalizedPaths
-            |> Array.distinct
-            |> Array.sortBy (fun path -> splitPath path |> Array.length, path)
-            |> Array.head
-
-        let adaptedFileEntries =
-            fileEntries
-            |> Array.filter (fun fileEntry -> normalizePath fileEntry.path <> rootPath)
-            // Deterministic order avoids creating parents from file entries before their directory entries.
-            |> Array.sortBy (fun fileEntry ->
-                let depth = splitPath fileEntry.path |> Array.length
-                depth, (if fileEntry.isDirectory then 0 else 1), normalizePath fileEntry.path
-            )
-
-        let rootElement =
-            let rootEntry =
-                fileEntries
-                |> Array.find (fun fileEntry -> normalizePath fileEntry.path = rootPath)
-
-            FileTreeNode.create (
-                rootEntry.name,
-                rootEntry.isDirectory,
-                rootPath,
-                System.Collections.Generic.Dictionary(),
-                rootEntry.isLfs
-            )
-
-        adaptedFileEntries
-        |> Array.iter (fun fileEntry -> insertEntry rootElement rootPath fileEntry)
-
-        rootElement
 
 open FileExplorerHelper
 
@@ -174,15 +58,14 @@ let FileTree () =
     | [||] -> EmptyFileTreePlaceholder()
     | _ ->
 
-        let fileTree = fileStateCtx.state.FileTree |> getFileTree
-        let rootRepoPath = fileTree.path |> normalizePath
+        let fileTree = fileStateCtx.state.FileTree |> toFileTreeNode
 
         let fileItem = loopPaths fileStateCtx.state.SelectedTreeItemPath fileTree
 
-        let runToggleLfsMark (repoPath: string) (relativePath: string) (markAsLfs: bool) = promise {
+        let runToggleLfsMark (relativePath: string) (markAsLfs: bool) = promise {
             let request: GitLfsRequest = {
                 RequestId = Guid.NewGuid().ToString()
-                RepoPath = repoPath
+                RepoPath = ""
                 Command =
                     if markAsLfs then
                         GitLfsCommand.Track
@@ -208,7 +91,7 @@ let FileTree () =
             | None -> pageStateCtx.setState (None)
 
         let toggleLfsMark =
-            FileExplorerGitLfsHelper.ToggleLfsMark(rootRepoPath, setError, runToggleLfsMark)
+            FileExplorerGitLfsHelper.ToggleLfsMark(setError, runToggleLfsMark)
 
         let contextMenuItems (item: FileItem) =
             FileExplorerGitLfsHelper.ContextMenuItems(item, toggleLfsMark)
@@ -217,9 +100,9 @@ let FileTree () =
             promise {
                 match item.Path with
                 | None -> pageStateCtx.setState (Some(PageState.ErrorPage $"File '{item.Name}' has no path."))
-                | Some path when item.IsDirectory -> pageStateCtx.setState (None)
+                | Some _ when item.IsDirectory -> pageStateCtx.setState (None)
                 | Some path ->
-                    let previewPath = resolvePreviewPath path
+                    let previewPath = resolveArcPreviewPath path
 
                     if previewPath <> normalizePath path then
                         console.log ($"[Renderer] Redirecting Datamap click to file: {previewPath}")

--- a/src/Electron/src/Renderer/Components/MainContent/NotesDraftTarget.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/NotesDraftTarget.fs
@@ -10,49 +10,6 @@ open ARCtrl.Contract
 open Renderer.Components.MainContent.Types
 open Renderer.Types
 
-module private NotesDraftTargetHelper =
-
-    open System
-
-    let tryGetExistingTargetRef (path: string) =
-        let segments = getPathParts path
-
-        let tryResolveTarget (folderName: string) (kind: NotesTargetKind) =
-            match
-                segments
-                |> Array.tryFindIndex (fun segment ->
-                    String.Equals(segment, folderName, StringComparison.OrdinalIgnoreCase)
-                )
-            with
-            | Some index when index + 1 < segments.Length ->
-                let name = segments.[index + 1].Trim()
-
-                if String.IsNullOrWhiteSpace name then
-                    None
-                else
-                    Some { Name = name; Kind = kind }
-            | _ -> None
-
-        match tryResolveTarget "studies" NotesTargetKind.Study with
-        | Some target -> Some target
-        | None -> tryResolveTarget "assays" NotesTargetKind.Assay
-
-    let createAvailableNotesTargets (fileEntries: FileEntry[]) =
-        fileEntries
-        |> Seq.choose (fun entry -> tryGetExistingTargetRef entry.path)
-        |> Seq.distinctBy (fun target -> target.Kind, target.Name)
-        |> Seq.sortBy (fun target ->
-            let kindOrder =
-                match target.Kind with
-                | NotesTargetKind.Study -> 0
-                | NotesTargetKind.Assay -> 1
-
-            kindOrder, target.Name.ToLowerInvariant()
-        )
-        |> ResizeArray
-
-open NotesDraftTargetHelper
-
 [<ReactComponent>]
 let NotesDraftTarget () =
 

--- a/src/Electron/src/Renderer/Components/WidgetRegister.fs
+++ b/src/Electron/src/Renderer/Components/WidgetRegister.fs
@@ -11,25 +11,16 @@ open ARCtrl.Contract
 let private filePickerServices: FilePickerWidgetServices = {
     pickPaths =
         fun () -> promise {
-            let! result = Api.ipcArcVaultApi.pickArcPaths (unbox null)
+            let! result = Api.ipcArcVaultApi.pickAbsolutePaths (unbox null)
             return result |> Result.mapError (fun error -> error.Message)
         }
 }
 
 let private dataAnnotatorServices: DataAnnotatorWidgetServices = {
-    pickPaths =
+    pickTextFiles =
         fun () -> promise {
-            let! result = Api.ipcArcVaultApi.pickPaths (unbox null)
+            let! result = Api.ipcArcVaultApi.pickExternalTextFiles (unbox null)
             return result |> Result.mapError (fun error -> error.Message)
-        }
-    loadTextFile =
-        fun path -> promise {
-            let! result = Api.ipcArcVaultApi.readExternalTextFile (unbox null) path
-
-            return
-                match result with
-                | Error error -> Error error.Message
-                | Ok content -> Ok content
         }
 }
 

--- a/src/Electron/src/Renderer/Components/WidgetRegister.fs
+++ b/src/Electron/src/Renderer/Components/WidgetRegister.fs
@@ -11,7 +11,7 @@ open ARCtrl.Contract
 let private filePickerServices: FilePickerWidgetServices = {
     pickPaths =
         fun () -> promise {
-            let! result = Api.ipcArcVaultApi.pickPaths (unbox null)
+            let! result = Api.ipcArcVaultApi.pickArcPaths (unbox null)
             return result |> Result.mapError (fun error -> error.Message)
         }
 }
@@ -24,15 +24,12 @@ let private dataAnnotatorServices: DataAnnotatorWidgetServices = {
         }
     loadTextFile =
         fun path -> promise {
-            let! result = Api.ipcArcVaultApi.openFile (unbox null) path
+            let! result = Api.ipcArcVaultApi.readExternalTextFile (unbox null) path
 
             return
                 match result with
                 | Error error -> Error error.Message
-                | Ok dto ->
-                    match dto.fileType with
-                    | DTOType.DTOTypeIsPlainTextVariant -> Ok dto.content
-                    | _ -> Error "Selected file could not be loaded as plain text."
+                | Ok content -> Ok content
         }
 }
 

--- a/src/Electron/src/Renderer/context/FileStateCtx.fs
+++ b/src/Electron/src/Renderer/context/FileStateCtx.fs
@@ -1,9 +1,5 @@
 module Renderer.Context.FileStateCtx
 
-open System.Collections.Generic
-open Swate.Components
-open Swate.Components.Types
-open Swate.Electron.Shared
 open Swate.Electron.Shared.IPCTypes
 open Swate.Electron.Shared.FileIOTypes
 open Fable.Electron.Remoting.Renderer

--- a/src/Electron/src/Renderer/context/FileStateCtx.fs
+++ b/src/Electron/src/Renderer/context/FileStateCtx.fs
@@ -1,5 +1,6 @@
 module Renderer.Context.FileStateCtx
 
+open System.Collections.Generic
 open Swate.Components
 open Swate.Components.Types
 open Swate.Electron.Shared
@@ -61,7 +62,9 @@ let FileStateCtxProvider (children: ReactElement) =
             (fun _ -> {
                 state = fileState
                 setState = setFileState
-                setFileTree = fun fileTree -> setFileState (fun fs -> { fs with FileTree = fileTree })
+                setFileTree =
+                    fun fileTree ->
+                        setFileState (fun fs -> { fs with FileTree = fileTree })
                 setSelectedTreeItemPath =
                     fun selectedTreeItemPath ->
                         setFileState (fun fs -> {

--- a/src/Electron/src/Swate.Electron.Shared/FileIOHelper.fs
+++ b/src/Electron/src/Swate.Electron.Shared/FileIOHelper.fs
@@ -29,7 +29,8 @@ let isSameOrDescendantPath (path: string) (ancestorPath: string) =
     let normalizedPath = normalizePath path
     let normalizedAncestorPath = normalizePath ancestorPath
 
-    normalizedPath = normalizedAncestorPath
+    String.IsNullOrWhiteSpace normalizedAncestorPath
+    || normalizedPath = normalizedAncestorPath
     || normalizedPath.StartsWith(normalizedAncestorPath + "/", StringComparison.OrdinalIgnoreCase)
 
 let tryGetPathSegmentAfterFolder (folderName: string) (path: string) =

--- a/src/Electron/src/Swate.Electron.Shared/FileIOHelper.fs
+++ b/src/Electron/src/Swate.Electron.Shared/FileIOHelper.fs
@@ -1,5 +1,11 @@
 module Swate.Electron.Shared.FileIOHelper
 
+open System
+open System.Collections.Generic
+open ARCtrl
+open Swate.Components.Notes.Editor
+open Swate.Electron.Shared.FileIOTypes
+
 /// normalizes the path by replacing backslashes with forward slashes, trimming whitespace, and removing trailing slashes
 let normalizePath (path: string) =
     path.Replace("\\", "/").Trim().TrimEnd('/')
@@ -8,14 +14,175 @@ let normalizePath (path: string) =
 let getPathParts (path: string) =
     normalizePath path |> (fun p -> p.Split("/"))
 
+let getNonEmptyPathParts (path: string) =
+    normalizePath path
+    |> fun p -> p.Split('/', StringSplitOptions.RemoveEmptyEntries)
+
+let getPathDepth (path: string) = path |> getNonEmptyPathParts |> Array.length
+
 let getFileName (path: string) = path |> getPathParts |> Array.last
 
 let pathsEqual (left: string) (right: string) =
     normalizePath left = normalizePath right
 
-let combineMany = ARCtrl.ArcPathHelper.combineMany
+let isSameOrDescendantPath (path: string) (ancestorPath: string) =
+    let normalizedPath = normalizePath path
+    let normalizedAncestorPath = normalizePath ancestorPath
 
-open ARCtrl
+    normalizedPath = normalizedAncestorPath
+    || normalizedPath.StartsWith(normalizedAncestorPath + "/", StringComparison.OrdinalIgnoreCase)
+
+let tryGetPathSegmentAfterFolder (folderName: string) (path: string) =
+    let segments = getNonEmptyPathParts path
+
+    match
+        segments
+        |> Array.tryFindIndex (fun segment -> String.Equals(segment, folderName, StringComparison.OrdinalIgnoreCase))
+    with
+    | Some index when index + 1 < segments.Length ->
+        let name = segments.[index + 1].Trim()
+
+        if String.IsNullOrWhiteSpace name then
+            None
+        else
+            Some name
+    | _ -> None
+
+let private tryGetParentPath (path: string) =
+    let normalizedPath = normalizePath path
+    let separatorIndex = normalizedPath.LastIndexOf('/')
+
+    if separatorIndex < 0 then
+        None
+    else
+        Some(normalizedPath.Substring(0, separatorIndex))
+
+let private tryResolveDatamapPreviewPath
+    (normalizedPath: string)
+    (folderSegment: string)
+    (targetFileName: string)
+    =
+    let lowered = normalizedPath.ToLowerInvariant()
+
+    if lowered.Contains(folderSegment) && lowered.EndsWith("/isa.datamap.xlsx") then
+        tryGetParentPath normalizedPath
+        |> Option.map (fun folderPath -> $"{folderPath}/{targetFileName}")
+    else
+        None
+
+let resolveArcPreviewPath (path: string) =
+    let normalizedPath = normalizePath path
+
+    [
+        tryResolveDatamapPreviewPath normalizedPath "/assays/" "isa.assay.xlsx"
+        tryResolveDatamapPreviewPath normalizedPath "/studies/" "isa.study.xlsx"
+        tryResolveDatamapPreviewPath normalizedPath "/runs/" "isa.run.xlsx"
+    ]
+    |> List.tryPick id
+    |> Option.defaultValue normalizedPath
+
+let private insertFileTreeEntry (root: FileTreeNode) (rootPath: string) (entry: FileEntry) =
+    let parts = getNonEmptyPathParts entry.path
+    let rootParts = getNonEmptyPathParts rootPath
+
+    if parts.Length > rootParts.Length then
+        let rec loop (node: FileTreeNode) index =
+            let part = parts[index]
+            let isLast = index = parts.Length - 1
+
+            let child =
+                match node.children.TryGetValue(part) with
+                | true, existing when ((not isLast) || entry.isDirectory) && not existing.isDirectory ->
+                    // A node may first appear via a file path segment; upgrade it to a directory when needed.
+                    let upgraded = { existing with isDirectory = true }
+                    node.children.[part] <- upgraded
+                    upgraded
+                | true, existing -> existing
+                | false, _ ->
+                    let newPath = parts.[0..index] |> String.concat "/"
+
+                    let newNode =
+                        FileTreeNode.create (
+                            part,
+                            (if isLast then entry.isDirectory else true),
+                            newPath,
+                            Dictionary(),
+                            entry.isLfs
+                        )
+
+                    node.children.Add(part, newNode)
+                    newNode
+
+            if not isLast then
+                loop child (index + 1)
+
+        loop root rootParts.Length
+
+let toFileTreeNode (fileEntries: FileEntry[]) =
+
+    if fileEntries.Length = 0 then
+        failwith "toFileTreeNode requires at least one file entry to determine the root path."
+
+    let normalizedPaths =
+        fileEntries |> Array.map (fun fileEntry -> normalizePath fileEntry.path)
+
+    let rootPath =
+        normalizedPaths
+        |> Array.distinct
+        |> Array.sortBy (fun path -> getPathDepth path, path)
+        |> Array.head
+
+    let adaptedFileEntries =
+        fileEntries
+        |> Array.filter (fun fileEntry -> normalizePath fileEntry.path <> rootPath)
+        // Deterministic order avoids creating parents from file entries before their directory entries.
+        |> Array.sortBy (fun fileEntry ->
+            let depth = getPathDepth fileEntry.path
+            depth, (if fileEntry.isDirectory then 0 else 1), normalizePath fileEntry.path
+        )
+
+    let rootElement =
+        let rootEntry =
+            fileEntries
+            |> Array.find (fun fileEntry -> normalizePath fileEntry.path = rootPath)
+
+        FileTreeNode.create (
+            rootEntry.name,
+            rootEntry.isDirectory,
+            rootPath,
+            Dictionary(),
+            rootEntry.isLfs
+        )
+
+    adaptedFileEntries
+    |> Array.iter (fun fileEntry -> insertFileTreeEntry rootElement rootPath fileEntry)
+
+    rootElement
+
+let tryGetExistingNotesTargetRef (path: string) : ExistingTargetRef option =
+    let tryResolveTarget folderName kind =
+        tryGetPathSegmentAfterFolder folderName path
+        |> Option.map (fun name -> { Name = name; Kind = kind })
+
+    match tryResolveTarget "studies" NotesTargetKind.Study with
+    | Some target -> Some target
+    | None -> tryResolveTarget "assays" NotesTargetKind.Assay
+
+let createAvailableNotesTargets (fileEntries: seq<FileEntry>) =
+    fileEntries
+    |> Seq.choose (fun entry -> tryGetExistingNotesTargetRef entry.path)
+    |> Seq.distinctBy (fun target -> target.Kind, target.Name)
+    |> Seq.sortBy (fun target ->
+        let kindOrder =
+            match target.Kind with
+            | NotesTargetKind.Study -> 0
+            | NotesTargetKind.Assay -> 1
+
+        kindOrder, target.Name.ToLowerInvariant()
+    )
+    |> ResizeArray
+
+let combineMany = ARCtrl.ArcPathHelper.combineMany
 
 let tryGetArcFilePath (arcRootPath: ArcRootPath) (arcFile: ArcFiles) =
     let arcRootPath = defaultArg arcRootPath ""

--- a/src/Electron/src/Swate.Electron.Shared/FileIOTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/FileIOTypes.fs
@@ -20,7 +20,7 @@ module FileEntryExtensions =
 
     type FileEntry with
 
-        static member create(name: string, path: string, isDirectory: bool, ?isLfs: bool option) = {
+        static member create(name: string, path: string, isDirectory: bool, ?isLfs: bool option) : FileEntry = {
             name = name
             path = path
             isDirectory = isDirectory

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -35,9 +35,9 @@ type IArcVaultsApi = {
     getRecentARCs: unit -> JS.Promise<SelectorTypes.ARCPointer[]>
     removeRecentARC: SelectorTypes.ARCPointer -> JS.Promise<Result<unit, exn>>
     pickArcPaths: IpcMainEvent -> JS.Promise<Result<string[], exn>>
-    pickPaths: IpcMainEvent -> JS.Promise<Result<string[], exn>>
+    pickAbsolutePaths: IpcMainEvent -> JS.Promise<Result<string[], exn>>
+    pickExternalTextFiles: IpcMainEvent -> JS.Promise<Result<ImportedTextFile[], exn>>
     openFile: IpcMainEvent -> string -> JS.Promise<Result<FileContentDTO, exn>>
-    readExternalTextFile: IpcMainEvent -> string -> JS.Promise<Result<string, exn>>
     readNotes: IpcMainEvent -> JS.Promise<Result<NoteSearch[], exn>>
     /// This IPC call is used to set changes to an ARC based on a smaller ArcFiles object. It can be used to trigger UpdateContract changes and write these changes to disc.
     saveArcFile: IpcMainEvent -> FileContentDTO -> JS.Promise<Result<unit, exn>>

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -34,9 +34,10 @@ type IArcVaultsApi = {
     getOpenPath: IpcMainEvent -> JS.Promise<string option>
     getRecentARCs: unit -> JS.Promise<SelectorTypes.ARCPointer[]>
     removeRecentARC: SelectorTypes.ARCPointer -> JS.Promise<Result<unit, exn>>
+    pickArcPaths: IpcMainEvent -> JS.Promise<Result<string[], exn>>
     pickPaths: IpcMainEvent -> JS.Promise<Result<string[], exn>>
-
     openFile: IpcMainEvent -> string -> JS.Promise<Result<FileContentDTO, exn>>
+    readExternalTextFile: IpcMainEvent -> string -> JS.Promise<Result<string, exn>>
     readNotes: IpcMainEvent -> JS.Promise<Result<NoteSearch[], exn>>
     /// This IPC call is used to set changes to an ARC based on a smaller ArcFiles object. It can be used to trigger UpdateContract changes and write these changes to disc.
     saveArcFile: IpcMainEvent -> FileContentDTO -> JS.Promise<Result<unit, exn>>


### PR DESCRIPTION
Replace absolute paths in functions and methods beside the FilePicker with relative paths.
Only the FilePicker is allowed to use absolute paths.