### PR TITLE
Git sidebar polish

### DIFF
--- a/docs/GitFunctionalityUserGuide.md
+++ b/docs/GitFunctionalityUserGuide.md
@@ -1,79 +1,96 @@
-﻿# Swate Git Guide (Electron)
+# Swate Git Functionality Guide
 
-This guide is about the implemented Git functionality in Swate Electron: how to call it, how auth is wired, and how the Main/IPC Git modules behave.
+This guide describes the current Git implementation used by Swate Electron. It is for developers who need to call, extend, test, or troubleshoot Git functionality in this repository.
 
-## 1. Quick Use
+## 1. Architecture
 
-### Where to call from
+Git functionality is implemented in the Electron Main process and exposed to Renderer through the typed IPC bridge.
 
-Renderer code calls Git via the `IGitApi` IPC bridge:
+Primary files:
 
-- Contract: `src/Electron/src/Swate.Electron.Shared/IPCTypes.fs` (`type IGitApi`)
-- Renderer client binding: `src/Electron/src/Swate.Electron.Shared/Api.fs` (`gitApi`)
+- Shared IPC and DTO contracts: `src/Electron/src/Swate.Electron.Shared/IPCTypes.fs`, `src/Electron/src/Swate.Electron.Shared/GitTypes.fs`
+- Main IPC implementation: `src/Electron/src/Main/IPC/IGitApi.fs`
+- Main Git implementation: `src/Electron/src/Main/Git`
+- Renderer wrapper: `src/Electron/src/Renderer/GitApiClient.fs`
+- Renderer workflow/state machine: `src/Electron/src/Renderer/Context/GitWorkflow.fs`
+- Renderer wiring: `src/Electron/src/Renderer/Context/GitStateContext.fs`
 
-Note: `Api.fs` only exposes the raw `IGitApi` client binding (`gitApi`) and no per-endpoint Git helper functions.
+Use `Renderer.GitApiClient` from Renderer code. It wraps the raw `IGitApi` bridge, supplies the Electron event placeholder required by the remoting library, and maps `Result<'T, exn>` to `Result<'T, string>`.
 
-All `IGitApi` methods are `IpcMainEvent -> ...`, where the `IpcMainEvent` is supplied by Electron/Main. Renderer code must **not** pass a placeholder event argument (it would get sent over IPC and shift the real arguments). Instead, coerce each endpoint once to a signature **without** the event parameter using `unbox` (see examples).
+Do not call `Api.ipcGitApi` directly from feature code unless you are extending the wrapper itself.
 
-Avoid calling endpoints as `gitApi.someMethod null ...` / `gitApi.someMethod Unchecked.defaultof<IpcMainEvent> ...` — this shifts arguments for methods that take parameters.
+## 2. Current Renderer API
 
-### `IGitApi` endpoints
+`Renderer.GitApiClient` exposes:
 
-- `getGitStatus`
-- `getGitDiffSummary`
-- `gitFetch`
-- `gitPull`
-- `gitPush`
-- `gitInitRepository`
-- `gitCloneRepository`
-- `gitStagePaths`
-- `gitUnstagePaths`
-- `gitCommit`
-- `createBranch`
-- `checkoutBranch`
+```fsharp
+getGitStatus: unit -> JS.Promise<Result<GitStatusDto, string>>
+getGitBranches: unit -> JS.Promise<Result<GitBranchRefDto[], string>>
+getGitLfsSettings: unit -> JS.Promise<Result<GitLfsSettingsDto, string>>
+getGitDiffViewData: string -> JS.Promise<Result<GitPageLoadResultDto<GitDiffViewDataDto>, string>>
+getGitMergeConflictViewData: string -> JS.Promise<Result<GitPageLoadResultDto<GitMergeConflictViewDataDto>, string>>
+installGitLfs: unit -> JS.Promise<Result<GitOperationResult, string>>
+previewGitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitPullPreflightResult, string>>
+gitFetch: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitPush: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitInitRepository: string -> JS.Promise<Result<string, string>>
+gitAddRemote: GitRemoteConfigRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitCloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, string>>
+createBranch: GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
+checkoutBranch: GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitStagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitUnstagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitCommit: GitCommitRequest -> JS.Promise<Result<GitOperationResult, string>>
+setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, string>>
+confirmGitMergeResolution: GitConfirmMergeResolutionRequest -> JS.Promise<Result<GitConfirmMergeResolutionResult, string>>
+```
 
-### Core result shape
+Most app code should access these through `GitWorkflow.GitDependencies`, which is populated in `GitStateContext.fs`. That dependency layer maps diff and merge page-load DTOs to `PageState`.
 
-Most write/sync operations return:
+## 3. Result Shapes
+
+Most write and sync operations return `GitOperationResult`:
 
 ```fsharp
 type GitOperationResult = {
     Success: bool
     Message: string option
     FailureKind: GitFailureKind option
+    WarningMessage: string option
+    WarningKind: GitFailureKind option
     Path: string option
 }
 ```
 
-Interpretation:
+Use it as follows:
 
-- `Success=true`: operation completed.
-- `Success=false`: Git operation failed; inspect `FailureKind` and `Message`.
-- outer `Result.Error exn`: IPC-level failure.
-- `Path` is used by provisioning endpoints:
-  - `gitInitRepository` success -> normalized path
-  - `gitCloneRepository` success -> normalized path
-  - other operations -> `None`
+- `Ok op` and `op.Success = true`: operation completed.
+- `Ok op` and `op.Success = false`: Git operation failed; inspect `FailureKind` and `Message`.
+- `Ok op` with `WarningMessage = Some ...`: main operation completed, but follow-up work had a recoverable warning.
+- `Error message`: IPC or wrapper-level failure.
+- `Path`: normalized path returned by provisioning operations. `gitInitRepository` maps success directly to `Result<string, string>` in the renderer wrapper.
 
-### Read operation result shapes
-
-`getGitStatus` and `getGitDiffSummary` return their own typed DTOs, not `GitOperationResult`:
+Read operations return typed DTOs:
 
 ```fsharp
-type GitFileStatusDto = {
-    Path: string
-    Index: string
-    WorkingDir: string
-    OriginalPath: string option
-}
-
 type GitStatusDto = {
     Current: string option
     Tracking: string option
     Ahead: int
     Behind: int
     IsClean: bool
+    Conflicted: string[]
+    IsMergeInProgress: bool
     Files: GitFileStatusDto[]
+}
+
+type GitBranchRefDto = {
+    RefName: string
+    DisplayLabel: string
+    Kind: GitBranchRefKind
+    IsCurrent: bool
+    IsTracking: bool
 }
 
 type GitDiffSummaryDto = {
@@ -83,488 +100,300 @@ type GitDiffSummaryDto = {
 }
 ```
 
-Return type: `JS.Promise<Result<GitStatusDto, exn>>` / `JS.Promise<Result<GitDiffSummaryDto, exn>>`.
+Failure kinds are `Unauthorized`, `Forbidden`, `Network`, `Timeout`, `Canceled`, `LfsInstallRequired`, and `Unknown`.
 
-Note: on failure, these operations return `Result.Error exn` with the failure kind embedded in the exception message (e.g., `"git status failed (Network): ..."`) — unlike write/sync operations which return structured `GitOperationResult` with a typed `FailureKind` field.
+## 4. Common Calls
 
----
-
-## 2. Usage Examples
-
-### 2.0 Check repository status
+Refresh status, branches, and LFS settings:
 
 ```fsharp
-open Fable.Core
-open Swate.Electron.Shared.IPCTypes
-open Api
+promise {
+    let! statusResult = Renderer.GitApiClient.getGitStatus ()
+    let! branchResult = Renderer.GitApiClient.getGitBranches ()
+    let! lfsSettingsResult = Renderer.GitApiClient.getGitLfsSettings ()
 
-let getGitStatus : unit -> JS.Promise<Result<GitStatusDto, exn>> =
-    unbox gitApi.getGitStatus
-
-let getGitDiffSummary : unit -> JS.Promise<Result<GitDiffSummaryDto, exn>> =
-    unbox gitApi.getGitDiffSummary
-
-let checkStatus () =
-    promise {
-        let! statusRes = getGitStatus ()
-        match statusRes with
-        | Ok status ->
-            Browser.Dom.console.log($"Branch: {status.Current}, Clean: {status.IsClean}")
-            Browser.Dom.console.log($"Ahead: {status.Ahead}, Behind: {status.Behind}")
-            for file in status.Files do
-                Browser.Dom.console.log($"  {file.Index}{file.WorkingDir} {file.Path}")
-        | Error ex ->
-            Browser.Dom.console.error($"Status error: {ex.Message}")
-
-        let! diffRes = getGitDiffSummary ()
-        match diffRes with
-        | Ok diff ->
-            Browser.Dom.console.log($"Changed: {diff.Changed}, +{diff.Insertions}, -{diff.Deletions}")
-        | Error ex ->
-            Browser.Dom.console.error($"Diff error: {ex.Message}")
-    }
+    match statusResult, branchResult, lfsSettingsResult with
+    | Ok status, Ok branches, Ok settings ->
+        Browser.Dom.console.log($"Branch: {status.Current}")
+        Browser.Dom.console.log($"Changes: {status.Files.Length}")
+        Browser.Dom.console.log($"Branches: {branches.Length}")
+        Browser.Dom.console.log($"LFS threshold: {settings.AutoTrackThresholdMb} MB")
+    | _ ->
+        Browser.Dom.console.warn("Could not refresh all Git state.")
+}
 ```
 
-### 2.1 Init a new repository
+Initialize an ARC folder as a repository:
 
 ```fsharp
-open Fable.Core
-open Swate.Electron.Shared.IPCTypes
-open Api
+promise {
+    let! result = Renderer.GitApiClient.gitInitRepository arcPath
 
-let gitInitRepository : string -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.gitInitRepository
-
-let initRepo (targetPath: string) =
-    promise {
-        let! response = gitInitRepository targetPath
-        match response with
-        | Error ex ->
-            Browser.Dom.console.error($"IPC error: {ex.Message}")
-        | Ok op when op.Success ->
-            Browser.Dom.console.log($"Initialized at {op.Path}")
-        | Ok op ->
-            Browser.Dom.console.error($"Init failed: {op.FailureKind} {op.Message}")
-    }
+    match result with
+    | Ok normalizedPath -> Browser.Dom.console.log($"Initialized: {normalizedPath}")
+    | Error message -> Browser.Dom.console.error(message)
+}
 ```
 
-### 2.2 Clone a repository
+Clone a repository:
 
 ```fsharp
-open Fable.Core
-open Swate.Electron.Shared.IPCTypes
-open Api
-
-let gitCloneRepository : GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.gitCloneRepository
-
-let cloneRepo () =
-    promise {
-        let request = {
-            RemoteUrl = "https://github.com/org/repo.git"
-            TargetPath = @"C:\repos\repo"
-            Branch = Some "main"
-        }
-
-        let! response = gitCloneRepository request
-        match response with
-        | Error ex ->
-            Browser.Dom.console.error($"IPC error: {ex.Message}")
-        | Ok op when op.Success ->
-            Browser.Dom.console.log($"Cloned to {op.Path}")
-        | Ok op ->
-            Browser.Dom.console.error($"Clone failed: {op.FailureKind} {op.Message}")
-    }
-```
-
-### 2.3 Fetch/pull/push
-
-```fsharp
-open Fable.Core
-open Swate.Electron.Shared.IPCTypes
-open Api
-
-let gitFetch : GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.gitFetch
-
-let gitPull : GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.gitPull
-
-let gitPush : GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.gitPush
-
-let syncRemote () =
-    promise {
-        let req = { Remote = Some "origin"; Branch = Some "main" }
-
-        let! fetchRes = gitFetch req
-        let! pullRes  = gitPull req
-        let! pushRes  = gitPush req
-
-        let report name result =
-            match result with
-            | Error ex -> Browser.Dom.console.error($"{name} IPC error: {ex.Message}")
-            | Ok op when op.Success -> Browser.Dom.console.log($"{name} ok")
-            | Ok op -> Browser.Dom.console.error($"{name} failed: {op.FailureKind} {op.Message}")
-
-        report "fetch" fetchRes
-        report "pull" pullRes
-        report "push" pushRes
-    }
-```
-
-### 2.4 Stage/unstage/commit
-
-```fsharp
-open Fable.Core
-open Swate.Electron.Shared.IPCTypes
-open Api
-
-let gitStagePaths : GitPathspecRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.gitStagePaths
-
-let gitCommit : GitCommitRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.gitCommit
-
-let commitFlow () =
-    promise {
-        let! stageRes = gitStagePaths { Pathspecs = [| "README.md" |] }
-        match stageRes with
-        | Ok s when s.Success ->
-            let! commitRes = gitCommit { Message = "Update README" }
-            match commitRes with
-            | Ok c when c.Success -> Browser.Dom.console.log("Commit complete")
-            | Ok c -> Browser.Dom.console.error($"Commit failed: {c.Message}")
-            | Error ex -> Browser.Dom.console.error($"Commit IPC error: {ex.Message}")
-        | Ok s -> Browser.Dom.console.error($"Stage failed: {s.Message}")
-        | Error ex -> Browser.Dom.console.error($"Stage IPC error: {ex.Message}")
-    }
-```
-
-### 2.5 Branch operations
-
-`createBranch` both creates and switches to the new branch (via `checkoutLocalBranch` or `checkoutBranch` in simple-git). There is no need to call `checkoutBranch` afterwards.
-
-`checkoutBranch` switches to an existing local branch. It fails if the branch does not exist locally.
-
-```fsharp
-open Fable.Core
-open Swate.Electron.Shared.IPCTypes
-open Api
-
-let createBranch : GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.createBranch
-
-let checkoutBranch : GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, exn>> =
-    unbox gitApi.checkoutBranch
-
-// Create a new branch and switch to it in one step:
-let createAndSwitch () =
-    promise {
-        let! result = createBranch { Name = "feature/my-change"; StartPoint = None }
-        match result with
-        | Ok op when op.Success -> Browser.Dom.console.log("Created and switched to feature/my-change")
-        | Ok op -> Browser.Dom.console.error($"Create failed: {op.FailureKind} {op.Message}")
-        | Error ex -> Browser.Dom.console.error($"IPC error: {ex.Message}")
-    }
-
-// Switch to an existing local branch:
-let switchBranch () =
-    promise {
-        let! result = checkoutBranch { Name = "main" }
-        match result with
-        | Ok op when op.Success -> Browser.Dom.console.log("Switched to main")
-        | Ok op -> Browser.Dom.console.error($"Checkout failed: {op.FailureKind} {op.Message}")
-        | Error ex -> Browser.Dom.console.error($"IPC error: {ex.Message}")
-    }
-```
-
----
-
-## 3. Token Provider (`GitTokenProvider.fs`)
-
-File:
-
-- `src/Electron/src/Main/Git/GitTokenProvider.fs`
-
-### 3.1 How it works
-
-```fsharp
-type GitTokenProvider = { TryGetAccessToken: string -> JS.Promise<string option> }
-```
-
-- Main process stores an active provider in memory.
-- Default provider always returns `None`.
-- Git services call `tryGetAccessToken host`.
-- Host comes from `tryExtractHostFromRemoteUrl` and must be from `https://` or `ssh://` URL.
-
-### 3.2 How to add your own provider
-
-```fsharp
-open Fable.Core
-open Main.Git.GitTokenProvider
-
-let provider : GitTokenProvider = {
-    TryGetAccessToken = fun host -> promise {
-        match host with
-        | "github.com" -> return Some "ghp_..."
-        | _ -> return None
-    }
+let request: GitCloneRepositoryRequest = {
+    RemoteUrl = "https://git.nfdi4plants.org/group/project.git"
+    TargetPath = @"C:\ARCs\project"
+    Branch = None
+    DownloadLargeFiles = true
 }
 
-setTokenProvider provider
+promise {
+    let! result = Renderer.GitApiClient.gitCloneRepository request
+
+    match result with
+    | Ok op when op.Success -> Browser.Dom.console.log(op.Path)
+    | Ok op -> Browser.Dom.console.error(op.Message |> Option.defaultValue "Clone failed.")
+    | Error message -> Browser.Dom.console.error(message)
+}
 ```
 
-Call this during Main startup before user-triggered Git operations.
+Commit selected files:
 
-### 3.3 Behavior impact
+```fsharp
+promise {
+    let! stageResult =
+        Renderer.GitApiClient.gitStagePaths {
+            Pathspecs = [| "assays/a1/dataset.xlsx"; "README.md" |]
+        }
 
-- Fetch/pull/push always require a token from the configured provider. If no token is available for the extracted host, the operation fails with `Unauthorized` — even for public remotes. There is no unauthenticated fallback for these operations.
-- Clone provisioning uses token-first strategy with one unauthenticated fallback for auth failures only. If no token is available, clone runs unauthenticated directly.
+    match stageResult with
+    | Ok op when op.Success ->
+        let! commitResult =
+            Renderer.GitApiClient.gitCommit {
+                Message = "Update assay metadata"
+            }
 
----
+        match commitResult with
+        | Ok commit when commit.Success -> Browser.Dom.console.log(commit.Message)
+        | Ok commit -> Browser.Dom.console.error(commit.Message)
+        | Error message -> Browser.Dom.console.error(message)
+    | Ok op -> Browser.Dom.console.error(op.Message)
+    | Error message -> Browser.Dom.console.error(message)
+}
+```
 
-## 4. `GitAuthAdapter.fs` internals
+Fetch, preview pull, pull, and push:
 
-File:
+```fsharp
+let remoteRequest: GitRemoteOperationRequest = {
+    Remote = None
+    Branch = None
+}
 
-- `src/Electron/src/Main/Git/GitAuthAdapter.fs`
+promise {
+    let! preview = Renderer.GitApiClient.previewGitPull remoteRequest
 
-### What it does
+    match preview with
+    | Ok { Status = GitPullPreflightStatus.SafeToPull } ->
+        let! pull = Renderer.GitApiClient.gitPull remoteRequest
+        Browser.Dom.console.log(pull)
+    | Ok { Status = GitPullPreflightStatus.WouldRequireMergeResolution; Message = message } ->
+        Browser.Dom.console.warn(defaultArg message "Pull would require merge resolution.")
+    | Ok { Status = GitPullPreflightStatus.Indeterminate; Message = message } ->
+        Browser.Dom.console.warn(defaultArg message "Pull preview was inconclusive.")
+    | Error message ->
+        Browser.Dom.console.error(message)
+}
+```
 
-1. Applies non-interactive env:
-   - `GIT_TERMINAL_PROMPT=0`
-2. Builds per-operation auth config:
-   - `-c http.extraHeader=Authorization: Bearer <token>`
-3. Redacts secrets in text/args.
+## 5. Main Git Services
 
-### Key functions
+`GitService.fs` owns Git operations for the active ARC repository path:
 
-- `createNonInteractiveEnv`
-- `applyNonInteractiveEnv`
-- `buildAuthArgs` (note: the `host` parameter is currently unused — host-specific auth argument shaping is reserved for future use)
-- `toConfigEntries`
-- `applyAuth`
-- `redactToken`
-- `redactArgs`
+- Status and refs: `getStatus`, `getBranches`
+- Diff and page data: `getDiffSummary`, `getDiff`, `getWordDiff`, `getDiffViewData`, `getMergeConflictViewData`
+- Remote sync: `fetch`, `previewPull`, `pull`, `push`
+- Local writes: `stagePaths`, `unstagePaths`, `commit`, `createBranch`, `checkoutBranch`, `addRemote`
+- LFS settings: `getLfsSettings`, `setLfsSettings`
+- Merge resolution: `confirmMergeResolution`
 
-Important detail: auth is injected in-memory per operation; token is not persisted to repo config files.
+`GitProvisioningService.fs` owns path-driven operations that do not require an active ARC:
 
----
+- `initRepository`
+- `cloneRepository`
 
-## 5. `GitService.fs` internals (ARC-scoped operations)
+`GitLfsService.fs` owns Git LFS command orchestration and push planning:
 
-File:
+- System install/probe: `installSystem`, `isSystemInstalled`
+- Tracking: `track`, `isTrackedByAttributes`
+- Push support: `planOutboundPush`, `uploadObjects`, `collectPushDiagnostics`
 
-- `src/Electron/src/Main/Git/GitService.fs`
+`GitAuthAdapter.fs` builds scoped auth config and redacts secrets. `GitTokenProvider.fs` is the process-wide token lookup hook installed by `AuthService`.
 
-### 5.1 Role
+## 6. Validation and Security Rules
 
-Handles Git operations for the active ARC repository path.
+Branch-like names are validated by `GitService.ensureValidBranchLikeName`.
 
-### 5.2 Validation layer
+Pathspecs are validated by `GitService.ensureValidPathspec` and must be ARC-relative. Empty values, absolute paths, traversal segments (`.` or `..`), and null characters are rejected.
 
-- `ensureValidBranchLikeName`
-- `ensureValidPathspec`
-- `validatePathspecs`
-- `validateRemoteName`
-- `ensureAllowedRemoteUrl`
+Remote names are validated by `GitService.validateRemoteName`; blank input defaults to `origin`.
 
-These block invalid refs, traversal, blocked protocols, and protocol override attempts.
+Remote URLs are validated by `GitService.ensureAllowedRemoteUrl`. Only full `https://` and `ssh://` URLs are accepted. These are rejected:
 
-### 5.3 Failure classification
+- `file://`
+- `ext::`
+- `fd::`
+- protocol override attempts such as `-c protocol...`
+- SCP-style SSH URLs such as `git@git.nfdi4plants.org:group/project.git`
 
-`classifyFailureKind` maps text to:
+Use `ssh://git@git.nfdi4plants.org/group/project.git` instead of SCP-style SSH.
 
-- `Unauthorized`
-- `Forbidden`
-- `Network`
-- `Timeout`
-- `Canceled`
-- `Unknown`
+All simple-git instances are created through `GitInternals.createGit`, which applies `GIT_TERMINAL_PROMPT=0`. Credentials are injected per command through config entries or command environment and are not persisted to repository config.
 
-Error text is redacted in shared failure pipeline.
+## 7. Authentication
 
-### 5.4 Execution wrappers
+`AuthService.fs` installs the active `GitTokenProvider` after sign-in. Git services extract the host from the remote URL and call `tryGetAccessToken host`.
 
-- `withLocalGit`: ensures repo exists at ARC path, then runs operation.
-- `withAuthenticatedGit`: resolves authenticated git instance then runs operation.
+Current behavior:
 
-`createAuthenticatedGit` steps:
+- `fetch`, `previewPull`, `pull`, and `push` require a token for the selected remote host. If none is available, they fail with `Unauthorized`.
+- `cloneRepository` uses a token when one is available. If no token is available, clone runs unauthenticated.
+- Authenticated clone failures are returned as failures. There is no unauthenticated retry/fallback after an authenticated clone failure.
+- `initRepository`, local status/diff/stage/commit/branch operations, and `addRemote` do not need a token.
 
-1. read remote URL (`remote get-url`)
-2. URL policy check
-3. host extraction
-4. token lookup
-5. auth-scoped git instance creation
+Auth config is scoped through `GitAuthAdapter.buildAuthArgs` and `GitAuthAdapter.applyAuth`. Error messages and diagnostics must pass through `redactToken` or the shared failure path before crossing IPC.
 
-### 5.5 Public operations
+## 8. Git LFS
 
-- Read:
-  - `getStatus`
-  - `getDiffSummary`
-- Remote sync:
-  - `fetch`
-  - `pull`
-  - `push`
-- Local modifications:
-  - `stagePaths`
-  - `unstagePaths`
-  - `commit`
-  - `createBranch`
-  - `checkoutBranch`
+Swate uses Git LFS in three places:
 
----
+- Stage-time auto tracking for selected files larger than `swate.lfs.autotrackthresholdmb`.
+- Commit-time validation that oversized staged blobs are tracked by LFS.
+- Pull/clone hydration of LFS content when `swate.lfs.downloadlargefiles` is true.
+- Push-time explicit upload of outbound LFS objects before the git ref push.
 
-## 6. `GitProvisioningService.fs` internals (init/clone)
+Settings are stored in local repository config:
 
-File:
+- `swate.lfs.autotrackthresholdmb`: integer, default `1`, maximum `100`.
+- `swate.lfs.downloadlargefiles`: boolean, default `true` in Main Git service.
 
-- `src/Electron/src/Main/Git/GitProvisioningService.fs`
+Renderer state starts with `DownloadLargeFiles = false` until repository settings are loaded. Use `getGitLfsSettings` after opening an ARC to get the effective repository values.
 
-### 6.1 `initRepository`
+When Git LFS is required but unavailable, operations return `FailureKind = Some GitFailureKind.LfsInstallRequired` with a message suitable for the install prompt. The renderer workflow calls `installGitLfs` and retries the original operation after a successful install.
 
-Flow:
+Clone always sets `GIT_LFS_SKIP_SMUDGE=1` first. If `DownloadLargeFiles = true`, clone then persists the setting and runs `git lfs pull` to hydrate content.
 
-1. validate target path (non-empty, no null byte)
-2. normalize absolute path
-3. if target exists:
-   - reject non-directory targets (files, symlinks/junctions)
-   - reject when already a git repository
-4. if missing, create directory recursively
-5. run `git init`
-6. return normalized path
+Pull applies `GIT_LFS_SKIP_SMUDGE` when large-file download is disabled. When enabled, it hydrates with `git lfs pull` after the git pull.
 
-### 6.2 `cloneRepository`
+Push uses `GitLfsService.planOutboundPush` to detect outbound LFS pointer objects. If needed, `GitLfsService.uploadObjects` uploads exact object IDs before the git push; if exact upload is unsupported by the installed git-lfs, it falls back to refspec upload.
 
-Flow:
+## 9. Branches and Pull Workflow
 
-1. validate remote URL policy
-2. extract host
-3. validate/normalize target path
-4. validate optional branch
-5. ensure parent path exists and is a directory (create if missing; reject non-directory/symlink)
-6. reject non-directory clone target (files, symlinks/junctions)
-7. enforce strict target emptiness (missing or empty directory only)
-8. set clone git `baseDir = targetParent`
-9. run token-first auth strategy
+`getGitBranches` returns local branches and remote branch refs. The renderer maps remote branch switches to:
 
-### 6.3 Clone auth/fallback behavior
+```fsharp
+{
+    Name = derivedLocalBranchName
+    StartPoint = Some remoteRefName
+}
+```
 
-- token present:
-  - try authenticated clone
-  - on `Forbidden`: retry once unauthenticated
-  - on `Unauthorized`: retry once unauthenticated **only** for common auth failures (HTTP 401/auth prompts/SSH publickey); otherwise no retry
-- token missing:
-  - unauthenticated clone directly
-- token provider throws:
-  - fail immediately
+`checkoutBranch` behavior:
 
-### 6.4 Retry cleanup behavior
+- `StartPoint = None`: switch to an existing local branch only.
+- `StartPoint = Some ref`: create/check out `Name` from the provided start point.
 
-Before the unauthenticated retry (after an auth failure), the service performs a guarded cleanup to avoid retrying against a dirty partially-cloned state.
+`createBranch` creates and switches to a new local branch. After branch creation or checkout, Main reconciles tracking against `origin/<branch>` when that remote branch exists.
 
-Current guard rules:
+`previewGitPull` fetches the remote and runs `git merge-tree --write-tree HEAD <upstream>` to classify the pull:
 
-- if target path is missing: nothing to clean
-- if target path is an empty directory: nothing to clean (keep it)
-- if target directory contains **only** a `.git` entry (case-insensitive): delete `.git` **only**
-- otherwise: refuse cleanup and fail the retry (unexpected files, symlinks/junctions, `.git` not a directory, concurrent directory changes)
+- `SafeToPull`: renderer may continue directly.
+- `WouldRequireMergeResolution`: renderer should ask before opening merge resolution flow.
+- `Indeterminate`: renderer should ask because the preflight could not classify safely.
 
----
+## 10. Diff and Merge Resolution
 
-## 7. IPC integration (`IGitApi`)
+The renderer loads diff pages through `getGitDiffViewData`. Main returns previous content, current content, and porcelain word-diff metadata. Explicitly unsupported binary-like extensions and likely binary buffers return `GitPageLoadResultDto.Unsupported`, which the IPC layer maps to an unsupported-content page instead of throwing.
 
-Files:
+Merge conflict flow:
 
-- `src/Electron/src/Swate.Electron.Shared/IPCTypes.fs` (shared contract)
-- `src/Electron/src/Main/IPC/IGitApi.fs`
-- `src/Electron/src/Main/main.fs` (Main registration)
-- `src/Electron/src/Preload/preload.fs` (Preload bridge)
+1. `getGitStatus` exposes `Conflicted` and `IsMergeInProgress`.
+2. `getGitMergeConflictViewData path` loads the current conflicted file content.
+3. Renderer edits the resolved content.
+4. `confirmGitMergeResolution` checks that the file still matches the expected conflict content, writes the resolved content, stages the path, and optionally commits when no conflicts remain.
 
-### 7.1 Added provisioning endpoints
+The expected-content guard prevents overwriting a file that changed after the renderer opened it.
 
-- `gitInitRepository`
-- `gitCloneRepository`
+## 11. IPC Busy and Progress Behavior
 
-These are path-driven and do not require active ARC path.
+`Main.IPC.IGitApi` maps `GitService.GitResult<'T>` to shared DTOs.
 
-### 7.2 Result mapping
+Operations wrapped in `withBusyWriting`:
 
-`toGitOperationResult` maps `GitService.GitResult<'T>` into shared DTO and now supports optional success path projection.
-
-- init/clone set `Path = Some normalizedPath` on success
-- existing operations keep `Path = None`
-
-### 7.3 Progress behavior
-
-- fetch/pull/push: progress reporter from active vault.
-- clone: progress reporter only if vault can be resolved from window id; otherwise clone still runs without progress callback.
-
-### 7.4 Busy-writing policy
-
-Operations wrapped with `withBusyWriting`:
 - `gitPull`
 - `gitStagePaths`
 - `gitUnstagePaths`
 - `gitCommit`
 - `createBranch`
 - `checkoutBranch`
+- `confirmGitMergeResolution`
 
-Operations **not** wrapped:
-- `gitFetch`, `gitPush` (no working tree edits; remote sync / `.git` metadata only)
-- `getGitStatus`, `getGitDiffSummary` (read-only)
-- `gitInitRepository`, `gitCloneRepository` (provisioning, no active ARC vault)
+Operations not wrapped:
 
----
+- Read-only calls: `getGitStatus`, `getGitBranches`, `getGitLfsSettings`, diff view loaders, merge conflict view loader.
+- Remote metadata/sync calls without working tree writes: `gitFetch`, `gitPush`, `previewGitPull`.
+- Provisioning calls: `gitInitRepository`, `gitCloneRepository`.
+- System Git LFS install.
 
-## 8. Troubleshooting
+Progress is sent through `IMainUpdateRendererApi.gitProgressUpdate`. Fetch, preview pull, pull, push, and clone can report progress. Clone only reports progress when Main can resolve a vault from the IPC window id; otherwise the clone still runs.
 
-### 8.1 Unauthorized on fetch/pull/push
+## 12. Extending Git Functionality
 
-Check:
+When adding a new Git operation:
 
-1. `setTokenProvider` registration exists in Main startup.
-2. provider returns token for extracted host.
-3. token is valid for target remote.
+1. Add or reuse DTOs in `Swate.Electron.Shared.GitTypes`.
+2. Add the IPC function to `IGitApi` in `IPCTypes.fs`.
+3. Implement Main handling in `src/Electron/src/Main/IPC/IGitApi.fs`.
+4. Put Git command logic in the appropriate Main service:
+   - Active ARC repo operation: `GitService.fs`
+   - Init/clone/path provisioning: `GitProvisioningService.fs`
+   - Git LFS orchestration: `GitLfsService.fs`
+   - Low-level spawned git: `GitLfsAdapter.fs`
+5. Add a wrapper in `Renderer.GitApiClient.fs`.
+6. Wire it into `GitWorkflow.GitDependencies` if renderer workflow state needs it.
+7. Add or update tests in `tests/Electron.Core`.
+8. Update this guide if behavior or consumer usage changes.
 
-### 8.2 Clone fallback still fails
+Keep validation in Main even if Renderer already validates input. Renderer validation is for UX; Main validation is the trust boundary.
 
-Possible reasons:
+## 13. Troubleshooting
 
-- cleanup before fallback retry failed
-- `Unauthorized` did not match an auth-failure signal -> no fallback retry
-- non-auth failure kind (network/timeout/canceled/unknown) -> no fallback retry
-- remote blocked by URL policy
+`Unauthorized` on fetch, preview pull, pull, or push:
 
-### 8.3 Remote URL rejected
+- Confirm an account is signed in and `AuthService` has installed a token provider.
+- Confirm the provider returns a token for the remote host.
+- Confirm the remote URL is `https://` or full-form `ssh://`.
 
-Only `https://` and `ssh://` full-URI forms are accepted.
+Clone fails although the repository is public:
 
-SCP-style SSH URLs (e.g., `git@github.com:org/repo.git`) are **not** accepted. Use the full URI form instead: `ssh://git@github.com/org/repo.git`.
+- If a token is available, clone runs authenticated and does not retry unauthenticated after failure.
+- Sign out or adjust the active account if you intentionally need unauthenticated clone behavior.
+- Check target path rules: target must be missing or an empty directory, not a symlink/junction.
 
-### 8.4 Pathspec rejected
+Git LFS install prompt appears:
 
-Pathspecs must be relative, non-empty, and must not include traversal segments (`.` or `..`), null characters, or Windows-style absolute prefixes (e.g., `C:/`).
+- The operation needs Git LFS but `git lfs` is not available.
+- Use `installGitLfs` through the renderer workflow; after success, retry the original operation.
 
-### 8.5 `checkoutBranch` fails for remote-only branches
+Pathspec rejected:
 
-`checkoutBranch` only works for branches that already exist locally. If you need to switch to a remote branch, fetch first, then create a local tracking branch with `createBranch`.
+- Use ARC-relative paths with `/`.
+- Do not pass absolute paths, `.` or `..` segments, empty values, or null characters.
 
----
+Remote branch checkout fails:
 
-## 9. Security and scope boundaries
+- For remote-only branches, call `checkoutBranch` with `StartPoint = Some "origin/branch"` and `Name = "branch"`.
+- Calling with `StartPoint = None` only works for existing local branches.
 
-Current behavior enforces:
+Unsupported diff or merge content:
 
-- no token persistence in repository files
-- non-interactive git env (`GIT_TERMINAL_PROMPT=0`)
-- redaction of bearer credentials/credential URLs in error paths
-- no automatic ARC opening/window switching after clone
-- no auto stage/commit/push after init
-
-### Additional notes
-
-- All git instances are created through `GitInternals.createGit`, which always applies `applyNonInteractiveEnv` to enforce `GIT_TERMINAL_PROMPT=0`.
-- `maxConcurrentProcesses = 1` serializes operations per repository instance to avoid overlapping write/sync races.
-- Cancellation/abort support is intentionally deferred. No cancel IPC contract exists in this milestone.
+- Binary files and explicitly unsupported extensions are intentionally routed to the unsupported-content page.
+- Text-based diff and merge views only support files Main can safely read as text.

--- a/src/Components/src/GenericComponents/Popover/Popover.fs
+++ b/src/Components/src/GenericComponents/Popover/Popover.fs
@@ -12,7 +12,8 @@ module private PopoverHelper =
         | Some ctx when not (isNullOrUndefined ctx) -> Some ctx
         | _ -> None
 
-    let missingContextError (componentName: string) =
+    [<ReactComponent>]
+    let MissingContextError (componentName: string) =
         Html.div [
             prop.className "swt:text-error swt:text-xs swt:p-1 swt:border swt:border-error swt:rounded"
             prop.text $"⚠ Popover.{componentName} must be used inside Popover.Popover."
@@ -125,7 +126,7 @@ type Popover =
     static member Trigger
         (children: ReactElement, ?className: string, ?interactionProps: obj, ?props: IReactProperty list, ?debug: string) =
         match PopoverHelper.tryContext () with
-        | None -> PopoverHelper.missingContextError "Trigger"
+        | None -> PopoverHelper.MissingContextError "Trigger"
         | Some ctx ->
             let resolvedDebug = debug |> Option.orElse ctx.debug
 
@@ -156,7 +157,7 @@ type Popover =
             ?interactionProps: obj
         ) =
         match PopoverHelper.tryContext () with
-        | None -> PopoverHelper.missingContextError "TriggerRender"
+        | None -> PopoverHelper.MissingContextError "TriggerRender"
         | Some ctx ->
             render {|
                 isOpen = ctx.isOpen
@@ -175,7 +176,7 @@ type Popover =
             ?ariaLabel: string
         ) =
         match PopoverHelper.tryContext () with
-        | None -> PopoverHelper.missingContextError "Content"
+        | None -> PopoverHelper.MissingContextError "Content"
         | Some ctx ->
             let resolvedDebug = debug |> Option.orElse ctx.debug
 
@@ -259,7 +260,7 @@ type Popover =
         )
 
         match ctxOpt with
-        | None -> PopoverHelper.missingContextError "Heading"
+        | None -> PopoverHelper.MissingContextError "Heading"
         | Some _ ->
             Html.h2 [
                 prop.id headingId
@@ -305,7 +306,7 @@ type Popover =
         )
 
         match ctxOpt with
-        | None -> PopoverHelper.missingContextError "Description"
+        | None -> PopoverHelper.MissingContextError "Description"
         | Some _ ->
             Html.p [
                 prop.id descriptionId
@@ -320,7 +321,7 @@ type Popover =
     [<ReactComponent>]
     static member Close(?children: ReactElement, ?className: string, ?props: IReactProperty list) =
         match PopoverHelper.tryContext () with
-        | None -> PopoverHelper.missingContextError "Close"
+        | None -> PopoverHelper.MissingContextError "Close"
         | Some ctx ->
             match children with
             | Some c ->

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -115,7 +115,10 @@ type private AdvancedActionsProps = {
     RemoteActionsEnabled: bool
     RemoteActionsWarning: string option
     SubmitDownloadLargeFiles: bool -> unit
-    SubmitSync: unit -> unit
+    SubmitUpdateFromOnline: unit -> unit
+    SubmitLocalCommit: unit -> unit
+    HasMarkedFiles: bool
+    CanRunPrimarySave: bool
     IsAdvancedActionsOpen: bool
     ToggleAdvancedActions: unit -> unit
     SubmitFetch: unit -> unit
@@ -184,6 +187,13 @@ type private ModalsProps = {
     IsMissingMessageModalOpen: bool
     SetMissingMessageModalOpen: bool -> unit
     CloseDialog: unit -> unit
+}
+
+[<NoEquality; NoComparison>]
+type private PendingRemoteActionDialogProps = {
+    PendingConfirmation: GitSidebarConfirmationDialog option
+    ConfirmPendingRemoteAction: unit -> unit
+    CancelPendingRemoteAction: unit -> unit
 }
 
 [<Erase; Mangle(false)>]
@@ -578,11 +588,11 @@ type GitSidebar =
                         ]
                     ]
                     GitSidebar.ActionButton(
-                        "Synchronize Changes",
+                        "Update ARC from Online",
                         "swt:fluent--arrow-sync-24-regular",
                         props.IsBusy || not props.RemoteActionsEnabled,
-                        props.SubmitSync,
-                        testId = "GitSidebarSyncButton"
+                        props.SubmitUpdateFromOnline,
+                        testId = "GitSidebarUpdateArcButton"
                     )
                     GitSidebar.ActionButton(
                         "More Git Actions",
@@ -628,6 +638,16 @@ type GitSidebar =
                         Html.div [
                             prop.className "swt:grid swt:grid-cols-2 swt:gap-2"
                             prop.children [
+                                GitSidebar.ActionButton(
+                                    (if props.HasMarkedFiles then
+                                         "Add and commit selected Changes"
+                                     else
+                                         "Add and commit all Changes"),
+                                    "swt:fluent--save-24-regular",
+                                    not props.CanRunPrimarySave,
+                                    props.SubmitLocalCommit,
+                                    testId = "GitSidebarLocalCommitButton"
+                                )
                                 GitSidebar.ActionButton(
                                     "Check for Changes",
                                     "swt:fluent--arrow-download-24-regular",
@@ -1125,6 +1145,36 @@ type GitSidebar =
         ]
 
     [<ReactComponent>]
+    static member private PendingRemoteActionDialog(props: PendingRemoteActionDialogProps) =
+        BaseModal.Modal(
+            isOpen = props.PendingConfirmation.IsSome,
+            setIsOpen =
+                (fun isOpen ->
+                    if not isOpen then
+                        props.CancelPendingRemoteAction ()),
+            header = Html.text (props.PendingConfirmation |> Option.map _.Title |> Option.defaultValue "Confirm"),
+            children =
+                Html.p [
+                    prop.className "swt:whitespace-pre-wrap"
+                    prop.text (props.PendingConfirmation |> Option.map _.Message |> Option.defaultValue "")
+                ],
+            footer =
+                React.Fragment [
+                    Html.button [
+                        prop.className "swt:btn"
+                        prop.text (props.PendingConfirmation |> Option.map _.CancelLabel |> Option.defaultValue "Cancel")
+                        prop.onClick (fun _ -> props.CancelPendingRemoteAction ())
+                    ]
+                    Html.button [
+                        prop.className "swt:btn swt:btn-primary swt:ml-auto"
+                        prop.text (props.PendingConfirmation |> Option.map _.ConfirmLabel |> Option.defaultValue "Continue")
+                        prop.onClick (fun _ -> props.ConfirmPendingRemoteAction ())
+                    ]
+                ],
+            debug = "GitSidebarPendingRemoteAction"
+        )
+
+    [<ReactComponent>]
     static member Main
         (
             status: GitSidebarStatus,
@@ -1137,6 +1187,7 @@ type GitSidebar =
             ?selectedFile: string,
             ?errorNotice: string,
             ?warningNotice: string,
+            ?pendingConfirmation: GitSidebarConfirmationDialog,
             ?remoteActionsEnabled: bool,
             ?remoteActionsWarning: string
         ) =
@@ -1144,6 +1195,7 @@ type GitSidebar =
         let runStatus = defaultArg runStatus GitSidebarRunStatus.Idle
         let errorNotice = errorNotice
         let warningNotice = warningNotice
+        let pendingConfirmation = pendingConfirmation
         let remoteActionsEnabled = defaultArg remoteActionsEnabled true
         let remoteActionsWarning = remoteActionsWarning
         let selectedFile = selectedFile
@@ -1151,9 +1203,13 @@ type GitSidebar =
         let onFetch = callbacks.OnFetch
         let onPull = callbacks.OnPull
         let onPush = callbacks.OnPush
-        let onSync = callbacks.OnSync
+        let onUpdateFromOnline = callbacks.OnUpdateFromOnline
+        let onPrimarySaveSelection = callbacks.OnPrimarySaveSelection
+        let onPrimarySaveAll = callbacks.OnPrimarySaveAll
         let onCommitSelection = callbacks.OnCommitSelection
         let onCommitAll = callbacks.OnCommitAll
+        let onConfirmPendingRemoteAction = callbacks.OnConfirmPendingRemoteAction
+        let onCancelPendingRemoteAction = callbacks.OnCancelPendingRemoteAction
         let onSaveDownloadLargeFiles = callbacks.OnSaveDownloadLargeFiles
         let onSaveLfsAutoTrackThreshold = callbacks.OnSaveLfsAutoTrackThreshold
         let onCreateBranch = callbacks.OnCreateBranch
@@ -1345,7 +1401,7 @@ type GitSidebar =
             elif hasMarkedFiles then
                 setLocalError None
 
-                onCommitSelection {
+                onPrimarySaveSelection {
                     Message = normalizedCommitMessage
                     Paths = markedPaths |> Set.toArray |> Array.sort
                 }
@@ -1354,9 +1410,25 @@ type GitSidebar =
                 setMarkedPaths (fun _ -> Set.empty)
             else
                 setLocalError None
-                onCommitAll normalizedCommitMessage
+                onPrimarySaveAll normalizedCommitMessage
                 setCommitMessage ""
 
+        let submitLocalCommit () =
+            let normalizedCommitMessage = commitMessage.Trim()
+            let hasMarkedFiles = (Set.count markedPaths) > 0
+
+            if String.IsNullOrWhiteSpace normalizedCommitMessage then
+                setMissingMessageModalOpen true
+            elif hasMarkedFiles then
+                setLocalError None
+
+                onCommitSelection {
+                    Message = normalizedCommitMessage
+                    Paths = markedPaths |> Set.toArray |> Array.sort
+                }
+            else
+                setLocalError None
+                onCommitAll normalizedCommitMessage
 
         let submitLfsThreshold () =
             let normalizedInput = lfsThresholdInput.Trim()
@@ -1448,10 +1520,13 @@ type GitSidebar =
                         RemoteActionsEnabled = remoteActionsEnabled
                         RemoteActionsWarning = remoteActionsWarning
                         SubmitDownloadLargeFiles = submitDownloadLargeFiles
-                        SubmitSync =
+                        SubmitUpdateFromOnline =
                             fun () ->
                                 setLocalError None
-                                onSync ()
+                                onUpdateFromOnline ()
+                        SubmitLocalCommit = submitLocalCommit
+                        HasMarkedFiles = hasMarkedFiles
+                        CanRunPrimarySave = canRunPrimarySave
                         IsAdvancedActionsOpen = isAdvancedActionsOpen
                         ToggleAdvancedActions =
                             fun () ->
@@ -1557,6 +1632,14 @@ type GitSidebar =
                         IsMissingMessageModalOpen = isMissingMessageModalOpen
                         SetMissingMessageModalOpen = setMissingMessageModalOpen
                         CloseDialog = fun () -> setActiveDialog ActiveDialog.None
+                    }
+                )
+
+                GitSidebar.PendingRemoteActionDialog(
+                    {
+                        PendingConfirmation = pendingConfirmation
+                        ConfirmPendingRemoteAction = onConfirmPendingRemoteAction
+                        CancelPendingRemoteAction = onCancelPendingRemoteAction
                     }
                 )
             ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -698,75 +698,70 @@ type GitSidebar =
             GitSidebar.SectionHeader("Save", None)
 
             Html.div [
-                prop.className "swt:px-3"
+                prop.testId "GitSidebarCommitSection"
+                prop.className "swt:px-3 swt:pb-3"
                 prop.children [
-                    Html.div [
-                        prop.className "swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-100 swt:p-3"
+                    Html.label [
+                        prop.className "swt:flex swt:flex-col swt:gap-2"
                         prop.children [
-                            Html.label [
-                                prop.className "swt:flex swt:flex-col swt:gap-2"
+                            Html.span [
+                                prop.className "swt:text-sm swt:font-medium"
+                                prop.text "Save message"
+                            ]
+                            Html.textarea [
+                                prop.testId "GitSidebarCommitMessageInput"
+                                prop.className
+                                    "swt:textarea swt:textarea-bordered swt:min-h-24 swt:w-full swt:resize-y"
+                                prop.disabled (not props.CanEditCommit)
+                                prop.value props.CommitMessage
+                                prop.placeholder (
+                                    if props.HasConflicts then
+                                        "Resolve merge conflicts before saving."
+                                    elif props.Status.IsClean then
+                                        "No changes to save."
+                                    else
+                                        "Describe your changes"
+                                )
+                                prop.onChange props.SetCommitMessage
+                            ]
+                        ]
+                    ]
+                    Html.div [
+                        prop.className
+                            "swt:mt-2 swt:flex swt:items-center swt:justify-between swt:gap-3 swt:text-xs swt:text-base-content/60"
+                        prop.children [
+                            Html.span (
+                                if props.MarkedCount = 1 then
+                                    "1 file marked to save"
+                                else
+                                    $"{props.MarkedCount} files marked to save"
+                            )
+                            if not props.CanEditCommit && props.HasConflicts then
+                                Html.span "Saving files is disabled while conflicts remain."
+                            elif not props.CanEditCommit && props.Status.IsClean then
+                                Html.span "No changes available to save."
+                            else
+                                Html.none
+                        ]
+                    ]
+                    Html.div [
+                        prop.className "swt:mt-3 swt:flex swt:flex-wrap swt:items-center swt:gap-2"
+                        prop.children [
+                            Html.button [
+                                prop.testId "GitSidebarPrimarySaveButton"
+                                prop.className "swt:btn swt:btn-sm swt:btn-success swt:gap-2 swt:normal-case"
+                                prop.disabled (not props.CanRunPrimarySave)
+                                prop.onClick (fun _ -> props.SubmitPrimarySave())
                                 prop.children [
                                     Html.span [
-                                        prop.className "swt:text-sm swt:font-medium"
-                                        prop.text "Save message"
+                                        prop.className "swt:iconify swt:fluent--checkmark-circle-24-regular swt:size-4"
                                     ]
-                                    Html.textarea [
-                                        prop.testId "GitSidebarCommitMessageInput"
-                                        prop.className
-                                            "swt:textarea swt:textarea-bordered swt:min-h-24 swt:w-full swt:resize-y"
-                                        prop.disabled (not props.CanEditCommit)
-                                        prop.value props.CommitMessage
-                                        prop.placeholder (
-                                            if props.HasConflicts then
-                                                "Resolve merge conflicts before saving."
-                                            elif props.Status.IsClean then
-                                                "No changes to save."
-                                            else
-                                                "Describe your changes"
-                                        )
-                                        prop.onChange props.SetCommitMessage
-                                    ]
-                                ]
-                            ]
-                            Html.div [
-                                prop.className
-                                    "swt:mt-2 swt:flex swt:items-center swt:justify-between swt:gap-3 swt:text-xs swt:text-base-content/60"
-                                prop.children [
                                     Html.span (
-                                        if props.MarkedCount = 1 then
-                                            "1 file marked to save"
+                                        if props.HasMarkedFiles then
+                                            "Save Selected Changes"
                                         else
-                                            $"{props.MarkedCount} files marked to save"
+                                            "Save All Changes"
                                     )
-                                    if not props.CanEditCommit && props.HasConflicts then
-                                        Html.span "Saving files is disabled while conflicts remain."
-                                    elif not props.CanEditCommit && props.Status.IsClean then
-                                        Html.span "No changes available to save."
-                                    else
-                                        Html.none
-                                ]
-                            ]
-                            Html.div [
-                                prop.className "swt:mt-3 swt:flex swt:flex-wrap swt:items-center swt:gap-2"
-                                prop.children [
-                                    Html.button [
-                                        prop.testId "GitSidebarPrimarySaveButton"
-                                        prop.className "swt:btn swt:btn-sm swt:btn-success swt:gap-2 swt:normal-case"
-                                        prop.disabled (not props.CanRunPrimarySave)
-                                        prop.onClick (fun _ -> props.SubmitPrimarySave())
-                                        prop.children [
-                                            Html.span [
-                                                prop.className
-                                                    "swt:iconify swt:fluent--checkmark-circle-24-regular swt:size-4"
-                                            ]
-                                            Html.span (
-                                                if props.HasMarkedFiles then
-                                                    "Save Selected Changes"
-                                                else
-                                                    "Save All Changes"
-                                            )
-                                        ]
-                                    ]
                                 ]
                             ]
                         ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -841,20 +841,26 @@ type GitSidebar =
                         Html.div [
                             prop.className "swt:min-w-0 swt:flex-1"
                             prop.children [
-                                Html.span [
-                                    prop.className "swt:block swt:truncate swt:text-sm swt:font-medium"
-                                    prop.text change.Path
-                                ]
-                                match change.OriginalPath with
-                                | Some originalPath ->
-                                    Html.div [
-                                        prop.className "swt:mt-0.5 swt:text-xs swt:text-base-content/60"
-                                        prop.text $"Renamed from {originalPath}"
+                                Html.div [
+                                    prop.className "swt:min-w-0"
+                                    prop.children [
+                                        Html.span [
+                                            prop.className "swt:block swt:break-words swt:text-sm swt:font-medium"
+                                            prop.text change.Path
+                                        ]
+                                        match change.OriginalPath with
+                                        | Some originalPath ->
+                                            Html.div [
+                                                prop.className "swt:mt-0.5 swt:text-xs swt:text-base-content/60"
+                                                prop.text $"Renamed from {originalPath}"
+                                            ]
+                                        | None -> Html.none
                                     ]
-                                | None -> Html.none
+                                ]
                             ]
                         ]
                         Html.div [
+                            prop.testId $"GitSidebarChangeStatusSlot-{props.Index}"
                             prop.className "swt:ml-auto swt:shrink-0 swt:self-start"
                             prop.children [ GitSidebar.ChangeStatusPopover(props.Index, change) ]
                         ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -75,6 +75,17 @@ module private GitSidebarInternal =
 
     let formatThresholdInput (thresholdMb: int) = string thresholdMb
 
+    let tryRangeBetween (orderedPaths: string[]) (anchorPath: string) (clickedPath: string) =
+        match
+            orderedPaths |> Array.tryFindIndex (fun path -> String.Equals(path, anchorPath, StringComparison.Ordinal)),
+            orderedPaths |> Array.tryFindIndex (fun path -> String.Equals(path, clickedPath, StringComparison.Ordinal))
+        with
+        | Some anchorIndex, Some clickedIndex ->
+            let lower = min anchorIndex clickedIndex
+            let upper = max anchorIndex clickedIndex
+            Some orderedPaths.[lower..upper]
+        | _ -> None
+
 [<RequireQualifiedAccess>]
 type private ActiveDialog =
     | None
@@ -122,21 +133,18 @@ type private CommitSectionProps = {
     CanEditCommit: bool
     CommitMessage: string
     SetCommitMessage: string -> unit
-    SelectedCommitCount: int
-    CanSubmitCommitSelection: bool
-    CanSubmitCommitAll: bool
-    ActiveAction: string option
-    SubmitCommitSelection: unit -> unit
-    SubmitCommitAll: unit -> unit
+    MarkedCount: int
+    HasMarkedFiles: bool
+    CanRunPrimarySave: bool
+    SubmitPrimarySave: unit -> unit
 }
 
 type private ChangedFilesListProps = {
     ChangedFiles: GitSidebarChange[]
     SelectedFile: string option
-    SelectedCommitPaths: Set<string>
+    MarkedPaths: Set<string>
     IsBusy: bool
-    CanEditCommit: bool
-    ToggleCommitSelection: string -> unit
+    UpdateMarkedSelection: GitSidebarChange -> bool -> bool -> unit
     OpenChange: GitSidebarChange -> unit
 }
 
@@ -144,10 +152,9 @@ type private ChangedFileRowProps = {
     Change: GitSidebarChange
     Index: int
     IsSelected: bool
-    IsSelectedForCommit: bool
+    IsMarked: bool
     IsBusy: bool
-    CanEditCommit: bool
-    ToggleCommitSelection: string -> unit
+    UpdateMarkedSelection: GitSidebarChange -> bool -> bool -> unit
     OpenChange: GitSidebarChange -> unit
     VirtualStart: int
     MeasureElementRef: VirtualMeasureElementRef
@@ -174,6 +181,8 @@ type private ModalsProps = {
     SelectedSwitchBranch: string option
     SetSelectedSwitchBranch: string option -> unit
     SubmitSwitchBranch: unit -> unit
+    IsMissingMessageModalOpen: bool
+    SetMissingMessageModalOpen: bool -> unit
     CloseDialog: unit -> unit
 }
 
@@ -704,13 +713,13 @@ type GitSidebar =
                                     "swt:mt-2 swt:flex swt:items-center swt:justify-between swt:gap-3 swt:text-xs swt:text-base-content/60"
                                 prop.children [
                                     Html.span (
-                                        if props.SelectedCommitCount = 1 then
-                                            "1 file selected to save"
+                                        if props.MarkedCount = 1 then
+                                            "1 file marked to save"
                                         else
-                                            $"{props.SelectedCommitCount} files selected to save"
+                                            $"{props.MarkedCount} files marked to save"
                                     )
                                     if not props.CanEditCommit && props.HasConflicts then
-                                        Html.span "Saving selected files is disabled while conflicts remain."
+                                        Html.span "Saving files is disabled while conflicts remain."
                                     elif not props.CanEditCommit && props.Status.IsClean then
                                         Html.span "No changes available to save."
                                     else
@@ -718,39 +727,21 @@ type GitSidebar =
                                 ]
                             ]
                             Html.div [
-                                prop.className "swt:mt-3 swt:grid swt:grid-cols-2 swt:gap-2"
+                                prop.className "swt:mt-3 swt:flex swt:flex-wrap swt:items-center swt:gap-2"
                                 prop.children [
                                     Html.button [
-                                        prop.testId "GitSidebarCommitSelectionButton"
-                                        prop.className "swt:btn swt:btn-sm swt:btn-outline swt:gap-2 swt:normal-case"
-                                        prop.disabled (not props.CanSubmitCommitSelection)
-                                        prop.onClick (fun _ -> props.SubmitCommitSelection())
-                                        prop.children [
-                                            Html.span [
-                                                prop.className
-                                                    "swt:iconify swt:fluent--checkbox-checked-24-regular swt:size-4"
-                                            ]
-                                            Html.span (
-                                                if props.ActiveAction = Some "Commit Selection" then
-                                                    "Committing..."
-                                                else
-                                                    "Save Selected Changes"
-                                            )
-                                        ]
-                                    ]
-                                    Html.button [
-                                        prop.testId "GitSidebarCommitAllButton"
-                                        prop.className "swt:btn swt:btn-sm swt:btn-secondary swt:gap-2 swt:normal-case"
-                                        prop.disabled (not props.CanSubmitCommitAll)
-                                        prop.onClick (fun _ -> props.SubmitCommitAll())
+                                        prop.testId "GitSidebarPrimarySaveButton"
+                                        prop.className "swt:btn swt:btn-sm swt:btn-success swt:gap-2 swt:normal-case"
+                                        prop.disabled (not props.CanRunPrimarySave)
+                                        prop.onClick (fun _ -> props.SubmitPrimarySave())
                                         prop.children [
                                             Html.span [
                                                 prop.className
                                                     "swt:iconify swt:fluent--checkmark-circle-24-regular swt:size-4"
                                             ]
                                             Html.span (
-                                                if props.ActiveAction = Some "Commit All" then
-                                                    "Committing..."
+                                                if props.HasMarkedFiles then
+                                                    "Save Selected Changes"
                                                 else
                                                     "Save All Changes"
                                             )
@@ -824,20 +815,16 @@ type GitSidebar =
                             "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
                         elif props.IsSelected then
                             "swt:border-primary/40 swt:bg-primary/5 hover:swt:bg-primary/10"
+                        elif props.IsMarked then
+                            "swt:border-success/40 swt:bg-success/10 hover:swt:bg-success/15"
                         else
                             "swt:border-base-content/10 swt:bg-base-100 hover:swt:bg-base-200/80"
                     ]
-                    prop.onClick (fun _ -> props.OpenChange change)
+                    prop.onClick (fun (event: MouseEvent) ->
+                        props.UpdateMarkedSelection change (event.ctrlKey || event.metaKey) event.shiftKey
+                        props.OpenChange change
+                    )
                     prop.children [
-                        Html.input [
-                            prop.testId ("GitSidebarCommitSelectionCheckbox-" + change.Path)
-                            prop.className "swt:checkbox swt:checkbox-sm swt:mt-0.5 swt:shrink-0"
-                            prop.type'.checkbox
-                            prop.disabled (not props.CanEditCommit || change.IsConflicted)
-                            prop.isChecked props.IsSelectedForCommit
-                            prop.onClick (fun event -> event.stopPropagation ())
-                            prop.onChange (fun (_: bool) -> props.ToggleCommitSelection change.Path)
-                        ]
                         Html.div [
                             prop.className "swt:min-w-0 swt:flex-1"
                             prop.children [
@@ -949,7 +936,7 @@ type GitSidebar =
                                             String.Equals(selected, change.Path, StringComparison.Ordinal)
                                         )
 
-                                    let isSelectedForCommit = Set.contains change.Path props.SelectedCommitPaths
+                                    let isMarked = Set.contains change.Path props.MarkedPaths
 
                                     React.KeyedFragment(
                                         change.Path,
@@ -959,10 +946,9 @@ type GitSidebar =
                                                     Change = change
                                                     Index = virtualItem.Index
                                                     IsSelected = isSelected
-                                                    IsSelectedForCommit = isSelectedForCommit
+                                                    IsMarked = isMarked
                                                     IsBusy = props.IsBusy
-                                                    CanEditCommit = props.CanEditCommit
-                                                    ToggleCommitSelection = props.ToggleCommitSelection
+                                                    UpdateMarkedSelection = props.UpdateMarkedSelection
                                                     OpenChange = props.OpenChange
                                                     VirtualStart = virtualItem.Start
                                                     MeasureElementRef = changedFileListVirtualizer.measureElement
@@ -1122,6 +1108,20 @@ type GitSidebar =
                         ]
                     ]
             )
+
+            BaseModal.Modal(
+                isOpen = props.IsMissingMessageModalOpen,
+                setIsOpen = props.SetMissingMessageModalOpen,
+                header = Html.text "Missing save message",
+                children = Html.p [ prop.text "Please add a description." ],
+                footer =
+                    Html.button [
+                        prop.className "swt:btn swt:btn-primary swt:ml-auto"
+                        prop.text "OK"
+                        prop.onClick (fun _ -> props.SetMissingMessageModalOpen false)
+                    ],
+                debug = "GitSidebarMissingMessage"
+            )
         ]
 
     [<ReactComponent>]
@@ -1165,6 +1165,7 @@ type GitSidebar =
         let activeDialog, setActiveDialog = React.useState ActiveDialog.None
         let branchName, setBranchName = React.useState ""
         let commitMessage, setCommitMessage = React.useState ""
+        let isMissingMessageModalOpen, setMissingMessageModalOpen = React.useState false
 
         let downloadLargeFilesInput, setDownloadLargeFilesInput =
             React.useState downloadLargeFiles
@@ -1172,8 +1173,11 @@ type GitSidebar =
         let lfsThresholdInput, setLfsThresholdInput =
             React.useState (GitSidebarInternal.formatThresholdInput lfsAutoTrackThresholdMb)
 
-        let selectedCommitPaths, setSelectedCommitPaths =
+        let markedPaths, setMarkedPaths =
             React.useStateWithUpdater Set.empty<string>
+
+        let selectionAnchorPath, setSelectionAnchorPath =
+            React.useStateWithUpdater (None: string option)
 
         let selectedStartPoint, setSelectedStartPoint = React.useState (None: string option)
 
@@ -1209,16 +1213,20 @@ type GitSidebar =
 
         let visibleError = errorNotice |> Option.orElse localError
 
-        // Sync selectedCommitPaths with changedFiles: remove paths that are no longer in the changed
+        // Sync marked paths with changedFiles: remove paths that are no longer in the changed
         // files list (e.g., after a commit or discard operation updates the server-side file list).
         React.useEffect (
             (fun () ->
-                setSelectedCommitPaths (fun current ->
+                let changedPathSet = changedFiles |> Array.map _.Path |> Set.ofArray
+
+                setMarkedPaths (fun current ->
                     current
-                    |> Set.filter (fun path ->
-                        changedFiles
-                        |> Array.exists (fun change -> String.Equals(change.Path, path, StringComparison.Ordinal))
-                    )
+                    |> Set.filter (fun path -> Set.contains path changedPathSet)
+                )
+
+                setSelectionAnchorPath (fun current ->
+                    current
+                    |> Option.filter (fun path -> Set.contains path changedPathSet)
                 )
             ),
             [| box changedFiles |]
@@ -1305,42 +1313,50 @@ type GitSidebar =
             setSelectedSwitchBranch defaultBranch
             setActiveDialog ActiveDialog.SwitchBranch
 
-        let toggleCommitSelection (path: string) =
-            setSelectedCommitPaths (fun current ->
-                if Set.contains path current then
-                    Set.remove path current
-                else
-                    Set.add path current
+        let updateMarkedSelection (change: GitSidebarChange) (ctrlKey: bool) (shiftKey: bool) =
+            let orderedPaths = changedFiles |> Array.map _.Path
+            let anchorPath = selectionAnchorPath |> Option.defaultValue change.Path
+
+            let rangePaths =
+                GitSidebarInternal.tryRangeBetween orderedPaths anchorPath change.Path
+                |> Option.defaultValue [| change.Path |]
+                |> Set.ofArray
+
+            setMarkedPaths (fun current ->
+                match ctrlKey, shiftKey with
+                | false, false -> Set.singleton change.Path
+                | true, false ->
+                    if Set.contains change.Path current then
+                        Set.remove change.Path current
+                    else
+                        Set.add change.Path current
+                | false, true -> rangePaths
+                | true, true -> Set.union current rangePaths
             )
 
-        let submitCommitSelection () =
+            setSelectionAnchorPath (fun _ -> Some change.Path)
+
+        let submitPrimarySave () =
             let normalizedCommitMessage = commitMessage.Trim()
-            let selectedPaths = selectedCommitPaths |> Set.toArray |> Array.sort
+            let hasMarkedFiles = (Set.count markedPaths) > 0
 
             if String.IsNullOrWhiteSpace normalizedCommitMessage then
-                setLocalError (Some "Save message must not be empty.")
-            elif selectedPaths.Length = 0 then
-                setLocalError (Some "Select at least one file to save.")
-            else
+                setMissingMessageModalOpen true
+            elif hasMarkedFiles then
                 setLocalError None
 
                 onCommitSelection {
                     Message = normalizedCommitMessage
-                    Paths = selectedPaths
+                    Paths = markedPaths |> Set.toArray |> Array.sort
                 }
 
                 setCommitMessage ""
-                setSelectedCommitPaths (fun _ -> Set.empty)
-
-        let submitCommitAll () =
-            let normalizedCommitMessage = commitMessage.Trim()
-
-            if String.IsNullOrWhiteSpace normalizedCommitMessage then
-                setLocalError (Some "Save message must not be empty.")
+                setMarkedPaths (fun _ -> Set.empty)
             else
                 setLocalError None
                 onCommitAll normalizedCommitMessage
                 setCommitMessage ""
+
 
         let submitLfsThreshold () =
             let normalizedInput = lfsThresholdInput.Trim()
@@ -1392,15 +1408,9 @@ type GitSidebar =
 
         let hasConflicts = GitSidebarInternal.hasConflicts status changedFiles
         let canEditCommit = not status.IsClean && not hasConflicts && not isBusy
-        let selectedCommitCount = Set.count selectedCommitPaths
-
-        let canSubmitCommitSelection =
-            canEditCommit
-            && selectedCommitCount > 0
-            && not (String.IsNullOrWhiteSpace(commitMessage.Trim()))
-
-        let canSubmitCommitAll =
-            canEditCommit && not (String.IsNullOrWhiteSpace(commitMessage.Trim()))
+        let markedCount = Set.count markedPaths
+        let hasMarkedFiles = markedCount > 0
+        let canRunPrimarySave = canEditCommit
 
         let normalizedLfsThresholdInput = lfsThresholdInput.Trim()
 
@@ -1484,12 +1494,10 @@ type GitSidebar =
                         CanEditCommit = canEditCommit
                         CommitMessage = commitMessage
                         SetCommitMessage = setCommitMessage
-                        SelectedCommitCount = selectedCommitCount
-                        CanSubmitCommitSelection = canSubmitCommitSelection
-                        CanSubmitCommitAll = canSubmitCommitAll
-                        ActiveAction = activeAction
-                        SubmitCommitSelection = submitCommitSelection
-                        SubmitCommitAll = submitCommitAll
+                        MarkedCount = markedCount
+                        HasMarkedFiles = hasMarkedFiles
+                        CanRunPrimarySave = canRunPrimarySave
+                        SubmitPrimarySave = submitPrimarySave
                     }
                 )
 
@@ -1522,10 +1530,9 @@ type GitSidebar =
                     {
                         ChangedFiles = changedFiles
                         SelectedFile = selectedFile
-                        SelectedCommitPaths = selectedCommitPaths
+                        MarkedPaths = markedPaths
                         IsBusy = isBusy
-                        CanEditCommit = canEditCommit
-                        ToggleCommitSelection = toggleCommitSelection
+                        UpdateMarkedSelection = updateMarkedSelection
                         OpenChange = fun change -> runSelectChangeAction change
                     }
                 )
@@ -1547,6 +1554,8 @@ type GitSidebar =
                         SelectedSwitchBranch = selectedSwitchBranch
                         SetSelectedSwitchBranch = setSelectedSwitchBranch
                         SubmitSwitchBranch = submitSwitchBranch
+                        IsMissingMessageModalOpen = isMissingMessageModalOpen
+                        SetMissingMessageModalOpen = setMissingMessageModalOpen
                         CloseDialog = fun () -> setActiveDialog ActiveDialog.None
                     }
                 )

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -140,10 +140,6 @@ type private ChangedFilesListProps = {
     OpenChange: GitSidebarChange -> unit
 }
 
-type private ChangeStatusBadgeProps = {
-    Change: GitSidebarChange
-}
-
 type private ChangedFileRowProps = {
     Change: GitSidebarChange
     Index: int
@@ -769,20 +765,38 @@ type GitSidebar =
         ]
 
     [<ReactComponent>]
-    static member private ChangeStatusBadge(props: ChangeStatusBadgeProps) =
-        let badgeLabel, badgeClass, iconClass = GitSidebarInternal.changePresentation props.Change
+    static member private ChangeStatusPopover(index: int, change: GitSidebarChange) =
+        let label, _, iconClass = GitSidebarInternal.changePresentation change
+        let gitReturn = GitSidebarInternal.describeChange change
 
-        Html.span [
-            prop.className [ badgeClass; "swt:gap-1" ]
-            prop.children [
-                Html.span [
-                    prop.className $"swt:iconify {iconClass} swt:size-3.5"
+        Popover.Popover(
+            debug = $"git_change_status_{index}",
+            children =
+                React.Fragment [
+                    Popover.Trigger(
+                        Html.span [ prop.className $"swt:iconify {iconClass} swt:size-4" ],
+                        className = "swt:btn swt:btn-ghost swt:btn-xs swt:min-h-0 swt:h-7 swt:w-7 swt:px-0",
+                        props = [ prop.testId $"GitSidebarChangeStatusButton-{index}" ]
+                    )
+                    Popover.Content(
+                        children =
+                            Html.div [
+                                prop.className "swt:flex swt:flex-col swt:gap-2"
+                                prop.children [
+                                    Popover.Heading(Html.text "File status")
+                                    Html.p [
+                                        prop.className "swt:text-sm"
+                                        prop.text $"This file was {label.ToLowerInvariant()}."
+                                    ]
+                                    Html.p [
+                                        prop.className "swt:text-sm swt:font-mono"
+                                        prop.text $"Git return: {gitReturn}"
+                                    ]
+                                ]
+                            ]
+                    )
                 ]
-                Html.span [
-                    prop.text badgeLabel
-                ]
-            ]
-        ]
+        )
 
     [<ReactComponent>]
     static member private ChangedFileRow(props: ChangedFileRowProps) =
@@ -824,28 +838,12 @@ type GitSidebar =
                             prop.onClick (fun event -> event.stopPropagation ())
                             prop.onChange (fun (_: bool) -> props.ToggleCommitSelection change.Path)
                         ]
-                        Html.span [
-                            prop.className [
-                                "swt:mt-0.5 swt:font-mono swt:text-[0.7rem]"
-                                if change.IsConflicted then
-                                    "swt:text-error"
-                                else
-                                    "swt:text-base-content/60"
-                            ]
-                            prop.text (GitSidebarInternal.describeChange change)
-                        ]
                         Html.div [
                             prop.className "swt:min-w-0 swt:flex-1"
                             prop.children [
-                                Html.div [
-                                    prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-1.5"
-                                    prop.children [
-                                        Html.span [
-                                            prop.className "swt:truncate swt:text-sm swt:font-medium"
-                                            prop.text change.Path
-                                        ]
-                                        GitSidebar.ChangeStatusBadge({ Change = change })
-                                    ]
+                                Html.span [
+                                    prop.className "swt:block swt:truncate swt:text-sm swt:font-medium"
+                                    prop.text change.Path
                                 ]
                                 match change.OriginalPath with
                                 | Some originalPath ->
@@ -855,6 +853,10 @@ type GitSidebar =
                                     ]
                                 | None -> Html.none
                             ]
+                        ]
+                        Html.div [
+                            prop.className "swt:ml-auto swt:shrink-0 swt:self-start"
+                            prop.children [ GitSidebar.ChangeStatusPopover(props.Index, change) ]
                         ]
                     ]
                 ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -837,7 +837,7 @@ type GitSidebar =
                     prop.tabIndex (if props.IsBusy then -1 else 0)
                     prop.custom ("aria-disabled", if props.IsBusy then "true" else "false")
                     prop.className [
-                        "swt:flex swt:w-full swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1.5 swt:text-left swt:transition-colors"
+                        "swt:flex swt:w-full swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1.5 swt:text-left swt:transition-colors swt:select-none"
                         if props.IsBusy then
                             "swt:cursor-not-allowed swt:opacity-60"
                         else
@@ -1399,18 +1399,22 @@ type GitSidebar =
                 |> Option.defaultValue [| change.Path |]
                 |> Set.ofArray
 
-            setMarkedPaths (fun current ->
+            let nextMarkedPaths =
                 match ctrlKey, shiftKey with
-                | false, false -> Set.singleton change.Path
-                | true, false ->
-                    if Set.contains change.Path current then
-                        Set.remove change.Path current
+                | false, false ->
+                    if Set.contains change.Path markedPaths then
+                        Set.remove change.Path markedPaths
                     else
-                        Set.add change.Path current
+                        Set.singleton change.Path
+                | true, false ->
+                    if Set.contains change.Path markedPaths then
+                        Set.remove change.Path markedPaths
+                    else
+                        Set.add change.Path markedPaths
                 | false, true -> rangePaths
-                | true, true -> Set.union current rangePaths
-            )
+                | true, true -> Set.union markedPaths rangePaths
 
+            setMarkedPaths (fun _ -> nextMarkedPaths)
             setSelectionAnchorPath (fun _ -> Some change.Path)
 
         let submitPrimarySave () =

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -120,7 +120,6 @@ type private AdvancedActionsProps = {
     RemoteActionsWarning: string option
     SubmitDownloadLargeFiles: bool -> unit
     SubmitUpdateFromOnline: unit -> unit
-    SubmitLocalCommit: unit -> unit
     HasMarkedFiles: bool
     CanRunPrimarySave: bool
     IsAdvancedActionsOpen: bool
@@ -144,6 +143,7 @@ type private CommitSectionProps = {
     HasMarkedFiles: bool
     CanRunPrimarySave: bool
     SubmitPrimarySave: unit -> unit
+    SubmitLocalCommit: unit -> unit
 }
 
 type private ChangedFilesListProps = {
@@ -629,16 +629,6 @@ type GitSidebar =
                             prop.className "swt:grid swt:grid-cols-2 swt:gap-2"
                             prop.children [
                                 GitSidebar.ActionButton(
-                                    (if props.HasMarkedFiles then
-                                         "Add and commit selected Changes"
-                                     else
-                                         "Add and commit all Changes"),
-                                    "swt:fluent--save-24-regular",
-                                    not props.CanRunPrimarySave,
-                                    props.SubmitLocalCommit,
-                                    testId = "GitSidebarLocalCommitButton"
-                                )
-                                GitSidebar.ActionButton(
                                     "Check for Changes",
                                     "swt:fluent--arrow-download-24-regular",
                                     props.IsBusy || not props.RemoteActionsEnabled,
@@ -694,9 +684,61 @@ type GitSidebar =
         ]
 
     [<ReactComponent>]
+    static member private SaveOptionsHelpPopover() =
+        Popover.Popover(
+            debug = "GitSidebarSaveOptionsHelp",
+            children =
+                React.Fragment [
+                    Popover.Trigger(
+                        Html.span "?",
+                        className = "swt:btn swt:btn-ghost swt:btn-xs swt:min-h-0 swt:h-6 swt:w-6 swt:px-0 swt:text-xs swt:font-bold",
+                        props = [ prop.testId "GitSidebarSaveOptionsHelpButton" ]
+                    )
+                    Popover.Content(
+                        children =
+                            Html.div [
+                                prop.className "swt:flex swt:max-w-72 swt:flex-col swt:gap-2 swt:text-sm"
+                                prop.children [
+                                    Popover.Heading(Html.text "Save options")
+                                    Html.p [
+                                        prop.text
+                                            "Save changes commits locally, then updates and uploads online when the repository can sync safely."
+                                    ]
+                                    Html.p [
+                                        prop.text
+                                            "Add and commit changes only writes the local Git commit. Online sync stays pending until you update or upload later."
+                                    ]
+                                ]
+                            ]
+                    )
+                ]
+        )
+
+    [<ReactComponent>]
     static member private CommitSection(props: CommitSectionProps) =
+        let isSaveMenuOpen, setSaveMenuOpen = React.useState false
+        let saveMenuRef = React.useElementRef ()
+
+        React.useListener.onClickAway (saveMenuRef, fun _ -> setSaveMenuOpen false)
+
+        let primarySaveLabel =
+            if props.HasMarkedFiles then
+                "Save Selected Changes"
+            else
+                "Save All Changes"
+
+        let localCommitLabel =
+            if props.HasMarkedFiles then
+                "Add and commit selected Changes"
+            else
+                "Add and commit all Changes"
+
         React.Fragment [
-            GitSidebar.SectionHeader("Save", None)
+            Html.div [
+                prop.className
+                    "swt:flex swt:items-center swt:justify-between swt:gap-2 swt:px-3 swt:pt-3 swt:text-xs swt:font-semibold swt:uppercase swt:tracking-[0.2em] swt:text-base-content/60"
+                prop.children [ Html.span "Save" ]
+            ]
 
             Html.div [
                 prop.testId "GitSidebarCommitSection"
@@ -741,24 +783,76 @@ type GitSidebar =
                         ]
                     ]
                     Html.div [
-                        prop.className "swt:mt-3 swt:flex swt:flex-wrap swt:items-center swt:gap-2"
+                        prop.className "swt:mt-3 swt:flex swt:flex-wrap swt:items-center swt:justify-between swt:gap-2"
                         prop.children [
-                            Html.button [
-                                prop.testId "GitSidebarPrimarySaveButton"
-                                prop.className "swt:btn swt:btn-sm swt:btn-success swt:gap-2 swt:normal-case"
-                                prop.disabled (not props.CanRunPrimarySave)
-                                prop.onClick (fun _ -> props.SubmitPrimarySave())
+                            Html.div [
+                                prop.ref saveMenuRef
+                                prop.className "swt:relative swt:inline-flex"
                                 prop.children [
-                                    Html.span [
-                                        prop.className "swt:iconify swt:fluent--checkmark-circle-24-regular swt:size-4"
+                                    Html.div [
+                                        prop.className "swt:join"
+                                        prop.children [
+                                            Html.button [
+                                                prop.testId "GitSidebarPrimarySaveButton"
+                                                prop.className "swt:btn swt:join-item swt:btn-sm swt:btn-success swt:gap-2 swt:normal-case"
+                                                prop.disabled (not props.CanRunPrimarySave)
+                                                prop.onClick (fun _ -> props.SubmitPrimarySave())
+                                                prop.children [
+                                                    Html.span [
+                                                        prop.className
+                                                            "swt:iconify swt:fluent--checkmark-circle-24-regular swt:size-4"
+                                                    ]
+                                                    Html.span primarySaveLabel
+                                                ]
+                                            ]
+                                            Html.button [
+                                                prop.testId "GitSidebarSaveOptionsButton"
+                                                prop.className
+                                                    "swt:btn swt:join-item swt:btn-sm swt:btn-success swt:min-w-0 swt:px-2"
+                                                prop.disabled (not props.CanRunPrimarySave)
+                                                prop.onClick (fun _ -> setSaveMenuOpen (not isSaveMenuOpen))
+                                                prop.children [
+                                                    Html.span [
+                                                        prop.className "swt:iconify swt:fluent--chevron-down-24-regular swt:size-4"
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
                                     ]
-                                    Html.span (
-                                        if props.HasMarkedFiles then
-                                            "Save Selected Changes"
-                                        else
-                                            "Save All Changes"
-                                    )
+                                    if isSaveMenuOpen then
+                                        Html.ul [
+                                            prop.testId "GitSidebarSaveOptionsMenu"
+                                            prop.tabIndex 0
+                                            prop.className
+                                                "swt:menu swt:absolute swt:left-0 swt:top-full swt:z-99 swt:mt-1 swt:w-full swt:min-w-0 swt:rounded-box swt:bg-base-200 swt:p-2 swt:shadow-sm"
+                                            prop.onClick (fun _ -> setSaveMenuOpen false)
+                                            prop.children [
+                                                Html.li [
+                                                    prop.children [
+                                                        Html.button [
+                                                            prop.testId "GitSidebarLocalCommitButton"
+                                                            prop.className "swt:items-start swt:gap-2 swt:whitespace-normal swt:text-left"
+                                                            prop.onClick (fun _ -> props.SubmitLocalCommit())
+                                                            prop.children [
+                                                                Html.span [
+                                                                    prop.className
+                                                                        "swt:iconify swt:fluent--save-24-regular swt:size-4 swt:shrink-0"
+                                                                ]
+                                                                Html.span [
+                                                                    prop.className "swt:min-w-0 swt:break-words"
+                                                                    prop.text localCommitLabel
+                                                                ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
                                 ]
+                            ]
+                            Html.div [
+                                prop.className "swt:ml-auto"
+                                prop.children [ GitSidebar.SaveOptionsHelpPopover() ]
                             ]
                         ]
                     ]
@@ -1551,7 +1645,6 @@ type GitSidebar =
                             fun () ->
                                 setLocalError None
                                 onUpdateFromOnline ()
-                        SubmitLocalCommit = submitLocalCommit
                         HasMarkedFiles = hasMarkedFiles
                         CanRunPrimarySave = canRunPrimarySave
                         IsAdvancedActionsOpen = isAdvancedActionsOpen
@@ -1600,6 +1693,7 @@ type GitSidebar =
                         HasMarkedFiles = hasMarkedFiles
                         CanRunPrimarySave = canRunPrimarySave
                         SubmitPrimarySave = submitPrimarySave
+                        SubmitLocalCommit = submitLocalCommit
                     }
                 )
 

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -577,17 +577,6 @@ type GitSidebar =
             Html.div [
                 prop.className "swt:grid swt:grid-cols-2 swt:gap-2 swt:px-3"
                 prop.children [
-                    Html.label [
-                        prop.className "swt:col-span-2"
-                        prop.children [
-                            GitSidebar.DownloadLargeFilesToggle(
-                                props.DownloadLargeFilesInput,
-                                props.IsBusy,
-                                props.SubmitDownloadLargeFiles,
-                                testId = "GitSidebarDownloadLargeFilesCheckbox"
-                            )
-                        ]
-                    ]
                     GitSidebar.ActionButton(
                         "Update ARC from Online",
                         "swt:fluent--arrow-sync-24-regular",
@@ -683,6 +672,17 @@ type GitSidebar =
                                     props.IsBusy || not props.CanSwitchBranch,
                                     props.OpenSwitchBranchModal,
                                     testId = "GitSidebarSwitchBranchButton"
+                                )
+                            ]
+                        ]
+                        Html.div [
+                            prop.className "swt:mt-3"
+                            prop.children [
+                                GitSidebar.DownloadLargeFilesToggle(
+                                    props.DownloadLargeFilesInput,
+                                    props.IsBusy,
+                                    props.SubmitDownloadLargeFiles,
+                                    testId = "GitSidebarDownloadLargeFilesCheckbox"
                                 )
                             ]
                         ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -181,7 +181,7 @@ type private ModalsProps = {
     SubmitCreateBranch: unit -> unit
     IsSwitchBranchModalOpen: bool
     SetSwitchBranchModalOpen: bool -> unit
-    LocalBranchOptionsForSwitch: GitSidebarBranchOption[]
+    BranchOptionsForSwitch: GitSidebarBranchOption[]
     SelectedSwitchBranch: string option
     SetSelectedSwitchBranch: string option -> unit
     SubmitSwitchBranch: unit -> unit
@@ -1086,7 +1086,7 @@ type GitSidebar =
                 isOpen = props.IsSwitchBranchModalOpen,
                 setIsOpen = props.SetSwitchBranchModalOpen,
                 header = Html.text "Switch Branch",
-                description = Html.text "Switch to an existing local branch.",
+                description = Html.text "Switch to an existing branch.",
                 debug = "GitSidebarSwitchBranchModal",
                 children =
                     Html.div [
@@ -1111,11 +1111,11 @@ type GitSidebar =
                                                 props.SetSelectedSwitchBranch(Some nextValue)
                                         )
                                         prop.children [
-                                            for branch in props.LocalBranchOptionsForSwitch do
+                                            for branch in props.BranchOptionsForSwitch do
                                                 Html.option [
                                                     prop.key branch.RefName
                                                     prop.value branch.RefName
-                                                    prop.text branch.DisplayLabel
+                                                    prop.text $"{branch.DisplayLabel} ({GitSidebarInternal.branchKindLabel branch.Kind})"
                                                 ]
                                         ]
                                     ]
@@ -1134,7 +1134,7 @@ type GitSidebar =
                         Html.button [
                             prop.testId "GitSidebarSwitchBranchSubmit"
                             prop.className "swt:btn swt:btn-primary swt:ml-auto"
-                            prop.disabled (props.ActiveAction.IsSome || props.LocalBranchOptionsForSwitch.Length = 0)
+                            prop.disabled (props.ActiveAction.IsSome || props.BranchOptionsForSwitch.Length = 0)
                             prop.text (
                                 if props.ActiveAction = Some "Switch Branch" then
                                     "Switching..."
@@ -1348,9 +1348,11 @@ type GitSidebar =
                     )
                 )
 
-        let localBranchOptionsForSwitch =
+        let branchOptionsForSwitch =
             branchOptions
-            |> Array.filter (fun branch -> branch.Kind = GitSidebarBranchKind.Local && not branch.IsCurrent)
+            |> Array.filter (fun branch -> not branch.IsCurrent)
+
+        let canSwitchBranch = branchOptionsForSwitch.Length > 0
 
         let runSelectChangeAction (change: GitSidebarChange) =
             promise {
@@ -1385,7 +1387,7 @@ type GitSidebar =
             setLocalError None
 
             let defaultBranch =
-                localBranchOptionsForSwitch |> Array.tryHead |> Option.map _.RefName
+                branchOptionsForSwitch |> Array.tryHead |> Option.map _.RefName
 
             setSelectedSwitchBranch defaultBranch
             setActiveDialog ActiveDialog.SwitchBranch
@@ -1575,7 +1577,7 @@ type GitSidebar =
                                 onPush ()
                         OpenCreateBranchModal = openCreateBranchModal
                         OpenSwitchBranchModal = openSwitchBranchModal
-                        CanSwitchBranch = localBranchOptionsForSwitch.Length > 0
+                        CanSwitchBranch = canSwitchBranch
                         LfsSettings = {
                             IsBusy = isBusy
                             LfsThresholdInput = lfsThresholdInput
@@ -1650,7 +1652,7 @@ type GitSidebar =
                         SubmitCreateBranch = submitCreateBranch
                         IsSwitchBranchModalOpen = isSwitchBranchModalOpen
                         SetSwitchBranchModalOpen = setSwitchBranchModalOpen
-                        LocalBranchOptionsForSwitch = localBranchOptionsForSwitch
+                        BranchOptionsForSwitch = branchOptionsForSwitch
                         SelectedSwitchBranch = selectedSwitchBranch
                         SetSelectedSwitchBranch = setSelectedSwitchBranch
                         SubmitSwitchBranch = submitSwitchBranch

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -3,6 +3,7 @@ namespace Swate.Components
 open System
 open Browser.Types
 open Fable.Core
+open Fable.Core.JsInterop
 open Feliz
 
 open Swate.Components.GitSidebarTypes
@@ -774,6 +775,13 @@ type GitSidebar =
     static member private ChangeStatusPopover(index: int, change: GitSidebarChange) =
         let label, _, iconClass = GitSidebarInternal.changePresentation change
         let gitReturn = GitSidebarInternal.describeChange change
+        let stopRowActivation (event: Event) = event.stopPropagation ()
+        let triggerInteractionProps =
+            createObj [
+                "onClick" ==> stopRowActivation
+                "onMouseDown" ==> stopRowActivation
+                "onKeyDown" ==> stopRowActivation
+            ]
 
         Popover.Popover(
             debug = $"git_change_status_{index}",
@@ -782,6 +790,7 @@ type GitSidebar =
                     Popover.Trigger(
                         Html.span [ prop.className $"swt:iconify {iconClass} swt:size-4" ],
                         className = "swt:btn swt:btn-ghost swt:btn-xs swt:min-h-0 swt:h-7 swt:w-7 swt:px-0",
+                        interactionProps = triggerInteractionProps,
                         props = [ prop.testId $"GitSidebarChangeStatusButton-{index}" ]
                     )
                     Popover.Content(
@@ -807,6 +816,10 @@ type GitSidebar =
     [<ReactComponent>]
     static member private ChangedFileRow(props: ChangedFileRowProps) =
         let change = props.Change
+        let activateRow ctrlKey shiftKey =
+            if not props.IsBusy then
+                props.UpdateMarkedSelection change ctrlKey shiftKey
+                props.OpenChange change
 
         Html.div [
             prop.role "listitem"
@@ -820,12 +833,18 @@ type GitSidebar =
                 style.custom ("transform", $"translateY({props.VirtualStart}px)")
             ]
             prop.children [
-                Html.button [
+                Html.div [
                     prop.testId $"GitSidebarChangeRow-{props.Index}"
                     prop.custom ("data-index", props.Index)
-                    prop.disabled props.IsBusy
+                    prop.role "button"
+                    prop.tabIndex (if props.IsBusy then -1 else 0)
+                    prop.custom ("aria-disabled", if props.IsBusy then "true" else "false")
                     prop.className [
                         "swt:flex swt:w-full swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1.5 swt:text-left swt:transition-colors"
+                        if props.IsBusy then
+                            "swt:cursor-not-allowed swt:opacity-60"
+                        else
+                            "swt:cursor-pointer"
                         if change.IsConflicted then
                             "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
                         elif props.IsSelected then
@@ -836,8 +855,12 @@ type GitSidebar =
                             "swt:border-base-content/10 swt:bg-base-100 hover:swt:bg-base-200/80"
                     ]
                     prop.onClick (fun (event: MouseEvent) ->
-                        props.UpdateMarkedSelection change (event.ctrlKey || event.metaKey) event.shiftKey
-                        props.OpenChange change
+                        activateRow (event.ctrlKey || event.metaKey) event.shiftKey
+                    )
+                    prop.onKeyDown (fun (event: KeyboardEvent) ->
+                        if event.key = "Enter" || event.key = " " then
+                            event.preventDefault ()
+                            activateRow (event.ctrlKey || event.metaKey) event.shiftKey
                     )
                     prop.children [
                         Html.div [

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -34,7 +34,11 @@ module private GitSidebarInternal =
 
         if change.IsConflicted then
             GitChangeKind.Conflict
-        elif change.OriginalPath.IsSome || indexCode.StartsWith("R", StringComparison.Ordinal) || worktreeCode.StartsWith("R", StringComparison.Ordinal) then
+        elif
+            change.OriginalPath.IsSome
+            || indexCode.StartsWith("R", StringComparison.Ordinal)
+            || worktreeCode.StartsWith("R", StringComparison.Ordinal)
+        then
             GitChangeKind.Renamed
         elif indexCode = "?" || worktreeCode = "?" then
             GitChangeKind.Untracked
@@ -47,12 +51,9 @@ module private GitSidebarInternal =
 
     let changePresentation (change: GitSidebarChange) =
         match classifyChange change with
-        | GitChangeKind.Added ->
-            "Added", "swt:badge swt:badge-success swt:badge-sm", "swt:fluent--add-24-regular"
-        | GitChangeKind.Modified ->
-            "Modified", "swt:badge swt:badge-info swt:badge-sm", "swt:fluent--edit-24-regular"
-        | GitChangeKind.Deleted ->
-            "Deleted", "swt:badge swt:badge-error swt:badge-sm", "swt:fluent--delete-24-regular"
+        | GitChangeKind.Added -> "Added", "swt:badge swt:badge-success swt:badge-sm", "swt:fluent--add-24-regular"
+        | GitChangeKind.Modified -> "Modified", "swt:badge swt:badge-info swt:badge-sm", "swt:fluent--edit-24-regular"
+        | GitChangeKind.Deleted -> "Deleted", "swt:badge swt:badge-error swt:badge-sm", "swt:fluent--delete-24-regular"
         | GitChangeKind.Renamed ->
             "Renamed", "swt:badge swt:badge-warning swt:badge-sm", "swt:fluent--arrow-swap-24-regular"
         | GitChangeKind.Untracked ->
@@ -78,8 +79,10 @@ module private GitSidebarInternal =
 
     let tryRangeBetween (orderedPaths: string[]) (anchorPath: string) (clickedPath: string) =
         match
-            orderedPaths |> Array.tryFindIndex (fun path -> String.Equals(path, anchorPath, StringComparison.Ordinal)),
-            orderedPaths |> Array.tryFindIndex (fun path -> String.Equals(path, clickedPath, StringComparison.Ordinal))
+            orderedPaths
+            |> Array.tryFindIndex (fun path -> String.Equals(path, anchorPath, StringComparison.Ordinal)),
+            orderedPaths
+            |> Array.tryFindIndex (fun path -> String.Equals(path, clickedPath, StringComparison.Ordinal))
         with
         | Some anchorIndex, Some clickedIndex ->
             let lower = min anchorIndex clickedIndex
@@ -164,10 +167,7 @@ type private ChangedFileRowProps = {
     MeasureElementRef: VirtualMeasureElementRef
 }
 
-type private ChangedFileVirtualItem = {
-    Index: int
-    Start: int
-}
+type private ChangedFileVirtualItem = { Index: int; Start: int }
 
 type private ModalsProps = {
     IsCreateBranchModalOpen: bool
@@ -705,14 +705,9 @@ type GitSidebar =
                     Html.label [
                         prop.className "swt:flex swt:flex-col swt:gap-2"
                         prop.children [
-                            Html.span [
-                                prop.className "swt:text-sm swt:font-medium"
-                                prop.text "Save message"
-                            ]
                             Html.textarea [
                                 prop.testId "GitSidebarCommitMessageInput"
-                                prop.className
-                                    "swt:textarea swt:textarea-bordered swt:min-h-24 swt:w-full swt:resize-y"
+                                prop.className "swt:textarea swt:textarea-bordered swt:min-h-24 swt:w-full swt:resize-y"
                                 prop.disabled (not props.CanEditCommit)
                                 prop.value props.CommitMessage
                                 prop.placeholder (
@@ -776,6 +771,7 @@ type GitSidebar =
         let label, _, iconClass = GitSidebarInternal.changePresentation change
         let gitReturn = GitSidebarInternal.describeChange change
         let stopRowActivation (event: Event) = event.stopPropagation ()
+
         let triggerInteractionProps =
             createObj [
                 "onClick" ==> stopRowActivation
@@ -816,6 +812,7 @@ type GitSidebar =
     [<ReactComponent>]
     static member private ChangedFileRow(props: ChangedFileRowProps) =
         let change = props.Change
+
         let activateRow ctrlKey shiftKey =
             if not props.IsBusy then
                 props.UpdateMarkedSelection change ctrlKey shiftKey
@@ -824,7 +821,7 @@ type GitSidebar =
         Html.div [
             prop.role "listitem"
             prop.custom ("data-index", props.Index)
-            prop.ref (fun element -> props.MeasureElementRef (Option.ofObj element))
+            prop.ref (fun element -> props.MeasureElementRef(Option.ofObj element))
             prop.className "swt:absolute swt:left-0 swt:w-full"
             prop.style [
                 style.top 0
@@ -963,7 +960,9 @@ type GitSidebar =
                             prop.testId "GitSidebarChangedFilesVirtualContent"
                             prop.role "list"
                             prop.className "swt:relative swt:mt-1"
-                            prop.style [ style.height (changedFileListVirtualizer.getTotalSize ()) ]
+                            prop.style [
+                                style.height (changedFileListVirtualizer.getTotalSize ())
+                            ]
                             prop.children [
                                 for virtualItem in virtualItems do
                                     let change = props.ChangedFiles.[virtualItem.Index]
@@ -1169,7 +1168,8 @@ type GitSidebar =
             setIsOpen =
                 (fun isOpen ->
                     if not isOpen then
-                        props.CancelPendingRemoteAction ()),
+                        props.CancelPendingRemoteAction()
+                ),
             header = Html.text (props.PendingConfirmation |> Option.map _.Title |> Option.defaultValue "Confirm"),
             children =
                 Html.p [
@@ -1180,13 +1180,21 @@ type GitSidebar =
                 React.Fragment [
                     Html.button [
                         prop.className "swt:btn"
-                        prop.text (props.PendingConfirmation |> Option.map _.CancelLabel |> Option.defaultValue "Cancel")
-                        prop.onClick (fun _ -> props.CancelPendingRemoteAction ())
+                        prop.text (
+                            props.PendingConfirmation
+                            |> Option.map _.CancelLabel
+                            |> Option.defaultValue "Cancel"
+                        )
+                        prop.onClick (fun _ -> props.CancelPendingRemoteAction())
                     ]
                     Html.button [
                         prop.className "swt:btn swt:btn-primary swt:ml-auto"
-                        prop.text (props.PendingConfirmation |> Option.map _.ConfirmLabel |> Option.defaultValue "Continue")
-                        prop.onClick (fun _ -> props.ConfirmPendingRemoteAction ())
+                        prop.text (
+                            props.PendingConfirmation
+                            |> Option.map _.ConfirmLabel
+                            |> Option.defaultValue "Continue"
+                        )
+                        prop.onClick (fun _ -> props.ConfirmPendingRemoteAction())
                     ]
                 ],
             debug = "GitSidebarPendingRemoteAction"
@@ -1247,8 +1255,7 @@ type GitSidebar =
         let lfsThresholdInput, setLfsThresholdInput =
             React.useState (GitSidebarInternal.formatThresholdInput lfsAutoTrackThresholdMb)
 
-        let markedPaths, setMarkedPaths =
-            React.useStateWithUpdater Set.empty<string>
+        let markedPaths, setMarkedPaths = React.useStateWithUpdater Set.empty<string>
 
         let selectionAnchorPath, setSelectionAnchorPath =
             React.useStateWithUpdater (None: string option)
@@ -1293,14 +1300,10 @@ type GitSidebar =
             (fun () ->
                 let changedPathSet = changedFiles |> Array.map _.Path |> Set.ofArray
 
-                setMarkedPaths (fun current ->
-                    current
-                    |> Set.filter (fun path -> Set.contains path changedPathSet)
-                )
+                setMarkedPaths (fun current -> current |> Set.filter (fun path -> Set.contains path changedPathSet))
 
                 setSelectionAnchorPath (fun current ->
-                    current
-                    |> Option.filter (fun path -> Set.contains path changedPathSet)
+                    current |> Option.filter (fun path -> Set.contains path changedPathSet)
                 )
             ),
             [| box changedFiles |]

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -263,7 +263,7 @@ export const ConflictsPresent: Story = {
       "Resolve all conflicted files before pushing.",
     );
     await expect(canvasElement.querySelectorAll("[data-testid^='GitSidebarChangeRow-']")).toHaveLength(4);
-    await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("Conflict");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusButton-0")).toBeInTheDocument();
   },
 };
 
@@ -318,8 +318,11 @@ export const DeletedFile: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("Deleted");
-    await expect(canvas.getByTestId("GitSidebar")).toHaveTextContent("git: D.");
+    const modal = within(document.body);
+    await expect(canvas.getByTestId("GitSidebar")).not.toHaveTextContent("git: D.");
+    await expect(canvas.getByTestId("GitSidebar")).not.toHaveTextContent("Deleted");
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeStatusButton-0"));
+    await expect(await modal.findByTestId("popover_content_git_change_status_0")).toHaveTextContent("Git return: git: D.");
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -459,10 +459,13 @@ export const CommitComposer: Story = {
     const legacyCard = canvas.getByTestId("GitSidebarCommitSection").firstElementChild as HTMLElement;
     await expect(legacyCard).not.toHaveClass("swt:rounded-box");
     await expect(legacyCard).not.toHaveClass("swt:border");
-    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
+await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
     await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save Selected Changes");
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionButton")).toBeNull();
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionCheckbox-README.md")).toBeNull();
+    // Click again to deselect – button text should switch back to "Save All Changes"
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
+    await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save All Changes");
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -456,6 +456,9 @@ export const CommitComposer: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const legacyCard = canvas.getByTestId("GitSidebarCommitSection").firstElementChild as HTMLElement;
+    await expect(legacyCard).not.toHaveClass("swt:rounded-box");
+    await expect(legacyCard).not.toHaveClass("swt:border");
     await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
     await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save Selected Changes");
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionButton")).toBeNull();

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -233,7 +233,6 @@ export const AdvancedActions: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByTestId("GitSidebarDownloadLargeFilesCheckbox")).toBeChecked();
     await userEvent.click(canvas.getByTestId("GitSidebarAdvancedActionsButton"));
     await expect(canvas.getByTestId("GitSidebarAdvancedActionsButton")).toHaveClass("swt:btn-primary");
     await expect(canvas.getByTestId("GitSidebarAdvancedActionsDivider")).toBeInTheDocument();
@@ -243,7 +242,17 @@ export const AdvancedActions: Story = {
     await expect(canvas.getByTestId("GitSidebarFetchButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPullButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPushButton")).toBeInTheDocument();
-    await expect(canvas.getByTestId("GitSidebarLfsThresholdInput")).toHaveValue(1);
+    const downloadLargeFilesCheckbox = canvas.getByTestId("GitSidebarDownloadLargeFilesCheckbox");
+    const lfsThresholdInput = canvas.getByTestId("GitSidebarLfsThresholdInput");
+
+    await expect(downloadLargeFilesCheckbox).toBeChecked();
+    await expect(lfsThresholdInput).toHaveValue(1);
+    await expect(
+      Boolean(
+        downloadLargeFilesCheckbox.compareDocumentPosition(lfsThresholdInput) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -441,6 +441,9 @@ export const SwitchBranchModal: Story = {
     await expect(modal.getByTestId("GitSidebarSwitchBranchSelect")).toHaveTextContent(
       "main",
     );
+    await expect(modal.getByTestId("GitSidebarSwitchBranchSelect")).toHaveTextContent(
+      "origin/main",
+    );
     await userEvent.click(modal.getByTestId("GitSidebarSwitchBranchSubmit"));
   },
 };

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -449,13 +449,10 @@ export const CommitComposer: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const commitMessageInput = canvas.getByTestId("GitSidebarCommitMessageInput");
-    await userEvent.type(commitMessageInput, "Add sidebar commit action");
-    await userEvent.click(
-      canvas.getByTestId("GitSidebarCommitSelectionCheckbox-README.md"),
-    );
-    await userEvent.click(canvas.getByTestId("GitSidebarCommitSelectionButton"));
-    await expect(canvas.getByTestId("GitSidebarCommitMessageInput")).toHaveValue("");
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
+    await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save Selected Changes");
+    await expect(canvas.queryByTestId("GitSidebarCommitSelectionButton")).toBeNull();
+    await expect(canvas.queryByTestId("GitSidebarCommitSelectionCheckbox-README.md")).toBeNull();
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -21,9 +21,13 @@ const baseCallbacks = {
   OnFetch: noop,
   OnPull: noop,
   OnPush: noop,
-  OnSync: noop,
+  OnUpdateFromOnline: noop,
+  OnPrimarySaveSelection: noopWithSelection,
+  OnPrimarySaveAll: noopWithMessage,
   OnCommitSelection: noopWithSelection,
   OnCommitAll: noopWithMessage,
+  OnConfirmPendingRemoteAction: noop,
+  OnCancelPendingRemoteAction: noop,
   OnSaveDownloadLargeFiles: noopWithDownloadPreference,
   OnSaveLfsAutoTrackThreshold: noopWithThreshold,
   OnCreateBranch: noopWithArg,
@@ -233,6 +237,9 @@ export const AdvancedActions: Story = {
     await userEvent.click(canvas.getByTestId("GitSidebarAdvancedActionsButton"));
     await expect(canvas.getByTestId("GitSidebarAdvancedActionsButton")).toHaveClass("swt:btn-primary");
     await expect(canvas.getByTestId("GitSidebarAdvancedActionsDivider")).toBeInTheDocument();
+    await expect(canvas.getByTestId("GitSidebarUpdateArcButton")).toHaveTextContent("Update ARC from Online");
+    await expect(canvas.queryByTestId("GitSidebarSyncButton")).toBeNull();
+    await expect(canvas.getByTestId("GitSidebarLocalCommitButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarFetchButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPullButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPushButton")).toBeInTheDocument();
@@ -466,15 +473,15 @@ export const RemoteActionsDisabled: Story = {
     lfsAutoTrackThresholdMb: 1,
     remoteActionsEnabled: false,
     remoteActionsWarning:
-      "Sign in to a DataHub account to use fetch, pull, push, or sync.",
+      "Sign in to a DataHub account to use fetch, pull, push, or update.",
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByTestId("GitSidebarSyncButton")).toBeDisabled();
+    await expect(canvas.getByTestId("GitSidebarUpdateArcButton")).toBeDisabled();
     await expect(
       canvas.getByTestId("GitSidebarRemoteAuthWarning"),
     ).toHaveTextContent(
-      "Sign in to a DataHub account to use fetch, pull, push, or sync.",
+      "Sign in to a DataHub account to use fetch, pull, push, or update.",
     );
   },
 };

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -238,7 +238,7 @@ export const AdvancedActions: Story = {
     await expect(canvas.getByTestId("GitSidebarAdvancedActionsDivider")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarUpdateArcButton")).toHaveTextContent("Update ARC from Online");
     await expect(canvas.queryByTestId("GitSidebarSyncButton")).toBeNull();
-    await expect(canvas.getByTestId("GitSidebarLocalCommitButton")).toBeInTheDocument();
+    await expect(canvas.queryByTestId("GitSidebarLocalCommitButton")).toBeNull();
     await expect(canvas.getByTestId("GitSidebarFetchButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPullButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPushButton")).toBeInTheDocument();
@@ -468,16 +468,36 @@ export const CommitComposer: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const modal = within(document.body);
     const legacyCard = canvas.getByTestId("GitSidebarCommitSection").firstElementChild as HTMLElement;
     await expect(legacyCard).not.toHaveClass("swt:rounded-box");
     await expect(legacyCard).not.toHaveClass("swt:border");
-await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
     await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save Selected Changes");
+    await userEvent.click(canvas.getByTestId("GitSidebarSaveOptionsButton"));
+    await expect(canvas.getByTestId("GitSidebarLocalCommitButton")).toHaveTextContent(
+      "Add and commit selected Changes",
+    );
+    const sidebarBounds = canvas.getByTestId("GitSidebar").getBoundingClientRect();
+    const menuBounds = canvas.getByTestId("GitSidebarSaveOptionsMenu").getBoundingClientRect();
+    expect(menuBounds.left).toBeGreaterThanOrEqual(sidebarBounds.left);
+    expect(menuBounds.right).toBeLessThanOrEqual(sidebarBounds.right);
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionButton")).toBeNull();
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionCheckbox-README.md")).toBeNull();
     // Click again to deselect – button text should switch back to "Save All Changes"
     await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
     await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save All Changes");
+    await userEvent.click(canvas.getByTestId("GitSidebarSaveOptionsButton"));
+    await expect(canvas.getByTestId("GitSidebarLocalCommitButton")).toHaveTextContent(
+      "Add and commit all Changes",
+    );
+    await userEvent.click(canvas.getByTestId("GitSidebarSaveOptionsHelpButton"));
+    await expect(await modal.findByTestId("popover_content_GitSidebarSaveOptionsHelp")).toHaveTextContent(
+      "Save changes commits locally",
+    );
+    await expect(modal.getByTestId("popover_content_GitSidebarSaveOptionsHelp")).toHaveTextContent(
+      "Add and commit changes only writes the local Git commit",
+    );
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -326,6 +326,30 @@ export const DeletedFile: Story = {
   },
 };
 
+export const LongWrappedFile: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: [
+      {
+        Path: "src/very/long/path/that/wraps/in/the/sidebar/and/needs/a/fixed/status/icon.txt",
+        OriginalPath: undefined,
+        IndexStatus: "M",
+        WorkingTreeStatus: " ",
+        IsConflicted: false,
+      },
+    ],
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("GitSidebarChangeStatusSlot-0")).toHaveClass("swt:ml-auto");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusSlot-0")).toHaveClass("swt:shrink-0");
+  },
+};
+
 export const BusyProgressState: Story = {
   args: {
     status: baseStatus,

--- a/src/Components/src/GitSidebar/Types.fs
+++ b/src/Components/src/GitSidebar/Types.fs
@@ -52,14 +52,25 @@ type GitSidebarCreateBranchRequest = {
 
 type GitSidebarCommitSelectionRequest = { Message: string; Paths: string[] }
 
+type GitSidebarConfirmationDialog = {
+    Title: string
+    Message: string
+    ConfirmLabel: string
+    CancelLabel: string
+}
+
 type GitSidebarCallbacks = {
     OnRefresh: unit -> unit
     OnFetch: unit -> unit
     OnPull: unit -> unit
     OnPush: unit -> unit
-    OnSync: unit -> unit
+    OnUpdateFromOnline: unit -> unit
+    OnPrimarySaveSelection: GitSidebarCommitSelectionRequest -> unit
+    OnPrimarySaveAll: string -> unit
     OnCommitSelection: GitSidebarCommitSelectionRequest -> unit
     OnCommitAll: string -> unit
+    OnConfirmPendingRemoteAction: unit -> unit
+    OnCancelPendingRemoteAction: unit -> unit
     OnSaveDownloadLargeFiles: bool -> unit
     OnSaveLfsAutoTrackThreshold: int -> unit
     OnCreateBranch: GitSidebarCreateBranchRequest -> unit

--- a/src/Electron/src/Main/Git/GitAuthAdapter.fs
+++ b/src/Electron/src/Main/Git/GitAuthAdapter.fs
@@ -8,6 +8,8 @@ open Main.Bindings.SimpleGit
 
 type GitFactory = SimpleGitOptions -> ISimpleGit
 
+/// Auth material that can be applied either through simple-git config entries or spawned git commands.
+/// ConfigArgs contains `-c key=value` pairs; Environment includes non-interactive prompt suppression.
 type GitCommandAuthentication = {
     ConfigArgs: string[]
     Environment: obj
@@ -25,6 +27,8 @@ let private credentialUrlPattern =
 let private baseConfigEntries (options: SimpleGitOptions) =
     options.config |> Option.defaultValue [||]
 
+/// Converts command-line `-c key=value` pairs into simple-git config entries.
+/// Used by applyAuth so credentials stay scoped to the in-memory git instance.
 let toConfigEntries (args: string[]) =
     args
     |> Array.mapi (fun index value ->
@@ -35,10 +39,13 @@ let toConfigEntries (args: string[]) =
     )
     |> Array.choose id
 
+/// Builds a git process environment that disables terminal prompts.
+/// All Git entry points should use this so Electron never blocks waiting for credentials.
 let createNonInteractiveEnv () : obj =
     // Keep all existing environment variables and disable git interactive prompts.
     emitJsExpr () "{ ...process.env, GIT_TERMINAL_PROMPT: '0' }"
 
+/// Applies the non-interactive environment to a simple-git instance.
 let applyNonInteractiveEnv (git: ISimpleGit) = git.env (createNonInteractiveEnv ())
 
 [<Emit("Buffer.from($0, 'utf8').toString('base64')")>]
@@ -80,6 +87,8 @@ let private tryBuildScopedAuthUrl (remoteUrl: string) =
     else
         None
 
+/// Builds per-command auth config for HTTPS Git and Git LFS operations.
+/// The token is injected as scoped config and optional authenticated remote URLs; nothing is persisted to repository config.
 let buildAuthArgs (_host: string) (token: string) (remoteName: string option) (remoteUrl: string option) : string[] = [|
     let authorizationValue = buildBasicAuthorizationValue gitLabBasicAuthUsername token
 
@@ -111,6 +120,7 @@ let buildAuthArgs (_host: string) (token: string) (remoteName: string option) (r
         ()
 |]
 
+/// Creates auth data for lower-level spawned commands such as `git lfs push`.
 let createCommandAuthentication
     (host: string)
     (token: string)
@@ -122,6 +132,8 @@ let createCommandAuthentication
         Environment = createNonInteractiveEnv ()
     }
 
+/// Returns a simple-git instance with authentication config merged into the supplied base options.
+/// Use this instead of writing credentials to `.git/config`.
 let applyAuth
     (gitFactory: GitFactory)
     (baseOptions: SimpleGitOptions)
@@ -143,6 +155,7 @@ let applyAuth
 
     gitFactory scopedOptions
 
+/// Redacts bearer/basic headers and credential URLs before errors or diagnostics leave Main.
 let redactToken (text: string) : string =
     if String.IsNullOrWhiteSpace text then
         text
@@ -160,4 +173,5 @@ let redactToken (text: string) : string =
             )
         |> fun t -> credentialUrlPattern.Replace(t, "$1[REDACTED]@")
 
+/// Redacts each command argument for diagnostic output.
 let redactArgs (args: string[]) : string[] = args |> Array.map redactToken

--- a/src/Electron/src/Main/Git/GitInternals.fs
+++ b/src/Electron/src/Main/Git/GitInternals.fs
@@ -29,6 +29,8 @@ let internal syncTimeout =
         stdErr = false
     )
 
+/// Creates the standard simple-git options used by Main Git services.
+/// maxConcurrentProcesses is intentionally one to serialize commands for a repository-scoped instance.
 let internal createOptions
     (baseDir: string)
     (timeout: SimpleGitTimeoutOptions)
@@ -48,9 +50,12 @@ let internal createOptions
 
     options
 
+/// Creates a simple-git instance with non-interactive prompt suppression applied.
 let internal createGit (options: SimpleGitOptions) : ISimpleGit =
     SimpleGit.create options |> applyNonInteractiveEnv
 
+/// Converts exceptions from simple-git/spawned Git into the service-specific failure record.
+/// Messages are redacted here before they can cross IPC.
 let internal toFailure
     (classifyFailureKind: string -> 'GitFailureKind)
     (createFailure: 'GitFailureKind -> string -> 'GitFailure)
@@ -65,6 +70,7 @@ let internal toFailure
 
     createFailure (classifyFailureKind message) message
 
+/// Convenience wrapper for returning a redacted, classified failure as Result.Error.
 let internal errorResult
     (classifyFailureKind: string -> 'GitFailureKind)
     (createFailure: 'GitFailureKind -> string -> 'GitFailure)
@@ -72,6 +78,8 @@ let internal errorResult
     : Result<'T, 'GitFailure> =
     Error(toFailure classifyFailureKind createFailure error)
 
+/// Runs a simple-git operation and maps thrown exceptions into the caller's GitResult shape.
+/// Services use this boundary so validation and command failures are reported consistently.
 let internal runSimpleGit
     (toFailure: exn -> 'GitFailure)
     (operation: ISimpleGit -> JS.Promise<'T>)

--- a/src/Electron/src/Main/Git/GitLfsService.fs
+++ b/src/Electron/src/Main/Git/GitLfsService.fs
@@ -9,9 +9,11 @@ open Main.Bindings.SimpleGit
 open Main.Git.GitLfsAdapter
 open Main.Git.GitAuthAdapter
 
+/// Default timeout for interactive Git LFS commands launched by the Electron main process.
 [<Literal>]
 let DefaultTimeoutMs = 30000
 
+/// Describes whether an outbound Git push needs a separate LFS object upload before the git ref push.
 [<RequireQualifiedAccess>]
 type OutboundPushPlan =
     | SkipLfsUpload
@@ -20,6 +22,7 @@ type OutboundPushPlan =
 let private maxLfsPointerProbeBytes = 1024L
 let mutable private cachedSystemInstalled = false
 
+/// Chooses the most useful text from a Git LFS adapter result for user-facing errors.
 let extractFailureMessage (result: GitLfsResult) =
     let errorText = result.Error |> Option.ofObj |> Option.defaultValue String.Empty |> _.Trim()
     let outputText = result.Output |> Option.ofObj |> Option.defaultValue String.Empty |> _.Trim()
@@ -37,6 +40,7 @@ let private redactDiagnosticText (text: string) =
     else
         redactToken text
 
+/// Builds a GitLfsRequest with a generated request id and default timeout.
 let createRequest
     (repoPath: string)
     (command: GitLfsCommand)
@@ -51,6 +55,7 @@ let createRequest
         TimeoutMs = Some(defaultArg timeoutMs DefaultTimeoutMs)
     }
 
+/// Runs a Git LFS adapter request and normalizes unsuccessful adapter results to Result.Error.
 let run
     (request: GitLfsRequest)
     (onProgress: string -> unit)
@@ -68,9 +73,11 @@ let run
             return Error ex
     }
 
+/// Runs Git LFS without progress or cancellation hooks.
 let runSilently (request: GitLfsRequest) : JS.Promise<Result<GitLfsResult, exn>> =
     run request ignore (fun () -> false)
 
+/// Tracks a repository-relative path in Git LFS. GitService uses this during automatic large-file staging.
 let track (repoPath: string) (relativePath: string) : JS.Promise<Result<unit, string>> =
     promise {
         let! result =
@@ -83,6 +90,7 @@ let track (repoPath: string) (relativePath: string) : JS.Promise<Result<unit, st
             | Error exn -> Error exn.Message
     }
 
+/// Runs `git lfs install` for a specific repository.
 let install (repoPath: string) : JS.Promise<Result<unit, string>> =
     promise {
         let! result =
@@ -95,6 +103,7 @@ let install (repoPath: string) : JS.Promise<Result<unit, string>> =
             | Error exn -> Error exn.Message
     }
 
+/// Runs system-level Git LFS install from the Main IPC endpoint and updates the installation cache on success.
 let installSystem () : JS.Promise<Result<unit, string>> =
     promise {
         try
@@ -110,6 +119,7 @@ let installSystem () : JS.Promise<Result<unit, string>> =
             return Error ex.Message
     }
 
+/// Probes whether `git lfs` is available on PATH. The positive result is cached for the Main process lifetime.
 let isSystemInstalled () : JS.Promise<bool> =
     promise {
         if cachedSystemInstalled then
@@ -124,6 +134,7 @@ let isSystemInstalled () : JS.Promise<bool> =
             return isInstalled
     }
 
+/// Checks whether `.gitattributes` marks a path for Git LFS.
 let isTrackedByAttributes (repoRoot: string) (relativePath: string) =
     gitLfs.IsTrackedByAttributes repoRoot relativePath
 
@@ -151,6 +162,7 @@ let private tryRunRawDiagnosticCommand
                 |> Option.map (fun message -> $"Unavailable: {message}")
     }
 
+/// Collects redacted Git LFS diagnostics after an LFS upload failure so push errors are actionable.
 let collectPushDiagnostics
     (runSimpleGitRaw: (ISimpleGit -> JS.Promise<string>) -> ISimpleGit -> JS.Promise<Result<string, 'Failure>>)
     (getFailureMessage: 'Failure -> string option)
@@ -183,6 +195,7 @@ let collectPushDiagnostics
                 | sections -> Some(String.concat "\n\n" sections)
     }
 
+/// Appends optional LFS diagnostic sections to the original push failure message.
 let appendPushDiagnostics (message: string) (diagnostics: string option) =
     match diagnostics |> Option.map _.Trim() with
     | Some value when not (String.IsNullOrWhiteSpace value) ->
@@ -600,6 +613,8 @@ let private getOutboundObjectIdsFromRemoteTips
                     Error(spawnFailure revListResult)
     }
 
+/// Determines whether an upcoming git push references LFS pointer objects that must be uploaded explicitly.
+/// Tests call this directly because the planning logic has several fallbacks for older git versions.
 let planOutboundPush
     (runSimpleGitRaw: (ISimpleGit -> JS.Promise<string>) -> ISimpleGit -> JS.Promise<Result<string, 'Failure>>)
     (runSpawnedGit: GitSpawnRequest -> JS.Promise<GitSpawnResult>)
@@ -695,6 +710,8 @@ let planOutboundPush
                                         )
     }
 
+/// Uploads the exact LFS object ids needed for a push, falling back to refspec upload when the local git-lfs is older.
+/// Authentication is supplied by GitAuthAdapter and is passed only for this spawned command.
 let uploadObjects
     (runSpawnedGit: GitSpawnRequest -> JS.Promise<GitSpawnResult>)
     (commandAuth: GitCommandAuthentication)

--- a/src/Electron/src/Main/Git/GitProvisioningService.fs
+++ b/src/Electron/src/Main/Git/GitProvisioningService.fs
@@ -90,6 +90,8 @@ let private tryGetExistingPathKind (pathValue: string) : JS.Promise<Result<Exist
 let private tryGetExistingPathKindNoFollow (pathValue: string) : JS.Promise<Result<ExistingPathKind option, exn>> =
     tryGetExistingPathKindWithStats lstatAsync pathValue
 
+/// Validates a user-selected repository path and normalizes it with the supplied resolver.
+/// Kept injectable so validation tests can avoid depending on OS path resolution.
 let validateAndNormalizeTargetPathWithResolver
     (resolvePath: string -> string)
     (targetPath: string)
@@ -110,6 +112,7 @@ let validateAndNormalizeTargetPathWithResolver
         with error ->
             Error(exn $"Target path could not be normalized: {error.Message}")
 
+/// Classifies whether a clone destination may be used by the provisioning flow.
 let classifyCloneTargetState (directoryExists: bool) (entryCount: int) : CloneTargetState =
     if directoryExists && entryCount > 0 then
         CloneTargetState.ExistingNonEmpty
@@ -118,6 +121,7 @@ let classifyCloneTargetState (directoryExists: bool) (entryCount: int) : CloneTa
     else
         CloneTargetState.Missing
 
+/// Enforces clone's strict "missing or empty directory only" destination rule.
 let ensureCloneTargetIsEmpty (state: CloneTargetState) : Result<unit, exn> =
     match state with
     | CloneTargetState.ExistingNonEmpty ->
@@ -126,6 +130,7 @@ let ensureCloneTargetIsEmpty (state: CloneTargetState) : Result<unit, exn> =
     | CloneTargetState.Missing ->
         Ok ()
 
+/// Converts an optional validated branch name into simple-git clone arguments.
 let buildCloneBranchOptions (branch: string option) : string[] =
     match branch with
     | None -> [||]
@@ -270,6 +275,8 @@ let private persistCloneDownloadPreference
         })
         repoGit
 
+/// Initializes a Git repository at a user-selected path.
+/// This is path-driven provisioning: it does not require an active ARC window and returns the normalized repository path.
 let initRepository (targetPath: string) : JS.Promise<GitService.GitResult<string>> =
     promise {
         match validateAndNormalizeTargetPathWithResolver resolveAbsolutePath targetPath with
@@ -329,6 +336,9 @@ let initRepository (targetPath: string) : JS.Promise<GitService.GitResult<string
                 return errorResult error
     }
 
+/// Clones a remote repository into a missing or empty target directory.
+/// If a token is available for the remote host, the clone and optional LFS hydration run authenticated; otherwise clone runs unauthenticated.
+/// The DownloadLargeFiles flag persists the repo preference and, when true, runs `git lfs pull` after clone.
 let cloneRepository
     (remoteUrl: string)
     (targetPath: string)

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -1800,28 +1800,43 @@ let addRemote (arcPath: string) (remoteName: string) (remoteUrl: string) : JS.Pr
                     })
 }
 
-let checkoutBranch (arcPath: string) (branchName: string) : JS.Promise<GitResult<unit>> = promise {
-    match ensureValidBranchLikeName "Branch name" branchName with
-    | Error branchError -> return errorResult branchError
-    | Ok safeBranchName ->
-        return!
-            withLocalGit
-                arcPath
-                (fun git -> promise {
-                    let! localBranches = git.branchLocal ()
-                    let branches = valueOrEmptyArray localBranches.all
+let checkoutBranch (arcPath: string) (request: GitCheckoutBranchRequest) : JS.Promise<GitResult<unit>> =
+    promise {
+        match ensureValidBranchLikeName "Branch name" request.Name with
+        | Error branchError -> return errorResult branchError
+        | Ok safeBranchName ->
+            match request.StartPoint with
+            | Some startPoint ->
+                match ensureValidBranchLikeName "Start point" startPoint with
+                | Error startPointError -> return errorResult startPointError
+                | Ok safeStartPoint ->
+                    return!
+                        withLocalGit
+                            arcPath
+                            (fun git -> promise {
+                                let! _ = git.checkoutBranch (safeBranchName, safeStartPoint)
+                                do! reconcileTrackingBranchForCheckout "origin" safeBranchName git
+                                return ()
+                            })
+            | None ->
+                return!
+                    withLocalGit
+                        arcPath
+                        (fun git -> promise {
+                            let! localBranches = git.branchLocal ()
+                            let branches = valueOrEmptyArray localBranches.all
 
-                    let exists =
-                        branches
-                        |> Array.exists (fun existing ->
-                            String.Equals(existing, safeBranchName, StringComparison.Ordinal)
-                        )
+                            let exists =
+                                branches
+                                |> Array.exists (fun existing ->
+                                    String.Equals(existing, safeBranchName, StringComparison.Ordinal)
+                                )
 
-                    if not exists then
-                        return abortGitPromise $"Branch '{safeBranchName}' does not exist in the local repository."
+                            if not exists then
+                                return abortGitPromise $"Branch '{safeBranchName}' does not exist in the local repository."
 
-                    let! _ = git.checkout (safeBranchName)
-                    do! reconcileTrackingBranchForCheckout "origin" safeBranchName git
-                    return ()
-                })
-}
+                            let! _ = git.checkout (safeBranchName)
+                            do! reconcileTrackingBranchForCheckout "origin" safeBranchName git
+                            return ()
+                        })
+    }

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -1296,6 +1296,109 @@ let fetch
                 return result
     }
 
+let previewPull
+    (arcPath: string)
+    (remoteName: string option)
+    (branchName: string option)
+    (progressCallback: GitProgressCallback option)
+    : JS.Promise<GitResult<GitPullPreflightResult>> =
+    promise {
+        match validateRemoteName (remoteName |> Option.defaultValue "origin") with
+        | Error remoteError -> return errorResult remoteError
+        | Ok safeRemoteName ->
+            match validateOptionalBranchName branchName with
+            | Error branchError -> return errorResult branchError
+            | Ok safeBranchName ->
+                return!
+                    withAuthenticatedGit
+                        arcPath
+                        safeRemoteName
+                        progressCallback
+                        (fun git -> promise {
+                            match safeBranchName with
+                            | None ->
+                                let! _ = git.fetch safeRemoteName
+                                ()
+                            | Some safeBranch ->
+                                let! _ = git.fetch (safeRemoteName, safeBranch)
+                                ()
+
+                            let! status = git.status ()
+
+                            let currentBranch =
+                                status.current
+                                |> Option.bind Option.ofObj
+                                |> Option.map _.Trim()
+                                |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
+                            match status.detached, currentBranch with
+                            | true, _
+                            | _, None ->
+                                return {
+                                    Status = GitPullPreflightStatus.Indeterminate
+                                    Message = Some "Cannot preview pull for a detached HEAD."
+                                }
+                            | false, Some _ ->
+                                let upstreamRef =
+                                    safeBranchName
+                                    |> Option.map (fun safeBranch -> $"{safeRemoteName}/{safeBranch}")
+                                    |> Option.orElseWith (fun () ->
+                                        status.tracking
+                                        |> Option.bind Option.ofObj
+                                        |> Option.map _.Trim()
+                                        |> Option.filter (String.IsNullOrWhiteSpace >> not)
+                                    )
+
+                                match upstreamRef with
+                                | None ->
+                                    return {
+                                        Status = GitPullPreflightStatus.Indeterminate
+                                        Message =
+                                            Some "No upstream tracking branch is configured for the current branch."
+                                    }
+                                | Some resolvedUpstreamRef ->
+                                    let! mergeTreeResult =
+                                        runGitCaptured {
+                                            WorkingDirectory = Some arcPath
+                                            Arguments = [| "merge-tree"; "--write-tree"; "HEAD"; resolvedUpstreamRef |]
+                                            Environment = None
+                                            StandardInput = None
+                                            TimeoutMs = Some 30000
+                                        }
+
+                                    if mergeTreeResult.ExitCode = 0 then
+                                        return {
+                                            Status = GitPullPreflightStatus.SafeToPull
+                                            Message = None
+                                        }
+                                    else
+                                        let diagnosticText =
+                                            $"{mergeTreeResult.StdoutText}\n{mergeTreeResult.StderrText}"
+
+                                        let normalizedDiagnostic = diagnosticText.ToLowerInvariant()
+
+                                        if
+                                            normalizedDiagnostic.Contains("conflict")
+                                            || normalizedDiagnostic.Contains("merge conflict")
+                                        then
+                                            return {
+                                                Status = GitPullPreflightStatus.WouldRequireMergeResolution
+                                                Message = Some "Pulling would require merge resolution."
+                                            }
+                                        else
+                                            let trimmedDiagnostic = diagnosticText.Trim()
+
+                                            return {
+                                                Status = GitPullPreflightStatus.Indeterminate
+                                                Message =
+                                                    if String.IsNullOrWhiteSpace trimmedDiagnostic then
+                                                        Some "Git pull preflight could not be classified safely."
+                                                    else
+                                                        Some $"Git pull preflight could not be classified safely: {trimmedDiagnostic}"
+                                            }
+                        })
+    }
+
 let pull
     (arcPath: string)
     (remoteName: string option)

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -952,7 +952,7 @@ let private createAuthenticatedGitSession
         let! remoteResult =
             runSimpleGit
                 (fun git -> promise {
-                    let! remoteUrl = git.raw [| "remote"; "get-url"; remoteName |]
+                    let! remoteUrl = git.raw [| "config"; "--get"; $"remote.{remoteName}.url" |]
                     return remoteUrl.Trim()
                 })
                 probeGit
@@ -1309,94 +1309,99 @@ let previewPull
             match validateOptionalBranchName branchName with
             | Error branchError -> return errorResult branchError
             | Ok safeBranchName ->
-                return!
-                    withAuthenticatedGit
-                        arcPath
-                        safeRemoteName
-                        progressCallback
-                        (fun git -> promise {
-                            match safeBranchName with
-                            | None ->
-                                let! _ = git.fetch safeRemoteName
-                                ()
-                            | Some safeBranch ->
-                                let! _ = git.fetch (safeRemoteName, safeBranch)
-                                ()
+                let! statusResult = withLocalGit arcPath (fun git -> git.status ())
 
-                            let! status = git.status ()
+                match statusResult with
+                | Error failure -> return Error failure
+                | Ok status ->
+                    let currentBranch =
+                        status.current
+                        |> Option.bind Option.ofObj
+                        |> Option.map _.Trim()
+                        |> Option.filter (String.IsNullOrWhiteSpace >> not)
 
-                            let currentBranch =
-                                status.current
+                    match status.detached, currentBranch with
+                    | true, _
+                    | _, None ->
+                        return
+                            Ok {
+                                Status = GitPullPreflightStatus.Indeterminate
+                                Message = Some "Cannot preview pull for a detached HEAD."
+                            }
+                    | false, Some _ ->
+                        let upstreamRef =
+                            safeBranchName
+                            |> Option.map (fun safeBranch -> $"{safeRemoteName}/{safeBranch}")
+                            |> Option.orElseWith (fun () ->
+                                status.tracking
                                 |> Option.bind Option.ofObj
                                 |> Option.map _.Trim()
                                 |> Option.filter (String.IsNullOrWhiteSpace >> not)
+                            )
 
-                            match status.detached, currentBranch with
-                            | true, _
-                            | _, None ->
-                                return {
+                        match upstreamRef with
+                        | None ->
+                            return
+                                Ok {
                                     Status = GitPullPreflightStatus.Indeterminate
-                                    Message = Some "Cannot preview pull for a detached HEAD."
+                                    Message =
+                                        Some "No upstream tracking branch is configured for the current branch."
                                 }
-                            | false, Some _ ->
-                                let upstreamRef =
-                                    safeBranchName
-                                    |> Option.map (fun safeBranch -> $"{safeRemoteName}/{safeBranch}")
-                                    |> Option.orElseWith (fun () ->
-                                        status.tracking
-                                        |> Option.bind Option.ofObj
-                                        |> Option.map _.Trim()
-                                        |> Option.filter (String.IsNullOrWhiteSpace >> not)
-                                    )
+                        | Some resolvedUpstreamRef ->
+                            return!
+                                withAuthenticatedGit
+                                    arcPath
+                                    safeRemoteName
+                                    progressCallback
+                                    (fun git -> promise {
+                                        match safeBranchName with
+                                        | None ->
+                                            let! _ = git.fetch safeRemoteName
+                                            ()
+                                        | Some safeBranch ->
+                                            let! _ = git.fetch (safeRemoteName, safeBranch)
+                                            ()
 
-                                match upstreamRef with
-                                | None ->
-                                    return {
-                                        Status = GitPullPreflightStatus.Indeterminate
-                                        Message =
-                                            Some "No upstream tracking branch is configured for the current branch."
-                                    }
-                                | Some resolvedUpstreamRef ->
-                                    let! mergeTreeResult =
-                                        runGitCaptured {
-                                            WorkingDirectory = Some arcPath
-                                            Arguments = [| "merge-tree"; "--write-tree"; "HEAD"; resolvedUpstreamRef |]
-                                            Environment = None
-                                            StandardInput = None
-                                            TimeoutMs = Some 30000
-                                        }
+                                        let! mergeTreeResult =
+                                            runGitCaptured {
+                                                WorkingDirectory = Some arcPath
+                                                Arguments = [| "merge-tree"; "--write-tree"; "HEAD"; resolvedUpstreamRef |]
+                                                Environment = None
+                                                StandardInput = None
+                                                TimeoutMs = Some 30000
+                                            }
 
-                                    if mergeTreeResult.ExitCode = 0 then
-                                        return {
-                                            Status = GitPullPreflightStatus.SafeToPull
-                                            Message = None
-                                        }
-                                    else
-                                        let diagnosticText =
-                                            $"{mergeTreeResult.StdoutText}\n{mergeTreeResult.StderrText}"
-
-                                        let normalizedDiagnostic = diagnosticText.ToLowerInvariant()
-
-                                        if
-                                            normalizedDiagnostic.Contains("conflict")
-                                            || normalizedDiagnostic.Contains("merge conflict")
-                                        then
+                                        if mergeTreeResult.ExitCode = 0 then
                                             return {
-                                                Status = GitPullPreflightStatus.WouldRequireMergeResolution
-                                                Message = Some "Pulling would require merge resolution."
+                                                Status = GitPullPreflightStatus.SafeToPull
+                                                Message = None
                                             }
                                         else
-                                            let trimmedDiagnostic = diagnosticText.Trim()
+                                            let diagnosticText =
+                                                $"{mergeTreeResult.StdoutText}\n{mergeTreeResult.StderrText}"
 
-                                            return {
-                                                Status = GitPullPreflightStatus.Indeterminate
-                                                Message =
-                                                    if String.IsNullOrWhiteSpace trimmedDiagnostic then
-                                                        Some "Git pull preflight could not be classified safely."
-                                                    else
-                                                        Some $"Git pull preflight could not be classified safely: {trimmedDiagnostic}"
-                                            }
-                        })
+                                            let normalizedDiagnostic = diagnosticText.ToLowerInvariant()
+
+                                            if
+                                                normalizedDiagnostic.Contains("conflict")
+                                                || normalizedDiagnostic.Contains("merge conflict")
+                                            then
+                                                return {
+                                                    Status = GitPullPreflightStatus.WouldRequireMergeResolution
+                                                    Message = Some "Pulling would require merge resolution."
+                                                }
+                                            else
+                                                let trimmedDiagnostic = diagnosticText.Trim()
+
+                                                return {
+                                                    Status = GitPullPreflightStatus.Indeterminate
+                                                    Message =
+                                                        if String.IsNullOrWhiteSpace trimmedDiagnostic then
+                                                            Some "Git pull preflight could not be classified safely."
+                                                        else
+                                                            Some $"Git pull preflight could not be classified safely: {trimmedDiagnostic}"
+                                                }
+                                    })
     }
 
 let pull

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -21,14 +21,17 @@ type GitFailure = {
     Message: string
 }
 
+/// Internal result type returned by Main Git services before IPC maps it to shared DTOs.
 type GitResult<'T> = Result<'T, GitFailure>
 
+/// Resolved push target used by push workflow and tests to decide refspec/upstream behavior.
 type GitPushTarget = {
     RefSpec: string
     PushBranch: string
     SetUpstream: bool
 }
 
+/// Pull result payload. Warning is reserved for recoverable follow-up issues such as LFS hydration failures.
 type GitPullResult = { Warning: GitFailure option }
 
 type GitProgressCallback = GitInternals.GitProgressCallback
@@ -58,6 +61,7 @@ let private lfsInstallRequiredTokens =
         "clean filter 'lfs' failed"
     |]
 
+/// Classifies git/simple-git/LFS error text into the shared failure taxonomy used over IPC.
 let classifyFailureKind (message: string) =
     let normalizedMessage =
         message
@@ -209,6 +213,7 @@ let private tryGetFileSizeInBytes (absolutePath: string) : JS.Promise<int64 opti
             | _ -> return raise error
     }
 
+/// Validates local branch names and branch-like start points before passing them to git.
 let ensureValidBranchLikeName (label: string) (value: string) =
     let trimmed = value.Trim()
     let containsControlCharacter = trimmed |> Seq.exists Char.IsControl
@@ -238,6 +243,7 @@ let ensureValidBranchLikeName (label: string) (value: string) =
     else
         Ok trimmed
 
+/// Validates renderer-provided pathspecs as ARC-relative paths before file or git access.
 let ensureValidPathspec (pathSpec: string) =
     let normalized = pathSpec.Replace("\\", "/").Trim()
 
@@ -257,6 +263,7 @@ let ensureValidPathspec (pathSpec: string) =
     else
         Ok normalized
 
+/// Validates a non-empty pathspec array and returns normalized pathspecs for git commands.
 let validatePathspecs (pathSpecs: string[]) =
     if isNull pathSpecs || pathSpecs.Length = 0 then
         Error(exn "At least one pathspec is required.")
@@ -272,6 +279,7 @@ let validatePathspecs (pathSpecs: string[]) =
             )
             (Ok [||])
 
+/// Validates a remote name and defaults blank input to `origin`.
 let validateRemoteName (remoteName: string) =
     let normalized =
         remoteName
@@ -285,6 +293,7 @@ let validateRemoteName (remoteName: string) =
     else
         Error(exn "Remote name contains unsupported characters.")
 
+/// Enforces Swate's remote URL policy before clone/add-remote/auth lookup.
 let ensureAllowedRemoteUrl (remoteUrl: string) =
     let normalized = remoteUrl.Trim()
 
@@ -317,6 +326,7 @@ let private unsupportedGitContentResult<'T> (path: string) : GitResult<'T> =
         Message = unsupportedGitContentMessage path
     }
 
+/// Converts the service's unsupported-content sentinel into a DTO that IPC can return without throwing.
 let tryGetUnsupportedGitContent (requestedPath: string) (failure: GitFailure) : GitUnsupportedContentDto option =
     if String.Equals(failure.Message, unsupportedGitContentMessage requestedPath, StringComparison.Ordinal) then
         Some {
@@ -579,6 +589,8 @@ let private normalizeOptionalGitRef (value: string option) =
     |> Option.map _.Trim()
     |> Option.filter (fun item -> not (String.IsNullOrWhiteSpace item))
 
+/// Resolves the branch/refspec to push and whether `--set-upstream` should be used.
+/// Exposed for tests because this policy affects new-branch publishing behavior.
 let resolvePushTarget
     (requestedBranchName: string option)
     (currentBranch: string option)
@@ -1021,6 +1033,7 @@ let private withAuthenticatedGit
         | Ok session -> return! runSimpleGit operation session.Git
     }
 
+/// Reads status for the active ARC repository, including conflict metadata used by the sidebar and merge UI.
 let getStatus (arcPath: string) : JS.Promise<GitResult<GitStatusDto>> =
     withLocalGit
         arcPath
@@ -1029,6 +1042,7 @@ let getStatus (arcPath: string) : JS.Promise<GitResult<GitStatusDto>> =
             return toStatusDto arcPath status
         })
 
+/// Lists local and remote branch refs for the sidebar branch picker.
 let getBranches (arcPath: string) : JS.Promise<GitResult<GitBranchRefDto[]>> =
     withLocalGit
         arcPath
@@ -1081,7 +1095,7 @@ let getBranches (arcPath: string) : JS.Promise<GitResult<GitBranchRefDto[]>> =
                 )
         })
 
-// GitService exposes LFS settings because the sidebar consumes them as part of the git workflow configuration surface.
+/// Exposes persisted LFS workflow settings consumed by the Git sidebar.
 let getLfsSettings (arcPath: string) : JS.Promise<GitResult<GitLfsSettingsDto>> =
     withLocalGit
         arcPath
@@ -1095,6 +1109,7 @@ let getLfsSettings (arcPath: string) : JS.Promise<GitResult<GitLfsSettingsDto>> 
             }
         })
 
+/// Returns aggregate unstaged diff counts for the active ARC repository.
 let getDiffSummary (arcPath: string) : JS.Promise<GitResult<GitDiffSummaryDto>> =
     withLocalGit
         arcPath
@@ -1108,6 +1123,7 @@ let getDiffSummary (arcPath: string) : JS.Promise<GitResult<GitDiffSummaryDto>> 
             }
         })
 
+/// Returns raw `git diff` text for validated pathspecs. Used by tests and lower-level consumers.
 let getDiff (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<string>> = promise {
     match validatePathspecs pathSpecs with
     | Error validationError -> return errorResult validationError
@@ -1122,6 +1138,7 @@ let getDiff (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<strin
                 })
 }
 
+/// Returns porcelain word-diff text for validated pathspecs.
 let getWordDiff (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<string>> = promise {
     match validatePathspecs pathSpecs with
     | Error validationError -> return errorResult validationError
@@ -1143,6 +1160,8 @@ let getWordDiff (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<s
                 })
 }
 
+/// Loads previous/current text plus word-diff metadata for the renderer diff view.
+/// Binary or explicitly unsupported files return the unsupported-content sentinel.
 let getDiffViewData (arcPath: string) (requestedPath: string) : JS.Promise<GitResult<GitDiffViewDataDto>> = promise {
     match ensureValidPathspec requestedPath with
     | Error validationError -> return errorResult validationError
@@ -1232,6 +1251,7 @@ let getDiffViewData (arcPath: string) (requestedPath: string) : JS.Promise<GitRe
                     })
 }
 
+/// Loads the current conflicted file content for the merge-resolution view.
 let getMergeConflictViewData (arcPath: string) (requestedPath: string) : JS.Promise<GitResult<GitMergeConflictViewDataDto>> = promise {
     match ensureValidPathspec requestedPath with
     | Error validationError -> return errorResult validationError
@@ -1265,6 +1285,7 @@ let getMergeConflictViewData (arcPath: string) (requestedPath: string) : JS.Prom
                     })
 }
 
+/// Fetches from a validated remote using the configured token provider and optional progress callback.
 let fetch
     (arcPath: string)
     (remoteName: string option)
@@ -1296,6 +1317,8 @@ let fetch
                 return result
     }
 
+/// Fetches and runs a merge-tree preflight to classify whether pull is likely safe or requires merge resolution.
+/// Renderer workflow uses this before "update from online" actions.
 let previewPull
     (arcPath: string)
     (remoteName: string option)
@@ -1404,6 +1427,8 @@ let previewPull
                                     })
     }
 
+/// Pulls from a validated remote using token-backed auth and the repository LFS download preference.
+/// When large-file download is enabled, LFS content is hydrated after the git pull.
 let pull
     (arcPath: string)
     (remoteName: string option)
@@ -1450,6 +1475,8 @@ let pull
                 return result
     }
 
+/// Coordinates LFS upload planning, optional LFS upload, and the final git push.
+/// Kept separately testable because it controls when git hooks are skipped after an explicit LFS upload.
 let executePushWorkflow
     (pushTarget: GitPushTarget)
     (buildOutboundPlan: unit -> JS.Promise<Result<OutboundPushPlan, GitFailure>>)
@@ -1481,7 +1508,7 @@ let executePushWorkflow
                     }
     }
 
-// Push keeps LFS planning and optional upload here because they are part of the repository push workflow.
+/// Pushes the current or requested branch, uploading referenced LFS objects first when needed.
 let push
     (arcPath: string)
     (remoteName: string option)
@@ -1566,7 +1593,7 @@ let push
                                         git)
     }
 
-// GitService writes LFS settings because the threshold is a git workflow policy setting owned by this service.
+/// Persists Git workflow LFS settings in local repository config.
 let setLfsSettings (arcPath: string) (settings: GitLfsSettingsDto) : JS.Promise<GitResult<unit>> =
     promise {
         match validateLfsThresholdMb settings.AutoTrackThresholdMb with
@@ -1596,7 +1623,7 @@ let setLfsSettings (arcPath: string) (settings: GitLfsSettingsDto) : JS.Promise<
                     })
     }
 
-// Staging keeps automatic LFS enforcement here because the decision must happen immediately after normal git add updates the index.
+/// Stages validated pathspecs and auto-tracks oversized selected files in Git LFS before restaging.
 let stagePaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<unit>> = promise {
     match validatePathspecs pathSpecs with
     | Error validationError -> return errorResult validationError
@@ -1614,6 +1641,7 @@ let stagePaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<un
                 })
 }
 
+/// Unstages validated pathspecs with a mixed reset while leaving working tree files unchanged.
 let unstagePaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<unit>> = promise {
     match validatePathspecs pathSpecs with
     | Error validationError -> return errorResult validationError
@@ -1629,7 +1657,7 @@ let unstagePaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<
                 })
 }
 
-// Commit validates the staged index only and never mutates staging.
+/// Commits the current index after validating the commit message and staged LFS policy.
 let commit (arcPath: string) (message: string) : JS.Promise<GitResult<string>> = promise {
     let normalizedMessage = message.Trim()
 
@@ -1656,6 +1684,8 @@ let commit (arcPath: string) (message: string) : JS.Promise<GitResult<string>> =
                 })
 }
 
+/// Writes resolved merge-conflict content, stages it, and optionally commits when no conflicts remain.
+/// The expected content guard prevents overwriting a file that changed since the renderer opened the conflict view.
 let confirmMergeResolution
     (arcPath: string)
     (requestedPath: string)
@@ -1742,6 +1772,8 @@ let confirmMergeResolution
                         })
     }
 
+/// Creates and checks out a new local branch, optionally from a validated start point.
+/// Tracking is reconciled against `origin/<branch>` when that remote branch exists.
 let createBranch (arcPath: string) (branchName: string) (startPoint: string option) : JS.Promise<GitResult<unit>> = promise {
     match ensureValidBranchLikeName "Branch name" branchName with
     | Error branchError -> return errorResult branchError
@@ -1770,6 +1802,7 @@ let createBranch (arcPath: string) (branchName: string) (startPoint: string opti
                         })
 }
 
+/// Adds a new validated remote to the active ARC repository.
 let addRemote (arcPath: string) (remoteName: string) (remoteUrl: string) : JS.Promise<GitResult<unit>> = promise {
     match validateRemoteName remoteName with
     | Error remoteError -> return errorResult remoteError
@@ -1800,6 +1833,8 @@ let addRemote (arcPath: string) (remoteName: string) (remoteUrl: string) : JS.Pr
                     })
 }
 
+/// Checks out an existing local branch, or creates/checks out a local branch from StartPoint.
+/// Renderer passes remote branch switches as Name=<local name>, StartPoint=<remote ref>.
 let checkoutBranch (arcPath: string) (request: GitCheckoutBranchRequest) : JS.Promise<GitResult<unit>> =
     promise {
         match ensureValidBranchLikeName "Branch name" request.Name with

--- a/src/Electron/src/Main/Git/GitTokenProvider.fs
+++ b/src/Electron/src/Main/Git/GitTokenProvider.fs
@@ -3,17 +3,22 @@ module Main.Git.GitTokenProvider
 open System
 open Fable.Core
 
+/// Main-process hook used by Git services to resolve an access token for a remote host.
+/// AuthService installs the active provider after sign-in; tests and startup code can reset it to the default provider.
 type GitTokenProvider = { TryGetAccessToken: string -> JS.Promise<string option> }
 
+/// Provider used when no account is active. Returning None keeps clone unauthenticated and makes authenticated sync fail clearly.
 let defaultTokenProvider: GitTokenProvider = {
     TryGetAccessToken = (fun _ -> promise { return None })
 }
 
 let mutable private activeTokenProvider: GitTokenProvider = defaultTokenProvider
 
+/// Replaces the process-wide token source used by subsequent Git operations.
 let setTokenProvider (provider: GitTokenProvider) =
     activeTokenProvider <- provider
 
+/// Resolves a token for a normalized host name. Callers decide whether None is allowed for their operation.
 let tryGetAccessToken (host: string) : JS.Promise<string option> =
     activeTokenProvider.TryGetAccessToken host
 
@@ -25,6 +30,8 @@ let private tryExtractHostFromAbsoluteUri (remoteUrl: string) =
     else
         Error(exn $"Remote URL '{remoteUrl}' is not a valid absolute URI.")
 
+/// Extracts the lowercase host from supported HTTPS/SSH remote URLs before token lookup.
+/// SCP-style SSH URLs are intentionally rejected by the shared remote URL policy.
 let tryExtractHostFromRemoteUrl (remoteUrl: string) : Result<string, exn> =
     let normalized = remoteUrl.Trim()
 

--- a/src/Electron/src/Main/Git/GitlfsAdapter.fs
+++ b/src/Electron/src/Main/Git/GitlfsAdapter.fs
@@ -9,6 +9,7 @@ open Main.Bindings.Node
 [<Literal>]
 let private repoValidationTimeoutMs = 5000
 
+/// Low-level spawned `git` request used when simple-git cannot stream or feed stdin in the shape needed by LFS planning.
 type GitSpawnRequest = {
     WorkingDirectory: string option
     Arguments: string[]
@@ -17,6 +18,7 @@ type GitSpawnRequest = {
     TimeoutMs: int option
 }
 
+/// Captured process result for spawned git commands, including raw stdout for binary-safe batch parsing.
 type GitSpawnResult = {
     ExitCode: int
     StdoutBuffer: obj
@@ -25,6 +27,7 @@ type GitSpawnResult = {
     TimedOut: bool
 }
 
+/// Runs `git` without a shell and captures stdout/stderr for callers that need exact output or stdin support.
 let runGitCaptured (request: GitSpawnRequest) : Promise<GitSpawnResult> =
     promise {
         let! result =
@@ -116,6 +119,8 @@ let runGitCaptured (request: GitSpawnRequest) : Promise<GitSpawnResult> =
         return result
     }
 
+/// Runs a small git command and returns stdout text, or None on command failure.
+/// Used for feature probes where failure should not surface as a user-facing Git error.
 let tryExecGitText
     (workingDirectory: string option)
     (timeoutMs: int)
@@ -155,6 +160,7 @@ let tryExecGitText
     }
 
 
+/// Adapter contract for Git LFS commands. Main services depend on this shape instead of direct child-process calls.
 type IGitLfs =
     abstract Run:
         request: GitLfsRequest -> onProgress: (string -> unit) -> cancel: (unit -> bool) -> Promise<GitLfsResult>
@@ -420,7 +426,8 @@ type NodeGitLfsAdapter() =
 
 
 
+/// Factory for the default Node-backed Git LFS adapter.
 let gitLfsAdapter () : IGitLfs = NodeGitLfsAdapter() :> IGitLfs
 
-// Adapter instance
+/// Process-wide adapter instance used by GitLfsService.
 let gitLfs = gitLfsAdapter ()

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -1,6 +1,7 @@
 module Main.IPC.IGitApi
 
 open System
+open System.Text.RegularExpressions
 open Swate.Electron.Shared.IPCTypes
 open Swate.Electron.Shared.GitTypes
 open Fable.Core
@@ -9,6 +10,37 @@ open Fable.Electron.Main
 open Fable.Electron.Remoting.Main
 open Main
 open Main.Git
+open Main.Git.GitLfsAdapter
+
+let private versionPattern = Regex(@"(\d+)\.(\d+)(?:\.(\d+))?")
+
+let private isAtLeast (major, minor, patch) (minMajor, minMinor, minPatch) =
+    major > minMajor
+    || (major = minMajor && minor > minMinor)
+    || (major = minMajor && minor = minMinor && patch >= minPatch)
+
+let private hasMinVersion minimum (output: string option) =
+    let m = versionPattern.Match(defaultArg output "")
+
+    if m.Success then
+        isAtLeast
+            (Int32.Parse m.Groups.[1].Value,
+             Int32.Parse m.Groups.[2].Value,
+             if m.Groups.[3].Success then Int32.Parse m.Groups.[3].Value else 0)
+            minimum
+    else
+        false
+
+let private checkGitVersions () = promise {
+    let! gitVersion = tryExecGitText None 5000 [| "--version" |]
+    let! gitLfsVersion = tryExecGitText None 5000 [| "lfs"; "--version" |]
+
+    return
+        if hasMinVersion (2, 32, 0) gitVersion && hasMinVersion (3, 7, 0) gitLfsVersion then
+            Ok()
+        else
+            Error(exn "Swate requires Git 2.32.0+ and Git LFS 3.7.0+ (`git lfs --version`).")
+}
 
 let private toGitOperationResult
     (successMessage: 'T -> string option)
@@ -70,6 +102,7 @@ let private createGitProgressReporter (vault: ArcVault) : GitService.GitProgress
         }
 
 let api: IGitApi = {
+    checkGitVersions = fun (_event: IpcMainEvent) -> checkGitVersions ()
     getGitStatus =
         fun (event: IpcMainEvent) -> promise {
             match tryGetVaultAndArcPath event with

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -353,7 +353,7 @@ let api: IGitApi = {
                     withBusyWriting
                         vault
                         (fun () -> promise {
-                            let! result = GitService.checkoutBranch arcPath request.Name
+                            let! result = GitService.checkoutBranch arcPath request
                             do! vault.RefreshFileTree()
 
                             return

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -103,6 +103,18 @@ let api: IGitApi = {
                 | Ok settings -> return Ok settings
                 | Error failure -> return Error(exn $"git lfs settings failed ({failure.Kind}): {failure.Message}")
         }
+    previewGitPull =
+        fun (event: IpcMainEvent) (request: GitRemoteOperationRequest) -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(vault, arcPath) ->
+                let progressReporter = createGitProgressReporter vault
+                let! result = GitService.previewPull arcPath request.Remote request.Branch (Some progressReporter)
+
+                match result with
+                | Ok preview -> return Ok preview
+                | Error failure -> return Error(exn $"git pull preview failed ({failure.Kind}): {failure.Message}")
+        }
     getGitDiffSummary =
         fun (event: IpcMainEvent) -> promise {
             match tryGetVaultAndArcPath event with

--- a/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
@@ -2,6 +2,8 @@ module Renderer.Components.LeftSidebar.GitSidebarPanel
 
 open Feliz
 
+let mutable private gitVersionCheckStarted = false
+
 [<ReactComponent>]
 let Main () =
 
@@ -10,6 +12,17 @@ let Main () =
     let pageStateCtx = Renderer.Context.PageStateContext.usePageStateCtx ()
     let runStatus = Renderer.Context.GitWorkflow.currentRunStatus gitStateCtx.state
     let remoteProjectName, setRemoteProjectName = React.useState ""
+
+    React.useEffectOnce (fun () ->
+        if not gitVersionCheckStarted then
+            gitVersionCheckStarted <- true
+
+            Renderer.GitApiClient.checkGitVersions ()
+            |> Promise.map (function
+                | Ok () -> ()
+                | Error message -> Browser.Dom.window.alert message)
+            |> ignore
+    )
 
     let remoteActionsEnabled =
         authState.UsableActiveUser().IsSome

--- a/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
@@ -18,7 +18,7 @@ let Main () =
         if remoteActionsEnabled then
             None
         else
-            Some "Sign in to a DataHub account to use fetch, pull, push, sync, and remote bootstrap."
+            Some "Sign in to a DataHub account to use fetch, pull, push, update, and remote bootstrap."
 
     let normalizedRemoteProjectName =
         remoteProjectName.Trim()
@@ -104,14 +104,19 @@ let Main () =
             ?selectedFile = gitStateCtx.state.SelectedChangePath,
             ?errorNotice = gitStateCtx.state.ErrorNotice,
             ?warningNotice = gitStateCtx.state.WarningNotice,
+            ?pendingConfirmation = gitStateCtx.state.PendingConfirmation,
             callbacks = {
                 OnRefresh = gitStateCtx.refresh
                 OnFetch = gitStateCtx.fetch
                 OnPull = gitStateCtx.pull
                 OnPush = gitStateCtx.push
-                OnSync = gitStateCtx.sync
+                OnUpdateFromOnline = gitStateCtx.updateFromOnline
+                OnPrimarySaveSelection = gitStateCtx.primarySaveSelection
+                OnPrimarySaveAll = gitStateCtx.primarySaveAll
                 OnCommitSelection = gitStateCtx.commitSelection
                 OnCommitAll = gitStateCtx.commitAll
+                OnConfirmPendingRemoteAction = gitStateCtx.confirmPendingRemoteAction
+                OnCancelPendingRemoteAction = gitStateCtx.cancelPendingRemoteAction
                 OnSaveDownloadLargeFiles = gitStateCtx.saveDownloadLargeFiles
                 OnSaveLfsAutoTrackThreshold = gitStateCtx.saveLfsAutoTrackThreshold
                 OnCreateBranch = gitStateCtx.createBranch

--- a/src/Electron/src/Renderer/Context/GitStateContext.fs
+++ b/src/Electron/src/Renderer/Context/GitStateContext.fs
@@ -19,10 +19,14 @@ type GitStateController = {
     fetch: unit -> unit
     pull: unit -> unit
     push: unit -> unit
+    updateFromOnline: unit -> unit
+    primarySaveSelection: GitSidebarCommitSelectionRequest -> unit
+    primarySaveAll: string -> unit
     cloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<string, string>>
-    sync: unit -> unit
     commitSelection: GitSidebarCommitSelectionRequest -> unit
     commitAll: string -> unit
+    confirmPendingRemoteAction: unit -> unit
+    cancelPendingRemoteAction: unit -> unit
     saveLfsAutoTrackThreshold: int -> unit
     saveDownloadLargeFiles: bool -> unit
     createBranch: GitSidebarCreateBranchRequest -> unit
@@ -66,6 +70,7 @@ module private Helper =
                 return result |> Result.mapError _.GitLabErrorToString
             }
         installGitLfs = Renderer.GitApiClient.installGitLfs
+        previewGitPull = Renderer.GitApiClient.previewGitPull
         gitFetch = Renderer.GitApiClient.gitFetch
         gitPull = Renderer.GitApiClient.gitPull
         gitPush = Renderer.GitApiClient.gitPush
@@ -90,10 +95,14 @@ let GitStateCtx =
             fetch = fun () -> ()
             pull = fun () -> ()
             push = fun () -> ()
+            updateFromOnline = fun () -> ()
+            primarySaveSelection = fun _ -> ()
+            primarySaveAll = fun _ -> ()
             cloneRepository = fun _ -> promise { return Ok "" }
-            sync = fun () -> ()
             commitSelection = fun _ -> ()
             commitAll = fun _ -> ()
+            confirmPendingRemoteAction = fun () -> ()
+            cancelPendingRemoteAction = fun () -> ()
             saveLfsAutoTrackThreshold = fun _ -> ()
             saveDownloadLargeFiles = fun _ -> ()
             createBranch = fun _ -> ()
@@ -126,15 +135,27 @@ let GitStateCtxProvider (children: ReactElement) =
 
     let push () = dispatch PushRequested
 
+    let updateFromOnline () = dispatch UpdateFromOnlineRequested
+
+    let primarySaveSelection (request: GitSidebarCommitSelectionRequest) =
+        dispatch (PrimarySaveSelectionRequested request)
+
+    let primarySaveAll (message: string) =
+        dispatch (PrimarySaveAllRequested message)
+
     let cloneRepository (request: GitCloneRepositoryRequest) =
         Promise.create (fun resolve _reject -> dispatch (CloneRequested(request, resolve)))
-
-    let sync () = dispatch SyncRequested
 
     let commitSelection (request: GitSidebarCommitSelectionRequest) =
         dispatch (CommitSelectionRequested request)
 
     let commitAll (message: string) = dispatch (CommitAllRequested message)
+
+    let confirmPendingRemoteAction () =
+        dispatch ConfirmPendingRemoteActionRequested
+
+    let cancelPendingRemoteAction () =
+        dispatch CancelPendingRemoteActionRequested
 
     let saveLfsAutoTrackThreshold (thresholdMb: int) =
         dispatch (SaveLfsAutoTrackThresholdRequested thresholdMb)
@@ -165,10 +186,14 @@ let GitStateCtxProvider (children: ReactElement) =
                 fetch = fetch
                 pull = pull
                 push = push
+                updateFromOnline = updateFromOnline
+                primarySaveSelection = primarySaveSelection
+                primarySaveAll = primarySaveAll
                 cloneRepository = cloneRepository
-                sync = sync
                 commitSelection = commitSelection
                 commitAll = commitAll
+                confirmPendingRemoteAction = confirmPendingRemoteAction
+                cancelPendingRemoteAction = cancelPendingRemoteAction
                 saveLfsAutoTrackThreshold = saveLfsAutoTrackThreshold
                 saveDownloadLargeFiles = saveDownloadLargeFiles
                 createBranch = createBranchFrom

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -49,6 +49,12 @@ type GitPageChange =
     | Set of PageState
     | Clear
 
+[<RequireQualifiedAccess>]
+type GitPendingRemoteAction =
+    | None
+    | UpdateFromOnline
+    | CompletePrimarySavePush
+
 type GitPullWorkflowResult = {
     Status: GitStatusDto option
     WarningMessage: string option
@@ -61,6 +67,9 @@ type GitState = {
     Status: GitSidebarStatus
     ChangedFiles: GitSidebarChange[]
     BranchOptions: GitSidebarBranchOption[]
+    PendingConfirmation: GitSidebarConfirmationDialog option
+    PendingRemoteAction: GitPendingRemoteAction
+    PendingPostMergePush: bool
     LfsAutoTrackThresholdMb: int
     DownloadLargeFiles: bool
     RepositoryAvailability: GitRepositoryAvailability
@@ -91,6 +100,9 @@ type GitState = {
         }
         ChangedFiles = [||]
         BranchOptions = [||]
+        PendingConfirmation = None
+        PendingRemoteAction = GitPendingRemoteAction.None
+        PendingPostMergePush = false
         LfsAutoTrackThresholdMb = 1
         DownloadLargeFiles = false
         RepositoryAvailability = GitRepositoryAvailability.Ready
@@ -135,7 +147,7 @@ type WriteRequest =
     | Fetch
     | Pull
     | Push
-    | Sync
+    | PrimarySave of PreparedCommitOperation
     | Clone of GitCloneRepositoryRequest * Reply<string>
     | CommitSelection of PreparedCommitOperation
     | CommitAll of PreparedCommitOperation
@@ -149,6 +161,7 @@ type WriteSuccess =
 
 type WriteAttemptOutcome =
     | Completed of WriteSuccess
+    | CompletedWithPendingRemoteConfirmation of WriteSuccess * GitSidebarConfirmationDialog * GitPendingRemoteAction
     | RequiresLfsInstall of string
 
 type private WriteOperationClassification =
@@ -176,10 +189,15 @@ type Msg =
     | FetchRequested
     | PullRequested
     | PushRequested
-    | SyncRequested
+    | UpdateFromOnlineRequested
+    | UpdatePreflightCompleted of sessionId: int * Result<GitPullPreflightResult, string>
     | CloneRequested of GitCloneRepositoryRequest * Reply<string>
+    | PrimarySaveSelectionRequested of GitSidebarCommitSelectionRequest
+    | PrimarySaveAllRequested of string
     | CommitSelectionRequested of GitSidebarCommitSelectionRequest
     | CommitAllRequested of string
+    | ConfirmPendingRemoteActionRequested
+    | CancelPendingRemoteActionRequested
     | CreateBranchRequested of GitSidebarCreateBranchRequest
     | SwitchBranchRequested of string
     | WriteRequested of WriteRequest
@@ -196,6 +214,7 @@ type GitDependencies = {
     initGitRepository: string -> JS.Promise<Result<string, string>>
     createDataHubProject: string -> JS.Promise<Result<ExploreProjectDto, string>>
     installGitLfs: unit -> JS.Promise<Result<GitOperationResult, string>>
+    previewGitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitPullPreflightResult, string>>
     gitFetch: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPush: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
@@ -540,7 +559,7 @@ let private busyOperationForWriteRequest =
     | Fetch -> GitBusyOperation.FetchingFromRemote
     | Pull -> GitBusyOperation.PullingFromRemote
     | Push -> GitBusyOperation.PushingToRemote
-    | Sync -> GitBusyOperation.PushingToRemote
+    | PrimarySave prepared -> prepared.BusyOperation
     | Clone _ -> GitBusyOperation.CloningRepository
     | CommitSelection prepared -> prepared.BusyOperation
     | CommitAll prepared -> prepared.BusyOperation
@@ -563,6 +582,7 @@ let private resolveCloneReplyCmd request result =
 let private resolveStaleWriteCompletedCmd request result =
     match result with
     | Ok(Completed success) -> resolveCloneReplyCmd request (Ok success)
+    | Ok(CompletedWithPendingRemoteConfirmation(success, _, _)) -> resolveCloneReplyCmd request (Ok success)
     | Ok(RequiresLfsInstall _) -> resolveCloneReplyCmd request (Error staleArcSessionMessage)
     | Error message -> resolveCloneReplyCmd request (Error message)
 
@@ -671,59 +691,6 @@ let private runPullAttemptAsync (deps: GitDependencies) = promise {
                 Ok(Completed(UnitSuccess(refreshResult, GitPageChange.NoChange, None, operationResult.WarningMessage)))
 }
 
-let private runSyncAttemptAsync (deps: GitDependencies) (state: GitState) = promise {
-    if shouldPublishCurrentBranchFirst state then
-        return!
-            runSimpleWriteAttemptAsync
-                deps
-                GitBusyOperation.PushingToRemote
-                (fun () -> deps.gitPush { Remote = None; Branch = None })
-    else
-        let! pullResult = deps.gitPull { Remote = None; Branch = None }
-
-        match classifyWriteResult GitBusyOperation.PullingFromRemote pullResult with
-        | Error message -> return Error message
-        | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
-        | Ok(WriteOperationReady pullOperation) ->
-            let! refreshResult = refreshAllAsync deps
-
-            match refreshResult.Status, refreshErrorMessage refreshResult with
-            | Error message, _ -> return Error message
-            | Ok _, Some message -> return Error message
-            | Ok latestStatus, None when
-                pullOperation.WarningMessage.IsSome
-                || latestStatus.Conflicted.Length > 0
-                || latestStatus.IsMergeInProgress
-                ->
-                let selectedChangePathOverride =
-                    latestStatus.Conflicted |> Array.tryHead |> Option.map Some
-
-                let! pageChangeResult =
-                    if latestStatus.Conflicted.Length > 0 then
-                        loadPageAsync deps latestStatus.Conflicted.[0] true
-                    else
-                        promise { return Ok GitPageChange.NoChange }
-
-                return
-                    pageChangeResult
-                    |> Result.map (fun pageChange ->
-                        Completed(
-                            UnitSuccess(
-                                refreshResult,
-                                pageChange,
-                                selectedChangePathOverride,
-                                pullOperation.WarningMessage
-                            )
-                        )
-                    )
-            | Ok _, None ->
-                return!
-                    runSimpleWriteAttemptAsync
-                        deps
-                        GitBusyOperation.PushingToRemote
-                        (fun () -> deps.gitPush { Remote = None; Branch = None })
-}
-
 let private runCommitAttemptAsync (deps: GitDependencies) (prepared: PreparedCommitOperation) = promise {
     if String.IsNullOrWhiteSpace prepared.NormalizedMessage then
         return Error "Commit message must not be empty."
@@ -757,6 +724,84 @@ let private runCommitAttemptAsync (deps: GitDependencies) (prepared: PreparedCom
                     return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.NoChange None
 }
 
+let private pendingPrimarySaveWarning =
+    "Changes were saved locally. Online sync is still pending."
+
+let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState) (prepared: PreparedCommitOperation) = promise {
+    let! commitAttempt = runCommitAttemptAsync deps prepared
+
+    match commitAttempt with
+    | Error message -> return Error message
+    | Ok(RequiresLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+    | Ok(Completed(UnitSuccess(refreshResult, pageChange, selectedChangePathOverride, _))) ->
+        if shouldPublishCurrentBranchFirst state then
+            return!
+                runSimpleWriteAttemptAsync
+                    deps
+                    GitBusyOperation.PushingToRemote
+                    (fun () -> deps.gitPush { Remote = None; Branch = None })
+        else
+            let! previewResult = deps.previewGitPull { Remote = None; Branch = None }
+
+            match previewResult with
+            | Error message -> return Error message
+            | Ok { Status = GitPullPreflightStatus.SafeToPull } ->
+                let! pullResult = deps.gitPull { Remote = None; Branch = None }
+
+                match classifyWriteResult GitBusyOperation.PullingFromRemote pullResult with
+                | Error message -> return Error message
+                | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+                | Ok(WriteOperationReady _) ->
+                    return!
+                        runSimpleWriteAttemptAsync
+                            deps
+                            GitBusyOperation.PushingToRemote
+                            (fun () -> deps.gitPush { Remote = None; Branch = None })
+            | Ok { Status = GitPullPreflightStatus.WouldRequireMergeResolution; Message = message } ->
+                return
+                    Ok(
+                        CompletedWithPendingRemoteConfirmation(
+                            UnitSuccess(
+                                refreshResult,
+                                pageChange,
+                                selectedChangePathOverride,
+                                Some pendingPrimarySaveWarning
+                            ),
+                            {
+                                Title = "Merge resolution required"
+                                Message = defaultArg message "Updating from online will require merge resolution. Continue?"
+                                ConfirmLabel = "Open Merge Resolution"
+                                CancelLabel = "Cancel"
+                            },
+                            GitPendingRemoteAction.CompletePrimarySavePush
+                        )
+                    )
+            | Ok { Status = GitPullPreflightStatus.Indeterminate; Message = message } ->
+                return
+                    Ok(
+                        CompletedWithPendingRemoteConfirmation(
+                            UnitSuccess(
+                                refreshResult,
+                                pageChange,
+                                selectedChangePathOverride,
+                                Some pendingPrimarySaveWarning
+                            ),
+                            {
+                                Title = "Update could not be previewed"
+                                Message =
+                                    defaultArg
+                                        message
+                                        "Swate could not determine safely whether updating will require merge resolution. Continue anyway?"
+                                ConfirmLabel = "Continue"
+                                CancelLabel = "Cancel"
+                            },
+                            GitPendingRemoteAction.CompletePrimarySavePush
+                        )
+                    )
+    | Ok(Completed(CloneSuccess _)) -> return Error "Primary save produced an invalid result."
+    | Ok(CompletedWithPendingRemoteConfirmation _ as outcome) -> return Ok outcome
+}
+
 let private runSaveLfsSettingsAttemptAsync
     (deps: GitDependencies)
     (busyOperation: GitBusyOperation)
@@ -787,7 +832,7 @@ let private executeWriteAttempt (deps: GitDependencies) (state: GitState) (reque
                 deps
                 GitBusyOperation.PushingToRemote
                 (fun () -> deps.gitPush { Remote = None; Branch = None })
-    | Sync -> return! runSyncAttemptAsync deps state
+    | PrimarySave prepared -> return! runPrimarySaveAttemptAsync deps state prepared
     | Clone(request, _) -> return! runCloneAttemptAsync deps request
     | CommitSelection prepared -> return! runCommitAttemptAsync deps prepared
     | CommitAll prepared -> return! runCommitAttemptAsync deps prepared
@@ -805,6 +850,9 @@ let private missingRepositoryModel (model: GitState) = {
         Status = GitState.Empty.Status
         ChangedFiles = [||]
         BranchOptions = [||]
+        PendingConfirmation = None
+        PendingRemoteAction = GitPendingRemoteAction.None
+        PendingPostMergePush = false
         LfsAutoTrackThresholdMb = GitState.Empty.LfsAutoTrackThresholdMb
         DownloadLargeFiles = GitState.Empty.DownloadLargeFiles
         RepositoryAvailability = GitRepositoryAvailability.MissingRepository
@@ -1069,10 +1117,21 @@ let update
                     MergeResolutionPendingPath = None
                     SelectedChangePath = outcome.NextConflictedPath
                     ErrorNotice = None
-                    WarningNotice = None
+                    WarningNotice = state.WarningNotice
             }
 
-        nextModel, applyPageChangeCmd setPageState outcome.PageChange
+        if
+            nextModel.PendingPostMergePush
+            && not outcome.UpdatedStatus.IsMergeInProgress
+            && outcome.UpdatedStatus.Conflicted.Length = 0
+        then
+            { nextModel with PendingPostMergePush = false },
+            Cmd.batch [
+                applyPageChangeCmd setPageState outcome.PageChange
+                Cmd.ofMsg (WriteRequested Push)
+            ]
+        else
+            nextModel, applyPageChangeCmd setPageState outcome.PageChange
     | SaveDownloadLargeFilesRequested downloadLargeFiles when model.CurrentArcPath.IsNone ->
         {
             model with
@@ -1102,11 +1161,102 @@ let update
     | FetchRequested -> model, Cmd.ofMsg (WriteRequested Fetch)
     | PullRequested -> model, Cmd.ofMsg (WriteRequested Pull)
     | PushRequested -> model, Cmd.ofMsg (WriteRequested Push)
-    | SyncRequested -> model, Cmd.ofMsg (WriteRequested Sync)
+    | UpdateFromOnlineRequested when model.CurrentArcPath.IsNone -> model, Cmd.none
+    | UpdateFromOnlineRequested ->
+        let nextModel =
+            model
+            |> withBusyOperation (Some GitBusyOperation.FetchingFromRemote)
+            |> fun state -> {
+                state with
+                    ErrorNotice = None
+                    WarningNotice = None
+            }
+
+        let cmd =
+            Cmd.OfPromise.either
+                deps.previewGitPull
+                { Remote = None; Branch = None }
+                (fun result -> UpdatePreflightCompleted(model.ArcSessionId, result))
+                (fun err -> UpdatePreflightCompleted(model.ArcSessionId, Error(string err)))
+
+        nextModel, cmd
+    | UpdatePreflightCompleted(sessionId, _) when sessionId <> model.ArcSessionId -> model, Cmd.none
+    | UpdatePreflightCompleted(_, Ok { Status = GitPullPreflightStatus.SafeToPull }) ->
+        model |> withBusyOperation None, Cmd.ofMsg (WriteRequested Pull)
+    | UpdatePreflightCompleted(_, Ok { Status = GitPullPreflightStatus.WouldRequireMergeResolution; Message = message }) ->
+        {
+            model with
+                BusyOperation = None
+                BusyNotice = None
+                PendingConfirmation =
+                    Some {
+                        Title = "Merge resolution required"
+                        Message = defaultArg message "Updating from online will require merge resolution. Continue?"
+                        ConfirmLabel = "Open Merge Resolution"
+                        CancelLabel = "Cancel"
+                    }
+                PendingRemoteAction = GitPendingRemoteAction.UpdateFromOnline
+        },
+        Cmd.none
+    | UpdatePreflightCompleted(_, Ok { Status = GitPullPreflightStatus.Indeterminate; Message = message }) ->
+        {
+            model with
+                BusyOperation = None
+                BusyNotice = None
+                PendingConfirmation =
+                    Some {
+                        Title = "Update could not be previewed"
+                        Message =
+                            defaultArg
+                                message
+                                "Swate could not determine safely whether updating will require merge resolution. Continue anyway?"
+                        ConfirmLabel = "Continue"
+                        CancelLabel = "Cancel"
+                    }
+                PendingRemoteAction = GitPendingRemoteAction.UpdateFromOnline
+        },
+        Cmd.none
+    | UpdatePreflightCompleted(_, Error message) ->
+        {
+            model with
+                BusyOperation = None
+                BusyNotice = None
+                ErrorNotice = Some message
+        },
+        Cmd.none
     | CloneRequested(request, reply) -> model, Cmd.ofMsg (WriteRequested(Clone(request, reply)))
+    | PrimarySaveSelectionRequested request ->
+        model, Cmd.ofMsg (WriteRequested(PrimarySave(prepareCommitSelection model request)))
+    | PrimarySaveAllRequested message -> model, Cmd.ofMsg (WriteRequested(PrimarySave(prepareCommitAll model message)))
     | CommitSelectionRequested request ->
         model, Cmd.ofMsg (WriteRequested(CommitSelection(prepareCommitSelection model request)))
     | CommitAllRequested message -> model, Cmd.ofMsg (WriteRequested(CommitAll(prepareCommitAll model message)))
+    | ConfirmPendingRemoteActionRequested ->
+        match model.PendingRemoteAction with
+        | GitPendingRemoteAction.UpdateFromOnline ->
+            {
+                model with
+                    PendingConfirmation = None
+                    PendingRemoteAction = GitPendingRemoteAction.None
+            },
+            Cmd.ofMsg (WriteRequested Pull)
+        | GitPendingRemoteAction.CompletePrimarySavePush ->
+            {
+                model with
+                    PendingConfirmation = None
+                    PendingRemoteAction = GitPendingRemoteAction.None
+                    PendingPostMergePush = true
+            },
+            Cmd.ofMsg (WriteRequested Pull)
+        | GitPendingRemoteAction.None -> model, Cmd.none
+    | CancelPendingRemoteActionRequested ->
+        {
+            model with
+                PendingConfirmation = None
+                PendingRemoteAction = GitPendingRemoteAction.None
+                PendingPostMergePush = false
+        },
+        Cmd.none
     | CreateBranchRequested request ->
         model,
         Cmd.ofMsg (
@@ -1237,6 +1387,40 @@ let update
                 (fun err -> WriteCompleted(sessionId, request, Error(string err)))
 
         nextModel, cmd
+    | WriteCompleted(_, PrimarySave _, Ok(CompletedWithPendingRemoteConfirmation(success, dialog, pendingRemoteAction))) ->
+        let baseModel, pageChange, warningMessage =
+            match success with
+            | UnitSuccess(refreshResult, pageChange, selectedChangePathOverride, warningMessage) ->
+                let refreshedModel = applyRefreshResult refreshResult model
+
+                let selectionAdjustedModel =
+                    match selectedChangePathOverride with
+                    | Some selectedChangePath -> {
+                        refreshedModel with
+                            SelectedChangePath = selectedChangePath
+                      }
+                    | None -> refreshedModel
+
+                selectionAdjustedModel, pageChange, warningMessage
+            | CloneSuccess _ -> model, GitPageChange.NoChange, None
+
+        let nextModel = {
+            baseModel with
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = None
+                WarningNotice = warningMessage
+                PendingConfirmation = Some dialog
+                PendingRemoteAction = pendingRemoteAction
+                PendingPostMergePush = false
+        }
+
+        nextModel, applyPageChangeCmd setPageState pageChange
+    | WriteCompleted(_, request, Ok(CompletedWithPendingRemoteConfirmation(_, _, _))) ->
+        let message = "Git operation produced an invalid pending remote confirmation."
+        let nextModel = writeErrorModel message model
+        nextModel, resolveCloneReplyCmd request (Error message)
     | WriteCompleted(_, request, Ok(Completed success)) ->
         let baseModel, pageChange, warningMessage =
             match success with

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -1278,7 +1278,27 @@ let update
         if String.IsNullOrWhiteSpace normalizedBranchName then
             model, Cmd.none
         else
-            model, Cmd.ofMsg (WriteRequested(SwitchBranch { Name = normalizedBranchName }))
+            let selectedBranch =
+                model.BranchOptions
+                |> Array.tryFind (fun b -> String.Equals(b.RefName, normalizedBranchName, StringComparison.Ordinal))
+
+            let startPoint, localName =
+                match selectedBranch with
+                | Some branch when branch.Kind = GitSidebarBranchKind.Remote ->
+                    let remotePrefix =
+                        let slashIndex = branch.RefName.IndexOf('/')
+                        if slashIndex > 0 then branch.RefName.[..slashIndex] else "origin/"
+
+                    let derivedLocalName =
+                        if normalizedBranchName.StartsWith(remotePrefix, StringComparison.Ordinal) then
+                            normalizedBranchName.[remotePrefix.Length..]
+                        else
+                            normalizedBranchName
+
+                    Some branch.RefName, derivedLocalName
+                | _ -> None, normalizedBranchName
+
+            model, Cmd.ofMsg (WriteRequested(SwitchBranch { Name = localName; StartPoint = startPoint }))
     | WriteRequested request when requiresArcForWriteRequest request && model.CurrentArcPath.IsNone -> model, Cmd.none
     | WriteRequested request ->
         let nextModel =

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -162,6 +162,7 @@ type WriteSuccess =
 type WriteAttemptOutcome =
     | Completed of WriteSuccess
     | CompletedWithPendingRemoteConfirmation of WriteSuccess * GitSidebarConfirmationDialog * GitPendingRemoteAction
+    | CompletedWithPendingRemoteFailure of WriteSuccess * string
     | RequiresLfsInstall of string
 
 type private WriteOperationClassification =
@@ -583,6 +584,7 @@ let private resolveStaleWriteCompletedCmd request result =
     match result with
     | Ok(Completed success) -> resolveCloneReplyCmd request (Ok success)
     | Ok(CompletedWithPendingRemoteConfirmation(success, _, _)) -> resolveCloneReplyCmd request (Ok success)
+    | Ok(CompletedWithPendingRemoteFailure(success, _)) -> resolveCloneReplyCmd request (Ok success)
     | Ok(RequiresLfsInstall _) -> resolveCloneReplyCmd request (Error staleArcSessionMessage)
     | Error message -> resolveCloneReplyCmd request (Error message)
 
@@ -727,6 +729,17 @@ let private runCommitAttemptAsync (deps: GitDependencies) (prepared: PreparedCom
 let private pendingPrimarySaveWarning =
     "Changes were saved locally. Online sync is still pending."
 
+let private indeterminateUpdateMessage (message: string option) =
+    let fallback =
+        "Swate could not determine safely whether updating will require merge resolution. Continue anyway?"
+
+    match message |> Option.map _.Trim() |> Option.filter (String.IsNullOrWhiteSpace >> not) with
+    | Some diagnostic -> $"{fallback} {diagnostic}"
+    | None -> fallback
+
+let private pendingPrimarySaveRemoteFailure localSuccess message =
+    Ok(CompletedWithPendingRemoteFailure(localSuccess, message))
+
 let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState) (prepared: PreparedCommitOperation) = promise {
     let! commitAttempt = runCommitAttemptAsync deps prepared
 
@@ -734,39 +747,41 @@ let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState)
     | Error message -> return Error message
     | Ok(RequiresLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
     | Ok(Completed(UnitSuccess(refreshResult, pageChange, selectedChangePathOverride, _))) ->
+        let localSuccessWithPendingWarning =
+            UnitSuccess(refreshResult, pageChange, selectedChangePathOverride, Some pendingPrimarySaveWarning)
+
+        let runPushAfterLocalCommit () =
+            promise {
+                let! pushResult = deps.gitPush { Remote = None; Branch = None }
+
+                match classifyWriteResult GitBusyOperation.PushingToRemote pushResult with
+                | Error message -> return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning message
+                | Ok(WriteOperationNeedsLfsInstall promptMessage) ->
+                    return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning promptMessage
+                | Ok(WriteOperationReady operationResult) ->
+                    return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.NoChange None
+            }
+
         if shouldPublishCurrentBranchFirst state then
-            return!
-                runSimpleWriteAttemptAsync
-                    deps
-                    GitBusyOperation.PushingToRemote
-                    (fun () -> deps.gitPush { Remote = None; Branch = None })
+            return! runPushAfterLocalCommit ()
         else
             let! previewResult = deps.previewGitPull { Remote = None; Branch = None }
 
             match previewResult with
-            | Error message -> return Error message
+            | Error message -> return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning message
             | Ok { Status = GitPullPreflightStatus.SafeToPull } ->
                 let! pullResult = deps.gitPull { Remote = None; Branch = None }
 
                 match classifyWriteResult GitBusyOperation.PullingFromRemote pullResult with
-                | Error message -> return Error message
-                | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
-                | Ok(WriteOperationReady _) ->
-                    return!
-                        runSimpleWriteAttemptAsync
-                            deps
-                            GitBusyOperation.PushingToRemote
-                            (fun () -> deps.gitPush { Remote = None; Branch = None })
+                | Error message -> return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning message
+                | Ok(WriteOperationNeedsLfsInstall promptMessage) ->
+                    return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning promptMessage
+                | Ok(WriteOperationReady _) -> return! runPushAfterLocalCommit ()
             | Ok { Status = GitPullPreflightStatus.WouldRequireMergeResolution; Message = message } ->
                 return
                     Ok(
                         CompletedWithPendingRemoteConfirmation(
-                            UnitSuccess(
-                                refreshResult,
-                                pageChange,
-                                selectedChangePathOverride,
-                                Some pendingPrimarySaveWarning
-                            ),
+                            localSuccessWithPendingWarning,
                             {
                                 Title = "Merge resolution required"
                                 Message = defaultArg message "Updating from online will require merge resolution. Continue?"
@@ -780,18 +795,10 @@ let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState)
                 return
                     Ok(
                         CompletedWithPendingRemoteConfirmation(
-                            UnitSuccess(
-                                refreshResult,
-                                pageChange,
-                                selectedChangePathOverride,
-                                Some pendingPrimarySaveWarning
-                            ),
+                            localSuccessWithPendingWarning,
                             {
                                 Title = "Update could not be previewed"
-                                Message =
-                                    defaultArg
-                                        message
-                                        "Swate could not determine safely whether updating will require merge resolution. Continue anyway?"
+                                Message = indeterminateUpdateMessage message
                                 ConfirmLabel = "Continue"
                                 CancelLabel = "Cancel"
                             },
@@ -800,6 +807,7 @@ let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState)
                     )
     | Ok(Completed(CloneSuccess _)) -> return Error "Primary save produced an invalid result."
     | Ok(CompletedWithPendingRemoteConfirmation _ as outcome) -> return Ok outcome
+    | Ok(CompletedWithPendingRemoteFailure _ as outcome) -> return Ok outcome
 }
 
 let private runSaveLfsSettingsAttemptAsync
@@ -1206,10 +1214,7 @@ let update
                 PendingConfirmation =
                     Some {
                         Title = "Update could not be previewed"
-                        Message =
-                            defaultArg
-                                message
-                                "Swate could not determine safely whether updating will require merge resolution. Continue anyway?"
+                        Message = indeterminateUpdateMessage message
                         ConfirmLabel = "Continue"
                         CancelLabel = "Cancel"
                     }
@@ -1417,8 +1422,42 @@ let update
         }
 
         nextModel, applyPageChangeCmd setPageState pageChange
+    | WriteCompleted(_, PrimarySave _, Ok(CompletedWithPendingRemoteFailure(success, message))) ->
+        let baseModel, pageChange, warningMessage =
+            match success with
+            | UnitSuccess(refreshResult, pageChange, selectedChangePathOverride, warningMessage) ->
+                let refreshedModel = applyRefreshResult refreshResult model
+
+                let selectionAdjustedModel =
+                    match selectedChangePathOverride with
+                    | Some selectedChangePath -> {
+                        refreshedModel with
+                            SelectedChangePath = selectedChangePath
+                      }
+                    | None -> refreshedModel
+
+                selectionAdjustedModel, pageChange, warningMessage
+            | CloneSuccess _ -> model, GitPageChange.NoChange, None
+
+        let nextModel = {
+            baseModel with
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = Some message
+                WarningNotice = warningMessage
+                PendingConfirmation = None
+                PendingRemoteAction = GitPendingRemoteAction.None
+                PendingPostMergePush = false
+        }
+
+        nextModel, applyPageChangeCmd setPageState pageChange
     | WriteCompleted(_, request, Ok(CompletedWithPendingRemoteConfirmation(_, _, _))) ->
         let message = "Git operation produced an invalid pending remote confirmation."
+        let nextModel = writeErrorModel message model
+        nextModel, resolveCloneReplyCmd request (Error message)
+    | WriteCompleted(_, request, Ok(CompletedWithPendingRemoteFailure(_, _))) ->
+        let message = "Git operation produced an invalid pending remote failure."
         let nextModel = writeErrorModel message model
         nextModel, resolveCloneReplyCmd request (Error message)
     | WriteCompleted(_, request, Ok(Completed success)) ->

--- a/src/Electron/src/Renderer/GitApiClient.fs
+++ b/src/Electron/src/Renderer/GitApiClient.fs
@@ -23,6 +23,9 @@ let private callIpcWith
         return mapExnResult result
     }
 
+let checkGitVersions () =
+    callIpc (fun () -> gitApi.checkGitVersions (unbox null))
+
 let getGitStatus () =
     callIpc (fun () -> gitApi.getGitStatus (unbox null))
 

--- a/src/Electron/src/Renderer/GitApiClient.fs
+++ b/src/Electron/src/Renderer/GitApiClient.fs
@@ -47,6 +47,9 @@ let gitFetch (request: GitRemoteOperationRequest) =
 let gitPull (request: GitRemoteOperationRequest) =
     callIpcWith request (gitApi.gitPull (unbox null))
 
+let previewGitPull (request: GitRemoteOperationRequest) =
+    callIpcWith request (gitApi.previewGitPull (unbox null))
+
 let gitPush (request: GitRemoteOperationRequest) =
     callIpcWith request (gitApi.gitPush (unbox null))
 

--- a/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
@@ -119,6 +119,17 @@ type GitRemoteOperationRequest = {
     Branch: string option
 }
 
+[<RequireQualifiedAccess>]
+type GitPullPreflightStatus =
+    | SafeToPull
+    | WouldRequireMergeResolution
+    | Indeterminate
+
+type GitPullPreflightResult = {
+    Status: GitPullPreflightStatus
+    Message: string option
+}
+
 type GitRemoteConfigRequest = {
     RemoteName: string
     RemoteUrl: string

--- a/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
@@ -156,7 +156,10 @@ type GitCreateBranchRequest = {
     StartPoint: string option
 }
 
-type GitCheckoutBranchRequest = { Name: string }
+type GitCheckoutBranchRequest = {
+    Name: string
+    StartPoint: string option
+}
 
 type GitConfirmMergeResolutionRequest = {
     Path: string

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -56,6 +56,7 @@ type IGitLfsApi = {
 
 /// Two Way Bridge: Renderer <-> Main
 type IGitApi = {
+    checkGitVersions: IpcMainEvent -> JS.Promise<Result<unit, exn>>
     getGitStatus: IpcMainEvent -> JS.Promise<Result<GitStatusDto, exn>>
     getGitBranches: IpcMainEvent -> JS.Promise<Result<GitBranchRefDto[], exn>>
     getGitLfsSettings: IpcMainEvent -> JS.Promise<Result<GitLfsSettingsDto, exn>>

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -59,6 +59,7 @@ type IGitApi = {
     getGitStatus: IpcMainEvent -> JS.Promise<Result<GitStatusDto, exn>>
     getGitBranches: IpcMainEvent -> JS.Promise<Result<GitBranchRefDto[], exn>>
     getGitLfsSettings: IpcMainEvent -> JS.Promise<Result<GitLfsSettingsDto, exn>>
+    previewGitPull: IpcMainEvent -> GitRemoteOperationRequest -> JS.Promise<Result<GitPullPreflightResult, exn>>
     getGitDiffSummary: IpcMainEvent -> JS.Promise<Result<GitDiffSummaryDto, exn>>
     getGitWordDiff: IpcMainEvent -> GitPathspecRequest -> JS.Promise<Result<string, exn>>
     getGitDiffViewData: IpcMainEvent -> string -> JS.Promise<Result<GitPageLoadResultDto<GitDiffViewDataDto>, exn>>

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -14,6 +14,7 @@ module GitProvisioningService = Main.Git.GitProvisioningService
 module GitAuthAdapter = Main.Git.GitAuthAdapter
 module GitLfsAdapter = Main.Git.GitLfsAdapter
 module GitLfsService = Main.Git.GitLfsService
+module GitTokenProvider = Main.Git.GitTokenProvider
 
 let private fsPromisesDynamic: obj = importAll "fs/promises"
 let private osDynamic: obj = importAll "os"
@@ -148,6 +149,44 @@ let private runSimpleGitRawWithFakeGit
 
 let private splitNonEmptyLines (text: string) =
     text.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
+
+let private testRemoteHost = "git.local.test"
+let private testRemoteToken = "swate-test-token"
+let private testRemoteUrl = $"https://{testRemoteHost}/origin.git"
+let private testAuthenticatedRemoteUrl = $"https://oauth2:{testRemoteToken}@{testRemoteHost}/origin.git"
+
+let private toFileRemoteUrl (path: string) =
+    let normalized = path.Replace("\\", "/")
+
+    if normalized.StartsWith("/", StringComparison.Ordinal) then
+        $"file://{normalized}"
+    else
+        $"file:///{normalized}"
+
+let private configureLocalRemoteRewrite (git: ISimpleGit) (remotePath: string) = promise {
+    let localRemoteUrl = toFileRemoteUrl remotePath
+    let! _ = git.raw [| "config"; "--add"; $"url.{localRemoteUrl}.insteadOf"; testRemoteUrl |]
+    let! _ = git.raw [| "config"; "--add"; $"url.{localRemoteUrl}.insteadOf"; testAuthenticatedRemoteUrl |]
+    return ()
+}
+
+let private withTestTokenProvider (body: unit -> JS.Promise<'T>) = promise {
+    GitTokenProvider.setTokenProvider {
+        TryGetAccessToken =
+            fun host -> promise {
+                return
+                    if String.Equals(host, testRemoteHost, StringComparison.OrdinalIgnoreCase) then
+                        Some testRemoteToken
+                    else
+                        None
+            }
+    }
+
+    try
+        return! body ()
+    finally
+        GitTokenProvider.setTokenProvider GitTokenProvider.defaultTokenProvider
+}
 
 let private withTempRepository (testBody: TempRepositoryContext -> JS.Promise<unit>) : JS.Promise<unit> = promise {
     let! rootPath = createTempDirectoryAsync ()
@@ -406,7 +445,8 @@ Vitest.describe (
                             |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
 
                         let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
-                        let! _ = context.Git.raw [| "remote"; "add"; "origin"; remotePath |]
+                        do! configureLocalRemoteRewrite context.Git remotePath
+                        let! _ = context.Git.raw [| "remote"; "add"; "origin"; testRemoteUrl |]
                         let! _ = context.Git.raw [| "push"; "-u"; "origin"; baseBranch |]
 
                         let! _ = context.Git.raw [| "clone"; remotePath; clonePath |]
@@ -420,11 +460,13 @@ Vitest.describe (
                         let! _ = cloneGit.raw [| "push"; "origin"; baseBranch |]
 
                         let! preview =
-                            unwrapResultAsync
-                                (GitService.previewPull context.RepoPath None None None)
-                                (expectOk "preview pull")
+                            withTestTokenProvider (fun () ->
+                                unwrapResultAsync
+                                    (GitService.previewPull context.RepoPath None None None)
+                                    (expectOk "preview pull")
+                            )
 
-                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.SafeToPull)
+                        Vitest.expect(preview.Status).toEqual (GitPullPreflightStatus.SafeToPull)
                     })
             })
 
@@ -453,7 +495,8 @@ Vitest.describe (
                             |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
 
                         let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
-                        let! _ = context.Git.raw [| "remote"; "add"; "origin"; remotePath |]
+                        do! configureLocalRemoteRewrite context.Git remotePath
+                        let! _ = context.Git.raw [| "remote"; "add"; "origin"; testRemoteUrl |]
                         let! _ = context.Git.raw [| "push"; "-u"; "origin"; baseBranch |]
 
                         let! _ = context.Git.raw [| "clone"; remotePath; clonePath |]
@@ -473,11 +516,13 @@ Vitest.describe (
                         let! _ = cloneGit.raw [| "push"; "origin"; baseBranch |]
 
                         let! preview =
-                            unwrapResultAsync
-                                (GitService.previewPull context.RepoPath None None None)
-                                (expectOk "preview pull")
+                            withTestTokenProvider (fun () ->
+                                unwrapResultAsync
+                                    (GitService.previewPull context.RepoPath None None None)
+                                    (expectOk "preview pull")
+                            )
 
-                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.WouldRequireMergeResolution)
+                        Vitest.expect(preview.Status).toEqual (GitPullPreflightStatus.WouldRequireMergeResolution)
                     })
             })
 
@@ -502,7 +547,7 @@ Vitest.describe (
                                 (GitService.previewPull context.RepoPath None None None)
                                 (expectOk "preview pull on detached head")
 
-                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.Indeterminate)
+                        Vitest.expect(preview.Status).toEqual (GitPullPreflightStatus.Indeterminate)
                     })
             })
 
@@ -526,14 +571,14 @@ Vitest.describe (
                                 (GitService.getStatus context.RepoPath)
                                 (expectOk "git status on branch without upstream")
 
-                        Vitest.expect(status.Tracking).toEqual (None)
+                        Vitest.expect(status.Tracking.IsNone).toBe (true)
 
                         let! preview =
                             unwrapResultAsync
                                 (GitService.previewPull context.RepoPath None None None)
                                 (expectOk "preview pull without upstream")
 
-                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.Indeterminate)
+                        Vitest.expect(preview.Status).toEqual (GitPullPreflightStatus.Indeterminate)
                     })
             })
 

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -381,6 +381,163 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "previewPull reports SafeToPull when the fetched upstream can be merged without conflicts",
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let remotePath = join [| context.RootPath; "origin.git" |]
+                        let clonePath = join [| context.RootPath; "incoming" |]
+                        let repoFilePath = join [| context.RepoPath; "workflow.txt" |]
+
+                        do! writeUtf8FileAsync repoFilePath "base\n"
+                        let! stageBase = GitService.stagePaths context.RepoPath [| "workflow.txt" |]
+                        expectOk "stage base file" stageBase |> ignore
+
+                        let! commitBase = GitService.commit context.RepoPath "test: base commit"
+                        expectOk "commit base" commitBase |> ignore
+
+                        let! baseStatus =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status after base commit")
+
+                        let baseBranch =
+                            baseStatus.Current
+                            |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
+
+                        let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
+                        let! _ = context.Git.raw [| "remote"; "add"; "origin"; remotePath |]
+                        let! _ = context.Git.raw [| "push"; "-u"; "origin"; baseBranch |]
+
+                        let! _ = context.Git.raw [| "clone"; remotePath; clonePath |]
+                        let cloneGit = createSimpleGit clonePath
+                        do! configureRepositoryAsync cloneGit
+
+                        let cloneFilePath = join [| clonePath; "workflow.txt" |]
+                        do! writeUtf8FileAsync cloneFilePath "remote only change\n"
+                        let! _ = cloneGit.raw [| "add"; "workflow.txt" |]
+                        let! _ = cloneGit.raw [| "commit"; "-m"; "test: remote only change" |]
+                        let! _ = cloneGit.raw [| "push"; "origin"; baseBranch |]
+
+                        let! preview =
+                            unwrapResultAsync
+                                (GitService.previewPull context.RepoPath None None None)
+                                (expectOk "preview pull")
+
+                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.SafeToPull)
+                    })
+            })
+
+        Vitest.test (
+            "previewPull reports WouldRequireMergeResolution when local and fetched upstream change the same lines differently",
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let remotePath = join [| context.RootPath; "origin.git" |]
+                        let clonePath = join [| context.RootPath; "incoming" |]
+                        let repoFilePath = join [| context.RepoPath; "conflict.txt" |]
+
+                        do! writeUtf8FileAsync repoFilePath "base\n"
+                        let! stageBase = GitService.stagePaths context.RepoPath [| "conflict.txt" |]
+                        expectOk "stage base file" stageBase |> ignore
+                        let! commitBase = GitService.commit context.RepoPath "test: base commit"
+                        expectOk "commit base" commitBase |> ignore
+
+                        let! baseStatus =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status after base commit")
+
+                        let baseBranch =
+                            baseStatus.Current
+                            |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
+
+                        let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
+                        let! _ = context.Git.raw [| "remote"; "add"; "origin"; remotePath |]
+                        let! _ = context.Git.raw [| "push"; "-u"; "origin"; baseBranch |]
+
+                        let! _ = context.Git.raw [| "clone"; remotePath; clonePath |]
+                        let cloneGit = createSimpleGit clonePath
+                        do! configureRepositoryAsync cloneGit
+
+                        do! writeUtf8FileAsync repoFilePath "local change\n"
+                        let! localStage = GitService.stagePaths context.RepoPath [| "conflict.txt" |]
+                        expectOk "stage local change" localStage |> ignore
+                        let! commitLocal = GitService.commit context.RepoPath "test: local change"
+                        expectOk "commit local" commitLocal |> ignore
+
+                        let cloneFilePath = join [| clonePath; "conflict.txt" |]
+                        do! writeUtf8FileAsync cloneFilePath "remote change\n"
+                        let! _ = cloneGit.raw [| "add"; "conflict.txt" |]
+                        let! _ = cloneGit.raw [| "commit"; "-m"; "test: remote change" |]
+                        let! _ = cloneGit.raw [| "push"; "origin"; baseBranch |]
+
+                        let! preview =
+                            unwrapResultAsync
+                                (GitService.previewPull context.RepoPath None None None)
+                                (expectOk "preview pull")
+
+                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.WouldRequireMergeResolution)
+                    })
+            })
+
+        Vitest.test (
+            "previewPull returns Indeterminate when HEAD is detached",
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let filePath = join [| context.RepoPath; "detached.txt" |]
+
+                        do! writeUtf8FileAsync filePath "base\n"
+                        let! stageBase = GitService.stagePaths context.RepoPath [| "detached.txt" |]
+                        expectOk "stage detached file" stageBase |> ignore
+
+                        let! commitBase = GitService.commit context.RepoPath "test: detached base"
+                        expectOk "commit detached base" commitBase |> ignore
+
+                        let! _ = context.Git.raw [| "checkout"; "--detach"; "HEAD" |]
+
+                        let! preview =
+                            unwrapResultAsync
+                                (GitService.previewPull context.RepoPath None None None)
+                                (expectOk "preview pull on detached head")
+
+                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.Indeterminate)
+                    })
+            })
+
+        Vitest.test (
+            "previewPull returns Indeterminate when no upstream tracking branch can be resolved",
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let filePath = join [| context.RepoPath; "no-upstream.txt" |]
+
+                        do! writeUtf8FileAsync filePath "base\n"
+                        let! stageBase = GitService.stagePaths context.RepoPath [| "no-upstream.txt" |]
+                        expectOk "stage no-upstream file" stageBase |> ignore
+
+                        let! commitBase = GitService.commit context.RepoPath "test: no upstream base"
+                        expectOk "commit no-upstream base" commitBase |> ignore
+
+                        let! _ = GitService.createBranch context.RepoPath "feature/no-upstream" None
+                        let! status =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status on branch without upstream")
+
+                        Vitest.expect(status.Tracking).toEqual (None)
+
+                        let! preview =
+                            unwrapResultAsync
+                                (GitService.previewPull context.RepoPath None None None)
+                                (expectOk "preview pull without upstream")
+
+                        Vitest.expect(preview.Status).toBe (GitPullPreflightStatus.Indeterminate)
+                    })
+            })
+
+        Vitest.test (
             "commit keeps the staged version when the working tree changes again before commit",
             fun () -> promise {
                 do!

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -339,7 +339,7 @@ Vitest.describe (
 
                         Vitest.expect(createdBranchStatus.Current |> Option.defaultValue "").toBe (featureBranchName)
 
-                        let! checkoutBaseBranchResult = GitService.checkoutBranch context.RepoPath initialBranch
+                        let! checkoutBaseBranchResult = GitService.checkoutBranch context.RepoPath { Name = initialBranch; StartPoint = None }
                         expectOk "checkout initial branch" checkoutBaseBranchResult |> ignore
 
                         let! baseBranchStatus =
@@ -349,7 +349,7 @@ Vitest.describe (
 
                         Vitest.expect(baseBranchStatus.Current |> Option.defaultValue "").toBe (initialBranch)
 
-                        let! checkoutFeatureBranchResult = GitService.checkoutBranch context.RepoPath featureBranchName
+                        let! checkoutFeatureBranchResult = GitService.checkoutBranch context.RepoPath { Name = featureBranchName; StartPoint = None }
                         expectOk "checkout feature branch" checkoutFeatureBranchResult |> ignore
 
                         let! featureBranchStatus =
@@ -1564,7 +1564,7 @@ Vitest.describe (
 
                         let! failure =
                             unwrapResultAsync
-                                (GitService.checkoutBranch context.RepoPath "missing/local-branch")
+                                (GitService.checkoutBranch context.RepoPath { Name = "missing/local-branch"; StartPoint = None })
                                 expectError
 
                         Vitest.expect(failure.Message.Contains("does not exist in the local repository")).toBe (true)
@@ -1620,10 +1620,10 @@ Vitest.describe (
 
                         Vitest.expect(poisonedStatus.Tracking).toEqual (Some $"origin/{initialBranch}")
 
-                        let! checkoutBaseResult = GitService.checkoutBranch context.RepoPath initialBranch
+                        let! checkoutBaseResult = GitService.checkoutBranch context.RepoPath { Name = initialBranch; StartPoint = None }
                         expectOk "checkout base branch" checkoutBaseResult |> ignore
 
-                        let! checkoutFeatureResult = GitService.checkoutBranch context.RepoPath featureBranchName
+                        let! checkoutFeatureResult = GitService.checkoutBranch context.RepoPath { Name = featureBranchName; StartPoint = None }
                         expectOk "checkout feature branch" checkoutFeatureResult |> ignore
 
                         let! featureStatus =
@@ -1741,7 +1741,7 @@ Vitest.describe (
                         let! featureCommitResult = GitService.commit context.RepoPath "test: feature change"
                         expectOk "commit feature change" featureCommitResult |> ignore
 
-                        let! checkoutBaseResult = GitService.checkoutBranch context.RepoPath baseBranch
+                        let! checkoutBaseResult = GitService.checkoutBranch context.RepoPath { Name = baseBranch; StartPoint = None }
                         expectOk "checkout base branch" checkoutBaseResult |> ignore
 
                         do! writeUtf8FileAsync filePath "main change\n"
@@ -1839,7 +1839,7 @@ Vitest.describe (
                         let! featureCommitResult = GitService.commit context.RepoPath "test: feature change"
                         expectOk "commit feature change" featureCommitResult |> ignore
 
-                        let! checkoutBaseResult = GitService.checkoutBranch context.RepoPath baseBranch
+                        let! checkoutBaseResult = GitService.checkoutBranch context.RepoPath { Name = baseBranch; StartPoint = None }
                         expectOk "checkout base branch" checkoutBaseResult |> ignore
 
                         do! writeUtf8FileAsync filePath "main change\n"

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -1559,7 +1559,7 @@ Vitest.describe (
                     )
 
                 Vitest.expect(container.textContent.Contains("studies/s-study-01/protocol.md")).toBe (true)
-                Vitest.expect(container.textContent.Contains("Conflict")).toBe (true)
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeStatusButton-3']")).not.toBeNull ()
 
                 cleanup ()
             }
@@ -1788,53 +1788,43 @@ Vitest.describe (
         )
 
         Vitest.test (
-            "GitSidebar labels deleted files explicitly instead of showing only a generic Changed badge",
+            "GitSidebar hides the inline git return text and exposes it through a popover trigger",
             fun () -> promise {
                 let! container, cleanup =
                     renderToBody (
-                        Html.div [
-                            prop.style [
-                                style.width 340
-                                style.height 760
-                            ]
-                            prop.children [
-                                Swate.Components.GitSidebar.Main(
-                                    status = {
-                                        CurrentBranch = Some "main"
-                                        TrackingBranch = Some "origin/main"
-                                        Ahead = 0
-                                        Behind = 0
-                                        IsClean = false
-                                        IsMergeInProgress = false
-                                    },
-                                    changedFiles =
-                                        [|
-                                            changedFile "obsolete.md" "D" " " false
-                                        |],
-                                    branchOptions = [| sidebarLocalBranch "main" true true |],
-                                    callbacks = {
-                                        OnRefresh = fun () -> ()
-                                        OnFetch = fun () -> ()
-                                        OnPull = fun () -> ()
-                                        OnPush = fun () -> ()
-                                        OnSync = fun () -> ()
-                                        OnCommitSelection = fun _ -> ()
-                                        OnCommitAll = fun _ -> ()
-                                        OnSaveDownloadLargeFiles = fun _ -> ()
-                                        OnSaveLfsAutoTrackThreshold = fun _ -> ()
-                                        OnCreateBranch = fun _ -> ()
-                                        OnSwitchBranch = fun _ -> ()
-                                        OnSelectChange = fun _ -> promise { return Ok() }
-                                    },
-                                    downloadLargeFiles = true,
-                                    lfsAutoTrackThresholdMb = 5
-                                )
-                            ]
-                        ]
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = [| changedFile "obsolete.md" "D" " " false |],
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnSync = fun () -> ()
+                                OnCommitSelection = fun _ -> ()
+                                OnCommitAll = fun _ -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
                     )
 
-                Vitest.expect(container.textContent.Contains("Deleted")).toBe (true)
-                Vitest.expect(container.textContent.Contains("git: D.")).toBe (true)
+                Vitest.expect(container.textContent.Contains("git: D.")).toBe (false)
+                Vitest.expect(container.textContent.Contains("Deleted")).toBe (false)
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeStatusButton-0']")).not.toBeNull ()
 
                 cleanup ()
             }

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -2676,6 +2676,67 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "GitSidebar plain click on a marked row deselects it and rows suppress native text selection",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = [|
+                                changedFile "README.md" "M" " " false
+                                changedFile "docs/guide.md" "M" " " false
+                            |],
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
+                                OnCommitSelection = fun _ -> ()
+                                OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let firstRow = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLElement
+
+                firstRow.click ()
+                do! Promise.sleep 0
+
+                Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
+
+                firstRow.click ()
+                do! Promise.sleep 0
+
+                Vitest.expect(container.textContent.Contains("Save All Changes")).toBe (true)
+
+                let rowClass = firstRow.className
+                Vitest.expect(rowClass.Contains("swt:select-none")).toBe (true)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
             "GitSidebar status popover trigger does not open the changed file row",
             fun () -> promise {
                 let mutable selectCalls = 0

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -1829,4 +1829,58 @@ Vitest.describe (
                 cleanup ()
             }
         )
+
+        Vitest.test (
+            "GitSidebar keeps the change-status icon in a fixed right-edge slot",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Html.div [
+                            prop.style [ style.width 340; style.height 760 ]
+                            prop.children [
+                                Swate.Components.GitSidebar.Main(
+                                    status = {
+                                        CurrentBranch = Some "main"
+                                        TrackingBranch = Some "origin/main"
+                                        Ahead = 0
+                                        Behind = 0
+                                        IsClean = false
+                                        IsMergeInProgress = false
+                                    },
+                                    changedFiles = [|
+                                        changedFile
+                                            "src/very/long/path/that/wraps/in/the/sidebar/and/needs/a/fixed/status/icon.txt"
+                                            "M"
+                                            " "
+                                            false
+                                    |],
+                                    branchOptions = [| sidebarLocalBranch "main" true true |],
+                                    callbacks = {
+                                        OnRefresh = fun () -> ()
+                                        OnFetch = fun () -> ()
+                                        OnPull = fun () -> ()
+                                        OnPush = fun () -> ()
+                                        OnSync = fun () -> ()
+                                        OnCommitSelection = fun _ -> ()
+                                        OnCommitAll = fun _ -> ()
+                                        OnSaveDownloadLargeFiles = fun _ -> ()
+                                        OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                        OnCreateBranch = fun _ -> ()
+                                        OnSwitchBranch = fun _ -> ()
+                                        OnSelectChange = fun _ -> promise { return Ok() }
+                                    },
+                                    downloadLargeFiles = true,
+                                    lfsAutoTrackThresholdMb = 5
+                                )
+                            ]
+                        ]
+                    )
+
+                let statusSlot = container.querySelector("[data-testid='GitSidebarChangeStatusSlot-0']") :?> HTMLElement
+                Vitest.expect(statusSlot.className.Contains("swt:ml-auto")).toBe (true)
+                Vitest.expect(statusSlot.className.Contains("swt:shrink-0")).toBe (true)
+
+                cleanup ()
+            }
+        )
 )

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -154,6 +154,9 @@ let private lastGitLabCreateProjectBody () : obj = jsNative
 [<Emit("Object.prototype.hasOwnProperty.call($0, $1)")>]
 let private hasOwnProperty (target: obj) (propertyName: string) : bool = jsNative
 
+[<Emit("$0.firstElementChild")>]
+let private firstElementChild (target: HTMLElement) : HTMLElement = jsNative
+
 [<Emit("$0[$1]")>]
 let private getProperty<'T> (target: obj) (propertyName: string) : 'T = jsNative
 
@@ -261,6 +264,25 @@ let private renderToBody (element: ReactElement) = promise {
             root.unmount ()
             container.remove ()
         )
+}
+
+let private noopCallbacks: GitSidebarCallbacks = {
+    OnRefresh = fun () -> ()
+    OnFetch = fun () -> ()
+    OnPull = fun () -> ()
+    OnPush = fun () -> ()
+    OnUpdateFromOnline = fun () -> ()
+    OnPrimarySaveSelection = fun _ -> ()
+    OnPrimarySaveAll = fun _ -> ()
+    OnCommitSelection = fun _ -> ()
+    OnCommitAll = fun _ -> ()
+    OnConfirmPendingRemoteAction = fun () -> ()
+    OnCancelPendingRemoteAction = fun () -> ()
+    OnSaveDownloadLargeFiles = fun _ -> ()
+    OnSaveLfsAutoTrackThreshold = fun _ -> ()
+    OnCreateBranch = fun _ -> ()
+    OnSwitchBranch = fun _ -> ()
+    OnSelectChange = fun _ -> promise { return Ok() }
 }
 
 Vitest.afterEach (fun () -> document.body.innerHTML <- "")
@@ -2517,6 +2539,37 @@ Vitest.describe (
 
                 Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
                 Vitest.expect(container.querySelector("[data-testid='GitSidebarErrorNotice']")).not.toBeNull ()
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar renders the save section without the old outer card wrapper",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = [| changedFile "README.md" "M" " " false |],
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = noopCallbacks,
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let saveSection = container.querySelector("[data-testid='GitSidebarCommitSection']") :?> HTMLElement
+                let legacyCard = firstElementChild saveSection
+                Vitest.expect(legacyCard.className.Contains("swt:rounded-box")).toBe (false)
+                Vitest.expect(legacyCard.className.Contains("swt:border")).toBe (false)
 
                 cleanup ()
             }

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -224,6 +224,7 @@ let private defaultDependencies: GitDependencies = {
     initGitRepository = fun path -> unexpectedPromise $"initGitRepository:{path}"
     createDataHubProject = fun name -> unexpectedPromise $"createDataHubProject:{name}"
     installGitLfs = fun () -> unexpectedPromise "installGitLfs"
+    previewGitPull = fun _ -> unexpectedPromise "previewGitPull"
     gitFetch = fun _ -> unexpectedPromise "gitFetch"
     gitPull = fun _ -> unexpectedPromise "gitPull"
     gitPush = fun _ -> unexpectedPromise "gitPush"
@@ -374,7 +375,6 @@ Vitest.describe (
             }
         )
 )
-
 Vitest.describe (
     "GitWorkflow update command flow",
     fun () ->
@@ -1165,6 +1165,361 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "Primary save commits locally, preflights pull, pulls, and pushes when the preflight is safe",
+            fun () -> promise {
+                let mutable stageCalls = 0
+                let mutable commitCalls = 0
+                let mutable previewCalls = 0
+                let mutable pullCalls = 0
+                let mutable pushCalls = 0
+
+                let deps = {
+                    defaultDependencies with
+                        getGitStatus = fun () -> promise { return Ok cleanStatus }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                        gitStagePaths =
+                            fun _ -> promise {
+                                stageCalls <- stageCalls + 1
+                                return Ok okOperationResult
+                            }
+                        gitCommit =
+                            fun _ -> promise {
+                                commitCalls <- commitCalls + 1
+                                return Ok okOperationResult
+                            }
+                        previewGitPull =
+                            fun _ -> promise {
+                                previewCalls <- previewCalls + 1
+                                return Ok { Status = GitPullPreflightStatus.SafeToPull; Message = None }
+                            }
+                        gitPull =
+                            fun _ -> promise {
+                                pullCalls <- pullCalls + 1
+                                return Ok okOperationResult
+                            }
+                        gitPush =
+                            fun _ -> promise {
+                                pushCalls <- pushCalls + 1
+                                return Ok okOperationResult
+                            }
+                }
+
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        ChangedFiles = [| changedFile "README.md" "M" " " false |]
+                }
+
+                let stateAfterRequest, requestCmd =
+                    update deps ignore (PrimarySaveAllRequested "Add polish") initialState
+
+                let! requestMessages = collectMessages requestCmd
+
+                let _, finishCmd =
+                    match requestMessages with
+                    | [| WriteCompleted(_, PrimarySave _, Ok(Completed(UnitSuccess(_, _, _, _)))) |] ->
+                        update deps ignore requestMessages[0] stateAfterRequest
+                    | _ -> failwith "Expected the primary save flow to finish as one completed write request."
+
+                let! _ = collectMessages finishCmd
+
+                Vitest.expect(stageCalls).toBe (1)
+                Vitest.expect(commitCalls).toBe (1)
+                Vitest.expect(previewCalls).toBe (1)
+                Vitest.expect(pullCalls).toBe (1)
+                Vitest.expect(pushCalls).toBe (1)
+            }
+        )
+
+        Vitest.test (
+            "Primary save publishes the branch first when no upstream is configured yet",
+            fun () -> promise {
+                let mutable previewCalls = 0
+                let mutable pullCalls = 0
+                let mutable pushCalls = 0
+
+                let deps = {
+                    defaultDependencies with
+                        getGitStatus = fun () -> promise { return Ok(statusForBranch "feature/new-branch") }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "feature/new-branch" true false |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                        gitStagePaths = fun _ -> promise { return Ok okOperationResult }
+                        gitCommit = fun _ -> promise { return Ok okOperationResult }
+                        previewGitPull =
+                            fun _ -> promise {
+                                previewCalls <- previewCalls + 1
+                                return Ok { Status = GitPullPreflightStatus.SafeToPull; Message = None }
+                            }
+                        gitPull =
+                            fun _ -> promise {
+                                pullCalls <- pullCalls + 1
+                                return Ok okOperationResult
+                            }
+                        gitPush =
+                            fun _ -> promise {
+                                pushCalls <- pushCalls + 1
+                                return Ok okOperationResult
+                            }
+                }
+
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        Status = {
+                            GitState.Empty.Status with
+                                CurrentBranch = Some "feature/new-branch"
+                                TrackingBranch = None
+                                IsClean = false
+                        }
+                        BranchOptions = [| sidebarLocalBranch "feature/new-branch" true false |]
+                        ChangedFiles = [| changedFile "README.md" "M" " " false |]
+                }
+
+                let stateAfterRequest, requestCmd =
+                    update deps ignore (PrimarySaveAllRequested "Publish branch") initialState
+
+                let! requestMessages = collectMessages requestCmd
+
+                let _, finishCmd =
+                    match requestMessages with
+                    | [| WriteCompleted(_, PrimarySave _, Ok(Completed(UnitSuccess(_, _, _, _)))) |] ->
+                        update deps ignore requestMessages[0] stateAfterRequest
+                    | _ -> failwith "Expected the primary save flow to publish the branch and finish."
+
+                let! _ = collectMessages finishCmd
+
+                Vitest.expect(pushCalls).toBe (1)
+                Vitest.expect(previewCalls).toBe (0)
+                Vitest.expect(pullCalls).toBe (0)
+            }
+        )
+
+        Vitest.test (
+            "Local-only save keeps the old add-and-commit behavior and never requests pull preflight",
+            fun () -> promise {
+                let mutable previewCalled = false
+
+                let deps = {
+                    defaultDependencies with
+                        gitStagePaths = fun _ -> promise { return Ok okOperationResult }
+                        gitCommit = fun _ -> promise { return Ok okOperationResult }
+                        previewGitPull =
+                            fun _ -> promise {
+                                previewCalled <- true
+                                return Ok { Status = GitPullPreflightStatus.SafeToPull; Message = None }
+                            }
+                        getGitStatus = fun () -> promise { return Ok cleanStatus }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                }
+
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        ChangedFiles = [| changedFile "README.md" "M" " " false |]
+                }
+
+                let _, cmd = update deps ignore (CommitAllRequested "Local only") state
+                let! _ = collectMessages cmd
+
+                Vitest.expect(previewCalled).toBe (false)
+            }
+        )
+
+        Vitest.test (
+            "Primary save keeps a warning and pending confirmation when preflight says online sync still needs merge resolution",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        getGitStatus = fun () -> promise { return Ok cleanStatus }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                        gitStagePaths = fun _ -> promise { return Ok okOperationResult }
+                        gitCommit = fun _ -> promise { return Ok okOperationResult }
+                        previewGitPull =
+                            fun _ -> promise {
+                                return
+                                    Ok {
+                                        Status = GitPullPreflightStatus.WouldRequireMergeResolution
+                                        Message = Some "Pulling would require merge resolution."
+                                    }
+                            }
+                }
+
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        ChangedFiles = [| changedFile "README.md" "M" " " false |]
+                }
+
+                let stateAfterRequest, requestCmd =
+                    update deps ignore (PrimarySaveAllRequested "Add polish") initialState
+
+                let! requestMessages = collectMessages requestCmd
+
+                let nextState, finishCmd =
+                    match requestMessages with
+                    | [| WriteCompleted(_, PrimarySave _, Ok(CompletedWithPendingRemoteConfirmation(UnitSuccess(_, _, _, Some warningText), _, GitPendingRemoteAction.CompletePrimarySavePush))) |] ->
+                        let updatedState, cmd = update deps ignore requestMessages[0] stateAfterRequest
+                        Vitest.expect(warningText).toContain ("saved locally")
+                        updatedState, cmd
+                    | _ -> failwith "Expected the primary save flow to request remote confirmation."
+
+                let! _ = collectMessages finishCmd
+
+                Vitest.expect(nextState.PendingConfirmation.IsSome).toBe (true)
+                Vitest.expect(nextState.PendingRemoteAction).toEqual (GitPendingRemoteAction.CompletePrimarySavePush)
+                Vitest.expect(nextState.WarningNotice |> Option.defaultValue "").toContain ("saved locally")
+
+                let stateAfterCancel, cancelCmd =
+                    update deps ignore CancelPendingRemoteActionRequested nextState
+
+                let! cancelMessages = collectMessages cancelCmd
+
+                Vitest.expect(cancelMessages).toEqual ([||])
+                Vitest.expect(stateAfterCancel.PendingConfirmation).toEqual (None)
+                Vitest.expect(stateAfterCancel.WarningNotice |> Option.defaultValue "").toContain ("saved locally")
+            }
+        )
+
+        Vitest.test (
+            "UpdateFromOnlineRequested opens a confirmation dialog instead of pulling when preflight predicts merge resolution",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        previewGitPull =
+                            fun _ -> promise {
+                                return
+                                    Ok {
+                                        Status = GitPullPreflightStatus.WouldRequireMergeResolution
+                                        Message = Some "Pulling would require merge resolution."
+                                    }
+                            }
+                }
+
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                }
+
+                let nextState, cmd = update deps ignore UpdateFromOnlineRequested state
+                let! messages = collectMessages cmd
+
+                Vitest.expect(messages).toEqual ([||])
+                Vitest.expect(nextState.PendingConfirmation.IsSome).toBe (true)
+                Vitest.expect(nextState.PendingRemoteAction).toEqual (GitPendingRemoteAction.UpdateFromOnline)
+            }
+        )
+
+        Vitest.test (
+            "UpdateFromOnlineRequested does nothing when no ARC is loaded",
+            fun () -> promise {
+                let nextState, cmd =
+                    update defaultDependencies ignore UpdateFromOnlineRequested GitState.Empty
+
+                let! messages = collectMessages cmd
+
+                Vitest.expect(messages).toEqual ([||])
+                Vitest.expect(nextState).toEqual (GitState.Empty)
+            }
+        )
+
+        Vitest.test (
+            "UpdateFromOnlineRequested shows the indeterminate confirmation wording when preflight cannot classify safely",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        previewGitPull =
+                            fun _ -> promise {
+                                return
+                                    Ok {
+                                        Status = GitPullPreflightStatus.Indeterminate
+                                        Message = Some "Git pull preflight could not be classified safely."
+                                    }
+                            }
+                }
+
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                }
+
+                let nextState, cmd = update deps ignore UpdateFromOnlineRequested state
+                let! messages = collectMessages cmd
+
+                Vitest.expect(messages).toEqual ([||])
+                Vitest.expect(nextState.PendingConfirmation |> Option.map _.Title).toEqual (Some "Update could not be previewed")
+                Vitest
+                    .expect(nextState.PendingConfirmation |> Option.map _.Message |> Option.defaultValue "")
+                    .toContain ("could not determine safely")
+            }
+        )
+
+        Vitest.test (
+            "UpdatePreflightCompleted ignores results from the previous ARC session",
+            fun () -> promise {
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc-b"
+                        ArcSessionId = 4
+                }
+
+                let nextState, cmd =
+                    update
+                        defaultDependencies
+                        ignore
+                        (UpdatePreflightCompleted(
+                            3,
+                            Ok {
+                                Status = GitPullPreflightStatus.WouldRequireMergeResolution
+                                Message = Some "stale"
+                            }
+                        ))
+                        state
+
+                let! messages = collectMessages cmd
+
+                Vitest.expect(messages).toEqual ([||])
+                Vitest.expect(nextState.PendingConfirmation).toEqual (None)
+            }
+        )
+
+        Vitest.test (
+            "ConfirmMergeResolutionCompleted dispatches Push when the pending primary-save push can resume",
+            fun () -> promise {
+                let state = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        ArcSessionId = 5
+                        PendingPostMergePush = true
+                        BusyOperation = Some(GitBusyOperation.ConfirmingMergeResolution "conflict.txt")
+                        MergeResolutionPendingPath = Some "conflict.txt"
+                        SelectedChangePath = Some "conflict.txt"
+                }
+
+                let nextState, cmd =
+                    update
+                        defaultDependencies
+                        ignore
+                        (ConfirmMergeResolutionCompleted(
+                            5,
+                            Ok {
+                                UpdatedStatus = cleanStatus
+                                NextConflictedPath = None
+                                PageChange = GitPageChange.Clear
+                            }
+                        ))
+                        state
+
+                let! messages = collectMessages cmd
+
+                Vitest.expect(nextState.PendingPostMergePush).toBe (false)
+                Vitest.expect(messages).toEqual ([| WriteRequested Push |])
+            }
+        )
+
+        Vitest.test (
             "ArcPathChanged schedules a bare RefreshRequested when switching repositories",
             fun () -> promise {
                 let nextState, cmd =
@@ -1381,9 +1736,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -1454,9 +1813,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -1467,15 +1830,15 @@ Vitest.describe (
                             lfsAutoTrackThresholdMb = 5,
                             remoteActionsEnabled = false,
                             remoteActionsWarning =
-                                "Sign in to a DataHub account to use fetch, pull, push, or sync."
+                                "Sign in to a DataHub account to use fetch, pull, push, or update."
                         )
                     )
 
-                let syncButton =
-                    container.querySelector ("[data-testid='GitSidebarSyncButton']")
+                let updateButton =
+                    container.querySelector ("[data-testid='GitSidebarUpdateArcButton']")
                     :?> HTMLButtonElement
 
-                Vitest.expect(syncButton.disabled).toBe (true)
+                Vitest.expect(updateButton.disabled).toBe (true)
                 Vitest.expect(container.textContent.Contains("Sign in to a DataHub account")).toBe (true)
 
                 cleanup ()
@@ -1503,9 +1866,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -1548,9 +1915,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -1596,9 +1967,13 @@ Vitest.describe (
                                         OnFetch = fun () -> ()
                                         OnPull = fun () -> ()
                                         OnPush = fun () -> ()
-                                        OnSync = fun () -> ()
+                                        OnUpdateFromOnline = fun () -> ()
+                                        OnPrimarySaveSelection = fun _ -> ()
+                                        OnPrimarySaveAll = fun _ -> ()
                                         OnCommitSelection = fun _ -> ()
                                         OnCommitAll = fun _ -> ()
+                                        OnConfirmPendingRemoteAction = fun () -> ()
+                                        OnCancelPendingRemoteAction = fun () -> ()
                                         OnSaveDownloadLargeFiles = fun _ -> ()
                                         OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                         OnCreateBranch = fun _ -> ()
@@ -1673,9 +2048,13 @@ Vitest.describe (
                                         OnFetch = fun () -> ()
                                         OnPull = fun () -> ()
                                         OnPush = fun () -> ()
-                                        OnSync = fun () -> ()
+                                        OnUpdateFromOnline = fun () -> ()
+                                        OnPrimarySaveSelection = fun _ -> ()
+                                        OnPrimarySaveAll = fun _ -> ()
                                         OnCommitSelection = fun _ -> ()
                                         OnCommitAll = fun _ -> ()
+                                        OnConfirmPendingRemoteAction = fun () -> ()
+                                        OnCancelPendingRemoteAction = fun () -> ()
                                         OnSaveDownloadLargeFiles = fun _ -> ()
                                         OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                         OnCreateBranch = fun _ -> ()
@@ -1753,9 +2132,13 @@ Vitest.describe (
                                                         OnFetch = fun () -> ()
                                                         OnPull = fun () -> ()
                                                         OnPush = fun () -> ()
-                                                        OnSync = fun () -> ()
+                                                        OnUpdateFromOnline = fun () -> ()
+                                                        OnPrimarySaveSelection = fun _ -> ()
+                                                        OnPrimarySaveAll = fun _ -> ()
                                                         OnCommitSelection = fun _ -> ()
                                                         OnCommitAll = fun _ -> ()
+                                                        OnConfirmPendingRemoteAction = fun () -> ()
+                                                        OnCancelPendingRemoteAction = fun () -> ()
                                                         OnSaveDownloadLargeFiles = fun _ -> ()
                                                         OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                                         OnCreateBranch = fun _ -> ()
@@ -1812,9 +2195,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -1864,9 +2251,13 @@ Vitest.describe (
                                         OnFetch = fun () -> ()
                                         OnPull = fun () -> ()
                                         OnPush = fun () -> ()
-                                        OnSync = fun () -> ()
+                                        OnUpdateFromOnline = fun () -> ()
+                                        OnPrimarySaveSelection = fun _ -> ()
+                                        OnPrimarySaveAll = fun _ -> ()
                                         OnCommitSelection = fun _ -> ()
                                         OnCommitAll = fun _ -> ()
+                                        OnConfirmPendingRemoteAction = fun () -> ()
+                                        OnCancelPendingRemoteAction = fun () -> ()
                                         OnSaveDownloadLargeFiles = fun _ -> ()
                                         OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                         OnCreateBranch = fun _ -> ()
@@ -1909,9 +2300,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -1964,9 +2359,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun request -> capturedSelection <- Some request
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -2026,9 +2425,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun request -> capturedSelection <- Some request
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()
@@ -2090,9 +2493,13 @@ Vitest.describe (
                                 OnFetch = fun () -> ()
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
-                                OnSync = fun () -> ()
+                                OnUpdateFromOnline = fun () -> ()
+                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnConfirmPendingRemoteAction = fun () -> ()
+                                OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
                                 OnSaveLfsAutoTrackThreshold = fun _ -> ()
                                 OnCreateBranch = fun _ -> ()

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -5,6 +5,7 @@ open Browser.Dom
 open Browser.Types
 open Elmish
 open Fable.Core
+open Fable.Core.JsInterop
 open Feliz
 open Renderer.Context.GitWorkflow
 open Renderer.Types
@@ -105,6 +106,9 @@ let private changedFile path indexStatus workingTreeStatus isConflicted = {
 
 [<Emit("new Event($0)")>]
 let private createEvent (eventType: string) : Browser.Types.Event = jsNative
+
+[<Emit("new MouseEvent($0, $1)")>]
+let private createMouseEvent (eventType: string) (eventInit: obj) : Browser.Types.MouseEvent = jsNative
 
 [<Emit("""
 globalThis.__swateOriginalFetch = globalThis.fetch;
@@ -1879,6 +1883,233 @@ Vitest.describe (
                 let statusSlot = container.querySelector("[data-testid='GitSidebarChangeStatusSlot-0']") :?> HTMLElement
                 Vitest.expect(statusSlot.className.Contains("swt:ml-auto")).toBe (true)
                 Vitest.expect(statusSlot.className.Contains("swt:shrink-0")).toBe (true)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar marks rows with Windows Explorer click semantics and shows one primary save button",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = manyChangedFiles 3,
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnSync = fun () -> ()
+                                OnCommitSelection = fun _ -> ()
+                                OnCommitAll = fun _ -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let firstRow = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
+                let thirdRow = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLButtonElement
+
+                firstRow.click ()
+
+                let shiftClick =
+                    createMouseEvent "click" (createObj [ "bubbles" ==> true; "shiftKey" ==> true ])
+
+                thirdRow.dispatchEvent shiftClick |> ignore
+
+                Vitest.expect(container.querySelectorAll("[data-testid='GitSidebarPrimarySaveButton']").length).toBe (1)
+                Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
+                Vitest.expect(container.querySelectorAll("[data-testid^='GitSidebarCommitSelectionCheckbox-']").length).toBe (0)
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar plain click clears previous marks and ctrl-click toggles a row on and back off",
+            fun () -> promise {
+                let mutable capturedSelection: GitSidebarCommitSelectionRequest option = None
+
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = manyChangedFiles 3,
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnSync = fun () -> ()
+                                OnCommitSelection = fun request -> capturedSelection <- Some request
+                                OnCommitAll = fun _ -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let row0 = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
+                let row1 = container.querySelector("[data-testid='GitSidebarChangeRow-1']") :?> HTMLButtonElement
+                let row2 = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLButtonElement
+                let messageInput = container.querySelector("[data-testid='GitSidebarCommitMessageInput']") :?> HTMLTextAreaElement
+                let saveButton = container.querySelector("[data-testid='GitSidebarPrimarySaveButton']") :?> HTMLButtonElement
+
+                row0.click ()
+
+                let ctrlClick =
+                    createMouseEvent "click" (createObj [ "bubbles" ==> true; "ctrlKey" ==> true ])
+
+                row2.dispatchEvent ctrlClick |> ignore
+                row2.dispatchEvent ctrlClick |> ignore
+                row1.click ()
+
+                messageInput.value <- "save one file"
+                messageInput.dispatchEvent (createEvent "input") |> ignore
+                saveButton.click ()
+
+                Vitest.expect(capturedSelection |> Option.map _.Paths).toEqual (Some [| "src/file-001.txt" |])
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar ctrl-shift-click adds the anchor range to the existing marked set",
+            fun () -> promise {
+                let mutable capturedSelection: GitSidebarCommitSelectionRequest option = None
+
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = manyChangedFiles 3,
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnSync = fun () -> ()
+                                OnCommitSelection = fun request -> capturedSelection <- Some request
+                                OnCommitAll = fun _ -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let row0 = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
+                let row2 = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLButtonElement
+                let messageInput = container.querySelector("[data-testid='GitSidebarCommitMessageInput']") :?> HTMLTextAreaElement
+                let saveButton = container.querySelector("[data-testid='GitSidebarPrimarySaveButton']") :?> HTMLButtonElement
+
+                row0.click ()
+
+                let ctrlShiftClick =
+                    createMouseEvent
+                        "click"
+                        (createObj [ "bubbles" ==> true; "ctrlKey" ==> true; "shiftKey" ==> true ])
+
+                row2.dispatchEvent ctrlShiftClick |> ignore
+
+                messageInput.value <- "save range"
+                messageInput.dispatchEvent (createEvent "input") |> ignore
+                saveButton.click ()
+
+                Vitest
+                    .expect(capturedSelection |> Option.map _.Paths)
+                    .toEqual (Some [| "src/file-000.txt"; "src/file-001.txt"; "src/file-002.txt" |])
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar keeps marked rows selected even when diff opening fails",
+            fun () -> promise {
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = [|
+                                changedFile "README.md" "M" " " false
+                                changedFile "docs/guide.md" "M" " " false
+                            |],
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                OnRefresh = fun () -> ()
+                                OnFetch = fun () -> ()
+                                OnPull = fun () -> ()
+                                OnPush = fun () -> ()
+                                OnSync = fun () -> ()
+                                OnCommitSelection = fun _ -> ()
+                                OnCommitAll = fun _ -> ()
+                                OnSaveDownloadLargeFiles = fun _ -> ()
+                                OnSaveLfsAutoTrackThreshold = fun _ -> ()
+                                OnCreateBranch = fun _ -> ()
+                                OnSwitchBranch = fun _ -> ()
+                                OnSelectChange = fun _ -> promise { return Error "Diff failed to load." }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let firstRow = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
+                firstRow.click ()
+                do! Promise.sleep 0
+
+                Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarErrorNotice']")).not.toBeNull ()
 
                 cleanup ()
             }

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -104,11 +104,18 @@ let private changedFile path indexStatus workingTreeStatus isConflicted = {
     IsConflicted = isConflicted
 }
 
-[<Emit("new Event($0)")>]
+[<Emit("new Event($0, { bubbles: true })")>]
 let private createEvent (eventType: string) : Browser.Types.Event = jsNative
 
 [<Emit("new MouseEvent($0, $1)")>]
 let private createMouseEvent (eventType: string) (eventInit: obj) : Browser.Types.MouseEvent = jsNative
+
+[<Emit("""
+const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value").set;
+setter.call($0, $1);
+$0.dispatchEvent(new Event("input", { bubbles: true }));
+""")>]
+let private setTextAreaValue (element: HTMLTextAreaElement) (value: string) : unit = jsNative
 
 [<Emit("""
 globalThis.__swateOriginalFetch = globalThis.fetch;
@@ -293,6 +300,21 @@ let private collectMessages (cmd: Cmd<Msg>) = promise {
     do! Promise.sleep 0
     return messages |> Seq.toArray
 }
+
+let private updateFromSingleMessage
+    (deps: GitDependencies)
+    (setPageState: PageState option -> unit)
+    (failureMessage: string)
+    (model: GitState)
+    (cmd: Cmd<Msg>)
+    =
+    promise {
+        let! messages = collectMessages cmd
+
+        match messages with
+        | [| message |] -> return update deps setPageState message model
+        | _ -> return failwith failureMessage
+    }
 
 Vitest.describe (
     "GitWorkflow request preparation",
@@ -1236,12 +1258,20 @@ Vitest.describe (
                 let stateAfterRequest, requestCmd =
                     update deps ignore (PrimarySaveAllRequested "Add polish") initialState
 
-                let! requestMessages = collectMessages requestCmd
+                let! stateAfterWriteRequest, writeCmd =
+                    updateFromSingleMessage
+                        deps
+                        ignore
+                        "Expected the primary save request to enqueue a write request."
+                        stateAfterRequest
+                        requestCmd
+
+                let! requestMessages = collectMessages writeCmd
 
                 let _, finishCmd =
                     match requestMessages with
                     | [| WriteCompleted(_, PrimarySave _, Ok(Completed(UnitSuccess(_, _, _, _)))) |] ->
-                        update deps ignore requestMessages[0] stateAfterRequest
+                        update deps ignore requestMessages[0] stateAfterWriteRequest
                     | _ -> failwith "Expected the primary save flow to finish as one completed write request."
 
                 let! _ = collectMessages finishCmd
@@ -1301,12 +1331,20 @@ Vitest.describe (
                 let stateAfterRequest, requestCmd =
                     update deps ignore (PrimarySaveAllRequested "Publish branch") initialState
 
-                let! requestMessages = collectMessages requestCmd
+                let! stateAfterWriteRequest, writeCmd =
+                    updateFromSingleMessage
+                        deps
+                        ignore
+                        "Expected the primary save request to enqueue a write request."
+                        stateAfterRequest
+                        requestCmd
+
+                let! requestMessages = collectMessages writeCmd
 
                 let _, finishCmd =
                     match requestMessages with
                     | [| WriteCompleted(_, PrimarySave _, Ok(Completed(UnitSuccess(_, _, _, _)))) |] ->
-                        update deps ignore requestMessages[0] stateAfterRequest
+                        update deps ignore requestMessages[0] stateAfterWriteRequest
                     | _ -> failwith "Expected the primary save flow to publish the branch and finish."
 
                 let! _ = collectMessages finishCmd
@@ -1378,12 +1416,20 @@ Vitest.describe (
                 let stateAfterRequest, requestCmd =
                     update deps ignore (PrimarySaveAllRequested "Add polish") initialState
 
-                let! requestMessages = collectMessages requestCmd
+                let! stateAfterWriteRequest, writeCmd =
+                    updateFromSingleMessage
+                        deps
+                        ignore
+                        "Expected the primary save request to enqueue a write request."
+                        stateAfterRequest
+                        requestCmd
+
+                let! requestMessages = collectMessages writeCmd
 
                 let nextState, finishCmd =
                     match requestMessages with
                     | [| WriteCompleted(_, PrimarySave _, Ok(CompletedWithPendingRemoteConfirmation(UnitSuccess(_, _, _, Some warningText), _, GitPendingRemoteAction.CompletePrimarySavePush))) |] ->
-                        let updatedState, cmd = update deps ignore requestMessages[0] stateAfterRequest
+                        let updatedState, cmd = update deps ignore requestMessages[0] stateAfterWriteRequest
                         Vitest.expect(warningText).toContain ("saved locally")
                         updatedState, cmd
                     | _ -> failwith "Expected the primary save flow to request remote confirmation."
@@ -1402,6 +1448,53 @@ Vitest.describe (
                 Vitest.expect(cancelMessages).toEqual ([||])
                 Vitest.expect(stateAfterCancel.PendingConfirmation).toEqual (None)
                 Vitest.expect(stateAfterCancel.WarningNotice |> Option.defaultValue "").toContain ("saved locally")
+            }
+        )
+
+        Vitest.test (
+            "Primary save preserves the local commit warning when remote preflight fails after commit",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        getGitStatus = fun () -> promise { return Ok cleanStatus }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                        gitStagePaths = fun _ -> promise { return Ok okOperationResult }
+                        gitCommit = fun _ -> promise { return Ok okOperationResult }
+                        previewGitPull = fun _ -> promise { return Error "Network unavailable during pull preflight." }
+                }
+
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        ChangedFiles = [| changedFile "README.md" "M" " " false |]
+                }
+
+                let stateAfterRequest, requestCmd =
+                    update deps ignore (PrimarySaveAllRequested "Save locally first") initialState
+
+                let! stateAfterWriteRequest, writeCmd =
+                    updateFromSingleMessage
+                        deps
+                        ignore
+                        "Expected the primary save request to enqueue a write request."
+                        stateAfterRequest
+                        requestCmd
+
+                let! requestMessages = collectMessages writeCmd
+
+                let nextState, finishCmd =
+                    match requestMessages with
+                    | [| WriteCompleted(_, PrimarySave _, Ok _) |] ->
+                        update deps ignore requestMessages[0] stateAfterWriteRequest
+                    | _ -> failwith "Expected the primary save command to complete with a local-save outcome."
+
+                let! finishMessages = collectMessages finishCmd
+
+                Vitest.expect(finishMessages).toEqual ([||])
+                Vitest.expect(nextState.WarningNotice |> Option.defaultValue "").toContain ("saved locally")
+                Vitest.expect(nextState.ErrorNotice).toEqual (Some "Network unavailable during pull preflight.")
+                Vitest.expect(nextState.Status.IsClean).toBe (true)
             }
         )
 
@@ -1425,8 +1518,17 @@ Vitest.describe (
                         CurrentArcPath = Some "C:/arc"
                 }
 
-                let nextState, cmd = update deps ignore UpdateFromOnlineRequested state
-                let! messages = collectMessages cmd
+                let stateAfterRequest, cmd = update deps ignore UpdateFromOnlineRequested state
+
+                let! nextState, finishCmd =
+                    updateFromSingleMessage
+                        deps
+                        ignore
+                        "Expected update preflight to complete."
+                        stateAfterRequest
+                        cmd
+
+                let! messages = collectMessages finishCmd
 
                 Vitest.expect(messages).toEqual ([||])
                 Vitest.expect(nextState.PendingConfirmation.IsSome).toBe (true)
@@ -1467,8 +1569,17 @@ Vitest.describe (
                         CurrentArcPath = Some "C:/arc"
                 }
 
-                let nextState, cmd = update deps ignore UpdateFromOnlineRequested state
-                let! messages = collectMessages cmd
+                let stateAfterRequest, cmd = update deps ignore UpdateFromOnlineRequested state
+
+                let! nextState, finishCmd =
+                    updateFromSingleMessage
+                        deps
+                        ignore
+                        "Expected update preflight to complete."
+                        stateAfterRequest
+                        cmd
+
+                let! messages = collectMessages finishCmd
 
                 Vitest.expect(messages).toEqual ([||])
                 Vitest.expect(nextState.PendingConfirmation |> Option.map _.Title).toEqual (Some "Update could not be previewed")
@@ -2340,15 +2451,17 @@ Vitest.describe (
                         )
                     )
 
-                let firstRow = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
-                let thirdRow = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLButtonElement
+                let firstRow = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLElement
+                let thirdRow = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLElement
 
                 firstRow.click ()
+                do! Promise.sleep 0
 
                 let shiftClick =
                     createMouseEvent "click" (createObj [ "bubbles" ==> true; "shiftKey" ==> true ])
 
                 thirdRow.dispatchEvent shiftClick |> ignore
+                do! Promise.sleep 0
 
                 Vitest.expect(container.querySelectorAll("[data-testid='GitSidebarPrimarySaveButton']").length).toBe (1)
                 Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
@@ -2382,9 +2495,9 @@ Vitest.describe (
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
                                 OnUpdateFromOnline = fun () -> ()
-                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveSelection = fun request -> capturedSelection <- Some request
                                 OnPrimarySaveAll = fun _ -> ()
-                                OnCommitSelection = fun request -> capturedSelection <- Some request
+                                OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
@@ -2399,24 +2512,34 @@ Vitest.describe (
                         )
                     )
 
-                let row0 = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
-                let row1 = container.querySelector("[data-testid='GitSidebarChangeRow-1']") :?> HTMLButtonElement
-                let row2 = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLButtonElement
+                let row0 = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLElement
+                let row1 = container.querySelector("[data-testid='GitSidebarChangeRow-1']") :?> HTMLElement
+                let row2 = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLElement
                 let messageInput = container.querySelector("[data-testid='GitSidebarCommitMessageInput']") :?> HTMLTextAreaElement
-                let saveButton = container.querySelector("[data-testid='GitSidebarPrimarySaveButton']") :?> HTMLButtonElement
 
                 row0.click ()
+                do! Promise.sleep 0
 
                 let ctrlClick =
                     createMouseEvent "click" (createObj [ "bubbles" ==> true; "ctrlKey" ==> true ])
 
                 row2.dispatchEvent ctrlClick |> ignore
+                do! Promise.sleep 0
                 row2.dispatchEvent ctrlClick |> ignore
+                do! Promise.sleep 0
                 row1.click ()
+                do! Promise.sleep 0
 
-                messageInput.value <- "save one file"
-                messageInput.dispatchEvent (createEvent "input") |> ignore
+                setTextAreaValue messageInput "save one file"
+                do! Promise.sleep 0
+
+                let saveButton =
+                    container.querySelector("[data-testid='GitSidebarPrimarySaveButton']") :?> HTMLButtonElement
+
+                Vitest.expect(saveButton.disabled).toBe (false)
+                Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
                 saveButton.click ()
+                do! Promise.sleep 0
 
                 Vitest.expect(capturedSelection |> Option.map _.Paths).toEqual (Some [| "src/file-001.txt" |])
 
@@ -2448,9 +2571,9 @@ Vitest.describe (
                                 OnPull = fun () -> ()
                                 OnPush = fun () -> ()
                                 OnUpdateFromOnline = fun () -> ()
-                                OnPrimarySaveSelection = fun _ -> ()
+                                OnPrimarySaveSelection = fun request -> capturedSelection <- Some request
                                 OnPrimarySaveAll = fun _ -> ()
-                                OnCommitSelection = fun request -> capturedSelection <- Some request
+                                OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
@@ -2465,12 +2588,12 @@ Vitest.describe (
                         )
                     )
 
-                let row0 = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
-                let row2 = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLButtonElement
+                let row0 = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLElement
+                let row2 = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLElement
                 let messageInput = container.querySelector("[data-testid='GitSidebarCommitMessageInput']") :?> HTMLTextAreaElement
-                let saveButton = container.querySelector("[data-testid='GitSidebarPrimarySaveButton']") :?> HTMLButtonElement
 
                 row0.click ()
+                do! Promise.sleep 0
 
                 let ctrlShiftClick =
                     createMouseEvent
@@ -2478,10 +2601,18 @@ Vitest.describe (
                         (createObj [ "bubbles" ==> true; "ctrlKey" ==> true; "shiftKey" ==> true ])
 
                 row2.dispatchEvent ctrlShiftClick |> ignore
+                do! Promise.sleep 0
 
-                messageInput.value <- "save range"
-                messageInput.dispatchEvent (createEvent "input") |> ignore
+                setTextAreaValue messageInput "save range"
+                do! Promise.sleep 0
+
+                let saveButton =
+                    container.querySelector("[data-testid='GitSidebarPrimarySaveButton']") :?> HTMLButtonElement
+
+                Vitest.expect(saveButton.disabled).toBe (false)
+                Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
                 saveButton.click ()
+                do! Promise.sleep 0
 
                 Vitest
                     .expect(capturedSelection |> Option.map _.Paths)
@@ -2533,12 +2664,54 @@ Vitest.describe (
                         )
                     )
 
-                let firstRow = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLButtonElement
+                let firstRow = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLElement
                 firstRow.click ()
                 do! Promise.sleep 0
 
                 Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
                 Vitest.expect(container.querySelector("[data-testid='GitSidebarErrorNotice']")).not.toBeNull ()
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar status popover trigger does not open the changed file row",
+            fun () -> promise {
+                let mutable selectCalls = 0
+
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = [| changedFile "README.md" "M" " " false |],
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                noopCallbacks with
+                                    OnSelectChange =
+                                        fun _ ->
+                                            selectCalls <- selectCalls + 1
+                                            promise { return Ok() }
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let statusButton =
+                    container.querySelector("[data-testid='GitSidebarChangeStatusButton-0']") :?> HTMLButtonElement
+
+                statusButton.click ()
+                do! Promise.sleep 0
+
+                Vitest.expect(selectCalls).toBe (0)
 
                 cleanup ()
             }


### PR DESCRIPTION
## Summary

- Polished the Git changed-file list with pinned status icons, status popovers, cleaner row markup, and Windows-style multi-selection behavior.
  - <img width="949" height="618" alt="image" src="https://github.com/user-attachments/assets/a395f626-7c3a-4284-988a-4408ad542be4" />
- Reworked Git save actions into a synced primary save flow that saves, commits, fetches, pulls with preflight checks, and pushes changes.
- Moved local-only “add and commit” actions into the save split-button dropdown for all or selected changes, with a help popover explaining the options.
  - <img width="329" height="190" alt="image" src="https://github.com/user-attachments/assets/bc0d1a4b-3638-49ab-90fe-c8d79e53e9fd" />
  - <img width="461" height="354" alt="image" src="https://github.com/user-attachments/assets/fe3c9e0f-fe7c-4427-8d3b-3ca3369a8de7" />
- Renamed and hardened the pull/update path with native pull preflight handling, merge-conflict confirmation, and clearer pending-sync behavior.
- Improved branch actions to support remote branch selection when switching or creating branches.
  - <img width="709" height="770" alt="image" src="https://github.com/user-attachments/assets/f437a96b-20d0-42a6-8edf-cf44f94ba111" />
  - Ignore my branch test names 👀
- Moved the Download Large Files option into More Git Actions directly above the LFS threshold setting.
- Added and updated component, renderer workflow, and Electron core tests for the new Git UI and workflow behavior.