### PR TITLE
Discard changes (git)

### DIFF
--- a/docs/GitFunctionalityUserGuide.md
+++ b/docs/GitFunctionalityUserGuide.md
@@ -41,6 +41,7 @@ createBranch: GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, st
 checkoutBranch: GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
 gitStagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
 gitUnstagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
+gitDiscardPaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
 gitCommit: GitCommitRequest -> JS.Promise<Result<GitOperationResult, string>>
 setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, string>>
 confirmGitMergeResolution: GitConfirmMergeResolutionRequest -> JS.Promise<Result<GitConfirmMergeResolutionResult, string>>
@@ -211,7 +212,7 @@ promise {
 - Status and refs: `getStatus`, `getBranches`
 - Diff and page data: `getDiffSummary`, `getDiff`, `getWordDiff`, `getDiffViewData`, `getMergeConflictViewData`
 - Remote sync: `fetch`, `previewPull`, `pull`, `push`
-- Local writes: `stagePaths`, `unstagePaths`, `commit`, `createBranch`, `checkoutBranch`, `addRemote`
+- Local writes: `stagePaths`, `unstagePaths`, `discardPaths`, `commit`, `createBranch`, `checkoutBranch`, `addRemote`
 - LFS settings: `getLfsSettings`, `setLfsSettings`
 - Merge resolution: `confirmMergeResolution`
 
@@ -331,6 +332,7 @@ Operations wrapped in `withBusyWriting`:
 - `gitPull`
 - `gitStagePaths`
 - `gitUnstagePaths`
+- `gitDiscardPaths`
 - `gitCommit`
 - `createBranch`
 - `checkoutBranch`

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -153,6 +153,7 @@ type private ChangedFilesListProps = {
     IsBusy: bool
     UpdateMarkedSelection: GitSidebarChange -> bool -> bool -> unit
     OpenChange: GitSidebarChange -> unit
+    DiscardChanges: string[] -> unit
 }
 
 type private ChangedFileRowProps = {
@@ -927,6 +928,7 @@ type GitSidebar =
                 Html.div [
                     prop.testId $"GitSidebarChangeRow-{props.Index}"
                     prop.custom ("data-index", props.Index)
+                    prop.custom ("data-git-change-path", change.Path)
                     prop.role "button"
                     prop.tabIndex (if props.IsBusy then -1 else 0)
                     prop.custom ("aria-disabled", if props.IsBusy then "true" else "false")
@@ -991,6 +993,59 @@ type GitSidebar =
         let itemSize = 64
         let itemGap = 4
         let overscan = 8
+
+        let contextMenuItemsForChange (change: GitSidebarChange) =
+            if props.IsBusy then
+                []
+            else
+                let targetPaths =
+                    if Set.contains change.Path props.MarkedPaths && not (Set.isEmpty props.MarkedPaths) then
+                        props.MarkedPaths |> Set.toArray |> Array.sort
+                    else
+                        [| change.Path |]
+
+                let label =
+                    if targetPaths.Length = 1 then
+                        "Discard Change"
+                    else
+                        "Discard Selected Changes"
+
+                [
+                    ContextMenuItem(
+                        text = Html.span label,
+                        icon =
+                            Html.span [
+                                prop.className "swt:iconify swt:fluent--arrow-undo-24-regular swt:size-4"
+                            ],
+                        onClick = fun _ -> props.DiscardChanges targetPaths
+                    )
+                ]
+
+        let contextMenu =
+            ContextMenu.ContextMenu(
+                (fun data ->
+                    data
+                    |> unbox<GitSidebarChange>
+                    |> contextMenuItemsForChange
+                ),
+                ref = scrollContainerRef,
+                onSpawn =
+                    (fun event ->
+                        if props.IsBusy then
+                            None
+                        else
+                            let target = event.target :?> HTMLElement
+
+                            match target.closest("[data-git-change-path]"), scrollContainerRef.current with
+                            | Some trigger, Some container when container.contains trigger ->
+                                let trigger = trigger :?> HTMLElement
+                                let path: string = !!trigger?dataset?gitChangePath
+
+                                props.ChangedFiles
+                                |> Array.tryFind (fun change -> String.Equals(change.Path, path, StringComparison.Ordinal))
+                                |> Option.map box
+                            | _ -> None)
+            )
 
         let changedFileListVirtualizer =
             Virtual.useVirtualizer (
@@ -1091,6 +1146,7 @@ type GitSidebar =
                         ]
                 ]
             ]
+            contextMenu
         ]
 
     [<ReactComponent>]
@@ -1328,6 +1384,7 @@ type GitSidebar =
         let onPrimarySaveAll = callbacks.OnPrimarySaveAll
         let onCommitSelection = callbacks.OnCommitSelection
         let onCommitAll = callbacks.OnCommitAll
+        let onDiscardSelection = callbacks.OnDiscardSelection
         let onConfirmPendingRemoteAction = callbacks.OnConfirmPendingRemoteAction
         let onCancelPendingRemoteAction = callbacks.OnCancelPendingRemoteAction
         let onSaveDownloadLargeFiles = callbacks.OnSaveDownloadLargeFiles
@@ -1551,6 +1608,22 @@ type GitSidebar =
                 setLocalError None
                 onCommitAll normalizedCommitMessage
 
+        let submitDiscardSelection (paths: string[]) =
+            let normalizedPaths =
+                paths
+                |> Array.map _.Trim()
+                |> Array.filter (String.IsNullOrWhiteSpace >> not)
+                |> Array.distinct
+                |> Array.sort
+
+            if normalizedPaths.Length = 0 then
+                setLocalError (Some "No selected changes to discard.")
+            else
+                setLocalError None
+                onDiscardSelection normalizedPaths
+                setMarkedPaths (fun _ -> Set.empty)
+                setSelectionAnchorPath (fun _ -> None)
+
         let submitLfsThreshold () =
             let normalizedInput = lfsThresholdInput.Trim()
 
@@ -1730,6 +1803,7 @@ type GitSidebar =
                         IsBusy = isBusy
                         UpdateMarkedSelection = updateMarkedSelection
                         OpenChange = fun change -> runSelectChangeAction change
+                        DiscardChanges = submitDiscardSelection
                     }
                 )
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -10,6 +10,7 @@ const noop = () => {};
 const noopWithArg = (_arg: unknown) => {};
 const noopWithMessage = (_message: string) => {};
 const noopWithSelection = (_request: unknown) => {};
+const noopWithPaths = (_paths: string[]) => {};
 const noopWithBranch = (_branchName: string) => {};
 const noopWithThreshold = (_thresholdMb: number) => {};
 const noopWithDownloadPreference = (_downloadLargeFiles: boolean) => {};
@@ -26,6 +27,7 @@ const baseCallbacks = {
   OnPrimarySaveAll: noopWithMessage,
   OnCommitSelection: noopWithSelection,
   OnCommitAll: noopWithMessage,
+  OnDiscardSelection: noopWithPaths,
   OnConfirmPendingRemoteAction: noop,
   OnCancelPendingRemoteAction: noop,
   OnSaveDownloadLargeFiles: noopWithDownloadPreference,

--- a/src/Components/src/GitSidebar/Types.fs
+++ b/src/Components/src/GitSidebar/Types.fs
@@ -69,6 +69,7 @@ type GitSidebarCallbacks = {
     OnPrimarySaveAll: string -> unit
     OnCommitSelection: GitSidebarCommitSelectionRequest -> unit
     OnCommitAll: string -> unit
+    OnDiscardSelection: string[] -> unit
     OnConfirmPendingRemoteAction: unit -> unit
     OnCancelPendingRemoteAction: unit -> unit
     OnSaveDownloadLargeFiles: bool -> unit

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -279,6 +279,18 @@ let validatePathspecs (pathSpecs: string[]) =
             )
             (Ok [||])
 
+let private splitGitOutputLines (text: string) =
+    text.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)
+    |> Array.map _.Trim()
+    |> Array.filter (String.IsNullOrWhiteSpace >> not)
+
+let private withGitPathspecs (command: string[]) (pathSpecs: string[]) =
+    [|
+        yield! command
+        yield "--"
+        yield! pathSpecs
+    |]
+
 /// Validates a remote name and defaults blank input to `origin`.
 let validateRemoteName (remoteName: string) =
     let normalized =
@@ -1654,6 +1666,112 @@ let unstagePaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<
 
                     let! _ = git.reset ("mixed", !^resetOptions)
                     return ()
+                })
+}
+
+let private hasHeadCommit (git: ISimpleGit) = promise {
+    let! headResult = runSimpleGit (fun currentGit -> currentGit.raw [| "rev-parse"; "--verify"; "HEAD" |]) git
+    return Result.isOk headResult
+}
+
+let private headPathsForPathspecs (git: ISimpleGit) (pathSpecs: string[]) = promise {
+    let! headPathsResult =
+        runSimpleGit
+            (fun currentGit ->
+                currentGit.raw (
+                    withGitPathspecs [|
+                        "ls-tree"
+                        "-r"
+                        "--name-only"
+                        "HEAD"
+                    |] pathSpecs
+                ))
+            git
+
+    match headPathsResult with
+    | Ok output -> return splitGitOutputLines output
+    | Error failure -> return abortGitPromise failure.Message
+}
+
+let private discardPathspecsWithOriginals (arcPath: string) (status: StatusResult) (safePathSpecs: string[]) =
+    let selectedPaths = safePathSpecs |> Set.ofArray
+    let statusDto = toStatusDto arcPath status
+
+    let originalPaths =
+        statusDto.Files
+        |> Array.choose (fun file ->
+            if selectedPaths.Contains file.Path then
+                file.OriginalPath
+            else
+                None)
+        |> Array.choose (fun path ->
+            match ensureValidPathspec path with
+            | Ok safePath -> Some safePath
+            | Error _ -> None)
+
+    Array.append safePathSpecs originalPaths
+    |> Array.distinct
+
+/// Discards validated pathspecs by restoring tracked paths from HEAD and cleaning selected untracked files.
+let discardPaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<unit>> = promise {
+    match validatePathspecs pathSpecs with
+    | Error validationError -> return errorResult validationError
+    | Ok safePathSpecs ->
+        return!
+            withLocalGit
+                arcPath
+                (fun git -> promise {
+                    let! status = git.status ()
+                    let discardPathSpecs = discardPathspecsWithOriginals arcPath status safePathSpecs
+                    let! hasHead = hasHeadCommit git
+
+                    if hasHead then
+                        let! resetResult =
+                            runSimpleGit
+                                (fun currentGit -> currentGit.raw (withGitPathspecs [| "reset" |] discardPathSpecs))
+                                git
+
+                        match resetResult with
+                        | Error failure -> return abortGitPromise failure.Message
+                        | Ok _ ->
+                            let! headPaths = headPathsForPathspecs git discardPathSpecs
+
+                            if headPaths.Length > 0 then
+                                let! restoreResult =
+                                    runSimpleGit
+                                        (fun currentGit ->
+                                            currentGit.raw (withGitPathspecs [| "restore"; "--worktree" |] headPaths))
+                                        git
+
+                                match restoreResult with
+                                | Error failure -> return abortGitPromise failure.Message
+                                | Ok _ -> ()
+                    else
+                        let! rmCachedResult =
+                            runSimpleGit
+                                (fun currentGit ->
+                                    currentGit.raw (
+                                        withGitPathspecs [|
+                                            "rm"
+                                            "--cached"
+                                            "-r"
+                                            "--ignore-unmatch"
+                                        |] discardPathSpecs
+                                    ))
+                                git
+
+                        match rmCachedResult with
+                        | Error failure -> return abortGitPromise failure.Message
+                        | Ok _ -> ()
+
+                    let! cleanResult =
+                        runSimpleGit
+                            (fun currentGit -> currentGit.raw (withGitPathspecs [| "clean"; "-fd" |] discardPathSpecs))
+                            git
+
+                    match cleanResult with
+                    | Error failure -> return abortGitPromise failure.Message
+                    | Ok _ -> return ()
                 })
 }
 

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -328,6 +328,21 @@ let api (event: IpcMainInvokeEvent) : IGitApi = {
                             return toGitOperationResult (fun () -> Some "Files unstaged.") None None result
                         })
         }
+    gitDiscardPaths =
+        fun (request: GitPathspecRequest) -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(vault, arcPath) ->
+                return!
+                    withBusyWriting
+                        vault
+                        (fun () -> promise {
+                            let! result = GitService.discardPaths arcPath request.Pathspecs
+                            if Result.isOk result then
+                                do! vault.RefreshFileTree()
+                            return toGitOperationResult (fun () -> Some "Files discarded.") None None result
+                        })
+        }
     gitCommit =
         fun (request: GitCommitRequest) -> promise {
             match tryGetVaultAndArcPath event with

--- a/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
@@ -128,6 +128,7 @@ let Main () =
                 OnPrimarySaveAll = gitStateCtx.primarySaveAll
                 OnCommitSelection = gitStateCtx.commitSelection
                 OnCommitAll = gitStateCtx.commitAll
+                OnDiscardSelection = gitStateCtx.discardSelection
                 OnConfirmPendingRemoteAction = gitStateCtx.confirmPendingRemoteAction
                 OnCancelPendingRemoteAction = gitStateCtx.cancelPendingRemoteAction
                 OnSaveDownloadLargeFiles = gitStateCtx.saveDownloadLargeFiles

--- a/src/Electron/src/Renderer/Context/GitStateContext.fs
+++ b/src/Electron/src/Renderer/Context/GitStateContext.fs
@@ -25,6 +25,7 @@ type GitStateController = {
     cloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<string, string>>
     commitSelection: GitSidebarCommitSelectionRequest -> unit
     commitAll: string -> unit
+    discardSelection: string[] -> unit
     confirmPendingRemoteAction: unit -> unit
     cancelPendingRemoteAction: unit -> unit
     saveLfsAutoTrackThreshold: int -> unit
@@ -80,6 +81,7 @@ module private Helper =
         checkoutBranch = Renderer.GitApiClient.checkoutBranch
         gitStagePaths = Renderer.GitApiClient.gitStagePaths
         gitUnstagePaths = Renderer.GitApiClient.gitUnstagePaths
+        gitDiscardPaths = Renderer.GitApiClient.gitDiscardPaths
         gitCommit = Renderer.GitApiClient.gitCommit
         setGitLfsSettings = Renderer.GitApiClient.setGitLfsSettings
         confirmGitMergeResolution = Renderer.GitApiClient.confirmGitMergeResolution
@@ -101,6 +103,7 @@ let GitStateCtx =
             cloneRepository = fun _ -> promise { return Ok "" }
             commitSelection = fun _ -> ()
             commitAll = fun _ -> ()
+            discardSelection = fun _ -> ()
             confirmPendingRemoteAction = fun () -> ()
             cancelPendingRemoteAction = fun () -> ()
             saveLfsAutoTrackThreshold = fun _ -> ()
@@ -151,6 +154,9 @@ let GitStateCtxProvider (children: ReactElement) =
 
     let commitAll (message: string) = dispatch (CommitAllRequested message)
 
+    let discardSelection (paths: string[]) =
+        dispatch (DiscardSelectionRequested paths)
+
     let confirmPendingRemoteAction () =
         dispatch ConfirmPendingRemoteActionRequested
 
@@ -192,6 +198,7 @@ let GitStateCtxProvider (children: ReactElement) =
                 cloneRepository = cloneRepository
                 commitSelection = commitSelection
                 commitAll = commitAll
+                discardSelection = discardSelection
                 confirmPendingRemoteAction = confirmPendingRemoteAction
                 cancelPendingRemoteAction = cancelPendingRemoteAction
                 saveLfsAutoTrackThreshold = saveLfsAutoTrackThreshold

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -26,6 +26,7 @@ type GitBusyOperation =
     | CloningRepository
     | CommittingSelectedChanges
     | CommittingAllChanges
+    | DiscardingSelectedChanges
     | SavingGitLfsThreshold
     | SavingGitLfsDownloadPreference
     | CreatingBranch
@@ -152,6 +153,7 @@ type WriteRequest =
     | Clone of GitCloneRepositoryRequest * Reply<string>
     | CommitSelection of PreparedCommitOperation
     | CommitAll of PreparedCommitOperation
+    | DiscardSelection of string[]
     | SaveLfsSettings of GitBusyOperation * GitLfsSettingsDto
     | CreateBranch of GitCreateBranchRequest
     | SwitchBranch of GitCheckoutBranchRequest
@@ -198,6 +200,7 @@ type Msg =
     | PrimarySaveAllRequested of string
     | CommitSelectionRequested of GitSidebarCommitSelectionRequest
     | CommitAllRequested of string
+    | DiscardSelectionRequested of string[]
     | ConfirmPendingRemoteActionRequested
     | CancelPendingRemoteActionRequested
     | CreateBranchRequested of GitSidebarCreateBranchRequest
@@ -226,6 +229,7 @@ type GitDependencies = {
     checkoutBranch: GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitStagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitUnstagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
+    gitDiscardPaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitCommit: GitCommitRequest -> JS.Promise<Result<GitOperationResult, string>>
     setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, string>>
     confirmGitMergeResolution:
@@ -260,6 +264,7 @@ let busyNoticeFromOperation =
     | GitBusyOperation.CloningRepository -> Some "Cloning repository"
     | GitBusyOperation.CommittingSelectedChanges -> Some "Committing selected changes"
     | GitBusyOperation.CommittingAllChanges -> Some "Committing all changes"
+    | GitBusyOperation.DiscardingSelectedChanges -> Some "Discarding selected changes"
     | GitBusyOperation.SavingGitLfsThreshold -> Some "Saving Git LFS threshold"
     | GitBusyOperation.SavingGitLfsDownloadPreference -> Some "Saving Git LFS download preference"
     | GitBusyOperation.CreatingBranch -> Some "Creating branch"
@@ -565,6 +570,7 @@ let private busyOperationForWriteRequest =
     | Clone _ -> GitBusyOperation.CloningRepository
     | CommitSelection prepared -> prepared.BusyOperation
     | CommitAll prepared -> prepared.BusyOperation
+    | DiscardSelection _ -> GitBusyOperation.DiscardingSelectedChanges
     | SaveLfsSettings(busyOperation, _) -> busyOperation
     | CreateBranch _ -> GitBusyOperation.CreatingBranch
     | SwitchBranch _ -> GitBusyOperation.SwitchingBranch
@@ -727,6 +733,21 @@ let private runCommitAttemptAsync (deps: GitDependencies) (prepared: PreparedCom
                     return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.NoChange None
 }
 
+let private runDiscardAttemptAsync (deps: GitDependencies) (paths: string[]) = promise {
+    let pathsToDiscard = distinctPaths paths
+
+    if pathsToDiscard.Length = 0 then
+        return Error "No selected changes to discard."
+    else
+        let! discardResult = deps.gitDiscardPaths { Pathspecs = pathsToDiscard }
+
+        match classifyWriteResult GitBusyOperation.DiscardingSelectedChanges discardResult with
+        | Error message -> return Error message
+        | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+        | Ok(WriteOperationReady operationResult) ->
+            return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.Clear (Some None)
+}
+
 let private pendingPrimarySaveWarning =
     "Changes were saved locally. Online sync is still pending."
 
@@ -845,6 +866,7 @@ let private executeWriteAttempt (deps: GitDependencies) (state: GitState) (reque
     | Clone(request, _) -> return! runCloneAttemptAsync deps request
     | CommitSelection prepared -> return! runCommitAttemptAsync deps prepared
     | CommitAll prepared -> return! runCommitAttemptAsync deps prepared
+    | DiscardSelection paths -> return! runDiscardAttemptAsync deps paths
     | SaveLfsSettings(busyOperation, settings) -> return! runSaveLfsSettingsAttemptAsync deps busyOperation settings
     | CreateBranch request ->
         return! runSimpleWriteAttemptAsync deps GitBusyOperation.CreatingBranch (fun () -> deps.createBranch request)
@@ -1237,6 +1259,7 @@ let update
     | CommitSelectionRequested request ->
         model, Cmd.ofMsg (WriteRequested(CommitSelection(prepareCommitSelection model request)))
     | CommitAllRequested message -> model, Cmd.ofMsg (WriteRequested(CommitAll(prepareCommitAll model message)))
+    | DiscardSelectionRequested paths -> model, Cmd.ofMsg (WriteRequested(DiscardSelection paths))
     | ConfirmPendingRemoteActionRequested ->
         match model.PendingRemoteAction with
         | GitPendingRemoteAction.UpdateFromOnline ->

--- a/src/Electron/src/Renderer/GitApiClient.fs
+++ b/src/Electron/src/Renderer/GitApiClient.fs
@@ -89,6 +89,9 @@ let gitStagePaths (request: GitPathspecRequest) =
 let gitUnstagePaths (request: GitPathspecRequest) =
     callIpcWith request (gitApi.gitUnstagePaths)
 
+let gitDiscardPaths (request: GitPathspecRequest) =
+    callIpcWith request (gitApi.gitDiscardPaths)
+
 let gitCommit (request: GitCommitRequest) =
     callIpcWith request (gitApi.gitCommit)
 

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -71,6 +71,7 @@ type IGitApi = {
     gitCloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitStagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitUnstagePaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, exn>>
+    gitDiscardPaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitCommit: GitCommitRequest -> JS.Promise<Result<GitOperationResult, exn>>
     setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, exn>>
     createBranch: GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, exn>>

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -403,6 +403,55 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "discardPaths restores tracked changes and removes selected untracked files",
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let trackedPath = join [| context.RepoPath; "tracked.txt" |]
+                        let untrackedPath = join [| context.RepoPath; "scratch.txt" |]
+
+                        do! writeUtf8FileAsync trackedPath "first\nsecond\n"
+
+                        let! initialStageResult = GitService.stagePaths context.RepoPath [| "tracked.txt" |]
+                        expectOk "stage tracked file" initialStageResult |> ignore
+
+                        let! initialCommitResult = GitService.commit context.RepoPath "test: track file"
+                        expectOk "commit tracked file" initialCommitResult |> ignore
+
+                        do! writeUtf8FileAsync trackedPath "first\nsecond changed\n"
+                        do! writeUtf8FileAsync untrackedPath "temporary\n"
+
+                        let! stageResult = GitService.stagePaths context.RepoPath [| "tracked.txt"; "scratch.txt" |]
+                        expectOk "stage selected changes" stageResult |> ignore
+
+                        let! discardResult = GitService.discardPaths context.RepoPath [| "tracked.txt"; "scratch.txt" |]
+                        expectOk "discard selected changes" discardResult |> ignore
+
+                        let! status =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status after discard")
+
+                        let! trackedContent =
+                            fsPromisesDynamic?readFile (trackedPath, "utf8") |> unbox<JS.Promise<string>>
+
+                        let! untrackedExists =
+                            promise {
+                                try
+                                    let! _ = fsPromisesDynamic?stat untrackedPath |> unbox<JS.Promise<obj>>
+                                    return true
+                                with _ ->
+                                    return false
+                            }
+
+                        Vitest.expect(status.IsClean).toBe (true)
+                        Vitest.expect(trackedContent).toBe ("first\nsecond\n")
+                        Vitest.expect(untrackedExists).toBe (false)
+                    })
+            }
+        )
+
+        Vitest.test (
             "addRemote stores the requested origin URL in the local repository config",
             fun () -> promise {
                 do!

--- a/tests/Electron.Core/GitValidation.test.fs
+++ b/tests/Electron.Core/GitValidation.test.fs
@@ -722,6 +722,17 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "Git discard paths is exposed through the typed renderer client and workflow dependencies",
+            fun () ->
+                let clientSourceText = getGitApiClientSource ()
+                let stateContextSourceText = getGitStateCtxSource ()
+
+                expectSourceContains clientSourceText "let gitDiscardPaths (request: GitPathspecRequest)"
+                expectSourceContains clientSourceText "gitApi.gitDiscardPaths"
+                expectSourceContains stateContextSourceText "gitDiscardPaths = Renderer.GitApiClient.gitDiscardPaths"
+        )
+
+        Vitest.test (
             "GitStateCtx uses the typed git client and no longer uses dynamic IPC dispatch",
             fun () ->
                 let sourceText = getGitStateCtxSource ()
@@ -789,6 +800,17 @@ Vitest.describe (
 
                 Vitest.expect(argumentTypes.Length).toBe (1)
                 Vitest.expect(argumentTypes.[0].FullName).toBe (typeof<GitCloneRepositoryRequest>.FullName)
+        )
+
+        Vitest.test (
+            "IGitApi.gitDiscardPaths uses GitPathspecRequest without IpcMainEvent",
+            fun () ->
+                let discardField = getRecordField typeof<IGitApi> "gitDiscardPaths"
+                let argumentTypes, returnType = flattenFunctionSignature discardField.PropertyType
+
+                Vitest.expect(argumentTypes.Length).toBe (1)
+                Vitest.expect(argumentTypes.[0].FullName).toBe (typeof<GitPathspecRequest>.FullName)
+                Vitest.expect(returnType.FullName.Contains("GitOperationResult")).toBe (true)
         )
 
         Vitest.test (

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -164,6 +164,9 @@ let private hasOwnProperty (target: obj) (propertyName: string) : bool = jsNativ
 [<Emit("$0.firstElementChild")>]
 let private firstElementChild (target: HTMLElement) : HTMLElement = jsNative
 
+[<Emit("Array.from(document.body.querySelectorAll('button')).find((button) => button.textContent && button.textContent.includes($0))")>]
+let private findBodyButtonContaining (text: string) : HTMLButtonElement option = jsNative
+
 [<Emit("$0[$1]")>]
 let private getProperty<'T> (target: obj) (propertyName: string) : 'T = jsNative
 
@@ -244,6 +247,7 @@ let private defaultDependencies: GitDependencies = {
     checkoutBranch = fun _ -> unexpectedPromise "checkoutBranch"
     gitStagePaths = fun _ -> unexpectedPromise "gitStagePaths"
     gitUnstagePaths = fun _ -> unexpectedPromise "gitUnstagePaths"
+    gitDiscardPaths = fun _ -> unexpectedPromise "gitDiscardPaths"
     gitCommit = fun _ -> unexpectedPromise "gitCommit"
     setGitLfsSettings = fun _ -> unexpectedPromise "setGitLfsSettings"
     confirmGitMergeResolution = fun _ -> unexpectedPromise "confirmGitMergeResolution"
@@ -283,6 +287,7 @@ let private noopCallbacks: GitSidebarCallbacks = {
     OnPrimarySaveAll = fun _ -> ()
     OnCommitSelection = fun _ -> ()
     OnCommitAll = fun _ -> ()
+    OnDiscardSelection = fun _ -> ()
     OnConfirmPendingRemoteAction = fun () -> ()
     OnCancelPendingRemoteAction = fun () -> ()
     OnSaveDownloadLargeFiles = fun _ -> ()
@@ -981,6 +986,55 @@ Vitest.describe (
                 Vitest.expect(nextState.BranchOptions |> Array.map _.RefName).toEqual ([| "feature/pushed" |])
                 Vitest.expect(nextState.LfsAutoTrackThresholdMb).toBe (9)
                 Vitest.expect(nextState.DownloadLargeFiles).toBe (true)
+            }
+        )
+
+        Vitest.test (
+            "WriteRequested discards selected paths, refreshes status, and clears the open diff",
+            fun () -> promise {
+                let discardedPathspecs = ResizeArray<string[]>()
+                let clearedPages = ResizeArray<PageState option>()
+
+                let deps = {
+                    defaultDependencies with
+                        gitDiscardPaths =
+                            fun request ->
+                                discardedPathspecs.Add request.Pathspecs
+                                promise { return Ok okOperationResult }
+                        getGitStatus = fun () -> promise { return Ok cleanStatus }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                }
+
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc-a"
+                        ChangedFiles = [|
+                            changedFile "README.md" "M" " " false
+                            changedFile "docs/guide.md" "M" " " false
+                        |]
+                        SelectedChangePath = Some "README.md"
+                }
+
+                let stateAfterRequest, requestCmd =
+                    update deps clearedPages.Add (WriteRequested(DiscardSelection [| "README.md"; "docs/guide.md" |])) initialState
+
+                let! requestMessages = collectMessages requestCmd
+
+                let nextState, finishCmd =
+                    match requestMessages with
+                    | [| WriteCompleted(_, DiscardSelection _, Ok(Completed(UnitSuccess(_, GitPageChange.Clear, Some None, None)))) |] ->
+                        update deps clearedPages.Add requestMessages[0] stateAfterRequest
+                    | _ -> failwith "Expected discard to clear the open diff after refreshing git status."
+
+                let! followUpMessages = collectMessages finishCmd
+
+                Vitest.expect(stateAfterRequest.BusyOperation).toEqual (Some GitBusyOperation.DiscardingSelectedChanges)
+                Vitest.expect(discardedPathspecs |> Seq.toArray).toEqual ([| [| "README.md"; "docs/guide.md" |] |])
+                Vitest.expect(nextState.ChangedFiles).toEqual ([||])
+                Vitest.expect(nextState.SelectedChangePath).toEqual (None)
+                Vitest.expect(clearedPages |> Seq.toArray).toEqual ([| None |])
+                Vitest.expect(followUpMessages).toEqual ([||])
             }
         )
 
@@ -1874,6 +1928,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -1951,6 +2006,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2004,6 +2060,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2053,6 +2110,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2105,6 +2163,7 @@ Vitest.describe (
                                         OnPrimarySaveAll = fun _ -> ()
                                         OnCommitSelection = fun _ -> ()
                                         OnCommitAll = fun _ -> ()
+                                        OnDiscardSelection = fun _ -> ()
                                         OnConfirmPendingRemoteAction = fun () -> ()
                                         OnCancelPendingRemoteAction = fun () -> ()
                                         OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2186,6 +2245,7 @@ Vitest.describe (
                                         OnPrimarySaveAll = fun _ -> ()
                                         OnCommitSelection = fun _ -> ()
                                         OnCommitAll = fun _ -> ()
+                                        OnDiscardSelection = fun _ -> ()
                                         OnConfirmPendingRemoteAction = fun () -> ()
                                         OnCancelPendingRemoteAction = fun () -> ()
                                         OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2270,6 +2330,7 @@ Vitest.describe (
                                                         OnPrimarySaveAll = fun _ -> ()
                                                         OnCommitSelection = fun _ -> ()
                                                         OnCommitAll = fun _ -> ()
+                                                        OnDiscardSelection = fun _ -> ()
                                                         OnConfirmPendingRemoteAction = fun () -> ()
                                                         OnCancelPendingRemoteAction = fun () -> ()
                                                         OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2333,6 +2394,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2389,6 +2451,7 @@ Vitest.describe (
                                         OnPrimarySaveAll = fun _ -> ()
                                         OnCommitSelection = fun _ -> ()
                                         OnCommitAll = fun _ -> ()
+                                        OnDiscardSelection = fun _ -> ()
                                         OnConfirmPendingRemoteAction = fun () -> ()
                                         OnCancelPendingRemoteAction = fun () -> ()
                                         OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2438,6 +2501,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2472,6 +2536,66 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "GitSidebar right-click menu discards the currently marked files",
+            fun () -> promise {
+                let mutable discardedPaths: string[] option = None
+
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = Some "origin/main"
+                                Ahead = 0
+                                Behind = 0
+                                IsClean = false
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = manyChangedFiles 3,
+                            branchOptions = [| sidebarLocalBranch "main" true true |],
+                            callbacks = {
+                                noopCallbacks with
+                                    OnDiscardSelection = fun paths -> discardedPaths <- Some paths
+                            },
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5
+                        )
+                    )
+
+                let row0 = container.querySelector("[data-testid='GitSidebarChangeRow-0']") :?> HTMLElement
+                let row2 = container.querySelector("[data-testid='GitSidebarChangeRow-2']") :?> HTMLElement
+
+                row0.click ()
+                do! Promise.sleep 0
+
+                let ctrlClick =
+                    createMouseEvent "click" (createObj [ "bubbles" ==> true; "ctrlKey" ==> true ])
+
+                row2.dispatchEvent ctrlClick |> ignore
+                do! Promise.sleep 0
+
+                let contextMenuEvent =
+                    createMouseEvent
+                        "contextmenu"
+                        (createObj [ "bubbles" ==> true; "clientX" ==> 32; "clientY" ==> 32; "button" ==> 2 ])
+
+                row0.dispatchEvent contextMenuEvent |> ignore
+                do! Promise.sleep 0
+
+                let discardButton =
+                    findBodyButtonContaining "Discard Selected Changes"
+                    |> Option.defaultWith (fun () -> failwith "Expected discard context menu action.")
+
+                discardButton.click ()
+                do! Promise.sleep 0
+
+                Vitest.expect(discardedPaths).toEqual (Some [| "src/file-000.txt"; "src/file-002.txt" |])
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
             "GitSidebar plain click clears previous marks and ctrl-click toggles a row on and back off",
             fun () -> promise {
                 let mutable capturedSelection: GitSidebarCommitSelectionRequest option = None
@@ -2499,6 +2623,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2575,6 +2700,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2651,6 +2777,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()
@@ -2704,6 +2831,7 @@ Vitest.describe (
                                 OnPrimarySaveAll = fun _ -> ()
                                 OnCommitSelection = fun _ -> ()
                                 OnCommitAll = fun _ -> ()
+                                OnDiscardSelection = fun _ -> ()
                                 OnConfirmPendingRemoteAction = fun () -> ()
                                 OnCancelPendingRemoteAction = fun () -> ()
                                 OnSaveDownloadLargeFiles = fun _ -> ()


### PR DESCRIPTION
Implemented discard/undo for selected Git sidebar files.

The main pieces are:

- Added GitService.discardPaths in GitService.fs, using Git reset/restore/clean behavior and handling selected rename originals.
- Added IPC/renderer plumbing through gitDiscardPaths.
- Added DiscardSelection workflow handling in GitWorkflow.fs, including busy state, refresh, and clearing the open diff after discard.
- Added a right-click context menu to changed file rows in GitSidebar.fs. If the right-clicked file is already selected, it discards the selected set; otherwise it discards that file only.

<img width="940" height="454" alt="image" src="https://github.com/user-attachments/assets/87959fc0-ab21-4aea-b403-865466f33abc" />
<img width="913" height="493" alt="image" src="https://github.com/user-attachments/assets/30af6278-2ca3-479c-b686-589030602e32" />
