### PR TITLE
Add simple check for empty auth when starting swate - electron

### DIFF
--- a/src/Electron/src/Renderer/Context/AuthStateCtx.fs
+++ b/src/Electron/src/Renderer/Context/AuthStateCtx.fs
@@ -7,6 +7,15 @@ open Swate.Components.Authentication.Types
 
 module private AuthStateHelper =
 
+    let private isEmptyAuthState (state: AuthStateDto) =
+        state.ActiveAccount.IsNone && state.StoredAccounts.Length = 0
+
+    let shouldLogRevalidationFailure (response: AuthResult) =
+        match response.Success, response.FailureKind, response.User with
+        | false, Some AuthFailureKind.Unauthorized, Some state when isEmptyAuthState state -> false
+        | false, _, _ -> true
+        | true, _, _ -> false
+
     let refreshState (setAuthState) (onError) = promise {
         let! stateResult = Api.ipcAuthApi.getAuthState ()
 
@@ -41,7 +50,7 @@ let Provider (children: ReactElement) =
             | Ok response ->
                 do! refreshState setAuthState ignore
 
-                if not response.Success then
+                if shouldLogRevalidationFailure response then
                     console.error (response.FailureKind, Fable.Core.JS.JSON.stringify response.Message)
             | Error ex -> console.error (Fable.Core.JS.JSON.stringify ex.Message)
 


### PR DESCRIPTION
Currently the following error is thrown when Electron is started:

<img width="769" height="259" alt="grafik" src="https://github.com/user-attachments/assets/5a5c41de-fa3b-4fbe-8503-3261774ac25c" />
