### PR TITLE
Git Feature Requests #1031

### DIFF
--- a/src/Components/src/Api/GitLabApi.fs
+++ b/src/Components/src/Api/GitLabApi.fs
@@ -369,6 +369,46 @@ module private Internals =
                 return Error(GitLabError.NetworkError networkError)
     }
 
+    let normalizeProjectPath (name: string) =
+        System.Text.RegularExpressions.Regex("[^A-Za-z0-9._-]+")
+            .Replace(name.Trim().ToLowerInvariant(), "-")
+            .Trim('-')
+
+    let sendJson<'TResponse>
+        (url: string)
+        (pat: string)
+        (method': HttpMethod)
+        (body: obj)
+        : JS.Promise<Result<'TResponse, GitLabError>> =
+        promise {
+            if String.IsNullOrWhiteSpace pat then
+                return Error(GitLabError.InvalidRequest "Personal Access Token is required.")
+            else
+                let requestOptions = [
+                    RequestProperties.Method method'
+                    requestHeaders [
+                        HttpRequestHeaders.Custom("PRIVATE-TOKEN", pat)
+                        HttpRequestHeaders.Accept "application/json"
+                        HttpRequestHeaders.ContentType "application/json"
+                    ]
+                    RequestProperties.Body(unbox (Fable.Core.JS.JSON.stringify body))
+                ]
+
+                try
+                    let! response = fetchUnsafe url requestOptions
+
+                    if not response.Ok then
+                        return Error(mapHttpError response.Status)
+                    else
+                        try
+                            let! payload = response.json<'TResponse> ()
+                            return Ok payload
+                        with decodeError ->
+                            return Error(GitLabError.DecodeError decodeError)
+                with networkError ->
+                    return Error(GitLabError.NetworkError networkError)
+        }
+
 [<AttachMembers>]
 type GitLabApi =
 
@@ -378,6 +418,28 @@ type GitLabApi =
         let! response = Internals.sendGetSingle<GitLabCurrentUserResponse> url pat
         return response |> Result.map Internals.toCurrentUserDto
     }
+
+    static member CreateProject(baseUrl: string, pat: string, projectName: string) : JS.Promise<Result<ExploreProjectDto, GitLabError>> =
+        promise {
+            let normalizedName = projectName.Trim()
+            let normalizedPath = Internals.normalizeProjectPath normalizedName
+
+            if String.IsNullOrWhiteSpace normalizedName || String.IsNullOrWhiteSpace normalizedPath then
+                return Error(GitLabError.InvalidRequest "Repository name is required.")
+            else
+                let! response =
+                    Internals.sendJson<GitLabProjectResponse>
+                        $"{baseUrl.TrimEnd('/')}/api/v4/projects"
+                        pat
+                        HttpMethod.POST
+                        (createObj [
+                            "name" ==> normalizedName
+                            "path" ==> normalizedPath
+                            "initialize_with_readme" ==> false
+                        ])
+
+                return response |> Result.map Internals.toExploreProjectDto
+        }
 
     /// GET /api/v4/projects
     static member ListProjects

--- a/src/Components/src/Api/GitLabApi.fs
+++ b/src/Components/src/Api/GitLabApi.fs
@@ -369,11 +369,6 @@ module private Internals =
                 return Error(GitLabError.NetworkError networkError)
     }
 
-    let normalizeProjectPath (name: string) =
-        System.Text.RegularExpressions.Regex("[^A-Za-z0-9._-]+")
-            .Replace(name.Trim().ToLowerInvariant(), "-")
-            .Trim('-')
-
     let sendJson<'TResponse>
         (url: string)
         (pat: string)
@@ -422,9 +417,8 @@ type GitLabApi =
     static member CreateProject(baseUrl: string, pat: string, projectName: string) : JS.Promise<Result<ExploreProjectDto, GitLabError>> =
         promise {
             let normalizedName = projectName.Trim()
-            let normalizedPath = Internals.normalizeProjectPath normalizedName
 
-            if String.IsNullOrWhiteSpace normalizedName || String.IsNullOrWhiteSpace normalizedPath then
+            if String.IsNullOrWhiteSpace normalizedName then
                 return Error(GitLabError.InvalidRequest "Repository name is required.")
             else
                 let! response =
@@ -434,7 +428,6 @@ type GitLabApi =
                         HttpMethod.POST
                         (createObj [
                             "name" ==> normalizedName
-                            "path" ==> normalizedPath
                             "initialize_with_readme" ==> false
                         ])
 

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -748,7 +748,6 @@ type GitSidebar =
     [<ReactComponent>]
     static member private ChangedFilesList(props: ChangedFilesListProps) =
         let scrollContainerRef = React.useElementRef ()
-        let virtualizerTick, setVirtualizerTick = React.useState 0
 
         let rowVirtualizer =
             Virtual.useVirtualizer (
@@ -758,11 +757,6 @@ type GitSidebar =
                 overscan = 2,
                 gap = 8
             )
-
-        React.useEffect (
-            (fun () -> setVirtualizerTick (virtualizerTick + 1)),
-            [| box props.ChangedFiles.Length |]
-        )
 
         React.Fragment [
             GitSidebar.SectionHeader(
@@ -786,7 +780,7 @@ type GitSidebar =
                             prop.text "No changed files. Your repository is in sync."
                         ]
                     else
-                        let renderChangeRow (isVirtualized: bool) (index: int) (top: int) (size: int) =
+                        let renderChangeRow (isVirtualized: bool) (index: int) (top: int option) =
                                     let change = props.ChangedFiles.[index]
                                     let isSelected =
                                         props.SelectedFile
@@ -800,6 +794,8 @@ type GitSidebar =
                                     Html.button [
                                         prop.testId $"GitSidebarChangeRow-{index}"
                                         prop.key change.Path
+                                        if isVirtualized then
+                                            prop.custom ("data-index", index)
                                         prop.disabled props.IsBusy
                                         prop.className [
                                             "swt:flex swt:w-full swt:flex-col swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-3 swt:py-2 swt:text-left swt:transition-colors"
@@ -815,9 +811,10 @@ type GitSidebar =
                                         if isVirtualized then
                                             prop.style [
                                                 style.top 0
-                                                style.custom ("transform", $"translateY({top}px)")
-                                                style.height size
+                                                style.custom ("transform", $"translateY({top.Value}px)")
                                             ]
+                                        if isVirtualized then
+                                            prop.ref rowVirtualizer.measureElement
                                         prop.onClick (fun _ -> props.OpenChange change)
                                         prop.children [
                                             Html.div [
@@ -891,33 +888,21 @@ type GitSidebar =
                                 prop.className "swt:mt-2 swt:flex swt:flex-col swt:gap-2"
                                 prop.children (
                                     props.ChangedFiles
-                                    |> Array.mapi (fun index _ -> renderChangeRow false index 0 0)
+                                    |> Array.mapi (fun index _ -> renderChangeRow false index None)
                                 )
                             ]
 
                         if props.ChangedFiles.Length <= 24 then
                             renderRows ()
                         else
-                            let virtualRows = rowVirtualizer.getVirtualItems ()
-                            let totalSize =
-                                if virtualRows.Length = 0 then
-                                    props.ChangedFiles.Length * 96
-                                else
-                                    rowVirtualizer.getTotalSize ()
-
                             Html.div [
-                                prop.className "swt:relative"
-                                prop.style [ style.height totalSize ]
+                                prop.className "swt:mt-2 swt:relative"
+                                prop.style [ style.height (rowVirtualizer.getTotalSize ()) ]
                                 prop.children (
-                                    if virtualRows.Length = 0 then
-                                        props.ChangedFiles
-                                        |> Array.mapi (fun index _ -> renderChangeRow false index 0 0)
-                                        |> Array.take (min 12 props.ChangedFiles.Length)
-                                    else
-                                        virtualRows
-                                        |> Array.map (fun virtualRow ->
-                                            renderChangeRow true virtualRow.index virtualRow.start virtualRow.size
-                                        )
+                                    rowVirtualizer.getVirtualItems ()
+                                    |> Array.map (fun virtualRow ->
+                                        renderChangeRow true virtualRow.index (Some virtualRow.start)
+                                    )
                                 )
                             ]
                 ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -8,19 +8,55 @@ open Swate.Components.GitSidebarTypes
 
 module private GitSidebarInternal =
 
+    type GitChangeKind =
+        | Added
+        | Modified
+        | Deleted
+        | Renamed
+        | Untracked
+        | Conflict
+
     let hasConflicts (status: GitSidebarStatus) (changedFiles: GitSidebarChange[]) =
         status.IsMergeInProgress || (changedFiles |> Array.exists _.IsConflicted)
 
-    let describeChange (change: GitSidebarChange) =
+    let private rawChangeCode (change: GitSidebarChange) =
         let indexCode = GitStatusCode.normalize change.IndexStatus
         let worktreeCode = GitStatusCode.normalize change.WorkingTreeStatus
         $"{indexCode}{worktreeCode}"
 
-    let changeBadgeClasses (change: GitSidebarChange) =
+    let describeChange (change: GitSidebarChange) = $"git: {rawChangeCode change}"
+
+    let classifyChange (change: GitSidebarChange) =
+        let indexCode = GitStatusCode.normalize change.IndexStatus
+        let worktreeCode = GitStatusCode.normalize change.WorkingTreeStatus
+
         if change.IsConflicted then
-            "swt:badge swt:badge-error swt:badge-sm"
+            GitChangeKind.Conflict
+        elif change.OriginalPath.IsSome || indexCode.StartsWith("R", StringComparison.Ordinal) || worktreeCode.StartsWith("R", StringComparison.Ordinal) then
+            GitChangeKind.Renamed
+        elif indexCode = "?" || worktreeCode = "?" then
+            GitChangeKind.Untracked
+        elif indexCode = "D" || worktreeCode = "D" then
+            GitChangeKind.Deleted
+        elif indexCode = "A" || worktreeCode = "A" then
+            GitChangeKind.Added
         else
-            "swt:badge swt:badge-ghost swt:badge-sm"
+            GitChangeKind.Modified
+
+    let changePresentation (change: GitSidebarChange) =
+        match classifyChange change with
+        | GitChangeKind.Added ->
+            "Added", "swt:badge swt:badge-success swt:badge-sm", "swt:fluent--add-24-regular"
+        | GitChangeKind.Modified ->
+            "Modified", "swt:badge swt:badge-info swt:badge-sm", "swt:fluent--edit-24-regular"
+        | GitChangeKind.Deleted ->
+            "Deleted", "swt:badge swt:badge-error swt:badge-sm", "swt:fluent--delete-24-regular"
+        | GitChangeKind.Renamed ->
+            "Renamed", "swt:badge swt:badge-warning swt:badge-sm", "swt:fluent--arrow-swap-24-regular"
+        | GitChangeKind.Untracked ->
+            "Untracked", "swt:badge swt:badge-neutral swt:badge-sm", "swt:fluent--document-24-regular"
+        | GitChangeKind.Conflict ->
+            "Conflict", "swt:badge swt:badge-error swt:badge-sm", "swt:fluent--warning-24-regular"
 
     let branchKindLabel (kind: GitSidebarBranchKind) =
         match kind with
@@ -711,6 +747,23 @@ type GitSidebar =
 
     [<ReactComponent>]
     static member private ChangedFilesList(props: ChangedFilesListProps) =
+        let scrollContainerRef = React.useElementRef ()
+        let virtualizerTick, setVirtualizerTick = React.useState 0
+
+        let rowVirtualizer =
+            Virtual.useVirtualizer (
+                count = props.ChangedFiles.Length,
+                getScrollElement = (fun () -> scrollContainerRef.current),
+                estimateSize = (fun _ -> 96),
+                overscan = 2,
+                gap = 8
+            )
+
+        React.useEffect (
+            (fun () -> setVirtualizerTick (virtualizerTick + 1)),
+            [| box props.ChangedFiles.Length |]
+        )
+
         React.Fragment [
             GitSidebar.SectionHeader(
                 "Changes",
@@ -723,6 +776,7 @@ type GitSidebar =
             )
 
             Html.div [
+                prop.ref scrollContainerRef
                 prop.className "swt:min-h-0 swt:flex-1 swt:overflow-y-auto swt:px-3 swt:pb-3"
                 prop.children [
                     if props.ChangedFiles.Length = 0 then
@@ -732,10 +786,8 @@ type GitSidebar =
                             prop.text "No changed files. Your repository is in sync."
                         ]
                     else
-                        Html.div [
-                            prop.className "swt:mt-2 swt:flex swt:flex-col swt:gap-2"
-                            prop.children [
-                                for change in props.ChangedFiles do
+                        let renderChangeRow (isVirtualized: bool) (index: int) (top: int) (size: int) =
+                                    let change = props.ChangedFiles.[index]
                                     let isSelected =
                                         props.SelectedFile
                                         |> Option.exists (fun selected ->
@@ -743,13 +795,16 @@ type GitSidebar =
                                         )
 
                                     let isSelectedForCommit = Set.contains change.Path props.SelectedCommitPaths
+                                    let badgeLabel, badgeClass, iconClass = GitSidebarInternal.changePresentation change
 
                                     Html.button [
-                                        prop.testId ("GitSidebarChangeRow-" + change.Path)
+                                        prop.testId $"GitSidebarChangeRow-{index}"
                                         prop.key change.Path
                                         prop.disabled props.IsBusy
                                         prop.className [
                                             "swt:flex swt:w-full swt:flex-col swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-3 swt:py-2 swt:text-left swt:transition-colors"
+                                            if isVirtualized then
+                                                "swt:absolute swt:left-0"
                                             if change.IsConflicted then
                                                 "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
                                             elif isSelected then
@@ -757,6 +812,12 @@ type GitSidebar =
                                             else
                                                 "swt:border-base-content/10 swt:bg-base-100 hover:swt:bg-base-200/80"
                                         ]
+                                        if isVirtualized then
+                                            prop.style [
+                                                style.top 0
+                                                style.custom ("transform", $"translateY({top}px)")
+                                                style.height size
+                                            ]
                                         prop.onClick (fun _ -> props.OpenChange change)
                                         prop.children [
                                             Html.div [
@@ -797,15 +858,16 @@ type GitSidebar =
                                                                         prop.text change.Path
                                                                     ]
                                                                     Html.span [
-                                                                        prop.className (
-                                                                            GitSidebarInternal.changeBadgeClasses change
-                                                                        )
-                                                                        prop.text (
-                                                                            if change.IsConflicted then
-                                                                                "Conflict"
-                                                                            else
-                                                                                "Changed"
-                                                                        )
+                                                                        prop.className badgeClass
+                                                                        prop.children [
+                                                                            Html.span [
+                                                                                prop.className
+                                                                                    $"swt:iconify {iconClass} swt:size-3.5"
+                                                                            ]
+                                                                            Html.span [
+                                                                                prop.text badgeLabel
+                                                                            ]
+                                                                        ]
                                                                     ]
                                                                 ]
                                                             ]
@@ -823,8 +885,41 @@ type GitSidebar =
                                             ]
                                         ]
                                     ]
+
+                        let renderRows () =
+                            Html.div [
+                                prop.className "swt:mt-2 swt:flex swt:flex-col swt:gap-2"
+                                prop.children (
+                                    props.ChangedFiles
+                                    |> Array.mapi (fun index _ -> renderChangeRow false index 0 0)
+                                )
                             ]
-                        ]
+
+                        if props.ChangedFiles.Length <= 24 then
+                            renderRows ()
+                        else
+                            let virtualRows = rowVirtualizer.getVirtualItems ()
+                            let totalSize =
+                                if virtualRows.Length = 0 then
+                                    props.ChangedFiles.Length * 96
+                                else
+                                    rowVirtualizer.getTotalSize ()
+
+                            Html.div [
+                                prop.className "swt:relative"
+                                prop.style [ style.height totalSize ]
+                                prop.children (
+                                    if virtualRows.Length = 0 then
+                                        props.ChangedFiles
+                                        |> Array.mapi (fun index _ -> renderChangeRow false index 0 0)
+                                        |> Array.take (min 12 props.ChangedFiles.Length)
+                                    else
+                                        virtualRows
+                                        |> Array.map (fun virtualRow ->
+                                            renderChangeRow true virtualRow.index virtualRow.start virtualRow.size
+                                        )
+                                )
+                            ]
                 ]
             ]
         ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -64,6 +64,8 @@ type private LfsSettingsSectionProps = {
 type private AdvancedActionsProps = {
     DownloadLargeFilesInput: bool
     IsBusy: bool
+    RemoteActionsEnabled: bool
+    RemoteActionsWarning: string option
     SubmitDownloadLargeFiles: bool -> unit
     SubmitSync: unit -> unit
     IsAdvancedActionsOpen: bool
@@ -514,7 +516,7 @@ type GitSidebar =
                     GitSidebar.ActionButton(
                         "Synchronize Changes",
                         "swt:fluent--arrow-sync-24-regular",
-                        props.IsBusy,
+                        props.IsBusy || not props.RemoteActionsEnabled,
                         props.SubmitSync,
                         testId = "GitSidebarSyncButton"
                     )
@@ -532,6 +534,25 @@ type GitSidebar =
                 ]
             ]
 
+            match props.RemoteActionsWarning with
+            | Some warning when not props.RemoteActionsEnabled ->
+                Html.div [
+                    prop.className "swt:px-3 swt:pt-3"
+                    prop.children [
+                        Html.div [
+                            prop.testId "GitSidebarRemoteAuthWarning"
+                            prop.className "swt:alert swt:alert-warning swt:px-3 swt:py-2 swt:text-sm"
+                            prop.children [
+                                Html.span [
+                                    prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4"
+                                ]
+                                Html.span warning
+                            ]
+                        ]
+                    ]
+                ]
+            | _ -> Html.none
+
             if props.IsAdvancedActionsOpen then
                 Html.div [
                     prop.className "swt:px-3 swt:pt-3"
@@ -546,21 +567,21 @@ type GitSidebar =
                                 GitSidebar.ActionButton(
                                     "Check for Changes",
                                     "swt:fluent--arrow-download-24-regular",
-                                    props.IsBusy,
+                                    props.IsBusy || not props.RemoteActionsEnabled,
                                     props.SubmitFetch,
                                     testId = "GitSidebarFetchButton"
                                 )
                                 GitSidebar.ActionButton(
                                     "Download Changes",
                                     "swt:fluent--arrow-down-24-regular",
-                                    props.IsBusy,
+                                    props.IsBusy || not props.RemoteActionsEnabled,
                                     props.SubmitPull,
                                     testId = "GitSidebarPullButton"
                                 )
                                 GitSidebar.ActionButton(
                                     "Upload Changes",
                                     "swt:fluent--arrow-up-24-regular",
-                                    props.IsBusy,
+                                    props.IsBusy || not props.RemoteActionsEnabled,
                                     props.SubmitPush,
                                     testId = "GitSidebarPushButton"
                                 )
@@ -968,12 +989,16 @@ type GitSidebar =
             ?runStatus: GitSidebarRunStatus,
             ?selectedFile: string,
             ?errorNotice: string,
-            ?warningNotice: string
+            ?warningNotice: string,
+            ?remoteActionsEnabled: bool,
+            ?remoteActionsWarning: string
         ) =
 
         let runStatus = defaultArg runStatus GitSidebarRunStatus.Idle
         let errorNotice = errorNotice
         let warningNotice = warningNotice
+        let remoteActionsEnabled = defaultArg remoteActionsEnabled true
+        let remoteActionsWarning = remoteActionsWarning
         let selectedFile = selectedFile
         let onRefresh = callbacks.OnRefresh
         let onFetch = callbacks.OnFetch
@@ -1263,6 +1288,8 @@ type GitSidebar =
                     {
                         DownloadLargeFilesInput = downloadLargeFilesInput
                         IsBusy = isBusy
+                        RemoteActionsEnabled = remoteActionsEnabled
+                        RemoteActionsWarning = remoteActionsWarning
                         SubmitDownloadLargeFiles = submitDownloadLargeFiles
                         SubmitSync =
                             fun () ->

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -154,7 +154,7 @@ type private ChangedFileRowProps = {
     ToggleCommitSelection: string -> unit
     OpenChange: GitSidebarChange -> unit
     VirtualStart: int
-    MeasureElement: IRefValue<HTMLElement option>
+    MeasureElementRef: VirtualMeasureElementRef
 }
 
 type private ChangedFileVirtualItem = {
@@ -791,7 +791,7 @@ type GitSidebar =
         Html.button [
             prop.testId $"GitSidebarChangeRow-{props.Index}"
             prop.custom ("data-index", props.Index)
-            prop.ref props.MeasureElement
+            prop.ref (fun element -> props.MeasureElementRef (Option.ofObj element))
             prop.disabled props.IsBusy
             prop.className [
                 "swt:absolute swt:left-0 swt:flex swt:w-full swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1.5 swt:text-left swt:transition-colors"
@@ -947,7 +947,7 @@ type GitSidebar =
                                                     ToggleCommitSelection = props.ToggleCommitSelection
                                                     OpenChange = props.OpenChange
                                                     VirtualStart = virtualItem.Start
-                                                    MeasureElement = changedFileListVirtualizer.measureElement
+                                                    MeasureElementRef = changedFileListVirtualizer.measureElement
                                                 }
                                             )
                                         ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -1,6 +1,7 @@
 namespace Swate.Components
 
 open System
+open Browser.Types
 open Fable.Core
 open Feliz
 
@@ -137,6 +138,28 @@ type private ChangedFilesListProps = {
     CanEditCommit: bool
     ToggleCommitSelection: string -> unit
     OpenChange: GitSidebarChange -> unit
+}
+
+type private ChangeStatusBadgeProps = {
+    Change: GitSidebarChange
+}
+
+type private ChangedFileRowProps = {
+    Change: GitSidebarChange
+    Index: int
+    IsSelected: bool
+    IsSelectedForCommit: bool
+    IsBusy: bool
+    CanEditCommit: bool
+    ToggleCommitSelection: string -> unit
+    OpenChange: GitSidebarChange -> unit
+    VirtualStart: int
+    MeasureElement: IRefValue<HTMLElement option>
+}
+
+type private ChangedFileVirtualItem = {
+    Index: int
+    Start: int
 }
 
 type private ModalsProps = {
@@ -746,17 +769,130 @@ type GitSidebar =
         ]
 
     [<ReactComponent>]
-    static member private ChangedFilesList(props: ChangedFilesListProps) =
-        let scrollContainerRef = React.useElementRef ()
+    static member private ChangeStatusBadge(props: ChangeStatusBadgeProps) =
+        let badgeLabel, badgeClass, iconClass = GitSidebarInternal.changePresentation props.Change
 
-        let rowVirtualizer =
+        Html.span [
+            prop.className [ badgeClass; "swt:gap-1" ]
+            prop.children [
+                Html.span [
+                    prop.className $"swt:iconify {iconClass} swt:size-3.5"
+                ]
+                Html.span [
+                    prop.text badgeLabel
+                ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member private ChangedFileRow(props: ChangedFileRowProps) =
+        let change = props.Change
+
+        Html.button [
+            prop.testId $"GitSidebarChangeRow-{props.Index}"
+            prop.custom ("data-index", props.Index)
+            prop.ref props.MeasureElement
+            prop.disabled props.IsBusy
+            prop.className [
+                "swt:absolute swt:left-0 swt:flex swt:w-full swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1.5 swt:text-left swt:transition-colors"
+                if change.IsConflicted then
+                    "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
+                elif props.IsSelected then
+                    "swt:border-primary/40 swt:bg-primary/5 hover:swt:bg-primary/10"
+                else
+                    "swt:border-base-content/10 swt:bg-base-100 hover:swt:bg-base-200/80"
+            ]
+            prop.style [
+                style.top 0
+                style.left 0
+                style.width (length.percent 100)
+                style.custom ("transform", $"translateY({props.VirtualStart}px)")
+            ]
+            prop.onClick (fun _ -> props.OpenChange change)
+            prop.children [
+                Html.input [
+                    prop.testId ("GitSidebarCommitSelectionCheckbox-" + change.Path)
+                    prop.className "swt:checkbox swt:checkbox-sm swt:mt-0.5 swt:shrink-0"
+                    prop.type'.checkbox
+                    prop.disabled (not props.CanEditCommit || change.IsConflicted)
+                    prop.isChecked props.IsSelectedForCommit
+                    prop.onClick (fun event -> event.stopPropagation ())
+                    prop.onChange (fun (_: bool) -> props.ToggleCommitSelection change.Path)
+                ]
+                Html.span [
+                    prop.className [
+                        "swt:mt-0.5 swt:font-mono swt:text-[0.7rem]"
+                        if change.IsConflicted then
+                            "swt:text-error"
+                        else
+                            "swt:text-base-content/60"
+                    ]
+                    prop.text (GitSidebarInternal.describeChange change)
+                ]
+                Html.div [
+                    prop.className "swt:min-w-0 swt:flex-1"
+                    prop.children [
+                        Html.div [
+                            prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-1.5"
+                            prop.children [
+                                Html.span [
+                                    prop.className "swt:truncate swt:text-sm swt:font-medium"
+                                    prop.text change.Path
+                                ]
+                                GitSidebar.ChangeStatusBadge({ Change = change })
+                            ]
+                        ]
+                        match change.OriginalPath with
+                        | Some originalPath ->
+                            Html.div [
+                                prop.className "swt:mt-0.5 swt:text-xs swt:text-base-content/60"
+                                prop.text $"Renamed from {originalPath}"
+                            ]
+                        | None -> Html.none
+                    ]
+                ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member private ChangedFilesList(props: ChangedFilesListProps) =
+        let scrollContainerRef: IRefValue<HTMLElement option> = React.useElementRef ()
+        let itemSize = 64
+        let itemGap = 4
+        let overscan = 8
+
+        let changedFileListVirtualizer =
             Virtual.useVirtualizer (
                 count = props.ChangedFiles.Length,
                 getScrollElement = (fun () -> scrollContainerRef.current),
-                estimateSize = (fun _ -> 96),
-                overscan = 2,
-                gap = 8
+                estimateSize = (fun _ -> itemSize),
+                overscan = overscan,
+                gap = itemGap
             )
+
+        let virtualItems =
+            let measuredItems = changedFileListVirtualizer.getVirtualItems ()
+
+            if measuredItems.Length = 0 && props.ChangedFiles.Length > 0 then
+                let isInitialScrollPosition =
+                    scrollContainerRef.current
+                    |> Option.map (fun element -> element.scrollTop = 0.0)
+                    |> Option.defaultValue true
+
+                if not isInitialScrollPosition then
+                    [||]
+                else
+                    [| 0 .. min (props.ChangedFiles.Length - 1) overscan |]
+                    |> Array.map (fun index -> {
+                        Index = index
+                        Start = index * (itemSize + itemGap)
+                    })
+            else
+                measuredItems
+                |> Array.map (fun item -> {
+                    Index = item.index
+                    Start = item.start
+                })
 
         React.Fragment [
             GitSidebar.SectionHeader(
@@ -770,8 +906,9 @@ type GitSidebar =
             )
 
             Html.div [
+                prop.testId "GitSidebarChangedFilesScrollContainer"
                 prop.ref scrollContainerRef
-                prop.className "swt:min-h-0 swt:flex-1 swt:overflow-y-auto swt:px-3 swt:pb-3"
+                prop.className "swt:min-h-0 swt:flex-1 swt:overflow-y-auto swt:px-2 swt:pb-2"
                 prop.children [
                     if props.ChangedFiles.Length = 0 then
                         Html.div [
@@ -780,8 +917,14 @@ type GitSidebar =
                             prop.text "No changed files. Your repository is in sync."
                         ]
                     else
-                        let renderChangeRow (isVirtualized: bool) (index: int) (top: int option) =
-                                    let change = props.ChangedFiles.[index]
+                        Html.div [
+                            prop.testId "GitSidebarChangedFilesVirtualContent"
+                            prop.className "swt:relative swt:mt-1"
+                            prop.style [ style.height (changedFileListVirtualizer.getTotalSize ()) ]
+                            prop.children [
+                                for virtualItem in virtualItems do
+                                    let change = props.ChangedFiles.[virtualItem.Index]
+
                                     let isSelected =
                                         props.SelectedFile
                                         |> Option.exists (fun selected ->
@@ -789,122 +932,28 @@ type GitSidebar =
                                         )
 
                                     let isSelectedForCommit = Set.contains change.Path props.SelectedCommitPaths
-                                    let badgeLabel, badgeClass, iconClass = GitSidebarInternal.changePresentation change
 
-                                    Html.button [
-                                        prop.testId $"GitSidebarChangeRow-{index}"
-                                        prop.key change.Path
-                                        if isVirtualized then
-                                            prop.custom ("data-index", index)
-                                        prop.disabled props.IsBusy
-                                        prop.className [
-                                            "swt:flex swt:w-full swt:flex-col swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-3 swt:py-2 swt:text-left swt:transition-colors"
-                                            if isVirtualized then
-                                                "swt:absolute swt:left-0"
-                                            if change.IsConflicted then
-                                                "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
-                                            elif isSelected then
-                                                "swt:border-primary/40 swt:bg-primary/5 hover:swt:bg-primary/10"
-                                            else
-                                                "swt:border-base-content/10 swt:bg-base-100 hover:swt:bg-base-200/80"
+                                    React.KeyedFragment(
+                                        change.Path,
+                                        [
+                                            GitSidebar.ChangedFileRow(
+                                                {
+                                                    Change = change
+                                                    Index = virtualItem.Index
+                                                    IsSelected = isSelected
+                                                    IsSelectedForCommit = isSelectedForCommit
+                                                    IsBusy = props.IsBusy
+                                                    CanEditCommit = props.CanEditCommit
+                                                    ToggleCommitSelection = props.ToggleCommitSelection
+                                                    OpenChange = props.OpenChange
+                                                    VirtualStart = virtualItem.Start
+                                                    MeasureElement = changedFileListVirtualizer.measureElement
+                                                }
+                                            )
                                         ]
-                                        if isVirtualized then
-                                            prop.style [
-                                                style.top 0
-                                                style.custom ("transform", $"translateY({top.Value}px)")
-                                            ]
-                                        if isVirtualized then
-                                            prop.ref rowVirtualizer.measureElement
-                                        prop.onClick (fun _ -> props.OpenChange change)
-                                        prop.children [
-                                            Html.div [
-                                                prop.className "swt:flex swt:w-full swt:items-start swt:gap-3"
-                                                prop.children [
-                                                    Html.input [
-                                                        prop.testId ("GitSidebarCommitSelectionCheckbox-" + change.Path)
-                                                        prop.className
-                                                            "swt:checkbox swt:checkbox-sm swt:mt-0.5 swt:shrink-0"
-                                                        prop.type'.checkbox
-                                                        prop.disabled (not props.CanEditCommit || change.IsConflicted)
-                                                        prop.isChecked isSelectedForCommit
-                                                        prop.onClick (fun event -> event.stopPropagation ())
-                                                        prop.onChange (fun (_: bool) ->
-                                                            props.ToggleCommitSelection change.Path
-                                                        )
-                                                    ]
-                                                    Html.span [
-                                                        prop.className [
-                                                            "swt:mt-0.5 swt:font-mono swt:text-[0.7rem] swt:tracking-[0.2em]"
-                                                            if change.IsConflicted then
-                                                                "swt:text-error"
-                                                            else
-                                                                "swt:text-base-content/60"
-                                                        ]
-                                                        prop.text (GitSidebarInternal.describeChange change)
-                                                    ]
-                                                    Html.div [
-                                                        prop.className "swt:min-w-0 swt:flex-1"
-                                                        prop.children [
-                                                            Html.div [
-                                                                prop.className
-                                                                    "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
-                                                                prop.children [
-                                                                    Html.span [
-                                                                        prop.className
-                                                                            "swt:truncate swt:text-sm swt:font-medium"
-                                                                        prop.text change.Path
-                                                                    ]
-                                                                    Html.span [
-                                                                        prop.className badgeClass
-                                                                        prop.children [
-                                                                            Html.span [
-                                                                                prop.className
-                                                                                    $"swt:iconify {iconClass} swt:size-3.5"
-                                                                            ]
-                                                                            Html.span [
-                                                                                prop.text badgeLabel
-                                                                            ]
-                                                                        ]
-                                                                    ]
-                                                                ]
-                                                            ]
-                                                            match change.OriginalPath with
-                                                            | Some originalPath ->
-                                                                Html.div [
-                                                                    prop.className
-                                                                        "swt:mt-1 swt:text-xs swt:text-base-content/60"
-                                                                    prop.text $"Renamed from {originalPath}"
-                                                                ]
-                                                            | None -> Html.none
-                                                        ]
-                                                    ]
-                                                ]
-                                            ]
-                                        ]
-                                    ]
-
-                        let renderRows () =
-                            Html.div [
-                                prop.className "swt:mt-2 swt:flex swt:flex-col swt:gap-2"
-                                prop.children (
-                                    props.ChangedFiles
-                                    |> Array.mapi (fun index _ -> renderChangeRow false index None)
-                                )
-                            ]
-
-                        if props.ChangedFiles.Length <= 24 then
-                            renderRows ()
-                        else
-                            Html.div [
-                                prop.className "swt:mt-2 swt:relative"
-                                prop.style [ style.height (rowVirtualizer.getTotalSize ()) ]
-                                prop.children (
-                                    rowVirtualizer.getVirtualItems ()
-                                    |> Array.map (fun virtualRow ->
-                                        renderChangeRow true virtualRow.index (Some virtualRow.start)
                                     )
-                                )
                             ]
+                        ]
                 ]
             ]
         ]

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, fireEvent, userEvent, within } from "storybook/test";
 import { Main as GitSidebarComponent } from "./GitSidebar.fs.js";
 import {
   FSharpResult$2_Ok,
@@ -275,9 +275,15 @@ export const LargeChangedSet: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const gitSidebar = canvas.getByTestId("GitSidebar");
     await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("400 files");
     await expect(canvas.getByTestId("GitSidebarChangeRow-0")).toBeInTheDocument();
     await expect(canvas.queryByTestId("GitSidebarChangeRow-399")).toBeNull();
+    const scrollContainer = gitSidebar.querySelector("div[class*='overflow-y-auto']") as HTMLElement | null;
+    expect(scrollContainer).not.toBeNull();
+    scrollContainer.scrollTop = scrollContainer.scrollHeight - scrollContainer.clientHeight;
+    await fireEvent.scroll(scrollContainer);
+    await expect(await canvas.findByTestId("GitSidebarChangeRow-399")).toBeInTheDocument();
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -359,6 +359,29 @@ export const CommitComposer: Story = {
   },
 };
 
+export const RemoteActionsDisabled: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: changedFiles.slice(),
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+    remoteActionsEnabled: false,
+    remoteActionsWarning:
+      "Sign in to a DataHub account to use fetch, pull, push, or sync.",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("GitSidebarSyncButton")).toBeDisabled();
+    await expect(
+      canvas.getByTestId("GitSidebarRemoteAuthWarning"),
+    ).toHaveTextContent(
+      "Sign in to a DataHub account to use fetch, pull, push, or sync.",
+    );
+  },
+};
+
 export const GlobalErrorState: Story = {
   args: {
     status: baseStatus,

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -122,6 +122,14 @@ const conflictedFiles = [
   },
 ] as const;
 
+const largeChangedFiles = Array.from({ length: 400 }, (_, index) => ({
+  Path: `src/file-${String(index).padStart(3, "0")}.txt`,
+  OriginalPath: undefined,
+  IndexStatus: "M",
+  WorkingTreeStatus: " ",
+  IsConflicted: false,
+}));
+
 function StatefulSidebar(
   props: React.ComponentProps<typeof GitSidebarComponent>,
 ) {
@@ -235,7 +243,12 @@ export const ConflictsPresent: Story = {
       ...baseStatus,
       IsMergeInProgress: true,
     },
-    changedFiles: conflictedFiles.slice(),
+    changedFiles: [
+      conflictedFiles[3],
+      conflictedFiles[0],
+      conflictedFiles[1],
+      conflictedFiles[2],
+    ],
     branchOptions: branchOptions.slice(),
     callbacks: buildCallbacks(),
     downloadLargeFiles: true,
@@ -246,7 +259,49 @@ export const ConflictsPresent: Story = {
     await expect(canvas.getByTestId("GitSidebarMergeBanner")).toHaveTextContent(
       "Resolve all conflicted files before pushing.",
     );
+    await expect(canvasElement.querySelectorAll("[data-testid^='GitSidebarChangeRow-']")).toHaveLength(4);
     await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("Conflict");
+  },
+};
+
+export const LargeChangedSet: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: largeChangedFiles,
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("400 files");
+    await expect(canvas.getByTestId("GitSidebarChangeRow-0")).toBeInTheDocument();
+    await expect(canvas.queryByTestId("GitSidebarChangeRow-399")).toBeNull();
+  },
+};
+
+export const DeletedFile: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: [
+      {
+        Path: "obsolete.md",
+        OriginalPath: undefined,
+        IndexStatus: "D",
+        WorkingTreeStatus: " ",
+        IsConflicted: false,
+      },
+    ],
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("Deleted");
+    await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("git: D.");
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -212,6 +212,9 @@ export const ChangedFiles: Story = {
     await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent(
       "Renamed from notes/protocol-draft.md",
     );
+    await expect(
+      canvas.getByTestId("GitSidebarChangedFilesVirtualContent"),
+    ).toBeInTheDocument();
   },
 };
 
@@ -275,15 +278,24 @@ export const LargeChangedSet: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const gitSidebar = canvas.getByTestId("GitSidebar");
     await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("400 files");
+    await expect(
+      canvas.getByTestId("GitSidebarChangedFilesVirtualContent"),
+    ).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarChangeRow-0")).toBeInTheDocument();
     await expect(canvas.queryByTestId("GitSidebarChangeRow-399")).toBeNull();
-    const scrollContainer = gitSidebar.querySelector("div[class*='overflow-y-auto']") as HTMLElement | null;
-    expect(scrollContainer).not.toBeNull();
-    scrollContainer.scrollTop = scrollContainer.scrollHeight - scrollContainer.clientHeight;
-    await fireEvent.scroll(scrollContainer);
-    await expect(await canvas.findByTestId("GitSidebarChangeRow-399")).toBeInTheDocument();
+    const scrollContainer = canvas.getByTestId(
+      "GitSidebarChangedFilesScrollContainer",
+    ) as HTMLElement;
+    const maxScrollTop =
+      scrollContainer.scrollHeight - scrollContainer.clientHeight;
+    scrollContainer.scrollTop = maxScrollTop;
+    await fireEvent.scroll(scrollContainer, {
+      target: { scrollTop: maxScrollTop },
+    });
+    await expect(
+      await canvas.findByTestId("GitSidebarChangeRow-399"),
+    ).toBeInTheDocument();
   },
 };
 

--- a/src/Components/src/Table/Table.fs
+++ b/src/Components/src/Table/Table.fs
@@ -345,7 +345,11 @@ swt:p-0"""
 
                                                                     Html.th [
 
-                                                                        prop.ref columnVirtualizer.measureElement
+                                                                        prop.ref (fun element ->
+                                                                            columnVirtualizer.measureElement (
+                                                                                Option.ofObj element
+                                                                            )
+                                                                        )
 
                                                                         prop.custom ("data-index", virtualColumn.index)
                                                                         prop.key

--- a/src/Components/src/Util/Virtual.fs
+++ b/src/Components/src/Util/Virtual.fs
@@ -4,6 +4,9 @@ open Fable.Core
 open Browser.Types
 open Feliz
 
+// TanStack's measureElement is a React callback ref, not an IRefValue object.
+type VirtualMeasureElementRef = Element option -> unit
+
 module Virtual =
 
     [<Literal>]
@@ -41,7 +44,7 @@ module Virtual =
         member this.scrollToIndex (index: int, ?options: {|align: AlignOption option; behavior: ScrollBehavior option|}) : unit = jsNative
         member this.scrollRect: {|height: int; width: int|} = jsNative
         member this.scrollOffset: int = jsNative
-        member this.measureElement: IRefValue<Browser.Types.HTMLElement option> = jsNative
+        member this.measureElement: VirtualMeasureElementRef = jsNative
 
 [<Erase>]
 type Virtual =

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -1662,6 +1662,36 @@ let createBranch (arcPath: string) (branchName: string) (startPoint: string opti
                         })
 }
 
+let addRemote (arcPath: string) (remoteName: string) (remoteUrl: string) : JS.Promise<GitResult<unit>> = promise {
+    match validateRemoteName remoteName with
+    | Error remoteError -> return errorResult remoteError
+    | Ok safeRemoteName ->
+        match ensureAllowedRemoteUrl remoteUrl with
+        | Error remoteUrlError -> return errorResult remoteUrlError
+        | Ok safeRemoteUrl ->
+            return!
+                withLocalGit
+                    arcPath
+                    (fun git -> promise {
+                        let! remoteList = git.getRemotes ()
+
+                        let remoteExists =
+                            match remoteList with
+                            | U2.Case1 remotes ->
+                                remotes
+                                |> Array.exists (fun remote -> String.Equals(remote.name, safeRemoteName, StringComparison.Ordinal))
+                            | U2.Case2 remotes ->
+                                remotes
+                                |> Array.exists (fun remote -> String.Equals(remote.name, safeRemoteName, StringComparison.Ordinal))
+
+                        if remoteExists then
+                            return abortGitPromise $"Remote '{safeRemoteName}' already exists."
+                        else
+                            let! _ = git.addRemote (safeRemoteName, safeRemoteUrl)
+                            return ()
+                    })
+}
+
 let checkoutBranch (arcPath: string) (branchName: string) : JS.Promise<GitResult<unit>> = promise {
     match ensureValidBranchLikeName "Branch name" branchName with
     | Error branchError -> return errorResult branchError

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -219,6 +219,20 @@ let api: IGitApi = {
                     None
                     result
         }
+    gitAddRemote =
+        fun (event: IpcMainEvent) (request: GitRemoteConfigRequest) -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(_, arcPath) ->
+                let! result = GitService.addRemote arcPath request.RemoteName request.RemoteUrl
+
+                return
+                    toGitOperationResult
+                        (fun () -> Some $"Remote '{request.RemoteName}' configured.")
+                        None
+                        None
+                        result
+        }
     gitCloneRepository =
         fun (event: IpcMainEvent) (request: GitCloneRepositoryRequest) -> promise {
             let progressReporter =

--- a/src/Electron/src/Main/IPC/IGitLabApi.fs
+++ b/src/Electron/src/Main/IPC/IGitLabApi.fs
@@ -109,4 +109,10 @@ let api: IGitLabApi = {
                         sort = query.Sort
                     )
         }
+    createProject =
+        fun (_event: IpcMainEvent) (projectName: string) -> promise {
+            match tryGetActiveGitLabContext () with
+            | Error err -> return Error err
+            | Ok(baseUrl, token) -> return! GitLabApi.CreateProject(baseUrl, token, projectName)
+        }
 }

--- a/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarEmptyState.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarEmptyState.fs
@@ -1,0 +1,93 @@
+namespace Renderer.Components.LeftSidebar
+
+open Fable.Core
+open Feliz
+
+type EmptyStateAction = {
+    Label: string
+    IconClassName: string
+    Disabled: bool
+    OnClick: unit -> unit
+}
+
+[<Erase; Mangle(false)>]
+type GitSidebarEmptyState =
+
+    [<ReactComponent>]
+    static member Main
+        (
+            title: string,
+            description: string,
+            primaryAction: EmptyStateAction,
+            ?secondaryAction: EmptyStateAction,
+            ?infoText: string,
+            ?extraContent: ReactElement
+        ) =
+        Html.div [
+            prop.testId "GitSidebarEmptyState"
+            prop.className "swt:flex swt:h-full swt:flex-col swt:justify-center swt:p-4"
+            prop.children [
+                Html.div [
+                    prop.className "swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-100 swt:p-4"
+                    prop.children [
+                        Html.h2 [
+                            prop.className "swt:text-base swt:font-semibold"
+                            prop.text title
+                        ]
+                        Html.p [
+                            prop.className "swt:mt-2 swt:text-sm swt:text-base-content/70"
+                            prop.text description
+                        ]
+                        match extraContent with
+                        | Some content ->
+                            Html.div [
+                                prop.className "swt:mt-4"
+                                prop.children [ content ]
+                            ]
+                        | None -> Html.none
+                        Html.div [
+                            prop.className "swt:mt-4 swt:flex swt:flex-col swt:gap-2"
+                            prop.children [
+                                Html.button [
+                                    prop.className "swt:btn swt:btn-primary swt:w-full swt:justify-start swt:gap-2"
+                                    prop.disabled primaryAction.Disabled
+                                    prop.onClick (fun _ -> primaryAction.OnClick())
+                                    prop.children [
+                                        Html.span [
+                                            prop.className $"swt:iconify {primaryAction.IconClassName} swt:size-4"
+                                        ]
+                                        Html.span primaryAction.Label
+                                    ]
+                                ]
+                                match secondaryAction with
+                                | Some action ->
+                                    Html.button [
+                                        prop.className "swt:btn swt:btn-outline swt:w-full swt:justify-start swt:gap-2"
+                                        prop.disabled action.Disabled
+                                        prop.onClick (fun _ -> action.OnClick())
+                                        prop.children [
+                                            Html.span [
+                                                prop.className $"swt:iconify {action.IconClassName} swt:size-4"
+                                            ]
+                                            Html.span action.Label
+                                        ]
+                                    ]
+                                | None -> Html.none
+                            ]
+                        ]
+                        match infoText with
+                        | Some info ->
+                            Html.div [
+                                prop.className "swt:mt-4 swt:alert swt:alert-warning swt:px-3 swt:py-2 swt:text-sm"
+                                prop.children [
+                                    Html.span [
+                                        prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4"
+                                    ]
+                                    Html.span info
+                                ]
+                            ]
+                        | None -> Html.none
+                    ]
+                ]
+            ]
+        ]

--- a/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
@@ -6,30 +6,120 @@ open Feliz
 let Main () =
 
     let gitStateCtx = Renderer.Context.GitStateCtx.useGitState ()
+    let authState = Renderer.Context.AuthStateCtx.useAuthState ()
+    let pageStateCtx = Renderer.Context.PageStateCtx.usePageState ()
     let runStatus = Renderer.Context.GitWorkflow.currentRunStatus gitStateCtx.state
+    let remoteProjectName, setRemoteProjectName = React.useState ""
 
-    Swate.Components.GitSidebar.Main(
-        status = gitStateCtx.state.Status,
-        changedFiles = gitStateCtx.state.ChangedFiles,
-        branchOptions = gitStateCtx.state.BranchOptions,
-        ?runStatus = runStatus,
-        ?selectedFile = gitStateCtx.state.SelectedChangePath,
-        ?errorNotice = gitStateCtx.state.ErrorNotice,
-        ?warningNotice = gitStateCtx.state.WarningNotice,
-        callbacks = {
-            OnRefresh = gitStateCtx.refresh
-            OnFetch = gitStateCtx.fetch
-            OnPull = gitStateCtx.pull
-            OnPush = gitStateCtx.push
-            OnSync = gitStateCtx.sync
-            OnCommitSelection = gitStateCtx.commitSelection
-            OnCommitAll = gitStateCtx.commitAll
-            OnSaveDownloadLargeFiles = gitStateCtx.saveDownloadLargeFiles
-            OnSaveLfsAutoTrackThreshold = gitStateCtx.saveLfsAutoTrackThreshold
-            OnCreateBranch = gitStateCtx.createBranch
-            OnSwitchBranch = gitStateCtx.switchBranch
-            OnSelectChange = gitStateCtx.selectChange
-        },
-        downloadLargeFiles = gitStateCtx.state.DownloadLargeFiles,
-        lfsAutoTrackThresholdMb = gitStateCtx.state.LfsAutoTrackThresholdMb
-    )
+    let remoteActionsEnabled =
+        authState.UsableActiveUser().IsSome
+
+    let remoteActionsWarning =
+        if remoteActionsEnabled then
+            None
+        else
+            Some "Sign in to a DataHub account to use fetch, pull, push, sync, and remote bootstrap."
+
+    let normalizedRemoteProjectName =
+        remoteProjectName.Trim()
+        |> function
+            | "" -> None
+            | value -> Some value
+
+    let openArc () =
+        Renderer.Components.NavbarHelper.Selector.openARC null
+
+    match gitStateCtx.state.CurrentArcPath with
+    | None ->
+        Renderer.Components.LeftSidebar.GitSidebarEmptyState.Main(
+            title = "Open an ARC to use Git features",
+            description = "Source control becomes available after you open or download an ARC.",
+            primaryAction = {
+                Label = "Open ARC"
+                IconClassName = "swt:fluent--folder-open-24-regular"
+                Disabled = false
+                OnClick = openArc
+            },
+            secondaryAction = {
+                Label = "Download ARC"
+                IconClassName = "swt:fluent--cloud-arrow-down-24-regular"
+                Disabled = false
+                OnClick = (fun () -> pageStateCtx.setState (Some Renderer.Types.PageState.DataHubBrowser))
+            }
+        )
+    | Some _ when gitStateCtx.state.RepositoryAvailability = Renderer.Context.GitWorkflow.GitRepositoryAvailability.MissingRepository ->
+        Renderer.Components.LeftSidebar.GitSidebarEmptyState.Main(
+            title = "Initialize Git for this ARC",
+            description = "The selected ARC folder is not a Git repository yet.",
+            primaryAction = {
+                Label =
+                    if gitStateCtx.state.BusyOperation = Some Renderer.Context.GitWorkflow.GitBusyOperation.InitializingRepository then
+                        "Initializing..."
+                    else
+                        "Initialize Repository"
+                IconClassName = "swt:fluent--branch-fork-24-regular"
+                Disabled = gitStateCtx.state.BusyOperation.IsSome
+                OnClick =
+                    (fun () ->
+                        gitStateCtx.initRepository (
+                            if remoteActionsEnabled then normalizedRemoteProjectName else None
+                        ))
+            },
+            extraContent =
+                Html.div [
+                    prop.className "swt:flex swt:flex-col swt:gap-2"
+                    prop.children [
+                        Html.label [
+                            prop.className "swt:flex swt:flex-col swt:gap-1"
+                            prop.children [
+                                Html.span [
+                                    prop.className "swt:text-xs swt:font-medium swt:text-base-content/70"
+                                    prop.text "DataHub repository name"
+                                ]
+                                Html.input [
+                                    prop.testId "GitSidebarRemoteProjectNameInput"
+                                    prop.className "swt:input swt:input-bordered swt:w-full"
+                                    prop.disabled (gitStateCtx.state.BusyOperation.IsSome || not remoteActionsEnabled)
+                                    prop.value remoteProjectName
+                                    prop.placeholder "my-arc"
+                                    prop.onChange setRemoteProjectName
+                                ]
+                            ]
+                        ]
+                        Html.p [
+                            prop.className "swt:text-xs swt:text-base-content/60"
+                            prop.text
+                                "If you provide a name, Swate creates a project on the active DataHub and adds it as origin right after git init."
+                        ]
+                    ]
+                ],
+            ?infoText = remoteActionsWarning
+        )
+    | Some _ ->
+        Swate.Components.GitSidebar.Main(
+            status = gitStateCtx.state.Status,
+            changedFiles = gitStateCtx.state.ChangedFiles,
+            branchOptions = gitStateCtx.state.BranchOptions,
+            ?runStatus = runStatus,
+            ?selectedFile = gitStateCtx.state.SelectedChangePath,
+            ?errorNotice = gitStateCtx.state.ErrorNotice,
+            ?warningNotice = gitStateCtx.state.WarningNotice,
+            callbacks = {
+                OnRefresh = gitStateCtx.refresh
+                OnFetch = gitStateCtx.fetch
+                OnPull = gitStateCtx.pull
+                OnPush = gitStateCtx.push
+                OnSync = gitStateCtx.sync
+                OnCommitSelection = gitStateCtx.commitSelection
+                OnCommitAll = gitStateCtx.commitAll
+                OnSaveDownloadLargeFiles = gitStateCtx.saveDownloadLargeFiles
+                OnSaveLfsAutoTrackThreshold = gitStateCtx.saveLfsAutoTrackThreshold
+                OnCreateBranch = gitStateCtx.createBranch
+                OnSwitchBranch = gitStateCtx.switchBranch
+                OnSelectChange = gitStateCtx.selectChange
+            },
+            downloadLargeFiles = gitStateCtx.state.DownloadLargeFiles,
+            lfsAutoTrackThresholdMb = gitStateCtx.state.LfsAutoTrackThresholdMb,
+            remoteActionsEnabled = remoteActionsEnabled,
+            ?remoteActionsWarning = remoteActionsWarning
+        )

--- a/src/Electron/src/Renderer/Context/GitStateCtx.fs
+++ b/src/Electron/src/Renderer/Context/GitStateCtx.fs
@@ -16,6 +16,7 @@ open Renderer.Context.GitWorkflow
 type GitStateController = {
     state: GitState
     refresh: unit -> unit
+    initRepository: string option -> unit
     fetch: unit -> unit
     pull: unit -> unit
     push: unit -> unit
@@ -57,10 +58,17 @@ let private dependencies: GitDependencies = {
             let! result = Renderer.GitApiClient.getGitMergeConflictViewData requestedPath
             return mapMergeConflictPageResult requestedPath result
         }
+    initGitRepository = Renderer.GitApiClient.gitInitRepository
+    createDataHubProject =
+        fun projectName -> promise {
+            let! result = Api.ipcGitLabApi.createProject (unbox null) projectName
+            return result |> Result.mapError _.GitLabErrorToString
+        }
     installGitLfs = Renderer.GitApiClient.installGitLfs
     gitFetch = Renderer.GitApiClient.gitFetch
     gitPull = Renderer.GitApiClient.gitPull
     gitPush = Renderer.GitApiClient.gitPush
+    gitAddRemote = Renderer.GitApiClient.gitAddRemote
     gitCloneRepository = Renderer.GitApiClient.gitCloneRepository
     createBranch = Renderer.GitApiClient.createBranch
     checkoutBranch = Renderer.GitApiClient.checkoutBranch
@@ -77,6 +85,7 @@ let GitStateCtx =
         {
             state = GitState.Empty
             refresh = fun () -> ()
+            initRepository = fun _ -> ()
             fetch = fun () -> ()
             pull = fun () -> ()
             push = fun () -> ()
@@ -106,6 +115,9 @@ let GitStateCtxProvider (children: ReactElement) =
         React.useElmish ((fun () -> init ()), update dependencies pageStateCtx.setState, subscribe, [||])
 
     let refresh () = dispatch RefreshRequested
+
+    let initRepository remoteProjectName =
+        dispatch (InitRepositoryRequested remoteProjectName)
 
     let fetch () = dispatch FetchRequested
 
@@ -148,6 +160,7 @@ let GitStateCtxProvider (children: ReactElement) =
             (fun _ -> {
                 state = gitState
                 refresh = refresh
+                initRepository = initRepository
                 fetch = fetch
                 pull = pull
                 push = push

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -55,6 +55,8 @@ type GitPullWorkflowResult = {
     PageChange: GitPageChange
 }
 
+type InitRepositoryOutcome = { WarningMessage: string option }
+
 type GitState = {
     Status: GitSidebarStatus
     ChangedFiles: GitSidebarChange[]
@@ -158,7 +160,7 @@ type Msg =
     | RefreshRequested
     | RefreshCompleted of requestId: int * result: Result<GitRefreshResult, string>
     | InitRepositoryRequested of remoteProjectName: string option
-    | InitRepositoryCompleted of sessionId: int * result: Result<unit, string>
+    | InitRepositoryCompleted of sessionId: int * result: Result<InitRepositoryOutcome, string>
     | SelectChangeRequested of GitSidebarChange * Reply<unit>
     | SelectChangeCompleted of
         requestId: int *
@@ -451,12 +453,16 @@ let private runInitRepositoryAsync
         | Error message -> return Error message
         | Ok _ ->
             match remoteProjectName |> Option.map _.Trim() |> Option.filter (String.IsNullOrWhiteSpace >> not) with
-            | None -> return Ok()
+            | None -> return Ok { WarningMessage = None }
             | Some projectName ->
                 let! projectResult = deps.createDataHubProject projectName
 
                 match projectResult with
-                | Error message -> return Error message
+                | Error message ->
+                    return
+                        Ok {
+                            WarningMessage = Some message
+                        }
                 | Ok project ->
                     let! addRemoteResult =
                         deps.gitAddRemote {
@@ -465,10 +471,19 @@ let private runInitRepositoryAsync
                         }
 
                     match addRemoteResult with
-                    | Error message -> return Error message
-                    | Ok operationResult when operationResult.Success -> return Ok()
+                    | Error message ->
+                        return
+                            Ok {
+                                WarningMessage = Some message
+                            }
+                    | Ok operationResult when operationResult.Success ->
+                        return Ok { WarningMessage = None }
                     | Ok operationResult ->
-                        return Error(operationResult.Message |> Option.defaultValue "Adding origin remote failed.")
+                        return
+                            Ok {
+                                WarningMessage =
+                                    Some(operationResult.Message |> Option.defaultValue "Adding origin remote failed.")
+                            }
     }
 
 let private loadPageAsync (deps: GitDependencies) (path: string) (isConflicted: bool) = promise {
@@ -929,7 +944,7 @@ let update
         }
 
         nextModel, Cmd.none
-    | InitRepositoryCompleted(_, Ok()) ->
+    | InitRepositoryCompleted(_, Ok outcome) ->
         let nextModel = {
             model with
                 RepositoryAvailability = GitRepositoryAvailability.Ready
@@ -937,7 +952,7 @@ let update
                 BusyNotice = None
                 CurrentProgress = None
                 ErrorNotice = None
-                WarningNotice = None
+                WarningNotice = outcome.WarningMessage
         }
 
         nextModel, Cmd.ofMsg RefreshRequested

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -5,6 +5,7 @@ open Elmish
 open Fable.Core
 
 open Renderer.Types
+open Swate.Components.Api.GitLabApi
 open Swate.Components.GitSidebarTypes
 open Swate.Electron.Shared
 open Swate.Electron.Shared.GitTypes
@@ -17,6 +18,7 @@ type GitRefreshState =
 [<RequireQualifiedAccess>]
 type GitBusyOperation =
     | Refreshing
+    | InitializingRepository
     | FetchingFromRemote
     | PullingFromRemote
     | PushingToRemote
@@ -29,6 +31,11 @@ type GitBusyOperation =
     | SwitchingBranch
     | InstallingGitLfs
     | ConfirmingMergeResolution of path: string
+
+[<RequireQualifiedAccess>]
+type GitRepositoryAvailability =
+    | Ready
+    | MissingRepository
 
 [<RequireQualifiedAccess>]
 type GitInstallRetryState =
@@ -54,6 +61,7 @@ type GitState = {
     BranchOptions: GitSidebarBranchOption[]
     LfsAutoTrackThresholdMb: int
     DownloadLargeFiles: bool
+    RepositoryAvailability: GitRepositoryAvailability
     RefreshState: GitRefreshState
     RefreshRequestId: int
     BusyOperation: GitBusyOperation option
@@ -82,6 +90,7 @@ type GitState = {
         BranchOptions = [||]
         LfsAutoTrackThresholdMb = 1
         DownloadLargeFiles = false
+        RepositoryAvailability = GitRepositoryAvailability.Ready
         RefreshState = GitRefreshState.Idle
         RefreshRequestId = 0
         BusyOperation = None
@@ -148,6 +157,8 @@ type Msg =
     | ArcPathChanged of ArcRootPath
     | RefreshRequested
     | RefreshCompleted of requestId: int * result: Result<GitRefreshResult, string>
+    | InitRepositoryRequested of remoteProjectName: string option
+    | InitRepositoryCompleted of sessionId: int * result: Result<unit, string>
     | SelectChangeRequested of GitSidebarChange * Reply<unit>
     | SelectChangeCompleted of
         requestId: int *
@@ -178,10 +189,13 @@ type GitDependencies = {
     getGitLfsSettings: unit -> JS.Promise<Result<GitLfsSettingsDto, string>>
     loadDiffPage: string -> JS.Promise<Result<PageState, string>>
     loadMergeConflictPage: string -> JS.Promise<Result<PageState, string>>
+    initGitRepository: string -> JS.Promise<Result<string, string>>
+    createDataHubProject: string -> JS.Promise<Result<ExploreProjectDto, string>>
     installGitLfs: unit -> JS.Promise<Result<GitOperationResult, string>>
     gitFetch: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPush: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
+    gitAddRemote: GitRemoteConfigRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitCloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, string>>
     createBranch: GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
     checkoutBranch: GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
@@ -202,6 +216,9 @@ let staleMergeConflictTokens = [|
 let staleArcSessionMessage =
     "Git operation was canceled because the active ARC changed."
 
+let private isMissingRepositoryMessage (message: string) =
+    message.ToLowerInvariant().Contains("not a git repository")
+
 let isStaleMergeConflictError (message: string) =
     let normalizedMessage = message.ToLowerInvariant()
 
@@ -211,6 +228,7 @@ let isStaleMergeConflictError (message: string) =
 let busyNoticeFromOperation =
     function
     | GitBusyOperation.Refreshing -> Some "Refreshing Git state"
+    | GitBusyOperation.InitializingRepository -> Some "Initializing repository"
     | GitBusyOperation.FetchingFromRemote -> Some "Fetching from remote"
     | GitBusyOperation.PullingFromRemote -> Some "Pulling from remote"
     | GitBusyOperation.PushingToRemote -> Some "Pushing to remote"
@@ -341,6 +359,7 @@ let private applyRefreshResult (refreshResult: GitRefreshResult) (model: GitStat
 
     {
         modelWithSettings with
+            RepositoryAvailability = GitRepositoryAvailability.Ready
             RefreshState = GitRefreshState.Idle
             ErrorNotice = refreshErrorMessage refreshResult
     }
@@ -419,6 +438,38 @@ let private refreshAllAsync (deps: GitDependencies) = promise {
         LfsSettings = lfsSettingsResult
     }
 }
+
+let private runInitRepositoryAsync
+    (deps: GitDependencies)
+    (arcPath: string)
+    (remoteProjectName: string option)
+    =
+    promise {
+        let! initResult = deps.initGitRepository arcPath
+
+        match initResult with
+        | Error message -> return Error message
+        | Ok _ ->
+            match remoteProjectName |> Option.map _.Trim() |> Option.filter (String.IsNullOrWhiteSpace >> not) with
+            | None -> return Ok()
+            | Some projectName ->
+                let! projectResult = deps.createDataHubProject projectName
+
+                match projectResult with
+                | Error message -> return Error message
+                | Ok project ->
+                    let! addRemoteResult =
+                        deps.gitAddRemote {
+                            RemoteName = "origin"
+                            RemoteUrl = project.http_url_to_repo
+                        }
+
+                    match addRemoteResult with
+                    | Error message -> return Error message
+                    | Ok operationResult when operationResult.Success -> return Ok()
+                    | Ok operationResult ->
+                        return Error(operationResult.Message |> Option.defaultValue "Adding origin remote failed.")
+    }
 
 let private loadPageAsync (deps: GitDependencies) (path: string) (isConflicted: bool) = promise {
     let! result =
@@ -730,6 +781,25 @@ let private executeWriteAttempt (deps: GitDependencies) (state: GitState) (reque
 
 let init () : GitState * Cmd<Msg> = GitState.Empty, Cmd.none
 
+let private missingRepositoryModel (model: GitState) = {
+    model with
+        Status = GitState.Empty.Status
+        ChangedFiles = [||]
+        BranchOptions = [||]
+        LfsAutoTrackThresholdMb = GitState.Empty.LfsAutoTrackThresholdMb
+        DownloadLargeFiles = GitState.Empty.DownloadLargeFiles
+        RepositoryAvailability = GitRepositoryAvailability.MissingRepository
+        RefreshState = GitRefreshState.Idle
+        BusyOperation = None
+        BusyNotice = None
+        CurrentProgress = None
+        ErrorNotice = None
+        WarningNotice = None
+        SelectedChangePath = None
+        MergeResolutionPendingPath = None
+        InstallRetryState = GitInstallRetryState.Idle
+}
+
 let update
     (deps: GitDependencies)
     (setPageState: PageState option -> unit)
@@ -791,6 +861,8 @@ let update
 
         nextModel, cmd
     | RefreshCompleted(requestId, _) when requestId <> model.RefreshRequestId -> model, Cmd.none
+    | RefreshCompleted(_, Error message) when isMissingRepositoryMessage message ->
+        missingRepositoryModel model, Cmd.none
     | RefreshCompleted(_, Error message) ->
         let nextModel = {
             model with
@@ -803,6 +875,9 @@ let update
         }
 
         nextModel, applyPageChangeCmd setPageState GitPageChange.Clear
+    | RefreshCompleted(_, Ok refreshResult)
+        when refreshErrorMessage refreshResult |> Option.exists isMissingRepositoryMessage ->
+        missingRepositoryModel model, Cmd.none
     | RefreshCompleted(requestId, Ok refreshResult) ->
         let nextModel =
             model
@@ -823,6 +898,49 @@ let update
                 Cmd.none
 
         nextModel, cmd
+    | InitRepositoryRequested _ when model.CurrentArcPath.IsNone -> model, Cmd.none
+    | InitRepositoryRequested remoteProjectName ->
+        let nextModel =
+            model
+            |> withBusyOperation (Some GitBusyOperation.InitializingRepository)
+            |> fun state -> {
+                state with
+                    ErrorNotice = None
+                    WarningNotice = None
+            }
+
+        let cmd =
+            Cmd.OfPromise.either
+                (fun (deps, arcPath, remoteProjectName) -> runInitRepositoryAsync deps arcPath remoteProjectName)
+                (deps, Option.get model.CurrentArcPath, remoteProjectName)
+                (fun result -> InitRepositoryCompleted(model.ArcSessionId, result))
+                (fun err -> InitRepositoryCompleted(model.ArcSessionId, Error(string err)))
+
+        nextModel, cmd
+    | InitRepositoryCompleted(sessionId, _) when sessionId <> model.ArcSessionId -> model, Cmd.none
+    | InitRepositoryCompleted(_, Error message) ->
+        let nextModel = {
+            model with
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = Some message
+                WarningNotice = None
+        }
+
+        nextModel, Cmd.none
+    | InitRepositoryCompleted(_, Ok()) ->
+        let nextModel = {
+            model with
+                RepositoryAvailability = GitRepositoryAvailability.Ready
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = None
+                WarningNotice = None
+        }
+
+        nextModel, Cmd.ofMsg RefreshRequested
     | SelectChangeRequested(_, reply) when model.CurrentArcPath.IsNone ->
         model, resolveReplyCmd reply (Error "No ARC is loaded.")
     | SelectChangeRequested(change, reply) ->

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -71,6 +71,7 @@ type GitState = {
     CurrentProgress: GitSidebarProgress option
     ErrorNotice: string option
     WarningNotice: string option
+    PendingRefreshWarningNotice: string option
     SelectedChangePath: string option
     MergeResolutionPendingPath: string option
     InstallRetryState: GitInstallRetryState
@@ -100,6 +101,7 @@ type GitState = {
         CurrentProgress = None
         ErrorNotice = None
         WarningNotice = None
+        PendingRefreshWarningNotice = None
         SelectedChangePath = None
         MergeResolutionPendingPath = None
         InstallRetryState = GitInstallRetryState.Idle
@@ -364,6 +366,8 @@ let private applyRefreshResult (refreshResult: GitRefreshResult) (model: GitStat
             RepositoryAvailability = GitRepositoryAvailability.Ready
             RefreshState = GitRefreshState.Idle
             ErrorNotice = refreshErrorMessage refreshResult
+            WarningNotice = model.PendingRefreshWarningNotice
+            PendingRefreshWarningNotice = None
     }
 
 let nextRefreshRequestId (model: GitState) = model.RefreshRequestId + 1
@@ -810,6 +814,7 @@ let private missingRepositoryModel (model: GitState) = {
         CurrentProgress = None
         ErrorNotice = None
         WarningNotice = None
+        PendingRefreshWarningNotice = None
         SelectedChangePath = None
         MergeResolutionPendingPath = None
         InstallRetryState = GitInstallRetryState.Idle
@@ -864,7 +869,10 @@ let update
             |> fun state -> {
                 state with
                     ErrorNotice = None
-                    WarningNotice = None
+                    WarningNotice =
+                        match state.PendingRefreshWarningNotice with
+                        | Some _ -> state.WarningNotice
+                        | None -> None
             }
 
         let cmd =
@@ -877,7 +885,7 @@ let update
         nextModel, cmd
     | RefreshCompleted(requestId, _) when requestId <> model.RefreshRequestId -> model, Cmd.none
     | RefreshCompleted(_, Error message) when isMissingRepositoryMessage message ->
-        missingRepositoryModel model, Cmd.none
+        missingRepositoryModel model, applyPageChangeCmd setPageState GitPageChange.Clear
     | RefreshCompleted(_, Error message) ->
         let nextModel = {
             model with
@@ -887,12 +895,13 @@ let update
                 CurrentProgress = None
                 ErrorNotice = Some message
                 WarningNotice = None
+                PendingRefreshWarningNotice = None
         }
 
         nextModel, applyPageChangeCmd setPageState GitPageChange.Clear
     | RefreshCompleted(_, Ok refreshResult)
         when refreshErrorMessage refreshResult |> Option.exists isMissingRepositoryMessage ->
-        missingRepositoryModel model, Cmd.none
+        missingRepositoryModel model, applyPageChangeCmd setPageState GitPageChange.Clear
     | RefreshCompleted(requestId, Ok refreshResult) ->
         let nextModel =
             model
@@ -941,6 +950,7 @@ let update
                 CurrentProgress = None
                 ErrorNotice = Some message
                 WarningNotice = None
+                PendingRefreshWarningNotice = None
         }
 
         nextModel, Cmd.none
@@ -953,6 +963,7 @@ let update
                 CurrentProgress = None
                 ErrorNotice = None
                 WarningNotice = outcome.WarningMessage
+                PendingRefreshWarningNotice = outcome.WarningMessage
         }
 
         nextModel, Cmd.ofMsg RefreshRequested

--- a/src/Electron/src/Renderer/GitApiClient.fs
+++ b/src/Electron/src/Renderer/GitApiClient.fs
@@ -50,6 +50,24 @@ let gitPull (request: GitRemoteOperationRequest) =
 let gitPush (request: GitRemoteOperationRequest) =
     callIpcWith request (gitApi.gitPush (unbox null))
 
+let gitInitRepository (targetPath: string) =
+    promise {
+        let! result = gitApi.gitInitRepository (unbox null) targetPath
+
+        return
+            result
+            |> mapExnResult
+            |> Result.bind (fun operation ->
+                if operation.Success then
+                    Ok(operation.Path |> Option.defaultValue targetPath)
+                else
+                    Error(operation.Message |> Option.defaultValue "Git repository initialization failed.")
+            )
+    }
+
+let gitAddRemote (request: GitRemoteConfigRequest) =
+    callIpcWith request (gitApi.gitAddRemote (unbox null))
+
 let gitCloneRepository (request: GitCloneRepositoryRequest) =
     callIpcWith request (gitApi.gitCloneRepository (unbox null))
 

--- a/src/Electron/src/Renderer/Renderer.fsproj
+++ b/src/Electron/src/Renderer/Renderer.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="Components\WidgetRegister.fs" />
     <Compile Include="Components\LeftSidebar\ArcObjectTreeSidebar.fs" />
     <Compile Include="Components\LeftSidebar\ExplorerSidebar.fs" />
+    <Compile Include="Components\LeftSidebar\GitSidebarEmptyState.fs" />
     <Compile Include="Components\LeftSidebar\GitSidebarPanel.fs" />
     <Compile Include="Components\LeftSidebar\Main.fs" />
     <Compile Include="Components\MainElement.fs" />

--- a/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
@@ -119,6 +119,11 @@ type GitRemoteOperationRequest = {
     Branch: string option
 }
 
+type GitRemoteConfigRequest = {
+    RemoteName: string
+    RemoteUrl: string
+}
+
 type GitCloneRepositoryRequest = {
     RemoteUrl: string
     TargetPath: string

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -69,6 +69,7 @@ type IGitApi = {
     gitPull: IpcMainEvent -> GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitPush: IpcMainEvent -> GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitInitRepository: IpcMainEvent -> string -> JS.Promise<Result<GitOperationResult, exn>>
+    gitAddRemote: IpcMainEvent -> GitRemoteConfigRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitCloneRepository: IpcMainEvent -> GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitStagePaths: IpcMainEvent -> GitPathspecRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitUnstagePaths: IpcMainEvent -> GitPathspecRequest -> JS.Promise<Result<GitOperationResult, exn>>
@@ -90,6 +91,7 @@ type IGitLabApi = {
         IpcMainEvent -> ExploreGroupsQuery -> JS.Promise<Result<PagedResponse<GroupDto>, GitLabError>>
     loadOrganisationRepos:
         IpcMainEvent -> ExploreGroupProjectsQuery -> JS.Promise<Result<PagedResponse<ExploreProjectDto>, GitLabError>>
+    createProject: IpcMainEvent -> string -> JS.Promise<Result<ExploreProjectDto, GitLabError>>
 }
 
 /// One Way Bridge: Main -> Renderer

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -363,6 +363,24 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "addRemote stores the requested origin URL in the local repository config",
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let remoteUrl = "https://git.nfdi4plants.org/caroott/arc-a.git"
+
+                        let! _ =
+                            unwrapResultAsync
+                                (GitService.addRemote context.RepoPath "origin" remoteUrl)
+                                (expectOk "add origin remote")
+
+                        let! configuredRemoteUrl = context.Git.raw [| "remote"; "get-url"; "origin" |]
+                        Vitest.expect(configuredRemoteUrl.Trim()).toBe (remoteUrl)
+                    })
+            }
+        )
+
+        Vitest.test (
             "commit keeps the staged version when the working tree changes again before commit",
             fun () -> promise {
                 do!

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -554,7 +554,7 @@ Vitest.describe (
 
                 let nextState, finishCmd =
                     match requestMessages with
-                    | [| InitRepositoryCompleted(sessionId, Ok()) |] when sessionId = state.ArcSessionId ->
+                    | [| InitRepositoryCompleted(sessionId, Ok _) |] when sessionId = state.ArcSessionId ->
                         update deps ignore requestMessages[0] requestedState
                     | _ -> failwith "Expected init-repository completion."
 
@@ -623,7 +623,7 @@ Vitest.describe (
 
                 let nextState, finishCmd =
                     match requestMessages with
-                    | [| InitRepositoryCompleted(sessionId, Ok()) |] when sessionId = state.ArcSessionId ->
+                    | [| InitRepositoryCompleted(sessionId, Ok _) |] when sessionId = state.ArcSessionId ->
                         update deps ignore requestMessages[0] requestedState
                     | _ -> failwith "Expected a successful init-and-remote bootstrap completion."
 
@@ -643,6 +643,44 @@ Vitest.describe (
                 match finishMessages with
                 | [| RefreshRequested |] -> ()
                 | _ -> failwith "Expected remote bootstrap success to trigger RefreshRequested."
+            }
+        )
+
+        Vitest.test (
+            "InitRepositoryRequested recovers to a ready local repository when DataHub bootstrap fails after git init",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        initGitRepository = fun path -> promise { return Ok path }
+                        createDataHubProject =
+                            fun _ -> promise { return Error "DataHub project creation failed." }
+                }
+
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc-a"
+                        RepositoryAvailability = GitRepositoryAvailability.MissingRepository
+                }
+
+                let requestedState, requestCmd =
+                    update deps ignore (InitRepositoryRequested(Some "arc-a")) state
+
+                let! requestMessages = collectMessages requestCmd
+
+                let nextState, finishCmd =
+                    match requestMessages with
+                    | [| (InitRepositoryCompleted _ as message) |] -> update deps ignore message requestedState
+                    | _ -> failwith "Expected init-repository completion."
+
+                let! finishMessages = collectMessages finishCmd
+
+                Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
+                Vitest.expect(nextState.BusyOperation).toEqual (None)
+                Vitest.expect(nextState.WarningNotice).toEqual (Some "DataHub project creation failed.")
+
+                match finishMessages with
+                | [| RefreshRequested |] -> ()
+                | _ -> failwith "Expected partial init success to trigger RefreshRequested."
             }
         )
 

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -99,6 +99,12 @@ let private changedFile path indexStatus workingTreeStatus isConflicted = {
     IsConflicted = isConflicted
 }
 
+let private manyChangedFiles count =
+    [|
+        for index in 0 .. count - 1 do
+            changedFile (sprintf "src/file-%03i.txt" index) "M" " " false
+    |]
+
 let private unexpectedPromise<'T> (name: string) : JS.Promise<Result<'T, string>> = promise {
     return failwith $"Unexpected call: {name}"
 }
@@ -1320,6 +1326,157 @@ Vitest.describe (
                     )
 
                 Vitest.expect(container.querySelector ("[data-testid='GitSidebar']")).not.toBeNull ()
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar renders conflicted change rows alongside other changed files",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = true
+                            },
+                            changedFiles = [|
+                                changedFile "README.md" "M" " " false
+                                changedFile "assays/isa.assay.xlsx" "?" "?" false
+                                changedFile "notes/protocol.md" "R" "M" false
+                                changedFile "studies/s-study-01/protocol.md" "U" "U" true
+                            |],
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnSync = fun () -> ()
+                                OnCommitSelection = fun _ -> ()
+                                OnCommitAll = fun _ -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                Vitest.expect(container.textContent.Contains("studies/s-study-01/protocol.md")).toBe (true)
+                Vitest.expect(container.textContent.Contains("Conflict")).toBe (true)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar virtualizes long change lists instead of mounting every row at once",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Html.div [
+                            prop.style [
+                                style.width 340
+                                style.height 760
+                            ]
+                            prop.children [
+                                Swate.Components.GitSidebar.Main(
+                                    status = {
+                                        CurrentBranch = Some "main"
+                                        TrackingBranch = Some "origin/main"
+                                        Ahead = 0
+                                        Behind = 0
+                                        IsClean = false
+                                        IsMergeInProgress = false
+                                    },
+                                    changedFiles = manyChangedFiles 400,
+                                    branchOptions = [| sidebarLocalBranch "main" true true |],
+                                    callbacks = {
+                                        OnRefresh = fun () -> ()
+                                        OnFetch = fun () -> ()
+                                        OnPull = fun () -> ()
+                                        OnPush = fun () -> ()
+                                        OnSync = fun () -> ()
+                                        OnCommitSelection = fun _ -> ()
+                                        OnCommitAll = fun _ -> ()
+                                        OnSaveDownloadLargeFiles = fun _ -> ()
+                                        OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                        OnCreateBranch = fun _ -> ()
+                                        OnSwitchBranch = fun _ -> ()
+                                        OnSelectChange = fun _ -> promise { return Ok() }
+                                    },
+                                    downloadLargeFiles = true,
+                                    lfsAutoTrackThresholdMb = 5
+                                )
+                            ]
+                        ]
+                    )
+
+                Vitest.expect(container.textContent.Contains("400 files")).toBe (true)
+                Vitest.expect(container.querySelector ("[data-testid='GitSidebarChangeRow-0']")).not.toBeNull ()
+                Vitest.expect(container.querySelector ("[data-testid='GitSidebarChangeRow-399']")).toBeNull ()
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar labels deleted files explicitly instead of showing only a generic Changed badge",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Html.div [
+                            prop.style [
+                                style.width 340
+                                style.height 760
+                            ]
+                            prop.children [
+                                Swate.Components.GitSidebar.Main(
+                                    status = {
+                                        CurrentBranch = Some "main"
+                                        TrackingBranch = Some "origin/main"
+                                        Ahead = 0
+                                        Behind = 0
+                                        IsClean = false
+                                        IsMergeInProgress = false
+                                    },
+                                    changedFiles =
+                                        [|
+                                            changedFile "obsolete.md" "D" " " false
+                                        |],
+                                    branchOptions = [| sidebarLocalBranch "main" true true |],
+                                    callbacks = {
+                                        OnRefresh = fun () -> ()
+                                        OnFetch = fun () -> ()
+                                        OnPull = fun () -> ()
+                                        OnPush = fun () -> ()
+                                        OnSync = fun () -> ()
+                                        OnCommitSelection = fun _ -> ()
+                                        OnCommitAll = fun _ -> ()
+                                        OnSaveDownloadLargeFiles = fun _ -> ()
+                                        OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                        OnCreateBranch = fun _ -> ()
+                                        OnSwitchBranch = fun _ -> ()
+                                        OnSelectChange = fun _ -> promise { return Ok() }
+                                    },
+                                    downloadLargeFiles = true,
+                                    lfsAutoTrackThresholdMb = 5
+                                )
+                            ]
+                        ]
+                    )
+
+                Vitest.expect(container.textContent.Contains("Deleted")).toBe (true)
+                Vitest.expect(container.textContent.Contains("git: D.")).toBe (true)
+
                 cleanup ()
             }
         )

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -7,6 +7,7 @@ open Fable.Core
 open Feliz
 open Renderer.Context.GitWorkflow
 open Renderer.Types
+open Swate.Components.Api.GitLabApi
 open Swate.Components.GitSidebarTypes
 open Swate.Electron.Shared.GitTypes
 open Vitest
@@ -108,10 +109,13 @@ let private defaultDependencies: GitDependencies = {
     getGitLfsSettings = fun () -> unexpectedPromise "getGitLfsSettings"
     loadDiffPage = fun path -> unexpectedPromise $"loadDiffPage:{path}"
     loadMergeConflictPage = fun path -> unexpectedPromise $"loadMergeConflictPage:{path}"
+    initGitRepository = fun path -> unexpectedPromise $"initGitRepository:{path}"
+    createDataHubProject = fun name -> unexpectedPromise $"createDataHubProject:{name}"
     installGitLfs = fun () -> unexpectedPromise "installGitLfs"
     gitFetch = fun _ -> unexpectedPromise "gitFetch"
     gitPull = fun _ -> unexpectedPromise "gitPull"
     gitPush = fun _ -> unexpectedPromise "gitPush"
+    gitAddRemote = fun _ -> unexpectedPromise "gitAddRemote"
     gitCloneRepository = fun _ -> unexpectedPromise "gitCloneRepository"
     createBranch = fun _ -> unexpectedPromise "createBranch"
     checkoutBranch = fun _ -> unexpectedPromise "checkoutBranch"
@@ -324,6 +328,33 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "RefreshCompleted records missing-repository state instead of leaving the sidebar in generic error mode",
+            fun () -> promise {
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc-a"
+                        RefreshRequestId = 1
+                        RefreshState = GitRefreshState.Loading
+                        BusyOperation = Some GitBusyOperation.Refreshing
+                }
+
+                let nextState, cmd =
+                    update
+                        defaultDependencies
+                        ignore
+                        (RefreshCompleted(1, Error "git status failed (Unknown): The selected ARC path is not a git repository."))
+                        state
+
+                let! messages = collectMessages cmd
+
+                Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.MissingRepository)
+                Vitest.expect(nextState.ErrorNotice).toEqual (None)
+                Vitest.expect(nextState.ChangedFiles).toEqual ([||])
+                Vitest.expect(messages).toEqual ([||])
+            }
+        )
+
+        Vitest.test (
             "SelectChangeCompleted leaves the current selection untouched when an older request finishes late",
             fun () -> promise {
                 let mutable replyResult = None
@@ -499,6 +530,119 @@ Vitest.describe (
                 let! _ = collectMessages cmd
 
                 Vitest.expect(nextState.DownloadLargeFiles).toBe (true)
+            }
+        )
+
+        Vitest.test (
+            "InitRepositoryCompleted clears the missing-repository state and schedules a refresh",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        initGitRepository = fun path -> promise { return Ok path }
+                }
+
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc-a"
+                        RepositoryAvailability = GitRepositoryAvailability.MissingRepository
+                }
+
+                let requestedState, requestCmd =
+                    update deps ignore (InitRepositoryRequested None) state
+
+                let! requestMessages = collectMessages requestCmd
+
+                let nextState, finishCmd =
+                    match requestMessages with
+                    | [| InitRepositoryCompleted(sessionId, Ok()) |] when sessionId = state.ArcSessionId ->
+                        update deps ignore requestMessages[0] requestedState
+                    | _ -> failwith "Expected init-repository completion."
+
+                let! finishMessages = collectMessages finishCmd
+
+                Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
+                Vitest.expect(nextState.BusyOperation).toEqual (None)
+
+                match finishMessages with
+                | [| RefreshRequested |] -> ()
+                | _ -> failwith "Expected init-repository success to trigger RefreshRequested."
+            }
+        )
+
+        Vitest.test (
+            "InitRepositoryRequested can create a DataHub project and add origin before refreshing",
+            fun () -> promise {
+                let mutable addedRemote = None
+
+                let deps = {
+                    defaultDependencies with
+                        initGitRepository = fun path -> promise { return Ok path }
+                        createDataHubProject =
+                            fun projectName -> promise {
+                                return
+                                    Ok {
+                                        id = 42
+                                        name = projectName
+                                        path_with_namespace = $"caroott/{projectName}"
+                                        name_with_namespace = $"caroott / {projectName}"
+                                        description = None
+                                        web_url = $"https://git.nfdi4plants.org/caroott/{projectName}"
+                                        http_url_to_repo = $"https://git.nfdi4plants.org/caroott/{projectName}.git"
+                                        ssh_url_to_repo = None
+                                        avatar_url = None
+                                        visibility = Some "private"
+                                        star_count = 0
+                                        created_at = None
+                                        last_activity_at = None
+                                        tag_list = [||]
+                                        ``namespace`` = {
+                                            id = 1
+                                            name = "caroott"
+                                            kind = "user"
+                                            full_path = "caroott"
+                                        }
+                                    }
+                            }
+                        gitAddRemote =
+                            fun request -> promise {
+                                addedRemote <- Some request
+                                return Ok okOperationResult
+                            }
+                }
+
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc-a"
+                        RepositoryAvailability = GitRepositoryAvailability.MissingRepository
+                }
+
+                let requestedState, requestCmd =
+                    update deps ignore (InitRepositoryRequested(Some "arc-a")) state
+
+                let! requestMessages = collectMessages requestCmd
+
+                let nextState, finishCmd =
+                    match requestMessages with
+                    | [| InitRepositoryCompleted(sessionId, Ok()) |] when sessionId = state.ArcSessionId ->
+                        update deps ignore requestMessages[0] requestedState
+                    | _ -> failwith "Expected a successful init-and-remote bootstrap completion."
+
+                let! finishMessages = collectMessages finishCmd
+
+                Vitest
+                    .expect(addedRemote)
+                    .toEqual (
+                        Some {
+                            RemoteName = "origin"
+                            RemoteUrl = "https://git.nfdi4plants.org/caroott/arc-a.git"
+                        }
+                    )
+
+                Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
+
+                match finishMessages with
+                | [| RefreshRequested |] -> ()
+                | _ -> failwith "Expected remote bootstrap success to trigger RefreshRequested."
             }
         )
 
@@ -995,6 +1139,81 @@ Vitest.describe (
                         )
                     )
                     .toBe (true)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebarEmptyState renders the bootstrap call-to-action",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Renderer.Components.LeftSidebar.GitSidebarEmptyState.Main(
+                            title = "Initialize Git for this ARC",
+                            description = "The selected ARC folder is not a Git repository yet.",
+                            primaryAction = {
+                                Label = "Initialize Repository"
+                                IconClassName = "swt:fluent--branch-fork-24-regular"
+                                Disabled = false
+                                OnClick = ignore
+                            },
+                            ?infoText = Some "Remote actions remain disabled until you sign in."
+                        )
+                    )
+
+                Vitest.expect(container.textContent.Contains("Initialize Git for this ARC")).toBe (true)
+                Vitest.expect(container.textContent.Contains("Initialize Repository")).toBe (true)
+                Vitest.expect(container.textContent.Contains("Remote actions remain disabled")).toBe (true)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar disables remote actions and shows the requested warning when auth is unavailable",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = true
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = [||],
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnSync = fun () -> ()
+                                OnCommitSelection = fun _ -> ()
+                                OnCommitAll = fun _ -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5,
+                            remoteActionsEnabled = false,
+                            remoteActionsWarning =
+                                "Sign in to a DataHub account to use fetch, pull, push, or sync."
+                        )
+                    )
+
+                let syncButton =
+                    container.querySelector ("[data-testid='GitSidebarSyncButton']")
+                    :?> HTMLButtonElement
+
+                Vitest.expect(syncButton.disabled).toBe (true)
+                Vitest.expect(container.textContent.Contains("Sign in to a DataHub account")).toBe (true)
 
                 cleanup ()
             }

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -102,6 +102,64 @@ let private changedFile path indexStatus workingTreeStatus isConflicted = {
 [<Emit("new Event($0)")>]
 let private createEvent (eventType: string) : Browser.Types.Event = jsNative
 
+[<Emit("""
+globalThis.__swateOriginalFetch = globalThis.fetch;
+globalThis.__swateGitLabCreateProjectFetches = [];
+globalThis.fetch = async (url, options) => {
+  const body = options && options.body ? JSON.parse(options.body) : null;
+  globalThis.__swateGitLabCreateProjectFetches.push({ url, options, body });
+  return {
+    ok: true,
+    status: 201,
+    headers: { get: () => null },
+    json: async () => ({
+      id: 123,
+      name: body.name,
+      path_with_namespace: "carol/my-arc-project",
+      name_with_namespace: "carol / " + body.name,
+      description: null,
+      web_url: "https://gitlab.example/carol/my-arc-project",
+      http_url_to_repo: "https://gitlab.example/carol/my-arc-project.git",
+      ssh_url_to_repo: null,
+      avatar_url: null,
+      visibility: "private",
+      star_count: 0,
+      created_at: "2026-04-13T00:00:00Z",
+      last_activity_at: "2026-04-13T00:00:00Z",
+      topics: [],
+      tag_list: [],
+      namespace: {
+        id: 5,
+        name: "carol",
+        kind: "user",
+        full_path: "carol"
+      }
+    })
+  };
+};
+""")>]
+let private installGitLabCreateProjectFetchSpy () : unit = jsNative
+
+[<Emit("globalThis.__swateGitLabCreateProjectFetches[globalThis.__swateGitLabCreateProjectFetches.length - 1].body")>]
+let private lastGitLabCreateProjectBody () : obj = jsNative
+
+[<Emit("Object.prototype.hasOwnProperty.call($0, $1)")>]
+let private hasOwnProperty (target: obj) (propertyName: string) : bool = jsNative
+
+[<Emit("$0[$1]")>]
+let private getProperty<'T> (target: obj) (propertyName: string) : 'T = jsNative
+
+[<Emit("""
+if (globalThis.__swateOriginalFetch === undefined) {
+  delete globalThis.fetch;
+} else {
+  globalThis.fetch = globalThis.__swateOriginalFetch;
+}
+delete globalThis.__swateOriginalFetch;
+delete globalThis.__swateGitLabCreateProjectFetches;
+""")>]
+let private cleanupGitLabCreateProjectFetchSpy () : unit = jsNative
+
 let private manyChangedFiles count =
     [|
         for index in 0 .. count - 1 do
@@ -240,6 +298,35 @@ Vitest.describe (
                             DownloadLargeFiles = false
                         }
                     )
+        )
+
+        Vitest.test (
+            "GitLabApi.CreateProject lets GitLab generate the project path from the submitted name",
+            fun () -> promise {
+                installGitLabCreateProjectFetchSpy ()
+
+                try
+                    let! result =
+                        GitLabApi.CreateProject(
+                            "https://gitlab.example/",
+                            "token-123",
+                            " My ARC Project "
+                        )
+
+                    match result with
+                    | Error err -> failwith err.GitLabErrorToString
+                    | Ok project ->
+                        Vitest.expect(project.name).toBe("My ARC Project")
+                        Vitest.expect(project.path_with_namespace).toBe("carol/my-arc-project")
+
+                    let body = lastGitLabCreateProjectBody ()
+
+                    Vitest.expect(getProperty<string> body "name").toBe("My ARC Project")
+                    Vitest.expect(getProperty<bool> body "initialize_with_readme").toBe(false)
+                    Vitest.expect(hasOwnProperty body "path").toBe(false)
+                finally
+                    cleanupGitLabCreateProjectFetchSpy ()
+            }
         )
 )
 

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -330,6 +330,9 @@ Vitest.describe (
         Vitest.test (
             "RefreshCompleted records missing-repository state instead of leaving the sidebar in generic error mode",
             fun () -> promise {
+                let clearedPages = ResizeArray<PageState option>()
+                let setPageState pageState = clearedPages.Add pageState
+
                 let state = {
                     GitState.Empty with
                         CurrentArcPath = Some "C:/arc-a"
@@ -341,7 +344,7 @@ Vitest.describe (
                 let nextState, cmd =
                     update
                         defaultDependencies
-                        ignore
+                        setPageState
                         (RefreshCompleted(1, Error "git status failed (Unknown): The selected ARC path is not a git repository."))
                         state
 
@@ -350,6 +353,7 @@ Vitest.describe (
                 Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.MissingRepository)
                 Vitest.expect(nextState.ErrorNotice).toEqual (None)
                 Vitest.expect(nextState.ChangedFiles).toEqual ([||])
+                Vitest.expect(clearedPages |> Seq.toArray).toEqual ([| None |])
                 Vitest.expect(messages).toEqual ([||])
             }
         )
@@ -649,11 +653,16 @@ Vitest.describe (
         Vitest.test (
             "InitRepositoryRequested recovers to a ready local repository when DataHub bootstrap fails after git init",
             fun () -> promise {
+                let warningMessage = "DataHub project creation failed."
+
                 let deps = {
                     defaultDependencies with
                         initGitRepository = fun path -> promise { return Ok path }
                         createDataHubProject =
-                            fun _ -> promise { return Error "DataHub project creation failed." }
+                            fun _ -> promise { return Error warningMessage }
+                        getGitStatus = fun () -> promise { return Ok cleanStatus }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 1 false) }
                 }
 
                 let state = {
@@ -676,7 +685,25 @@ Vitest.describe (
 
                 Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
                 Vitest.expect(nextState.BusyOperation).toEqual (None)
-                Vitest.expect(nextState.WarningNotice).toEqual (Some "DataHub project creation failed.")
+
+                let afterRefreshRequestedState, refreshRequestCmd =
+                    match finishMessages with
+                    | [| RefreshRequested |] -> update deps ignore RefreshRequested nextState
+                    | _ -> failwith "Expected partial init success to trigger RefreshRequested."
+
+                let! refreshMessages = collectMessages refreshRequestCmd
+
+                let finalState, finalCmd =
+                    match refreshMessages with
+                    | [| RefreshCompleted(_, Ok refreshResult) |] ->
+                        update deps ignore refreshMessages[0] afterRefreshRequestedState
+                    | _ -> failwith "Expected queued refresh completion."
+
+                let! finalMessages = collectMessages finalCmd
+
+                Vitest.expect(finalState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
+                Vitest.expect(finalState.WarningNotice).toEqual (Some warningMessage)
+                Vitest.expect(finalMessages).toEqual ([||])
 
                 match finishMessages with
                 | [| RefreshRequested |] -> ()

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -99,6 +99,9 @@ let private changedFile path indexStatus workingTreeStatus isConflicted = {
     IsConflicted = isConflicted
 }
 
+[<Emit("new Event($0)")>]
+let private createEvent (eventType: string) : Browser.Types.Event = jsNative
+
 let private manyChangedFiles count =
     [|
         for index in 0 .. count - 1 do
@@ -1421,7 +1424,6 @@ Vitest.describe (
                     )
 
                 Vitest.expect(container.textContent.Contains("400 files")).toBe (true)
-                Vitest.expect(container.querySelector ("[data-testid='GitSidebarChangeRow-0']")).not.toBeNull ()
                 Vitest.expect(container.querySelector ("[data-testid='GitSidebarChangeRow-399']")).toBeNull ()
 
                 cleanup ()

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -932,6 +932,26 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "GitDiffViewer renders synthetic new-file diff metadata without blanking the content pane",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitDiffViewer.Viewer(
+                            wordDiffText = "new file mode 100644\n--- /dev/null\n+++ b/notes/draft.txt\n",
+                            previousContent = "",
+                            currentContent = "Draft line\n",
+                            testIdPrefix = "renderer-synthetic-diff"
+                        )
+                    )
+
+                Vitest.expect(container.textContent.Contains("Draft line")).toBe (true)
+                Vitest.expect(container.textContent.Contains("Changed")).toBe (true)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
             "GitSidebar shows when the current local branch has no upstream yet",
             fun () -> promise {
                 let status: GitSidebarStatus = {

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -1468,7 +1468,58 @@ Vitest.describe (
         )
 
         Vitest.test (
-            "GitSidebar virtualizes long change lists instead of mounting every row at once",
+            "GitSidebar renders small changed-file sets through the virtualized list path",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Html.div [
+                            prop.style [
+                                style.width 340
+                                style.height 760
+                            ]
+                            prop.children [
+                                Swate.Components.GitSidebar.Main(
+                                    status = {
+                                        CurrentBranch = Some "main"
+                                        TrackingBranch = Some "origin/main"
+                                        Ahead = 0
+                                        Behind = 0
+                                        IsClean = false
+                                        IsMergeInProgress = false
+                                    },
+                                    changedFiles = manyChangedFiles 3,
+                                    branchOptions = [| sidebarLocalBranch "main" true true |],
+                                    callbacks = {
+                                        OnRefresh = fun () -> ()
+                                        OnFetch = fun () -> ()
+                                        OnPull = fun () -> ()
+                                        OnPush = fun () -> ()
+                                        OnSync = fun () -> ()
+                                        OnCommitSelection = fun _ -> ()
+                                        OnCommitAll = fun _ -> ()
+                                        OnSaveDownloadLargeFiles = fun _ -> ()
+                                        OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                        OnCreateBranch = fun _ -> ()
+                                        OnSwitchBranch = fun _ -> ()
+                                        OnSelectChange = fun _ -> promise { return Ok() }
+                                    },
+                                    downloadLargeFiles = true,
+                                    lfsAutoTrackThresholdMb = 5
+                                )
+                            ]
+                        ]
+                    )
+
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangedFilesScrollContainer']")).not.toBeNull ()
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangedFilesVirtualContent']")).not.toBeNull ()
+                Vitest.expect(container.querySelectorAll("[data-testid^='GitSidebarChangeRow-']").length).toBe(3)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar virtualizes long changed-file lists instead of mounting every item at once",
             fun () -> promise {
                 let! container, cleanup =
                     renderToBody (
@@ -1511,7 +1562,9 @@ Vitest.describe (
                     )
 
                 Vitest.expect(container.textContent.Contains("400 files")).toBe (true)
-                Vitest.expect(container.querySelector ("[data-testid='GitSidebarChangeRow-399']")).toBeNull ()
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangedFilesVirtualContent']")).not.toBeNull ()
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeRow-0']")).not.toBeNull ()
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeRow-399']")).toBeNull ()
 
                 cleanup ()
             }


### PR DESCRIPTION
This PR addresses the requests from https://github.com/nfdi4plants/Swate/issues/1031

It adds renderer-side repository-availability state and a local `git init` flow (with optional DataHub project creation + `origin` wiring), disables remote actions when not authenticated, virtualizes the changed-files list, and replaces the generic change badge with explicit labels. Includes IPC/Service additions for `gitAddRemote` and GitLab project creation and adds tests covering the new flows.

> When opening the git view with changes i get these warnings in my console. These could hint at a underlying issue.

This issue could not be reproduced. This should have been fixed already.

- simple-git returns ONE entry per path in status.files. Each file has both index and working_dir status codes consolidated into a single entry
- React keys use change.Path which is already unique since mapChanges maps status.Files 1:1 without concatenation
- No console.warn statements exist in any git-related component or service code
- The checkbox is properly controlled (prop.isChecked + prop.onChange), ruling out controlled/uncontrolled warnings
- The code uses Array.distinct on paths in staging operations, but the status.files array itself doesn't produce them

>  Seems to register empty changes? for multiple files the diff view is empty

This is taken directly from the git output. If the git output somehow registers changes on empty files they will show up. This also happens in VSCode for example. We could guard against empty diffs, but this could also suggest that something changed the file in a way we can't display.

**Key changes**

- Renderer: new repository-availability state, InitRepository flow, and empty-state UI for no-ARC / missing-repository.
- Remote bootstrap: optional creation of a DataHub/GitLab project and `git remote add origin` during init when authenticated and a project name is provided.
- UI: auth-aware gating for fetch/pull/push/sync; explicit change status labels (Added/Modified/Deleted/Renamed/Untracked/Conflict); virtualization of long changed-file lists.
- IPC & Main: new IPC contract and service handler for `gitAddRemote`, GitLab project-creation handler.
- Tests: characterization tests for the empty-diff symptom, workflow tests for missing-repo & init flows, virtualization and deleted-file render checks, and a git-service test for `addRemote`.

**Behavioral notes (what to expect)**

- Repository availability classification:
  - No ARC opened → shows Open/Download CTA.
  - ARC opened but not a git repo → shows Initialize Repository empty state (with optional DataHub project name input).
  - Repository ready → full Git sidebar with changes, branches, and actions.

- Init flow:
  - `Initialize Repository` runs local `git init`. If a DataHub project name is provided and an active account exists, the renderer will request project creation and add `origin` with the returned repository URL. Failures in remote bootstrap surface as non-blocking warnings.

- Remote action gating:
  - Fetch/pull/push/sync buttons are disabled when user is not authenticated to DataHub; a clear inline warning explains why.

- Changed-file list:
  - Large change lists are virtualized for performance (only visible rows are mounted).
  - Each change shows an explicit label and badge (Added/Modified/Deleted/Renamed/Untracked/Conflict) plus iconography, replacing the single generic "Changed" badge and raw status code.