### PR TITLE
Git sidebar visual improvement

### DIFF
--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -1031,7 +1031,7 @@ type GitSidebar =
                     prop.role "button"
                     prop.tabIndex 0
                     prop.className [
-                        "swt:group swt:flex swt:min-h-9 swt:w-full swt:min-w-0 swt:items-center swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1 swt:text-left swt:transition-colors swt:select-none swt:@max-xs:gap-1.5"
+                        "swt:group swt:flex swt:min-h-6 swt:w-full swt:min-w-0 swt:items-center swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:text-left swt:transition-colors swt:select-none swt:@max-xs:gap-1.5"
                         "swt:cursor-pointer"
                         if change.IsConflicted then
                             "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
@@ -1115,7 +1115,7 @@ type GitSidebar =
     [<ReactComponent>]
     static member private ChangedFilesList(props: ChangedFilesListProps) =
         let scrollContainerRef: IRefValue<HTMLElement option> = React.useElementRef ()
-        let itemSize = 40
+        let itemSize = 28
         let itemGap = 4
         let overscan = 8
 

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -3,7 +3,6 @@ namespace Swate.Components
 open System
 open Browser.Types
 open Fable.Core
-open Fable.Core.JsInterop
 open Feliz
 
 open Swate.Components.GitSidebarTypes
@@ -189,6 +188,8 @@ type private ChangedFileRowProps = {
     IsSelected: bool
     IsMarked: bool
     IsBusy: bool
+    DiscardPaths: string[]
+    DiscardChanges: string[] -> unit
     UpdateMarkedSelection: GitSidebarChange -> bool -> bool -> unit
     OpenChange: GitSidebarChange -> unit
     VirtualStart: int
@@ -966,9 +967,8 @@ type GitSidebar =
         let change = props.Change
 
         let activateRow ctrlKey shiftKey =
-            if not props.IsBusy then
-                props.UpdateMarkedSelection change ctrlKey shiftKey
-                props.OpenChange change
+            props.UpdateMarkedSelection change ctrlKey shiftKey
+            props.OpenChange change
 
         Html.div [
             prop.role "listitem"
@@ -985,16 +985,11 @@ type GitSidebar =
                 Html.div [
                     prop.testId $"GitSidebarChangeRow-{props.Index}"
                     prop.custom ("data-index", props.Index)
-                    prop.custom ("data-git-change-path", change.Path)
                     prop.role "button"
-                    prop.tabIndex (if props.IsBusy then -1 else 0)
-                    prop.custom ("aria-disabled", if props.IsBusy then "true" else "false")
+                    prop.tabIndex 0
                     prop.className [
-                        "swt:flex swt:w-full swt:items-start swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1.5 swt:text-left swt:transition-colors swt:select-none"
-                        if props.IsBusy then
-                            "swt:cursor-not-allowed swt:opacity-60"
-                        else
-                            "swt:cursor-pointer"
+                        "swt:group swt:flex swt:min-h-9 swt:w-full swt:min-w-0 swt:items-center swt:gap-2 swt:rounded-box swt:border swt:px-2 swt:py-1 swt:text-left swt:transition-colors swt:select-none swt:@max-xs:gap-1.5"
+                        "swt:cursor-pointer"
                         if change.IsConflicted then
                             "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
                         elif props.IsSelected then
@@ -1020,13 +1015,16 @@ type GitSidebar =
                                     prop.className "swt:min-w-0"
                                     prop.children [
                                         Html.span [
-                                            prop.className "swt:block swt:break-words swt:text-sm swt:font-medium"
+                                            prop.className
+                                                "swt:block swt:min-w-0 swt:truncate swt:text-sm swt:font-medium swt:@max-xs:text-xs"
+                                            prop.title change.Path
                                             prop.text change.Path
                                         ]
                                         match change.OriginalPath with
                                         | Some originalPath ->
                                             Html.div [
-                                                prop.className "swt:mt-0.5 swt:text-xs swt:text-base-content/60"
+                                                prop.className "swt:mt-0.5 swt:truncate swt:text-xs swt:text-base-content/60"
+                                                prop.title $"Renamed from {originalPath}"
                                                 prop.text $"Renamed from {originalPath}"
                                             ]
                                         | None -> Html.none
@@ -1036,8 +1034,43 @@ type GitSidebar =
                         ]
                         Html.div [
                             prop.testId $"GitSidebarChangeStatusSlot-{props.Index}"
-                            prop.className "swt:ml-auto swt:shrink-0 swt:self-start"
-                            prop.children [ GitSidebar.ChangeStatusTooltip(props.Index, change) ]
+                            prop.className "swt:ml-auto swt:flex swt:shrink-0 swt:items-center swt:gap-1 swt:self-center"
+                            prop.children [
+                                GitSidebar.ChangeStatusTooltip(props.Index, change)
+
+                                let discardLabel =
+                                    if props.DiscardPaths.Length = 1 then
+                                        "Discard change"
+                                    else
+                                        $"Discard {props.DiscardPaths.Length} selected changes"
+
+                                GitSidebar.Tooltip(
+                                    discardLabel,
+                                    Html.button [
+                                        prop.testId $"GitSidebarDiscardChangeButton-{props.Index}"
+                                        prop.type'.button
+                                        prop.className
+                                            "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
+                                        prop.ariaLabel discardLabel
+                                        prop.title discardLabel
+                                        prop.disabled props.IsBusy
+                                        prop.onClick (fun (event: MouseEvent) ->
+                                            event.preventDefault ()
+                                            event.stopPropagation ()
+                                            props.DiscardChanges props.DiscardPaths
+                                        )
+                                        prop.children [
+                                            Html.span [
+                                                prop.className
+                                                    "swt:iconify swt:fluent--arrow-undo-24-regular swt:size-4 swt:text-error"
+                                            ]
+                                        ]
+                                    ],
+                                    placementClassName = "swt:tooltip-left",
+                                    testId = $"GitSidebarDiscardChangeTooltip-{props.Index}",
+                                    className = "swt:inline-flex swt:items-center"
+                                )
+                            ]
                         ]
                     ]
                 ]
@@ -1047,62 +1080,15 @@ type GitSidebar =
     [<ReactComponent>]
     static member private ChangedFilesList(props: ChangedFilesListProps) =
         let scrollContainerRef: IRefValue<HTMLElement option> = React.useElementRef ()
-        let itemSize = 64
+        let itemSize = 40
         let itemGap = 4
         let overscan = 8
 
-        let contextMenuItemsForChange (change: GitSidebarChange) =
-            if props.IsBusy then
-                []
+        let discardPathsForChange (change: GitSidebarChange) =
+            if Set.contains change.Path props.MarkedPaths && not (Set.isEmpty props.MarkedPaths) then
+                props.MarkedPaths |> Set.toArray |> Array.sort
             else
-                let targetPaths =
-                    if Set.contains change.Path props.MarkedPaths && not (Set.isEmpty props.MarkedPaths) then
-                        props.MarkedPaths |> Set.toArray |> Array.sort
-                    else
-                        [| change.Path |]
-
-                let label =
-                    if targetPaths.Length = 1 then
-                        "Discard Change"
-                    else
-                        "Discard Selected Changes"
-
-                [
-                    ContextMenuItem(
-                        text = Html.span label,
-                        icon =
-                            Html.span [
-                                prop.className "swt:iconify swt:fluent--arrow-undo-24-regular swt:size-4"
-                            ],
-                        onClick = fun _ -> props.DiscardChanges targetPaths
-                    )
-                ]
-
-        let contextMenu =
-            ContextMenu.ContextMenu(
-                (fun data ->
-                    data
-                    |> unbox<GitSidebarChange>
-                    |> contextMenuItemsForChange
-                ),
-                ref = scrollContainerRef,
-                onSpawn =
-                    (fun event ->
-                        if props.IsBusy then
-                            None
-                        else
-                            let target = event.target :?> HTMLElement
-
-                            match target.closest("[data-git-change-path]"), scrollContainerRef.current with
-                            | Some trigger, Some container when container.contains trigger ->
-                                let trigger = trigger :?> HTMLElement
-                                let path: string = !!trigger?dataset?gitChangePath
-
-                                props.ChangedFiles
-                                |> Array.tryFind (fun change -> String.Equals(change.Path, path, StringComparison.Ordinal))
-                                |> Option.map box
-                            | _ -> None)
-            )
+                [| change.Path |]
 
         let changedFileListVirtualizer =
             Virtual.useVirtualizer (
@@ -1180,6 +1166,7 @@ type GitSidebar =
                                         )
 
                                     let isMarked = Set.contains change.Path props.MarkedPaths
+                                    let discardPaths = discardPathsForChange change
 
                                     React.KeyedFragment(
                                         change.Path,
@@ -1191,6 +1178,8 @@ type GitSidebar =
                                                     IsSelected = isSelected
                                                     IsMarked = isMarked
                                                     IsBusy = props.IsBusy
+                                                    DiscardPaths = discardPaths
+                                                    DiscardChanges = props.DiscardChanges
                                                     UpdateMarkedSelection = props.UpdateMarkedSelection
                                                     OpenChange = props.OpenChange
                                                     VirtualStart = virtualItem.Start
@@ -1203,7 +1192,6 @@ type GitSidebar =
                         ]
                 ]
             ]
-            contextMenu
         ]
 
     [<ReactComponent>]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -993,6 +993,7 @@ type GitSidebar =
         let presentation = GitSidebarInternal.changePresentation change
         let gitReturn = GitSidebarInternal.describeChange change
         let tooltipText = $"{presentation.Label}:\n- {gitReturn}"
+        let stopRowActivation (event: MouseEvent) = event.stopPropagation ()
 
         Html.span [
             prop.testId $"GitSidebarChangeStatusIcon-{index}"
@@ -1003,6 +1004,8 @@ type GitSidebar =
             ]
             prop.title tooltipText
             prop.ariaLabel tooltipText
+            prop.onMouseDown stopRowActivation
+            prop.onClick stopRowActivation
         ]
 
     [<ReactComponent>]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -136,7 +136,6 @@ type private LfsSettingsSectionProps = {
     SetLfsThresholdInput: string -> unit
     CanSaveLfsThreshold: bool
     SubmitLfsThreshold: unit -> unit
-    ActiveAction: string option
 }
 
 type private AdvancedActionsProps = {
@@ -174,7 +173,6 @@ type private CommitSectionProps = {
 
 type private ChangedFilesListProps = {
     ChangedFiles: GitSidebarChange[]
-    SelectedFile: string option
     MarkedPaths: Set<string>
     IsBusy: bool
     UpdateMarkedSelection: GitSidebarChange -> bool -> bool -> unit
@@ -185,7 +183,6 @@ type private ChangedFilesListProps = {
 type private ChangedFileRowProps = {
     Change: GitSidebarChange
     Index: int
-    IsSelected: bool
     IsMarked: bool
     IsBusy: bool
     DiscardPaths: string[]
@@ -206,7 +203,6 @@ type private ModalsProps = {
     BranchOptionsWithHead: (string option * string)[]
     SelectedStartPoint: string option
     SetSelectedStartPoint: string option -> unit
-    ActiveAction: string option
     SubmitCreateBranch: unit -> unit
     IsSwitchBranchModalOpen: bool
     SetSwitchBranchModalOpen: bool -> unit
@@ -620,12 +616,7 @@ type GitSidebar =
                                 Html.span [
                                     prop.className "swt:iconify swt:fluent--save-24-regular swt:size-4"
                                 ]
-                                Html.span (
-                                    if props.ActiveAction = Some "Save Git LFS Threshold" then
-                                        "Saving..."
-                                    else
-                                        "Save Threshold"
-                                )
+                                Html.span "Save Threshold"
                             ]
                         ]
                     ]
@@ -992,8 +983,6 @@ type GitSidebar =
                         "swt:cursor-pointer"
                         if change.IsConflicted then
                             "swt:border-error/40 swt:bg-error/5 hover:swt:bg-error/10"
-                        elif props.IsSelected then
-                            "swt:border-primary/40 swt:bg-primary/5 hover:swt:bg-primary/10"
                         elif props.IsMarked then
                             "swt:border-success/40 swt:bg-success/10 hover:swt:bg-success/15"
                         else
@@ -1159,12 +1148,6 @@ type GitSidebar =
                                 for virtualItem in virtualItems do
                                     let change = props.ChangedFiles.[virtualItem.Index]
 
-                                    let isSelected =
-                                        props.SelectedFile
-                                        |> Option.exists (fun selected ->
-                                            String.Equals(selected, change.Path, StringComparison.Ordinal)
-                                        )
-
                                     let isMarked = Set.contains change.Path props.MarkedPaths
                                     let discardPaths = discardPathsForChange change
 
@@ -1175,7 +1158,6 @@ type GitSidebar =
                                                 {
                                                     Change = change
                                                     Index = virtualItem.Index
-                                                    IsSelected = isSelected
                                                     IsMarked = isMarked
                                                     IsBusy = props.IsBusy
                                                     DiscardPaths = discardPaths
@@ -1258,20 +1240,13 @@ type GitSidebar =
                     React.Fragment [
                         Html.button [
                             prop.className "swt:btn swt:btn-ghost"
-                            prop.disabled props.ActiveAction.IsSome
                             prop.text "Cancel"
                             prop.onClick (fun _ -> props.CloseDialog())
                         ]
                         Html.button [
                             prop.testId "GitSidebarCreateBranchSubmit"
                             prop.className "swt:btn swt:btn-primary swt:ml-auto"
-                            prop.disabled props.ActiveAction.IsSome
-                            prop.text (
-                                if props.ActiveAction = Some "Create Branch From" then
-                                    "Creating..."
-                                else
-                                    "Create Branch"
-                            )
+                            prop.text "Create Branch"
                             prop.onClick (fun _ -> props.SubmitCreateBranch())
                         ]
                     ]
@@ -1322,20 +1297,14 @@ type GitSidebar =
                     React.Fragment [
                         Html.button [
                             prop.className "swt:btn swt:btn-ghost"
-                            prop.disabled props.ActiveAction.IsSome
                             prop.text "Cancel"
                             prop.onClick (fun _ -> props.CloseDialog())
                         ]
                         Html.button [
                             prop.testId "GitSidebarSwitchBranchSubmit"
                             prop.className "swt:btn swt:btn-primary swt:ml-auto"
-                            prop.disabled (props.ActiveAction.IsSome || props.BranchOptionsForSwitch.Length = 0)
-                            prop.text (
-                                if props.ActiveAction = Some "Switch Branch" then
-                                    "Switching..."
-                                else
-                                    "Switch Branch"
-                            )
+                            prop.disabled (props.BranchOptionsForSwitch.Length = 0)
+                            prop.text "Switch Branch"
                             prop.onClick (fun _ -> props.SubmitSwitchBranch())
                         ]
                     ]
@@ -1419,7 +1388,7 @@ type GitSidebar =
         let pendingConfirmation = pendingConfirmation
         let remoteActionsEnabled = defaultArg remoteActionsEnabled true
         let remoteActionsWarning = remoteActionsWarning
-        let selectedFile = selectedFile
+        let _selectedFileForCompatibility = selectedFile
         let onRefresh = callbacks.OnRefresh
         let onFetch = callbacks.OnFetch
         let onPull = callbacks.OnPull
@@ -1439,7 +1408,6 @@ type GitSidebar =
         let onSelectChange = callbacks.OnSelectChange
 
         let localError, setLocalError = React.useState (None: string option)
-        let activeAction, setActiveAction = React.useState (None: string option)
         let activeDialog, setActiveDialog = React.useState ActiveDialog.None
         let branchName, setBranchName = React.useState ""
         let commitMessage, setCommitMessage = React.useState ""
@@ -1482,11 +1450,10 @@ type GitSidebar =
             )
 
         let isBusy =
-            activeAction.IsSome
-            || match runStatus with
-               | GitSidebarRunStatus.Idle -> false
-               | GitSidebarRunStatus.Busy _
-               | GitSidebarRunStatus.Progress _ -> true
+            match runStatus with
+            | GitSidebarRunStatus.Idle -> false
+            | GitSidebarRunStatus.Busy _
+            | GitSidebarRunStatus.Progress _ -> true
 
         let visibleError = errorNotice |> Option.orElse localError
 
@@ -1553,16 +1520,12 @@ type GitSidebar =
         let runSelectChangeAction (change: GitSidebarChange) =
             promise {
                 setLocalError None
-                setActiveAction (Some $"Open {change.Path}")
 
-                try
-                    let! result = onSelectChange change
+                let! result = onSelectChange change
 
-                    match result with
-                    | Ok() -> ()
-                    | Error message -> setLocalError (Some message)
-                finally
-                    setActiveAction None
+                match result with
+                | Ok() -> ()
+                | Error message -> setLocalError (Some message)
             }
             |> Promise.start
 
@@ -1796,7 +1759,6 @@ type GitSidebar =
                             SetLfsThresholdInput = setLfsThresholdInput
                             CanSaveLfsThreshold = canSaveLfsThreshold
                             SubmitLfsThreshold = submitLfsThreshold
-                            ActiveAction = activeAction
                         }
                     }
                 )
@@ -1844,7 +1806,6 @@ type GitSidebar =
                 GitSidebar.ChangedFilesList(
                     {
                         ChangedFiles = changedFiles
-                        SelectedFile = selectedFile
                         MarkedPaths = markedPaths
                         IsBusy = isBusy
                         UpdateMarkedSelection = updateMarkedSelection
@@ -1862,7 +1823,6 @@ type GitSidebar =
                         BranchOptionsWithHead = branchOptionsWithHead
                         SelectedStartPoint = selectedStartPoint
                         SetSelectedStartPoint = setSelectedStartPoint
-                        ActiveAction = activeAction
                         SubmitCreateBranch = submitCreateBranch
                         IsSwitchBranchModalOpen = isSwitchBranchModalOpen
                         SetSwitchBranchModalOpen = setSwitchBranchModalOpen

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -1077,8 +1077,6 @@ type GitSidebar =
                             prop.className
                                 "swt:ml-auto swt:flex swt:shrink-0 swt:items-center swt:gap-1 swt:self-center"
                             prop.children [
-                                GitSidebar.ChangeStatusTooltip(props.Index, change)
-
                                 let discardLabel =
                                     if props.DiscardPaths.Length = 1 then
                                         "Discard change"
@@ -1105,6 +1103,8 @@ type GitSidebar =
                                         ]
                                     ]
                                 ]
+
+                                GitSidebar.ChangeStatusTooltip(props.Index, change)
                             ]
                         ]
                     ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -250,7 +250,8 @@ type GitSidebar =
                                 "swt:alert swt:alert-info swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4 swt:shrink-0"
+                                    prop.className
+                                        "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4 swt:shrink-0"
                                 ]
                                 Html.span [
                                     prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
@@ -324,7 +325,8 @@ type GitSidebar =
                                 "swt:alert swt:alert-warning swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4 swt:shrink-0"
+                                    prop.className
+                                        "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4 swt:shrink-0"
                                 ]
                                 Html.span [
                                     prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
@@ -364,13 +366,15 @@ type GitSidebar =
                     prop.className "swt:flex swt:min-w-0 swt:flex-col"
                     prop.children [
                         Html.span [
-                            prop.className "swt:min-w-0 swt:break-words swt:text-sm swt:font-medium swt:[overflow-wrap:anywhere]"
+                            prop.className
+                                "swt:min-w-0 swt:break-words swt:text-sm swt:font-medium swt:[overflow-wrap:anywhere]"
                             prop.text (defaultArg label "Download Large Files")
                         ]
                         match description with
                         | Some text ->
                             Html.span [
-                                prop.className "swt:min-w-0 swt:break-words swt:text-xs swt:text-base-content/70 swt:[overflow-wrap:anywhere]"
+                                prop.className
+                                    "swt:min-w-0 swt:break-words swt:text-xs swt:text-base-content/70 swt:[overflow-wrap:anywhere]"
                                 prop.text text
                             ]
                         | None -> Html.none
@@ -415,7 +419,7 @@ type GitSidebar =
             prop.ariaLabel label
             prop.children [
                 Html.div [
-                    prop.className "swt:tooltip-content swt:max-w-64 swt:text-xs"
+                    prop.className "swt:tooltip-content swt:max-w-64 swt:text-xs swt:text-left swt:whitespace-pre-line"
                     prop.text label
                 ]
                 children
@@ -424,45 +428,48 @@ type GitSidebar =
 
     [<ReactComponent>]
     static member private ActionButton
-        (label: string, iconClassName: string, isBusy: bool, onClick: unit -> unit, ?isActive: bool, ?testId: string)
-        =
+        (
+            label: string,
+            iconClassName: string,
+            isBusy: bool,
+            onClick: unit -> unit,
+            ?isActive: bool,
+            ?testId: string,
+            ?tooltipText: string
+        ) =
         let isActive = defaultArg isActive false
+        let titleText = defaultArg tooltipText label
 
-        let button =
-            Html.button [
-                if testId.IsSome then
-                    prop.testId testId.Value
+        Html.button [
+            if testId.IsSome then
+                prop.testId testId.Value
 
-                prop.className [
-                    "swt:btn swt:btn-sm swt:w-full swt:min-w-0 swt:justify-start swt:gap-2 swt:overflow-hidden swt:px-2 swt:normal-case"
-                    "swt:@max-2xs/gitSidebar:gap-1 swt:@max-3xs/gitSidebar:justify-center swt:@max-3xs/gitSidebar:gap-0 swt:@max-3xs/gitSidebar:px-0"
-                    if isActive then
-                        "swt:btn-primary"
-                    else
-                        "swt:bg-base-100 swt:border-base-300"
+            prop.className [
+                "swt:btn swt:btn-sm swt:w-full swt:min-w-0 swt:justify-start swt:gap-2 swt:overflow-hidden swt:px-2 swt:normal-case"
+                "swt:@max-2xs/gitSidebar:gap-1 swt:@max-3xs/gitSidebar:justify-center swt:@max-3xs/gitSidebar:gap-0 swt:@max-3xs/gitSidebar:px-0"
+                if isActive then
+                    "swt:btn-primary"
+                else
+                    "swt:bg-base-100 swt:border-base-300"
+            ]
+            prop.disabled isBusy
+            prop.ariaLabel label
+            prop.title titleText
+            prop.onClick (fun _ -> onClick ())
+            prop.children [
+                Html.span [
+                    prop.className [ "swt:iconify"; iconClassName; "swt:size-4 swt:shrink-0" ]
                 ]
-                prop.disabled isBusy
-                prop.ariaLabel label
-                prop.title label
-                prop.onClick (fun _ -> onClick ())
-                prop.children [
-                    Html.span [
-                        prop.className [ "swt:iconify"; iconClassName; "swt:size-4 swt:shrink-0" ]
-                    ]
-                    Html.span [
-                        if testId.IsSome then
-                            prop.testId (testId.Value + "Label")
+                Html.span [
+                    if testId.IsSome then
+                        prop.testId (testId.Value + "Label")
 
-                        prop.className
-                            "swt:min-w-0 swt:flex-1 swt:truncate swt:text-left swt:@max-3xs/gitSidebar:sr-only"
-                        prop.text label
-                    ]
+                    prop.className
+                        "swt:min-w-0 swt:flex-1 swt:truncate swt:text-left swt:@max-3xs/gitSidebar:sr-only"
+                    prop.text label
                 ]
             ]
-
-        let tooltipTestId = testId |> Option.map (fun value -> value + "Tooltip")
-
-        GitSidebar.Tooltip(label, button, ?testId = tooltipTestId)
+        ]
 
     [<ReactComponent>]
     static member private BranchHeader(props: BranchHeaderProps) =
@@ -552,7 +559,8 @@ type GitSidebar =
                                         "swt:mt-2 swt:flex swt:min-w-0 swt:items-start swt:gap-2 swt:text-xs swt:text-base-content/70"
                                     prop.children [
                                         Html.span [
-                                            prop.className "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4 swt:shrink-0"
+                                            prop.className
+                                                "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4 swt:shrink-0"
                                         ]
                                         Html.span [
                                             prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
@@ -572,7 +580,8 @@ type GitSidebar =
                                                     "swt:iconify swt:fluent--branch-request-20-regular swt:size-4 swt:shrink-0"
                                             ]
                                             Html.span [
-                                                prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                                prop.className
+                                                    "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
                                                 prop.text
                                                     $"No upstream configured yet. Push will publish and track origin/{currentBranch}."
                                             ]
@@ -595,7 +604,8 @@ type GitSidebar =
                     prop.className "swt:flex swt:min-w-0 swt:items-center swt:gap-2"
                     prop.children [
                         Html.span [
-                            prop.className "swt:iconify swt:fluent--document-arrow-right-24-regular swt:size-4 swt:shrink-0"
+                            prop.className
+                                "swt:iconify swt:fluent--document-arrow-right-24-regular swt:size-4 swt:shrink-0"
                         ]
                         Html.span [
                             prop.className "swt:min-w-0 swt:truncate swt:text-sm swt:font-medium"
@@ -604,7 +614,8 @@ type GitSidebar =
                     ]
                 ]
                 Html.p [
-                    prop.className "swt:mt-2 swt:break-words swt:text-xs swt:text-base-content/70 swt:[overflow-wrap:anywhere]"
+                    prop.className
+                        "swt:mt-2 swt:break-words swt:text-xs swt:text-base-content/70 swt:[overflow-wrap:anywhere]"
                     prop.text
                         "Files larger than this limit are automatically re-staged through Git LFS during save operations."
                 ]
@@ -652,7 +663,8 @@ type GitSidebar =
                     ]
                 ]
                 Html.div [
-                    prop.className "swt:mt-2 swt:break-words swt:text-xs swt:text-base-content/60 swt:[overflow-wrap:anywhere]"
+                    prop.className
+                        "swt:mt-2 swt:break-words swt:text-xs swt:text-base-content/60 swt:[overflow-wrap:anywhere]"
                     prop.text "Threshold setting: 1-100 MB. This does not cap LFS-tracked file size."
                 ]
             ]
@@ -671,7 +683,8 @@ type GitSidebar =
                         "swt:fluent--arrow-sync-24-regular",
                         props.IsBusy || not props.RemoteActionsEnabled,
                         props.SubmitUpdateFromOnline,
-                        testId = "GitSidebarUpdateArcButton"
+                        testId = "GitSidebarUpdateArcButton",
+                        tooltipText = "Update ARC from Online:\n- git fetch origin\n- git merge-tree (conflict preflight)\n- git pull origin"
                     )
                     GitSidebar.ActionButton(
                         "More Git Actions",
@@ -694,10 +707,12 @@ type GitSidebar =
                     prop.children [
                         Html.div [
                             prop.testId "GitSidebarRemoteAuthWarning"
-                            prop.className "swt:alert swt:alert-warning swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
+                            prop.className
+                                "swt:alert swt:alert-warning swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4 swt:shrink-0"
+                                    prop.className
+                                        "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4 swt:shrink-0"
                                 ]
                                 Html.span [
                                     prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
@@ -725,35 +740,40 @@ type GitSidebar =
                                     "swt:fluent--arrow-download-24-regular",
                                     props.IsBusy || not props.RemoteActionsEnabled,
                                     props.SubmitFetch,
-                                    testId = "GitSidebarFetchButton"
+                                    testId = "GitSidebarFetchButton",
+                                    tooltipText = "Check for Changes:\n- git fetch origin"
                                 )
                                 GitSidebar.ActionButton(
                                     "Download Changes",
                                     "swt:fluent--arrow-down-24-regular",
                                     props.IsBusy || not props.RemoteActionsEnabled,
                                     props.SubmitPull,
-                                    testId = "GitSidebarPullButton"
+                                    testId = "GitSidebarPullButton",
+                                    tooltipText = "Download Changes:\n- git pull origin"
                                 )
                                 GitSidebar.ActionButton(
                                     "Upload Changes",
                                     "swt:fluent--arrow-up-24-regular",
                                     props.IsBusy || not props.RemoteActionsEnabled,
                                     props.SubmitPush,
-                                    testId = "GitSidebarPushButton"
+                                    testId = "GitSidebarPushButton",
+                                    tooltipText = "Upload Changes:\n- git push origin"
                                 )
                                 GitSidebar.ActionButton(
                                     "Create Work Copy",
                                     "swt:fluent--branch-fork-24-regular",
                                     props.IsBusy,
                                     props.OpenCreateBranchModal,
-                                    testId = "GitSidebarCreateBranchButton"
+                                    testId = "GitSidebarCreateBranchButton",
+                                    tooltipText = "Create Work Copy:\n- git checkout -b <name>"
                                 )
                                 GitSidebar.ActionButton(
                                     "Switch To Work Copy",
                                     "swt:fluent--arrow-swap-24-regular",
                                     props.IsBusy || not props.CanSwitchBranch,
                                     props.OpenSwitchBranchModal,
-                                    testId = "GitSidebarSwitchBranchButton"
+                                    testId = "GitSidebarSwitchBranchButton",
+                                    tooltipText = "Switch To Work Copy:\n- git checkout <branch>"
                                 )
                             ]
                         ]
@@ -783,7 +803,8 @@ type GitSidebar =
                 React.Fragment [
                     Popover.Trigger(
                         Html.span "?",
-                        className = "swt:btn swt:btn-ghost swt:btn-xs swt:min-h-0 swt:h-6 swt:w-6 swt:px-0 swt:text-xs swt:font-bold",
+                        className =
+                            "swt:btn swt:btn-ghost swt:btn-xs swt:min-h-0 swt:h-6 swt:w-6 swt:px-0 swt:text-xs swt:font-bold",
                         props = [ prop.testId "GitSidebarSaveOptionsHelpButton" ]
                     )
                     Popover.Content(
@@ -936,7 +957,8 @@ type GitSidebar =
                                                     prop.children [
                                                         Html.button [
                                                             prop.testId "GitSidebarLocalCommitButton"
-                                                            prop.className "swt:items-start swt:gap-2 swt:whitespace-normal swt:text-left"
+                                                            prop.className
+                                                                "swt:items-start swt:gap-2 swt:whitespace-normal swt:text-left"
                                                             prop.onClick (fun _ -> props.SubmitLocalCommit())
                                                             prop.children [
                                                                 Html.span [
@@ -944,7 +966,8 @@ type GitSidebar =
                                                                         "swt:iconify swt:fluent--save-24-regular swt:size-4 swt:shrink-0"
                                                                 ]
                                                                 Html.span [
-                                                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                                                    prop.className
+                                                                        "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
                                                                     prop.text localCommitLabel
                                                                 ]
                                                             ]
@@ -969,34 +992,17 @@ type GitSidebar =
     static member private ChangeStatusTooltip(index: int, change: GitSidebarChange) =
         let presentation = GitSidebarInternal.changePresentation change
         let gitReturn = GitSidebarInternal.describeChange change
-        let tooltipText = $"{presentation.Label}. Git return: {gitReturn}"
-        let isTooltipVisible, setIsTooltipVisible = React.useState false
+        let tooltipText = $"{presentation.Label}:\n- {gitReturn}"
 
-        Html.div [
-            prop.testId $"GitSidebarChangeStatusTooltip-{index}"
-            prop.className "swt:tooltip swt:tooltip-left swt:inline-flex swt:items-center"
-            prop.ariaLabel tooltipText
-            prop.onMouseEnter (fun _ -> setIsTooltipVisible true)
-            prop.onMouseLeave (fun _ -> setIsTooltipVisible false)
-            prop.onFocus (fun _ -> setIsTooltipVisible true)
-            prop.onBlur (fun _ -> setIsTooltipVisible false)
-            prop.children [
-                if isTooltipVisible then
-                    Html.div [
-                        prop.className "swt:tooltip-content swt:max-w-64 swt:text-xs"
-                        prop.text tooltipText
-                    ]
-                Html.span [
-                    prop.testId $"GitSidebarChangeStatusIcon-{index}"
-                    prop.className [
-                        "swt:iconify swt:size-4 swt:shrink-0"
-                        presentation.IconClassName
-                        presentation.ToneClassName
-                    ]
-                    prop.ariaLabel tooltipText
-                    prop.title tooltipText
-                ]
+        Html.span [
+            prop.testId $"GitSidebarChangeStatusIcon-{index}"
+            prop.className [
+                "swt:iconify swt:size-4 swt:shrink-0"
+                presentation.IconClassName
+                presentation.ToneClassName
             ]
+            prop.title tooltipText
+            prop.ariaLabel tooltipText
         ]
 
     [<ReactComponent>]
@@ -1052,14 +1058,13 @@ type GitSidebar =
                                         Html.span [
                                             prop.className
                                                 "swt:block swt:min-w-0 swt:truncate swt:text-sm swt:font-medium swt:@max-xs:text-xs"
-                                            prop.title change.Path
                                             prop.text change.Path
                                         ]
                                         match change.OriginalPath with
                                         | Some originalPath ->
                                             Html.div [
-                                                prop.className "swt:mt-0.5 swt:truncate swt:text-xs swt:text-base-content/60"
-                                                prop.title $"Renamed from {originalPath}"
+                                                prop.className
+                                                    "swt:mt-0.5 swt:truncate swt:text-xs swt:text-base-content/60"
                                                 prop.text $"Renamed from {originalPath}"
                                             ]
                                         | None -> Html.none
@@ -1069,7 +1074,8 @@ type GitSidebar =
                         ]
                         Html.div [
                             prop.testId $"GitSidebarChangeStatusSlot-{props.Index}"
-                            prop.className "swt:ml-auto swt:flex swt:shrink-0 swt:items-center swt:gap-1 swt:self-center"
+                            prop.className
+                                "swt:ml-auto swt:flex swt:shrink-0 swt:items-center swt:gap-1 swt:self-center"
                             prop.children [
                                 GitSidebar.ChangeStatusTooltip(props.Index, change)
 
@@ -1079,32 +1085,26 @@ type GitSidebar =
                                     else
                                         $"Discard {props.DiscardPaths.Length} selected changes"
 
-                                GitSidebar.Tooltip(
-                                    discardLabel,
-                                    Html.button [
-                                        prop.testId $"GitSidebarDiscardChangeButton-{props.Index}"
-                                        prop.type'.button
-                                        prop.className
-                                            "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
-                                        prop.ariaLabel discardLabel
-                                        prop.title discardLabel
-                                        prop.disabled props.IsBusy
-                                        prop.onClick (fun (event: MouseEvent) ->
-                                            event.preventDefault ()
-                                            event.stopPropagation ()
-                                            props.DiscardChanges props.DiscardPaths
-                                        )
-                                        prop.children [
-                                            Html.span [
-                                                prop.className
-                                                    "swt:iconify swt:fluent--arrow-undo-24-regular swt:size-4 swt:text-error"
-                                            ]
+                                Html.button [
+                                    prop.testId $"GitSidebarDiscardChangeButton-{props.Index}"
+                                    prop.type'.button
+                                    prop.className
+                                        "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
+                                    prop.ariaLabel discardLabel
+                                    prop.title discardLabel
+                                    prop.disabled props.IsBusy
+                                    prop.onClick (fun (event: MouseEvent) ->
+                                        event.preventDefault ()
+                                        event.stopPropagation ()
+                                        props.DiscardChanges props.DiscardPaths
+                                    )
+                                    prop.children [
+                                        Html.span [
+                                            prop.className
+                                                "swt:iconify swt:fluent--arrow-undo-24-regular swt:size-4 swt:text-error"
                                         ]
-                                    ],
-                                    placementClassName = "swt:tooltip-left",
-                                    testId = $"GitSidebarDiscardChangeTooltip-{props.Index}",
-                                    className = "swt:inline-flex swt:items-center"
-                                )
+                                    ]
+                                ]
                             ]
                         ]
                     ]
@@ -1120,7 +1120,10 @@ type GitSidebar =
         let overscan = 8
 
         let discardPathsForChange (change: GitSidebarChange) =
-            if Set.contains change.Path props.MarkedPaths && not (Set.isEmpty props.MarkedPaths) then
+            if
+                Set.contains change.Path props.MarkedPaths
+                && not (Set.isEmpty props.MarkedPaths)
+            then
                 props.MarkedPaths |> Set.toArray |> Array.sort
             else
                 [| change.Path |]
@@ -1332,7 +1335,8 @@ type GitSidebar =
                                                 Html.option [
                                                     prop.key branch.RefName
                                                     prop.value branch.RefName
-                                                    prop.text $"{branch.DisplayLabel} ({GitSidebarInternal.branchKindLabel branch.Kind})"
+                                                    prop.text
+                                                        $"{branch.DisplayLabel} ({GitSidebarInternal.branchKindLabel branch.Kind})"
                                                 ]
                                         ]
                                     ]
@@ -1559,8 +1563,7 @@ type GitSidebar =
                 )
 
         let branchOptionsForSwitch =
-            branchOptions
-            |> Array.filter (fun branch -> not branch.IsCurrent)
+            branchOptions |> Array.filter (fun branch -> not branch.IsCurrent)
 
         let canSwitchBranch = branchOptionsForSwitch.Length > 0
 
@@ -1592,8 +1595,7 @@ type GitSidebar =
         let openSwitchBranchModal () =
             setLocalError None
 
-            let defaultBranch =
-                branchOptionsForSwitch |> Array.tryHead |> Option.map _.RefName
+            let defaultBranch = branchOptionsForSwitch |> Array.tryHead |> Option.map _.RefName
 
             setSelectedSwitchBranch defaultBranch
             setActiveDialog ActiveDialog.SwitchBranch

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -241,17 +241,19 @@ type GitSidebar =
             match runStatus with
             | GitSidebarRunStatus.Progress progress ->
                 Html.div [
-                    prop.className "swt:px-3 swt:pt-3"
+                    prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                     prop.children [
                         Html.div [
                             if busyTestId.IsSome then
                                 prop.testId busyTestId.Value
-                            prop.className "swt:alert swt:alert-info swt:px-3 swt:py-2 swt:text-sm"
+                            prop.className
+                                "swt:alert swt:alert-info swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4"
+                                    prop.className "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4 swt:shrink-0"
                                 ]
                                 Html.span [
+                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
                                     prop.text (
                                         GitSidebarInternal.progressText progress
                                         |> function
@@ -265,17 +267,21 @@ type GitSidebar =
                 ]
             | GitSidebarRunStatus.Busy notice ->
                 Html.div [
-                    prop.className "swt:px-3 swt:pt-3"
+                    prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                     prop.children [
                         Html.div [
                             if busyTestId.IsSome then
                                 prop.testId busyTestId.Value
-                            prop.className "swt:alert swt:alert-info swt:px-3 swt:py-2 swt:text-sm"
+                            prop.className
+                                "swt:alert swt:alert-info swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--clock-24-regular swt:size-4"
+                                    prop.className "swt:iconify swt:fluent--clock-24-regular swt:size-4 swt:shrink-0"
                                 ]
-                                Html.span notice
+                                Html.span [
+                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                    prop.text notice
+                                ]
                             ]
                         ]
                     ]
@@ -285,17 +291,21 @@ type GitSidebar =
             match errorNotice with
             | Some message ->
                 Html.div [
-                    prop.className "swt:px-3 swt:pt-3"
+                    prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                     prop.children [
                         Html.div [
                             if errorTestId.IsSome then
                                 prop.testId errorTestId.Value
-                            prop.className "swt:alert swt:alert-error swt:px-3 swt:py-2 swt:text-sm"
+                            prop.className
+                                "swt:alert swt:alert-error swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--warning-24-regular swt:size-4"
+                                    prop.className "swt:iconify swt:fluent--warning-24-regular swt:size-4 swt:shrink-0"
                                 ]
-                                Html.span message
+                                Html.span [
+                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                    prop.text message
+                                ]
                             ]
                         ]
                     ]
@@ -305,17 +315,21 @@ type GitSidebar =
             match warningNotice with
             | Some message ->
                 Html.div [
-                    prop.className "swt:px-3 swt:pt-3"
+                    prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                     prop.children [
                         Html.div [
                             if warningTestId.IsSome then
                                 prop.testId warningTestId.Value
-                            prop.className "swt:alert swt:alert-warning swt:px-3 swt:py-2 swt:text-sm"
+                            prop.className
+                                "swt:alert swt:alert-warning swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4"
+                                    prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4 swt:shrink-0"
                                 ]
-                                Html.span message
+                                Html.span [
+                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                    prop.text message
+                                ]
                             ]
                         ]
                     ]
@@ -335,7 +349,7 @@ type GitSidebar =
         ) =
         Html.label [
             prop.className
-                "swt:flex swt:items-start swt:gap-3 swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-100 swt:px-3 swt:py-3"
+                "swt:flex swt:min-w-0 swt:items-start swt:gap-3 swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-100 swt:px-3 swt:py-3 swt:@max-xs:px-2"
             prop.children [
                 Html.input [
                     if testId.IsSome then
@@ -350,13 +364,13 @@ type GitSidebar =
                     prop.className "swt:flex swt:min-w-0 swt:flex-col"
                     prop.children [
                         Html.span [
-                            prop.className "swt:text-sm swt:font-medium"
+                            prop.className "swt:min-w-0 swt:break-words swt:text-sm swt:font-medium swt:[overflow-wrap:anywhere]"
                             prop.text (defaultArg label "Download Large Files")
                         ]
                         match description with
                         | Some text ->
                             Html.span [
-                                prop.className "swt:text-xs swt:text-base-content/70"
+                                prop.className "swt:min-w-0 swt:break-words swt:text-xs swt:text-base-content/70 swt:[overflow-wrap:anywhere]"
                                 prop.text text
                             ]
                         | None -> Html.none
@@ -369,13 +383,16 @@ type GitSidebar =
     static member private SectionHeader(title: string, countText: string option) =
         Html.div [
             prop.className
-                "swt:flex swt:items-center swt:justify-between swt:gap-2 swt:px-3 swt:pt-3 swt:text-xs swt:font-semibold swt:uppercase swt:tracking-[0.2em] swt:text-base-content/60"
+                "swt:flex swt:min-w-0 swt:items-center swt:justify-between swt:gap-2 swt:px-3 swt:pt-3 swt:text-xs swt:font-semibold swt:uppercase swt:tracking-[0.2em] swt:text-base-content/60 swt:@max-xs:px-2 swt:@max-xs:tracking-[0.12em]"
             prop.children [
-                Html.span title
+                Html.span [
+                    prop.className "swt:min-w-0 swt:truncate"
+                    prop.text title
+                ]
                 match countText with
                 | Some value ->
                     Html.span [
-                        prop.className "swt:text-[0.65rem] swt:text-base-content/50"
+                        prop.className "swt:shrink-0 swt:text-[0.65rem] swt:text-base-content/50"
                         prop.text value
                     ]
                 | None -> Html.none
@@ -481,7 +498,7 @@ type GitSidebar =
                     ]
                     Html.button [
                         prop.testId "GitSidebarRefreshButton"
-                        prop.className "swt:btn swt:btn-ghost swt:btn-square swt:btn-sm"
+                        prop.className "swt:btn swt:btn-ghost swt:btn-square swt:btn-sm swt:shrink-0"
                         prop.disabled props.IsBusy
                         prop.title "Refresh git status"
                         prop.onClick (fun _ -> props.OnRefresh())
@@ -494,11 +511,11 @@ type GitSidebar =
                 ]
             ]
             Html.div [
-                prop.className "swt:px-3 swt:pt-3"
+                prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                 prop.children [
                     Html.div [
                         prop.className
-                            "swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-200/60 swt:p-3"
+                            "swt:min-w-0 swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-200/60 swt:p-3 swt:@max-xs:p-2"
                         prop.children [
                             Html.div [
                                 prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
@@ -532,12 +549,15 @@ type GitSidebar =
                             | Some trackingBranch ->
                                 Html.div [
                                     prop.className
-                                        "swt:mt-2 swt:flex swt:items-center swt:gap-2 swt:text-xs swt:text-base-content/70"
+                                        "swt:mt-2 swt:flex swt:min-w-0 swt:items-start swt:gap-2 swt:text-xs swt:text-base-content/70"
                                     prop.children [
                                         Html.span [
-                                            prop.className "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4"
+                                            prop.className "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4 swt:shrink-0"
                                         ]
-                                        Html.span $"Tracking {trackingBranch}"
+                                        Html.span [
+                                            prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                            prop.text $"Tracking {trackingBranch}"
+                                        ]
                                     ]
                                 ]
                             | None ->
@@ -545,14 +565,17 @@ type GitSidebar =
                                 | Some currentBranch ->
                                     Html.div [
                                         prop.className
-                                            "swt:mt-2 swt:flex swt:items-center swt:gap-2 swt:text-xs swt:text-base-content/70"
+                                            "swt:mt-2 swt:flex swt:min-w-0 swt:items-start swt:gap-2 swt:text-xs swt:text-base-content/70"
                                         prop.children [
                                             Html.span [
                                                 prop.className
-                                                    "swt:iconify swt:fluent--branch-request-20-regular swt:size-4"
+                                                    "swt:iconify swt:fluent--branch-request-20-regular swt:size-4 swt:shrink-0"
                                             ]
-                                            Html.span
-                                                $"No upstream configured yet. Push will publish and track origin/{currentBranch}."
+                                            Html.span [
+                                                prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                                prop.text
+                                                    $"No upstream configured yet. Push will publish and track origin/{currentBranch}."
+                                            ]
                                         ]
                                     ]
                                 | None -> Html.none
@@ -565,22 +588,23 @@ type GitSidebar =
     [<ReactComponent>]
     static member private LfsSettingsSection(props: LfsSettingsSectionProps) =
         Html.div [
-            prop.className "swt:mt-3 swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-100 swt:p-3"
+            prop.className
+                "swt:mt-3 swt:min-w-0 swt:rounded-box swt:border swt:border-base-content/10 swt:bg-base-100 swt:p-3 swt:@max-xs:p-2"
             prop.children [
                 Html.div [
-                    prop.className "swt:flex swt:items-center swt:gap-2"
+                    prop.className "swt:flex swt:min-w-0 swt:items-center swt:gap-2"
                     prop.children [
                         Html.span [
-                            prop.className "swt:iconify swt:fluent--document-arrow-right-24-regular swt:size-4"
+                            prop.className "swt:iconify swt:fluent--document-arrow-right-24-regular swt:size-4 swt:shrink-0"
                         ]
                         Html.span [
-                            prop.className "swt:text-sm swt:font-medium"
+                            prop.className "swt:min-w-0 swt:truncate swt:text-sm swt:font-medium"
                             prop.text "Git LFS auto-track threshold"
                         ]
                     ]
                 ]
                 Html.p [
-                    prop.className "swt:mt-2 swt:text-xs swt:text-base-content/70"
+                    prop.className "swt:mt-2 swt:break-words swt:text-xs swt:text-base-content/70 swt:[overflow-wrap:anywhere]"
                     prop.text
                         "Files larger than this limit are automatically re-staged through Git LFS during save operations."
                 ]
@@ -588,7 +612,8 @@ type GitSidebar =
                     prop.className "swt:mt-3 swt:flex swt:flex-wrap swt:items-end swt:gap-2"
                     prop.children [
                         Html.label [
-                            prop.className "swt:flex swt:min-w-[10rem] swt:flex-1 swt:flex-col swt:gap-2"
+                            prop.className
+                                "swt:flex swt:min-w-[10rem] swt:flex-1 swt:flex-col swt:gap-2 swt:@max-xs:min-w-0"
                             prop.children [
                                 Html.span [
                                     prop.className "swt:text-xs swt:font-medium swt:text-base-content/70"
@@ -596,7 +621,7 @@ type GitSidebar =
                                 ]
                                 Html.input [
                                     prop.testId "GitSidebarLfsThresholdInput"
-                                    prop.className "swt:input swt:input-bordered swt:w-full"
+                                    prop.className "swt:input swt:input-bordered swt:w-full swt:min-w-0"
                                     prop.type'.number
                                     prop.custom ("step", "1")
                                     prop.custom ("min", "1")
@@ -609,20 +634,25 @@ type GitSidebar =
                         ]
                         Html.button [
                             prop.testId "GitSidebarLfsThresholdSaveButton"
-                            prop.className "swt:btn swt:btn-sm swt:btn-outline swt:gap-2 swt:normal-case"
+                            prop.className
+                                "swt:btn swt:btn-sm swt:btn-outline swt:min-w-0 swt:gap-2 swt:overflow-hidden swt:px-2 swt:normal-case swt:@max-xs:justify-center swt:@max-xs:gap-0"
                             prop.disabled (not props.CanSaveLfsThreshold)
+                            prop.title "Save Threshold"
                             prop.onClick (fun _ -> props.SubmitLfsThreshold())
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--save-24-regular swt:size-4"
+                                    prop.className "swt:iconify swt:fluent--save-24-regular swt:size-4 swt:shrink-0"
                                 ]
-                                Html.span "Save Threshold"
+                                Html.span [
+                                    prop.className "swt:min-w-0 swt:truncate swt:@max-xs:sr-only"
+                                    prop.text "Save Threshold"
+                                ]
                             ]
                         ]
                     ]
                 ]
                 Html.div [
-                    prop.className "swt:mt-2 swt:text-xs swt:text-base-content/60"
+                    prop.className "swt:mt-2 swt:break-words swt:text-xs swt:text-base-content/60 swt:[overflow-wrap:anywhere]"
                     prop.text "Threshold setting: 1-100 MB. This does not cap LFS-tracked file size."
                 ]
             ]
@@ -634,7 +664,7 @@ type GitSidebar =
             GitSidebar.SectionHeader("Actions", None)
 
             Html.div [
-                prop.className "swt:grid swt:grid-cols-2 swt:gap-2 swt:px-3"
+                prop.className "swt:grid swt:grid-cols-2 swt:gap-2 swt:px-3 swt:@max-xs:gap-1 swt:@max-xs:px-2"
                 prop.children [
                     GitSidebar.ActionButton(
                         "Update ARC from Online",
@@ -660,16 +690,19 @@ type GitSidebar =
             match props.RemoteActionsWarning with
             | Some warning when not props.RemoteActionsEnabled ->
                 Html.div [
-                    prop.className "swt:px-3 swt:pt-3"
+                    prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                     prop.children [
                         Html.div [
                             prop.testId "GitSidebarRemoteAuthWarning"
-                            prop.className "swt:alert swt:alert-warning swt:px-3 swt:py-2 swt:text-sm"
+                            prop.className "swt:alert swt:alert-warning swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4"
+                                    prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4 swt:shrink-0"
                                 ]
-                                Html.span warning
+                                Html.span [
+                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                    prop.text warning
+                                ]
                             ]
                         ]
                     ]
@@ -678,14 +711,14 @@ type GitSidebar =
 
             if props.IsAdvancedActionsOpen then
                 Html.div [
-                    prop.className "swt:px-3 swt:pt-3"
+                    prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                     prop.children [
                         Html.div [
                             prop.testId "GitSidebarAdvancedActionsDivider"
                             prop.className "swt:mb-3 swt:border-t swt:border-base-content/10"
                         ]
                         Html.div [
-                            prop.className "swt:grid swt:grid-cols-2 swt:gap-2"
+                            prop.className "swt:grid swt:grid-cols-2 swt:gap-2 swt:@max-xs:gap-1"
                             prop.children [
                                 GitSidebar.ActionButton(
                                     "Check for Changes",
@@ -793,22 +826,19 @@ type GitSidebar =
                 "Add and commit all Changes"
 
         React.Fragment [
-            Html.div [
-                prop.className
-                    "swt:flex swt:items-center swt:justify-between swt:gap-2 swt:px-3 swt:pt-3 swt:text-xs swt:font-semibold swt:uppercase swt:tracking-[0.2em] swt:text-base-content/60"
-                prop.children [ Html.span "Save" ]
-            ]
+            GitSidebar.SectionHeader("Save", None)
 
             Html.div [
                 prop.testId "GitSidebarCommitSection"
-                prop.className "swt:px-3 swt:pb-3"
+                prop.className "swt:px-3 swt:pb-3 swt:@max-xs:px-2"
                 prop.children [
                     Html.label [
                         prop.className "swt:flex swt:flex-col swt:gap-2"
                         prop.children [
                             Html.textarea [
                                 prop.testId "GitSidebarCommitMessageInput"
-                                prop.className "swt:textarea swt:textarea-bordered swt:min-h-24 swt:w-full swt:resize-y"
+                                prop.className
+                                    "swt:textarea swt:textarea-bordered swt:min-h-24 swt:w-full swt:min-w-0 swt:resize-y swt:@max-xs:text-sm"
                                 prop.disabled (not props.CanEditCommit)
                                 prop.value props.CommitMessage
                                 prop.placeholder (
@@ -825,54 +855,70 @@ type GitSidebar =
                     ]
                     Html.div [
                         prop.className
-                            "swt:mt-2 swt:flex swt:items-center swt:justify-between swt:gap-3 swt:text-xs swt:text-base-content/60"
+                            "swt:mt-2 swt:flex swt:min-w-0 swt:flex-wrap swt:items-center swt:justify-between swt:gap-2 swt:text-xs swt:text-base-content/60"
                         prop.children [
-                            Html.span (
-                                if props.MarkedCount = 1 then
-                                    "1 file marked to save"
-                                else
-                                    $"{props.MarkedCount} files marked to save"
-                            )
+                            Html.span [
+                                prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                prop.text (
+                                    if props.MarkedCount = 1 then
+                                        "1 file marked to save"
+                                    else
+                                        $"{props.MarkedCount} files marked to save"
+                                )
+                            ]
                             if not props.CanEditCommit && props.HasConflicts then
-                                Html.span "Saving files is disabled while conflicts remain."
+                                Html.span [
+                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                    prop.text "Saving files is disabled while conflicts remain."
+                                ]
                             elif not props.CanEditCommit && props.Status.IsClean then
-                                Html.span "No changes available to save."
+                                Html.span [
+                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                    prop.text "No changes available to save."
+                                ]
                             else
                                 Html.none
                         ]
                     ]
                     Html.div [
-                        prop.className "swt:mt-3 swt:flex swt:flex-wrap swt:items-center swt:justify-between swt:gap-2"
+                        prop.className "swt:mt-3 swt:flex swt:min-w-0 swt:items-center swt:justify-between swt:gap-2"
                         prop.children [
                             Html.div [
                                 prop.ref saveMenuRef
-                                prop.className "swt:relative swt:inline-flex"
+                                prop.className "swt:relative swt:inline-flex swt:min-w-0 swt:flex-1"
                                 prop.children [
                                     Html.div [
-                                        prop.className "swt:join"
+                                        prop.className "swt:join swt:flex swt:min-w-0 swt:flex-1"
                                         prop.children [
                                             Html.button [
                                                 prop.testId "GitSidebarPrimarySaveButton"
-                                                prop.className "swt:btn swt:join-item swt:btn-sm swt:btn-success swt:gap-2 swt:normal-case"
+                                                prop.className
+                                                    "swt:btn swt:join-item swt:btn-sm swt:btn-success swt:min-w-0 swt:flex-1 swt:gap-2 swt:overflow-hidden swt:px-2 swt:normal-case swt:@max-xs:justify-center swt:@max-xs:gap-0"
                                                 prop.disabled (not props.CanRunPrimarySave)
+                                                prop.title primarySaveLabel
                                                 prop.onClick (fun _ -> props.SubmitPrimarySave())
                                                 prop.children [
                                                     Html.span [
                                                         prop.className
-                                                            "swt:iconify swt:fluent--checkmark-circle-24-regular swt:size-4"
+                                                            "swt:iconify swt:fluent--checkmark-circle-24-regular swt:size-4 swt:shrink-0"
                                                     ]
-                                                    Html.span primarySaveLabel
+                                                    Html.span [
+                                                        prop.className "swt:min-w-0 swt:truncate swt:@max-xs:sr-only"
+                                                        prop.text primarySaveLabel
+                                                    ]
                                                 ]
                                             ]
                                             Html.button [
                                                 prop.testId "GitSidebarSaveOptionsButton"
                                                 prop.className
-                                                    "swt:btn swt:join-item swt:btn-sm swt:btn-success swt:min-w-0 swt:px-2"
+                                                    "swt:btn swt:join-item swt:btn-sm swt:btn-success swt:shrink-0 swt:px-2"
                                                 prop.disabled (not props.CanRunPrimarySave)
+                                                prop.title "Save options"
                                                 prop.onClick (fun _ -> setSaveMenuOpen (not isSaveMenuOpen))
                                                 prop.children [
                                                     Html.span [
-                                                        prop.className "swt:iconify swt:fluent--chevron-down-24-regular swt:size-4"
+                                                        prop.className
+                                                            "swt:iconify swt:fluent--chevron-down-24-regular swt:size-4 swt:shrink-0"
                                                     ]
                                                 ]
                                             ]
@@ -898,7 +944,7 @@ type GitSidebar =
                                                                         "swt:iconify swt:fluent--save-24-regular swt:size-4 swt:shrink-0"
                                                                 ]
                                                                 Html.span [
-                                                                    prop.className "swt:min-w-0 swt:break-words"
+                                                                    prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
                                                                     prop.text localCommitLabel
                                                                 ]
                                                             ]
@@ -910,7 +956,7 @@ type GitSidebar =
                                 ]
                             ]
                             Html.div [
-                                prop.className "swt:ml-auto"
+                                prop.className "swt:shrink-0"
                                 prop.children [ GitSidebar.SaveOptionsHelpPopover() ]
                             ]
                         ]
@@ -1128,19 +1174,20 @@ type GitSidebar =
                 prop.role "region"
                 prop.ariaLabel "Changed files"
                 prop.ref scrollContainerRef
-                prop.className "swt:min-h-0 swt:flex-1 swt:overflow-y-auto swt:px-2 swt:pb-2"
+                prop.className
+                    "swt:min-h-0 swt:min-w-0 swt:flex-1 swt:overflow-y-auto swt:overflow-x-hidden swt:px-2 swt:pb-2 swt:@max-xs:px-1"
                 prop.children [
                     if props.ChangedFiles.Length = 0 then
                         Html.div [
                             prop.className
-                                "swt:mt-2 swt:rounded-box swt:border swt:border-dashed swt:border-base-content/15 swt:bg-base-200/40 swt:px-4 swt:py-6 swt:text-sm swt:text-base-content/60"
+                                "swt:mt-2 swt:min-w-0 swt:break-words swt:rounded-box swt:border swt:border-dashed swt:border-base-content/15 swt:bg-base-200/40 swt:px-4 swt:py-6 swt:text-sm swt:text-base-content/60 swt:[overflow-wrap:anywhere] swt:@max-xs:px-2"
                             prop.text "No changed files. Your repository is in sync."
                         ]
                     else
                         Html.div [
                             prop.testId "GitSidebarChangedFilesVirtualContent"
                             prop.role "list"
-                            prop.className "swt:relative swt:mt-1"
+                            prop.className "swt:relative swt:mt-1 swt:min-w-0"
                             prop.style [
                                 style.height (changedFileListVirtualizer.getTotalSize ())
                             ]
@@ -1788,16 +1835,21 @@ type GitSidebar =
 
                 if hasConflicts then
                     Html.div [
-                        prop.className "swt:px-3 swt:pt-3"
+                        prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                         prop.children [
                             Html.div [
                                 prop.testId "GitSidebarMergeBanner"
-                                prop.className "swt:alert swt:alert-warning swt:px-3 swt:py-2 swt:text-sm"
+                                prop.className
+                                    "swt:alert swt:alert-warning swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                                 prop.children [
                                     Html.span [
-                                        prop.className "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4"
+                                        prop.className
+                                            "swt:iconify swt:fluent--warning-shield-24-regular swt:size-4 swt:shrink-0"
                                     ]
-                                    Html.span "Resolve all conflicted files before pushing."
+                                    Html.span [
+                                        prop.className "swt:min-w-0 swt:break-words swt:[overflow-wrap:anywhere]"
+                                        prop.text "Resolve all conflicted files before pushing."
+                                    ]
                                 ]
                             ]
                         ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -359,53 +359,92 @@ type GitSidebar =
         ]
 
     [<ReactComponent>]
+    static member private Tooltip
+        (label: string, children: ReactElement, ?placementClassName: string, ?testId: string, ?className: string)
+        =
+        Html.div [
+            if testId.IsSome then
+                prop.testId testId.Value
+
+            prop.className [
+                "swt:tooltip"
+                placementClassName |> Option.defaultValue "swt:tooltip-left"
+                yield! Option.toList className
+            ]
+            prop.ariaLabel label
+            prop.children [
+                Html.div [
+                    prop.className "swt:tooltip-content swt:max-w-64 swt:text-xs"
+                    prop.text label
+                ]
+                children
+            ]
+        ]
+
+    [<ReactComponent>]
     static member private ActionButton
         (label: string, iconClassName: string, isBusy: bool, onClick: unit -> unit, ?isActive: bool, ?testId: string)
         =
         let isActive = defaultArg isActive false
 
-        Html.button [
-            if testId.IsSome then
-                prop.testId testId.Value
-            prop.className [
-                "swt:btn swt:btn-sm swt:justify-start swt:gap-2 swt:normal-case"
-                if isActive then
-                    "swt:btn-primary"
-                else
-                    "swt:bg-base-100 swt:border-base-300"
-            ]
-            prop.disabled isBusy
-            prop.onClick (fun _ -> onClick ())
-            prop.children [
-                Html.span [
-                    prop.className [ "swt:iconify"; iconClassName; "swt:size-4" ]
+        let button =
+            Html.button [
+                if testId.IsSome then
+                    prop.testId testId.Value
+
+                prop.className [
+                    "swt:btn swt:btn-sm swt:w-full swt:min-w-0 swt:justify-start swt:gap-2 swt:overflow-hidden swt:px-2 swt:normal-case"
+                    "swt:@max-2xs/gitSidebar:gap-1 swt:@max-3xs/gitSidebar:justify-center swt:@max-3xs/gitSidebar:gap-0 swt:@max-3xs/gitSidebar:px-0"
+                    if isActive then
+                        "swt:btn-primary"
+                    else
+                        "swt:bg-base-100 swt:border-base-300"
                 ]
-                Html.span label
+                prop.disabled isBusy
+                prop.ariaLabel label
+                prop.title label
+                prop.onClick (fun _ -> onClick ())
+                prop.children [
+                    Html.span [
+                        prop.className [ "swt:iconify"; iconClassName; "swt:size-4 swt:shrink-0" ]
+                    ]
+                    Html.span [
+                        if testId.IsSome then
+                            prop.testId (testId.Value + "Label")
+
+                        prop.className
+                            "swt:min-w-0 swt:flex-1 swt:truncate swt:text-left swt:@max-3xs/gitSidebar:sr-only"
+                        prop.text label
+                    ]
+                ]
             ]
-        ]
+
+        let tooltipTestId = testId |> Option.map (fun value -> value + "Tooltip")
+
+        GitSidebar.Tooltip(label, button, ?testId = tooltipTestId)
 
     [<ReactComponent>]
     static member private BranchHeader(props: BranchHeaderProps) =
         React.Fragment [
             Html.div [
                 prop.className
-                    "swt:flex swt:items-center swt:justify-between swt:border-b swt:border-base-content/10 swt:px-3 swt:py-3"
+                    "swt:flex swt:min-w-0 swt:items-center swt:justify-between swt:gap-2 swt:border-b swt:border-base-content/10 swt:px-3 swt:py-3 swt:@max-xs:px-2"
                 prop.children [
                     Html.div [
-                        prop.className "swt:flex swt:items-center swt:gap-2"
+                        prop.className "swt:flex swt:min-w-0 swt:items-center swt:gap-2"
                         prop.children [
                             Html.span [
-                                prop.className "swt:iconify swt:fluent--branch-fork-24-regular swt:size-5"
+                                prop.className "swt:iconify swt:fluent--branch-fork-24-regular swt:size-5 swt:shrink-0"
                             ]
                             Html.div [
-                                prop.className "swt:flex swt:flex-col"
+                                prop.className "swt:flex swt:min-w-0 swt:flex-col"
                                 prop.children [
                                     Html.span [
-                                        prop.className "swt:text-sm swt:font-semibold"
+                                        prop.className "swt:truncate swt:text-sm swt:font-semibold"
                                         prop.text "Source Control"
                                     ]
                                     Html.span [
-                                        prop.className "swt:text-xs swt:text-base-content/60"
+                                        prop.className "swt:truncate swt:text-xs swt:text-base-content/60"
                                         prop.text (
                                             match props.Status.CurrentBranch with
                                             | Some branch -> branch
@@ -1693,7 +1732,8 @@ type GitSidebar =
 
         Html.div [
             prop.testId "GitSidebar"
-            prop.className "swt:flex swt:h-full swt:min-h-0 swt:flex-col swt:bg-base-100"
+            prop.className
+                "swt:@container/gitSidebar swt:flex swt:h-full swt:min-h-0 swt:min-w-0 swt:flex-col swt:overflow-x-hidden swt:bg-base-100"
             prop.children [
                 GitSidebar.BranchHeader(
                     {

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -18,6 +18,12 @@ module private GitSidebarInternal =
         | Untracked
         | Conflict
 
+    type ChangePresentation = {
+        Label: string
+        IconClassName: string
+        ToneClassName: string
+    }
+
     let hasConflicts (status: GitSidebarStatus) (changedFiles: GitSidebarChange[]) =
         status.IsMergeInProgress || (changedFiles |> Array.exists _.IsConflicted)
 
@@ -51,15 +57,36 @@ module private GitSidebarInternal =
 
     let changePresentation (change: GitSidebarChange) =
         match classifyChange change with
-        | GitChangeKind.Added -> "Added", "swt:badge swt:badge-success swt:badge-sm", "swt:fluent--add-24-regular"
-        | GitChangeKind.Modified -> "Modified", "swt:badge swt:badge-info swt:badge-sm", "swt:fluent--edit-24-regular"
-        | GitChangeKind.Deleted -> "Deleted", "swt:badge swt:badge-error swt:badge-sm", "swt:fluent--delete-24-regular"
-        | GitChangeKind.Renamed ->
-            "Renamed", "swt:badge swt:badge-warning swt:badge-sm", "swt:fluent--arrow-swap-24-regular"
-        | GitChangeKind.Untracked ->
-            "Untracked", "swt:badge swt:badge-neutral swt:badge-sm", "swt:fluent--document-24-regular"
-        | GitChangeKind.Conflict ->
-            "Conflict", "swt:badge swt:badge-error swt:badge-sm", "swt:fluent--warning-24-regular"
+        | GitChangeKind.Added -> {
+            Label = "Added"
+            IconClassName = "swt:fluent--add-24-regular"
+            ToneClassName = "swt:text-success"
+          }
+        | GitChangeKind.Modified -> {
+            Label = "Modified"
+            IconClassName = "swt:fluent--edit-24-regular"
+            ToneClassName = "swt:text-warning"
+          }
+        | GitChangeKind.Deleted -> {
+            Label = "Deleted"
+            IconClassName = "swt:fluent--delete-24-regular"
+            ToneClassName = "swt:text-error"
+          }
+        | GitChangeKind.Renamed -> {
+            Label = "Renamed"
+            IconClassName = "swt:fluent--arrow-swap-24-regular"
+            ToneClassName = "swt:text-info"
+          }
+        | GitChangeKind.Untracked -> {
+            Label = "Untracked"
+            IconClassName = "swt:fluent--add-24-regular"
+            ToneClassName = "swt:text-success"
+          }
+        | GitChangeKind.Conflict -> {
+            Label = "Conflict"
+            IconClassName = "swt:fluent--warning-24-regular"
+            ToneClassName = "swt:text-error"
+          }
 
     let branchKindLabel (kind: GitSidebarBranchKind) =
         match kind with
@@ -901,47 +928,38 @@ type GitSidebar =
         ]
 
     [<ReactComponent>]
-    static member private ChangeStatusPopover(index: int, change: GitSidebarChange) =
-        let label, _, iconClass = GitSidebarInternal.changePresentation change
+    static member private ChangeStatusTooltip(index: int, change: GitSidebarChange) =
+        let presentation = GitSidebarInternal.changePresentation change
         let gitReturn = GitSidebarInternal.describeChange change
-        let stopRowActivation (event: Event) = event.stopPropagation ()
+        let tooltipText = $"{presentation.Label}. Git return: {gitReturn}"
+        let isTooltipVisible, setIsTooltipVisible = React.useState false
 
-        let triggerInteractionProps =
-            createObj [
-                "onClick" ==> stopRowActivation
-                "onMouseDown" ==> stopRowActivation
-                "onKeyDown" ==> stopRowActivation
-            ]
-
-        Popover.Popover(
-            debug = $"git_change_status_{index}",
-            children =
-                React.Fragment [
-                    Popover.Trigger(
-                        Html.span [ prop.className $"swt:iconify {iconClass} swt:size-4" ],
-                        className = "swt:btn swt:btn-ghost swt:btn-xs swt:min-h-0 swt:h-7 swt:w-7 swt:px-0",
-                        interactionProps = triggerInteractionProps,
-                        props = [ prop.testId $"GitSidebarChangeStatusButton-{index}" ]
-                    )
-                    Popover.Content(
-                        children =
-                            Html.div [
-                                prop.className "swt:flex swt:flex-col swt:gap-2"
-                                prop.children [
-                                    Popover.Heading(Html.text "File status")
-                                    Html.p [
-                                        prop.className "swt:text-sm"
-                                        prop.text $"This file was {label.ToLowerInvariant()}."
-                                    ]
-                                    Html.p [
-                                        prop.className "swt:text-sm swt:font-mono"
-                                        prop.text $"Git return: {gitReturn}"
-                                    ]
-                                ]
-                            ]
-                    )
+        Html.div [
+            prop.testId $"GitSidebarChangeStatusTooltip-{index}"
+            prop.className "swt:tooltip swt:tooltip-left swt:inline-flex swt:items-center"
+            prop.ariaLabel tooltipText
+            prop.onMouseEnter (fun _ -> setIsTooltipVisible true)
+            prop.onMouseLeave (fun _ -> setIsTooltipVisible false)
+            prop.onFocus (fun _ -> setIsTooltipVisible true)
+            prop.onBlur (fun _ -> setIsTooltipVisible false)
+            prop.children [
+                if isTooltipVisible then
+                    Html.div [
+                        prop.className "swt:tooltip-content swt:max-w-64 swt:text-xs"
+                        prop.text tooltipText
+                    ]
+                Html.span [
+                    prop.testId $"GitSidebarChangeStatusIcon-{index}"
+                    prop.className [
+                        "swt:iconify swt:size-4 swt:shrink-0"
+                        presentation.IconClassName
+                        presentation.ToneClassName
+                    ]
+                    prop.ariaLabel tooltipText
+                    prop.title tooltipText
                 ]
-        )
+            ]
+        ]
 
     [<ReactComponent>]
     static member private ChangedFileRow(props: ChangedFileRowProps) =
@@ -1019,7 +1037,7 @@ type GitSidebar =
                         Html.div [
                             prop.testId $"GitSidebarChangeStatusSlot-{props.Index}"
                             prop.className "swt:ml-auto swt:shrink-0 swt:self-start"
-                            prop.children [ GitSidebar.ChangeStatusPopover(props.Index, change) ]
+                            prop.children [ GitSidebar.ChangeStatusTooltip(props.Index, change) ]
                         ]
                     ]
                 ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -1611,11 +1611,7 @@ type GitSidebar =
 
             let nextMarkedPaths =
                 match ctrlKey, shiftKey with
-                | false, false ->
-                    if Set.contains change.Path markedPaths then
-                        Set.remove change.Path markedPaths
-                    else
-                        Set.singleton change.Path
+                | false, false -> Set.singleton change.Path
                 | true, false ->
                     if Set.contains change.Path markedPaths then
                         Set.remove change.Path markedPaths

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -659,8 +659,8 @@ export const CommitComposer: Story = {
     expect(menuBounds.right).toBeLessThanOrEqual(sidebarBounds.right);
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionButton")).toBeNull();
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionCheckbox-README.md")).toBeNull();
-    // Click again to deselect – button text should switch back to "Save All Changes"
-    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
+    // Ctrl+click to deselect – button text should switch back to "Save All Changes"
+    fireEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"), { ctrlKey: true });
     await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save All Changes");
     await userEvent.click(canvas.getByTestId("GitSidebarSaveOptionsButton"));
     await expect(canvas.getByTestId("GitSidebarLocalCommitButton")).toHaveTextContent(

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -245,7 +245,8 @@ export const MarkedSelectionWithoutLastClickedHighlight: Story = {
     await expect(canvas.getByTestId("GitSidebarChangeRow-1")).toHaveClass("swt:border-success/40");
     await expect(canvas.getByTestId("GitSidebarChangeRow-1")).toHaveClass("swt:bg-success/10");
 
-    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-1"));
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
+    await expect(canvas.getByTestId("GitSidebarChangeRow-0")).toHaveClass("swt:border-success/40");
     await expect(canvas.getByTestId("GitSidebarChangeRow-1")).not.toHaveClass("swt:border-success/40");
     await expect(canvas.getByTestId("GitSidebarChangeRow-1")).not.toHaveClass("swt:bg-success/10");
   },

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -224,6 +224,56 @@ export const ChangedFiles: Story = {
   },
 };
 
+export const MarkedSelectionWithoutLastClickedHighlight: Story = {
+  render: (args) => <StatefulSidebar {...args} />,
+  args: {
+    status: baseStatus,
+    changedFiles: changedFiles.slice(),
+    selectedFile: "README.md",
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId("GitSidebarChangeRow-0")).not.toHaveClass("swt:border-primary/40");
+    await expect(canvas.getByTestId("GitSidebarChangeRow-0")).not.toHaveClass("swt:bg-primary/5");
+
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-1"));
+    await expect(canvas.getByTestId("GitSidebarChangeRow-1")).toHaveClass("swt:border-success/40");
+    await expect(canvas.getByTestId("GitSidebarChangeRow-1")).toHaveClass("swt:bg-success/10");
+
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-1"));
+    await expect(canvas.getByTestId("GitSidebarChangeRow-1")).not.toHaveClass("swt:border-success/40");
+    await expect(canvas.getByTestId("GitSidebarChangeRow-1")).not.toHaveClass("swt:bg-success/10");
+  },
+};
+
+export const SlowOpenDoesNotGreyRows: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: changedFiles.slice(),
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks({
+      OnSelectChange: () =>
+        new Promise((resolve) => {
+          window.setTimeout(() => resolve(FSharpResult$2_Ok<void, string>(undefined)), 250);
+        }),
+    }),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"));
+    await expect(canvas.getByTestId("GitSidebarChangeRow-0")).not.toHaveClass("swt:opacity-60");
+    await expect(canvas.getByTestId("GitSidebarChangeRow-1")).not.toHaveClass("swt:opacity-60");
+  },
+};
+
 export const AdvancedActions: Story = {
   args: {
     status: baseStatus,

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -444,8 +444,42 @@ export const LongWrappedFile: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByTestId("GitSidebarChangeStatusSlot-0")).toHaveClass("swt:ml-auto");
+    await expect(canvas.getByTestId("GitSidebarChangeRow-0")).toHaveClass("swt:items-center");
     await expect(canvas.getByTestId("GitSidebarChangeStatusSlot-0")).toHaveClass("swt:shrink-0");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusSlot-0")).toHaveClass("swt:self-center");
+  },
+};
+
+const discardSelectionSpy = fn();
+
+export const HoverDiscardChange: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: changedFiles.slice(),
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks({
+      OnDiscardSelection: discardSelectionSpy,
+    }),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    discardSelectionSpy.mockClear();
+    const canvas = within(canvasElement);
+
+    const row = canvas.getByTestId("GitSidebarChangeRow-0");
+    await expect(row).toHaveClass("swt:items-center");
+    await expect(row).toHaveClass("swt:py-1");
+
+    await userEvent.hover(row);
+    await expect(canvas.getByTestId("GitSidebarDiscardChangeButton-0")).toBeInTheDocument();
+    await expect(canvas.getByTestId("GitSidebarDiscardChangeButton-0")).toHaveClass("swt:opacity-0");
+    await expect(canvas.getByTestId("GitSidebarDiscardChangeButton-0")).toHaveClass(
+      "swt:group-hover:opacity-100",
+    );
+
+    await userEvent.click(canvas.getByTestId("GitSidebarDiscardChangeButton-0"));
+    await expect(discardSelectionSpy).toHaveBeenCalledWith(["README.md"]);
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -311,7 +311,7 @@ export const ConflictsPresent: Story = {
       "Resolve all conflicted files before pushing.",
     );
     await expect(canvasElement.querySelectorAll("[data-testid^='GitSidebarChangeRow-']")).toHaveLength(4);
-    await expect(canvas.getByTestId("GitSidebarChangeStatusButton-0")).toBeInTheDocument();
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-0")).toBeInTheDocument();
   },
 };
 
@@ -366,11 +366,62 @@ export const DeletedFile: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const modal = within(document.body);
     await expect(canvas.getByTestId("GitSidebar")).not.toHaveTextContent("git: D.");
     await expect(canvas.getByTestId("GitSidebar")).not.toHaveTextContent("Deleted");
-    await userEvent.click(canvas.getByTestId("GitSidebarChangeStatusButton-0"));
-    await expect(await modal.findByTestId("popover_content_git_change_status_0")).toHaveTextContent("Git return: git: D.");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-0")).toHaveClass("swt:text-error");
+
+    await userEvent.hover(canvas.getByTestId("GitSidebarChangeStatusIcon-0"));
+    await expect(canvas.getByTestId("GitSidebarChangeStatusTooltip-0")).toHaveTextContent("Deleted");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusTooltip-0")).toHaveTextContent("Git return: git: D.");
+  },
+};
+
+export const ChangeStatusIconColors: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: [
+      {
+        Path: "new-file.md",
+        OriginalPath: undefined,
+        IndexStatus: "A",
+        WorkingTreeStatus: " ",
+        IsConflicted: false,
+      },
+      {
+        Path: "changed-file.md",
+        OriginalPath: undefined,
+        IndexStatus: "M",
+        WorkingTreeStatus: " ",
+        IsConflicted: false,
+      },
+      {
+        Path: "deleted-file.md",
+        OriginalPath: undefined,
+        IndexStatus: "D",
+        WorkingTreeStatus: " ",
+        IsConflicted: false,
+      },
+    ],
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-0")).toHaveClass("swt:text-success");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-0")).toHaveClass(
+      "swt:fluent--add-24-regular",
+    );
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-1")).toHaveClass("swt:text-warning");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-1")).toHaveClass(
+      "swt:fluent--edit-24-regular",
+    );
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-2")).toHaveClass("swt:text-error");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-2")).toHaveClass(
+      "swt:fluent--delete-24-regular",
+    );
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -526,7 +526,7 @@ export const HoverDiscardChange: Story = {
 
     const row = canvas.getByTestId("GitSidebarChangeRow-0");
     await expect(row).toHaveClass("swt:items-center");
-    await expect(row).toHaveClass("swt:py-1");
+    await expect(row).toHaveClass("swt:min-h-6");
 
     await userEvent.hover(row);
     await expect(canvas.getByTestId("GitSidebarDiscardChangeButton-0")).toBeInTheDocument();

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -320,21 +320,28 @@ export const ActionTooltipsAndResponsiveLabels: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.getByTestId("GitSidebarUpdateArcButtonTooltip")).toHaveClass("swt:tooltip");
+    await expect(canvas.getByTestId("GitSidebarUpdateArcButton")).toHaveAttribute(
+      "title",
+      "Update ARC from Online:\n- git fetch origin\n- git merge-tree (conflict preflight)\n- git pull origin",
+    );
     await expect(canvas.getByTestId("GitSidebarUpdateArcButtonLabel")).toHaveClass("swt:truncate");
     await expect(canvas.getByTestId("GitSidebarUpdateArcButtonLabel")).toHaveClass(
       "swt:@max-3xs/gitSidebar:sr-only",
     );
 
-    await userEvent.hover(canvas.getByTestId("GitSidebarUpdateArcButton"));
-    await expect(canvas.getByTestId("GitSidebarUpdateArcButtonTooltip")).toHaveTextContent(
-      "Update ARC from Online",
-    );
-
     await userEvent.click(canvas.getByTestId("GitSidebarAdvancedActionsButton"));
-    await expect(canvas.getByTestId("GitSidebarFetchButtonTooltip")).toHaveClass("swt:tooltip");
-    await expect(canvas.getByTestId("GitSidebarPullButtonTooltip")).toHaveClass("swt:tooltip");
-    await expect(canvas.getByTestId("GitSidebarPushButtonTooltip")).toHaveClass("swt:tooltip");
+    await expect(canvas.getByTestId("GitSidebarFetchButton")).toHaveAttribute(
+      "title",
+      "Check for Changes:\n- git fetch origin",
+    );
+    await expect(canvas.getByTestId("GitSidebarPullButton")).toHaveAttribute(
+      "title",
+      "Download Changes:\n- git pull origin",
+    );
+    await expect(canvas.getByTestId("GitSidebarPushButton")).toHaveAttribute(
+      "title",
+      "Upload Changes:\n- git push origin",
+    );
   },
 };
 
@@ -419,10 +426,10 @@ export const DeletedFile: Story = {
     await expect(canvas.getByTestId("GitSidebar")).not.toHaveTextContent("git: D.");
     await expect(canvas.getByTestId("GitSidebar")).not.toHaveTextContent("Deleted");
     await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-0")).toHaveClass("swt:text-error");
-
-    await userEvent.hover(canvas.getByTestId("GitSidebarChangeStatusIcon-0"));
-    await expect(canvas.getByTestId("GitSidebarChangeStatusTooltip-0")).toHaveTextContent("Deleted");
-    await expect(canvas.getByTestId("GitSidebarChangeStatusTooltip-0")).toHaveTextContent("Git return: git: D.");
+    await expect(canvas.getByTestId("GitSidebarChangeStatusIcon-0")).toHaveAttribute(
+      "title",
+      "Deleted:\n- git: D.",
+    );
   },
 };
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fireEvent, fn, userEvent, within } from "storybook/test";
+import { expect, fireEvent, fn, userEvent, waitFor, within } from "storybook/test";
 import { Main as GitSidebarComponent } from "./GitSidebar.fs.js";
 import {
   FSharpResult$2_Ok,
@@ -660,11 +660,16 @@ export const CommitComposer: Story = {
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionButton")).toBeNull();
     await expect(canvas.queryByTestId("GitSidebarCommitSelectionCheckbox-README.md")).toBeNull();
     // Ctrl+click to deselect – button text should switch back to "Save All Changes"
+    fireEvent.mouseDown(canvas.getByTestId("GitSidebarChangeRow-0"), { ctrlKey: true });
     fireEvent.click(canvas.getByTestId("GitSidebarChangeRow-0"), { ctrlKey: true });
-    await expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save All Changes");
+    await waitFor(() =>
+      expect(canvas.getByTestId("GitSidebarPrimarySaveButton")).toHaveTextContent("Save All Changes"),
+    );
     await userEvent.click(canvas.getByTestId("GitSidebarSaveOptionsButton"));
-    await expect(canvas.getByTestId("GitSidebarLocalCommitButton")).toHaveTextContent(
-      "Add and commit all Changes",
+    await waitFor(() =>
+      expect(canvas.getByTestId("GitSidebarLocalCommitButton")).toHaveTextContent(
+        "Add and commit all Changes",
+      ),
     );
     await userEvent.click(canvas.getByTestId("GitSidebarSaveOptionsHelpButton"));
     await expect(await modal.findByTestId("popover_content_GitSidebarSaveOptionsHelp")).toHaveTextContent(

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fireEvent, userEvent, within } from "storybook/test";
+import { expect, fireEvent, fn, userEvent, within } from "storybook/test";
 import { Main as GitSidebarComponent } from "./GitSidebar.fs.js";
 import {
   FSharpResult$2_Ok,
@@ -255,6 +255,36 @@ export const AdvancedActions: Story = {
           Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(true);
+  },
+};
+
+export const ActionTooltipsAndResponsiveLabels: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: changedFiles.slice(),
+    branchOptions: branchOptions.slice(),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId("GitSidebarUpdateArcButtonTooltip")).toHaveClass("swt:tooltip");
+    await expect(canvas.getByTestId("GitSidebarUpdateArcButtonLabel")).toHaveClass("swt:truncate");
+    await expect(canvas.getByTestId("GitSidebarUpdateArcButtonLabel")).toHaveClass(
+      "swt:@max-3xs/gitSidebar:sr-only",
+    );
+
+    await userEvent.hover(canvas.getByTestId("GitSidebarUpdateArcButton"));
+    await expect(canvas.getByTestId("GitSidebarUpdateArcButtonTooltip")).toHaveTextContent(
+      "Update ARC from Online",
+    );
+
+    await userEvent.click(canvas.getByTestId("GitSidebarAdvancedActionsButton"));
+    await expect(canvas.getByTestId("GitSidebarFetchButtonTooltip")).toHaveClass("swt:tooltip");
+    await expect(canvas.getByTestId("GitSidebarPullButtonTooltip")).toHaveClass("swt:tooltip");
+    await expect(canvas.getByTestId("GitSidebarPushButtonTooltip")).toHaveClass("swt:tooltip");
   },
 };
 

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -2125,7 +2125,7 @@ Vitest.describe (
                     )
 
                 Vitest.expect(container.textContent.Contains("studies/s-study-01/protocol.md")).toBe (true)
-                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeStatusButton-3']")).not.toBeNull ()
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeStatusIcon-3']")).not.toBeNull ()
 
                 cleanup ()
             }
@@ -2410,7 +2410,7 @@ Vitest.describe (
 
                 Vitest.expect(container.textContent.Contains("git: D.")).toBe (false)
                 Vitest.expect(container.textContent.Contains("Deleted")).toBe (false)
-                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeStatusButton-0']")).not.toBeNull ()
+                Vitest.expect(container.querySelector("[data-testid='GitSidebarChangeStatusIcon-0']")).not.toBeNull ()
 
                 cleanup ()
             }
@@ -2536,7 +2536,7 @@ Vitest.describe (
         )
 
         Vitest.test (
-            "GitSidebar right-click menu discards the currently marked files",
+            "GitSidebar hover discard button discards the currently marked files",
             fun () -> promise {
                 let mutable discardedPaths: string[] option = None
 
@@ -2574,17 +2574,14 @@ Vitest.describe (
                 row2.dispatchEvent ctrlClick |> ignore
                 do! Promise.sleep 0
 
-                let contextMenuEvent =
-                    createMouseEvent
-                        "contextmenu"
-                        (createObj [ "bubbles" ==> true; "clientX" ==> 32; "clientY" ==> 32; "button" ==> 2 ])
+                let hoverEvent =
+                    createMouseEvent "mouseenter" (createObj [ "bubbles" ==> true ])
 
-                row0.dispatchEvent contextMenuEvent |> ignore
+                row0.dispatchEvent hoverEvent |> ignore
                 do! Promise.sleep 0
 
                 let discardButton =
-                    findBodyButtonContaining "Discard Selected Changes"
-                    |> Option.defaultWith (fun () -> failwith "Expected discard context menu action.")
+                    container.querySelector("[data-testid='GitSidebarDiscardChangeButton-0']") :?> HTMLElement
 
                 discardButton.click ()
                 do! Promise.sleep 0
@@ -2803,7 +2800,7 @@ Vitest.describe (
         )
 
         Vitest.test (
-            "GitSidebar plain click on a marked row deselects it and rows suppress native text selection",
+            "GitSidebar Ctrl+click on a marked row deselects it and rows suppress native text selection",
             fun () -> promise {
                 let! container, cleanup =
                     renderToBody (
@@ -2852,7 +2849,10 @@ Vitest.describe (
 
                 Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
 
-                firstRow.click ()
+                let ctrlClick =
+                    createMouseEvent "click" (createObj [ "bubbles" ==> true; "ctrlKey" ==> true ])
+
+                firstRow.dispatchEvent ctrlClick |> ignore
                 do! Promise.sleep 0
 
                 Vitest.expect(container.textContent.Contains("Save All Changes")).toBe (true)
@@ -2865,7 +2865,7 @@ Vitest.describe (
         )
 
         Vitest.test (
-            "GitSidebar status popover trigger does not open the changed file row",
+            "GitSidebar status icon click does not open the changed file row",
             fun () -> promise {
                 let mutable selectCalls = 0
 
@@ -2894,10 +2894,13 @@ Vitest.describe (
                         )
                     )
 
-                let statusButton =
-                    container.querySelector("[data-testid='GitSidebarChangeStatusButton-0']") :?> HTMLButtonElement
+                let statusIcon =
+                    container.querySelector("[data-testid='GitSidebarChangeStatusIcon-0']") :?> HTMLElement
 
-                statusButton.click ()
+                let clickEvent =
+                    createMouseEvent "click" (createObj [ "bubbles" ==> true ])
+
+                statusIcon.dispatchEvent clickEvent |> ignore
                 do! Promise.sleep 0
 
                 Vitest.expect(selectCalls).toBe (0)


### PR DESCRIPTION
## Summary

Overhauled the Git sidebar visuals and interaction behavior for a cleaner, more informative interface.

### Changes

- **Git command hints** — Action buttons display the underlying git commands in native tooltips (e.g., `Update ARC from Online` shows its `git fetch`/`git merge-tree`/`git pull origin` sequence). Change status icons show the raw git status code on hover.
  - <img width="735" height="221" alt="image" src="https://github.com/user-attachments/assets/c30a6bba-05fc-4ce7-bf3e-f38d5201410d" />
- **Compact file rows** — Changed-file rows are now half the height (24px `min-h-6`, no vertical padding). The discard button appears on row hover instead of requiring a right-click context menu.
- **Colored status icons** — File changes use distinct colored Fluent icons: green add for Added/Untracked, yellow edit for Modified, red delete for Deleted, blue swap for Renamed, red warning for Conflicted.
  - <img width="723" height="261" alt="image" src="https://github.com/user-attachments/assets/36136b23-dd3c-4435-9fa8-8beb36a42528" />
- **Windows-style file marking** — Plain click selects only the clicked file and deselects everything else, matching Windows Explorer behavior. Ctrl+click toggles individual files, Shift+click selects a range.
- **Removed stale state** — Dropped the confusing last-opened-file highlight. Rows no longer grey out during slow file opens. Removed unused `activeAction` local state and internal context menu code.