### PR TITLE
Refactor code locations, make layout components generic, create ThemeSelector, create SettingsPage

### DIFF
--- a/src/Client/Index.fs
+++ b/src/Client/Index.fs
@@ -3,7 +3,6 @@ module Index
 
 open Messages
 open Model
-open Swate.Components.ThemeProvider.Context
 
 
 ///<summary> This is a basic test case used in Client unit tests </summary>
@@ -20,8 +19,7 @@ let View (model: Model) (dispatch: Msg -> unit) =
         | _ -> None
 
     // React.strictMode [
-    Swate.Components.ThemeProvider.ThemeProvider.ThemeProvider(
-        ThemeCtx,
+    Swate.Components.Theme.ThemeProvider.ThemeProvider(
         Swate.Components.TermSearch.TermSearchConfigProvider.TIBQueryProvider(
             Swate.Components.AnnotationTable.AnnotationTableContextProvider.AnnotationTableContextProvider(
 

--- a/src/Client/Pages/Settings/SettingsView.fs
+++ b/src/Client/Pages/Settings/SettingsView.fs
@@ -9,7 +9,7 @@ open Messages
 open Feliz
 
 open Swate.Components
-open Swate.Components.ThemeProvider.Context
+open Swate.Components.Theme.Context
 
 type Settings =
 

--- a/src/Components/playground/App.tsx
+++ b/src/Components/playground/App.tsx
@@ -25,6 +25,7 @@ import {Entry as AuthButton} from '../src/Authentication/Authentication.fs.ts';
 import {GitLabEntry as DataHubBrowser} from '../src/DataHub/DataHubBrowser.fs.ts';
 import {Entry as ARCSelectorEntry} from '../src/ARCSelector/Selector.fs.ts';
 import {Entry as ArcFileEditor} from '../src/ArcFileEditor/ArcFileEditor.fs.ts';
+import {Entry as SettingsPage} from '../src/PageComponents/SettingsPage/SettingsPage.fs.ts';
 
 function TermSearchContainer() {
   const [term, setTerm] = React.useState(undefined);
@@ -226,7 +227,8 @@ function ArcFileEditorContainer() {
 
 const App = () => {
     return (
-        <ArcFileEditorContainer />
+        <SettingsPage />
+        // <ArcFileEditorContainer />
         // <AuthButtonContainer />
         // <div className="swt:container swt:mx-auto swt:flex swt:flex-col swt:p-2 swt:gap-8 swt:mb-12">
         //     <NoteSearch />

--- a/src/Components/src/GenericComponents/LayoutComponents.fs
+++ b/src/Components/src/GenericComponents/LayoutComponents.fs
@@ -1,10 +1,10 @@
-namespace Swate.Components.Metadata
+namespace Swate.Components
 
 open Feliz
 open Swate.Components
 
 [<RequireQualifiedAccess>]
-type Generic =
+type LayoutComponents =
 
     [<ReactComponent>]
     static member FieldTitle(title: string) =

--- a/src/Components/src/GenericComponents/Select.fs
+++ b/src/Components/src/GenericComponents/Select.fs
@@ -7,6 +7,7 @@ open Swate.Components.GenericComponents.SelectContext
 [<Erase; Mangle(false)>]
 type Select =
 
+    [<ReactComponent>]
     static member private InnerBaseOptionRender
         (label: string, isSelected: bool, ?ref: IRefValue<option<Browser.Types.HTMLInputElement>>)
         =
@@ -29,6 +30,7 @@ type Select =
             Html.div label
         ]
 
+    [<ReactComponent>]
     static member private OuterBaseOptionRender
         (
             isActive: bool,

--- a/src/Components/src/Layout/Layout.fs
+++ b/src/Components/src/Layout/Layout.fs
@@ -108,7 +108,7 @@ type Layout =
         ]
 
     [<ReactComponent>]
-    static member LeftSidebarToggleBtn(?activeBorderStyle: bool) =
+    static member LeftSidebarToggleBtn() =
         let ctx = useLeftSidebarCtx ()
 
         Layout.LayoutBtn(
@@ -123,7 +123,7 @@ type Layout =
         )
 
     [<ReactComponent>]
-    static member RightSidebarToggleBtn(?activeBorderStyle: bool) =
+    static member RightSidebarToggleBtn() =
         let ctx = useRightSidebarCtx ()
 
         Layout.LayoutBtn(

--- a/src/Components/src/Layout/Layout.fs
+++ b/src/Components/src/Layout/Layout.fs
@@ -110,14 +110,13 @@ type Layout =
     [<ReactComponent>]
     static member LeftSidebarToggleBtn(?activeBorderStyle: bool) =
         let ctx = useLeftSidebarCtx ()
-        let showIsActive = activeBorderStyle |> Option.map (fun _ -> ctx.state)
 
         Layout.LayoutBtn(
             iconClassName =
                 (if ctx.state then
-                     "swt:fluent--panel-right-48-filled"
+                     "swt:fluent--panel-left-48-filled"
                  else
-                     "swt:fluent--panel-right-48-regular"),
+                     "swt:fluent--panel-left-48-regular"),
             tooltip = "Toggle left sidebar",
             tooltipClassName = "swt:tooltip-left",
             onClick = (fun () -> ctx.setState (not ctx.state))
@@ -126,14 +125,13 @@ type Layout =
     [<ReactComponent>]
     static member RightSidebarToggleBtn(?activeBorderStyle: bool) =
         let ctx = useRightSidebarCtx ()
-        let showIsActive = activeBorderStyle |> Option.map (fun _ -> ctx.isOpen)
 
         Layout.LayoutBtn(
             iconClassName =
                 (if ctx.isOpen then
-                     "swt:fluent--panel-left-48-filled"
+                     "swt:fluent--panel-right-48-filled"
                  else
-                     "swt:fluent--panel-left-48-regular"),
+                     "swt:fluent--panel-right-48-regular"),
             tooltip = "Toggle right sidebar",
             tooltipClassName = "swt:tooltip-left",
             onClick = fun () -> ctx.setIsOpen (not ctx.isOpen)

--- a/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/MarkdownText/TextInputWithMarkdown.fs
@@ -7,7 +7,6 @@ open Fable.Core.JsInterop
 open Feliz
 
 open Swate.Components
-open Swate.Components.Metadata
 open Swate.Components.MarkdownText.JsBindings
 open Swate.Components.MarkdownText.Plugins
 
@@ -16,21 +15,35 @@ module private MarkdownCommands =
 
     let private bold: ICommand = ReactMDEditor.commands?bold |> unbox<ICommand>
     let private italic: ICommand = ReactMDEditor.commands?italic |> unbox<ICommand>
-    let private strikethrough: ICommand = ReactMDEditor.commands?strikethrough |> unbox<ICommand>
+
+    let private strikethrough: ICommand =
+        ReactMDEditor.commands?strikethrough |> unbox<ICommand>
+
     let private link: ICommand = ReactMDEditor.commands?link |> unbox<ICommand>
     let private quote: ICommand = ReactMDEditor.commands?quote |> unbox<ICommand>
     let private code: ICommand = ReactMDEditor.commands?code |> unbox<ICommand>
-    let private codeBlock: ICommand = ReactMDEditor.commands?codeBlock |> unbox<ICommand>
-    let private unorderedListCommand: ICommand = ReactMDEditor.commands?unorderedListCommand |> unbox<ICommand>
-    let private orderedListCommand: ICommand = ReactMDEditor.commands?orderedListCommand |> unbox<ICommand>
-    let private checkedListCommand: ICommand = ReactMDEditor.commands?checkedListCommand |> unbox<ICommand>
 
-    let defaultToolbarGroups: ICommand[][] =
+    let private codeBlock: ICommand =
+        ReactMDEditor.commands?codeBlock |> unbox<ICommand>
+
+    let private unorderedListCommand: ICommand =
+        ReactMDEditor.commands?unorderedListCommand |> unbox<ICommand>
+
+    let private orderedListCommand: ICommand =
+        ReactMDEditor.commands?orderedListCommand |> unbox<ICommand>
+
+    let private checkedListCommand: ICommand =
+        ReactMDEditor.commands?checkedListCommand |> unbox<ICommand>
+
+    let defaultToolbarGroups: ICommand[][] = [|
+        [| bold; italic; strikethrough |]
+        [| link; quote; code; codeBlock |]
         [|
-            [| bold; italic; strikethrough |]
-            [| link; quote; code; codeBlock |]
-            [| unorderedListCommand; orderedListCommand; checkedListCommand |]
+            unorderedListCommand
+            orderedListCommand
+            checkedListCommand
         |]
+    |]
 
     let toolbarGroupsWithPlugins (pluginCommands: ICommand[]) =
         if pluginCommands.Length = 0 then
@@ -38,7 +51,8 @@ module private MarkdownCommands =
         else
             Array.append defaultToolbarGroups [| pluginCommands |]
 
-    let shortcutCommands (pluginCommands: ICommand[]) = toolbarGroupsWithPlugins pluginCommands |> Array.concat
+    let shortcutCommands (pluginCommands: ICommand[]) =
+        toolbarGroupsWithPlugins pluginCommands |> Array.concat
 
 [<Erase; Mangle(false)>]
 type TextInputWithMarkdown =
@@ -64,26 +78,31 @@ type TextInputWithMarkdown =
         let disabled = defaultArg disabled false
         let isJoin = defaultArg isJoin false
 
-        let options =
-            {
-                MarkdownOptions.defaults with
-                    Height = defaultArg height MarkdownOptions.defaults.Height
-                    Mode = defaultArg mode MarkdownOptions.defaults.Mode
-                    PreviewClassName =
-                        match previewClassName with
-                        | Some value -> Some value
-                        | None -> MarkdownOptions.defaults.PreviewClassName
-            }
+        let options = {
+            MarkdownOptions.defaults with
+                Height = defaultArg height MarkdownOptions.defaults.Height
+                Mode = defaultArg mode MarkdownOptions.defaults.Mode
+                PreviewClassName =
+                    match previewClassName with
+                    | Some value -> Some value
+                    | None -> MarkdownOptions.defaults.PreviewClassName
+        }
 
         let startedChange = React.useRef false
         let tempValue, setTempValue = React.useState value
         let activeMode, setActiveMode = React.useState options.Mode
         let debouncedValue = React.useDebounce (tempValue, 300)
         let validationError, setValidationError = React.useState (None: string option)
-        let activePrompt, setActivePrompt = React.useState (None: MarkdownPromptPlugin option)
+
+        let activePrompt, setActivePrompt =
+            React.useState (None: MarkdownPromptPlugin option)
+
         let promptInput, setPromptInput = React.useState ""
         let promptError, setPromptError = React.useState (None: string option)
-        let promptFiles, setPromptFiles = React.useStateWithUpdater ([]: MarkdownPromptFile list)
+
+        let promptFiles, setPromptFiles =
+            React.useStateWithUpdater ([]: MarkdownPromptFile list)
+
         let promptFileDropActive, setPromptFileDropActive = React.useState false
 
         let textareaRef = React.useElementRef ()
@@ -113,7 +132,8 @@ type TextInputWithMarkdown =
                         setValidationError None
                         setValue debouncedValue
 
-                    startedChange.current <- false),
+                    startedChange.current <- false
+            ),
             [| box debouncedValue |]
         )
 
@@ -123,7 +143,8 @@ type TextInputWithMarkdown =
             (fun () ->
                 match mode with
                 | Some value -> setActiveMode value
-                | None -> ()),
+                | None -> ()
+            ),
             [| box mode |]
         )
 
@@ -136,7 +157,8 @@ type TextInputWithMarkdown =
                         textarea.focus ()
                         textarea?setSelectionRange (startIndex, endIndex)
                         promptSelectionRef.current <- None
-                    | _ -> ()),
+                    | _ -> ()
+            ),
             [| box activePrompt; box tempValue |]
         )
 
@@ -146,7 +168,7 @@ type TextInputWithMarkdown =
 
         let ensureCommandOrchestrator () =
             match commandOrchestratorRef.current, tryGetTextarea () with
-            | Some orchestrator, Some textarea when obj.ReferenceEquals (orchestrator.textArea, textarea) ->
+            | Some orchestrator, Some textarea when obj.ReferenceEquals(orchestrator.textArea, textarea) ->
                 Some orchestrator
             | _, Some textarea ->
                 let orchestrator = TextAreaCommandOrchestrator(textarea)
@@ -177,6 +199,7 @@ type TextInputWithMarkdown =
                     let combined = currentFiles @ files
                     PluginTextInputHelpers.normalizePromptFiles activePrompt combined
                 )
+
                 if promptError.IsSome then
                     setPromptError None
 
@@ -194,12 +217,7 @@ type TextInputWithMarkdown =
             setPromptFiles (fun currentFiles ->
                 currentFiles
                 |> List.indexed
-                |> List.choose (fun (index, file) ->
-                    if index = indexToRemove then
-                        None
-                    else
-                        Some file
-                )
+                |> List.choose (fun (index, file) -> if index = indexToRemove then None else Some file)
             )
 
         let triggerPromptFileSelection () =
@@ -211,8 +229,7 @@ type TextInputWithMarkdown =
                     applyPickedPromptFiles files
                 | None ->
                     // Built-in fallback: standard browser file input dialog.
-                    promptFileInputRef.current
-                    |> Option.iter (fun input -> input.click ())
+                    promptFileInputRef.current |> Option.iter (fun input -> input.click ())
             }
             |> Promise.catch (fun err ->
                 if isMountedRef.current then
@@ -226,8 +243,7 @@ type TextInputWithMarkdown =
                 applyPickedPromptFiles selected
 
                 // Reset the input value so selecting the same file triggers onChange.
-                promptFileInputRef.current
-                |> Option.iter (fun input -> input.value <- "")
+                promptFileInputRef.current |> Option.iter (fun input -> input.value <- "")
 
         let handlePromptDrop =
             fun (e: DragEvent) ->
@@ -287,22 +303,19 @@ type TextInputWithMarkdown =
                             | Some(startIndex, endIndex) -> startIndex, endIndex
                             | None -> getSelectionOrEnd ()
 
-                        let nextValue, selection =
-                            prompt.Apply tempValue startIndex endIndex promptInput
+                        let nextValue, selection = prompt.Apply tempValue startIndex endIndex promptInput
 
                         applyPromptResult nextValue selection
 
                 | MarkdownPromptInputMode.File ->
                     let selectedFiles =
-                        promptFiles
-                        |> PluginTextInputHelpers.normalizePromptFiles activePrompt
+                        promptFiles |> PluginTextInputHelpers.normalizePromptFiles activePrompt
 
                     if List.isEmpty selectedFiles then
                         setPromptError (Some "Select at least one file.")
                     else
                         match prompt.ApplyFiles with
-                        | None ->
-                            setPromptError (Some "This plugin does not support file input.")
+                        | None -> setPromptError (Some "This plugin does not support file input.")
                         | Some applyFiles ->
                             promise {
                                 let mutable resolvedFiles: (MarkdownPromptFile * string) list = []
@@ -310,6 +323,7 @@ type TextInputWithMarkdown =
                                 for file in selectedFiles do
                                     let! resolvedPath =
                                         PluginTextInputHelpers.resolvePromptFilePath filePickerAdapter file
+
                                     resolvedFiles <- (file, resolvedPath) :: resolvedFiles
 
                                 return List.rev resolvedFiles
@@ -321,8 +335,7 @@ type TextInputWithMarkdown =
                                         | Some(startIndex, endIndex) -> startIndex, endIndex
                                         | None -> getSelectionOrEnd ()
 
-                                    let nextValue, selection =
-                                        applyFiles tempValue startIndex endIndex resolvedFiles
+                                    let nextValue, selection = applyFiles tempValue startIndex endIndex resolvedFiles
 
                                     applyPromptResult nextValue selection
                             )
@@ -355,7 +368,11 @@ type TextInputWithMarkdown =
                 fallback
             else
                 let ariaLabel: obj = command.buttonProps?``aria-label``
-                if isNullOrUndefined ariaLabel then fallback else string ariaLabel
+
+                if isNullOrUndefined ariaLabel then
+                    fallback
+                else
+                    string ariaLabel
 
         let runEditorCommand (command: ICommand) =
             ensureCommandOrchestrator ()
@@ -422,6 +439,7 @@ type TextInputWithMarkdown =
         let handlePromptInputChange =
             fun (text: string) ->
                 setPromptInput text
+
                 if promptError.IsSome then
                     setPromptError None
 
@@ -434,7 +452,7 @@ type TextInputWithMarkdown =
             )
             prop.children [
                 if label.IsSome && not isJoin then
-                    Generic.FieldTitle label.Value
+                    LayoutComponents.FieldTitle label.Value
 
                 Html.div [
                     prop.className "swt:flex swt:gap-2 swt:items-start swt:w-full"
@@ -598,9 +616,4 @@ flowchart TD
 
         let value, setValue = React.useState entryInitialValue
 
-        TextInputWithMarkdown.TextInputWithMarkdown(
-            value,
-            setValue,
-            placeholder = "Write markdown...",
-            height = 440
-        )
+        TextInputWithMarkdown.TextInputWithMarkdown(value, setValue, placeholder = "Write markdown...", height = 440)

--- a/src/Components/src/Metadata/ArcFileMetadata.fs
+++ b/src/Components/src/Metadata/ArcFileMetadata.fs
@@ -12,30 +12,31 @@ type private LazyComponents =
     static member LazyInvestigationMetadata
         (investigation: ArcInvestigation, setInvestigation: ArcInvestigation -> unit)
         =
-        InvestigationMetadata.InvestigationMetadata(investigation, setInvestigation)
+        InvestigationMetadata.InvestigationMetadata(investigation = investigation, setInvestigation = setInvestigation)
 
     [<ReactLazyComponent>]
     static member LazyStudyMetadata(study: ArcStudy, setStudy: ArcStudy -> unit) =
-        StudyMetadata.StudyMetadata(study, setStudy)
+        StudyMetadata.StudyMetadata(study = study, setStudy = setStudy)
 
     [<ReactLazyComponent>]
     static member LazyAssayMetadata(assay: ArcAssay, setAssay: ArcAssay -> unit) =
-        AssayMetadata.AssayMetadata(assay, setAssay)
+        AssayMetadata.AssayMetadata(assay = assay, setAssay = setAssay)
 
     [<ReactLazyComponent>]
-    static member LazyRunMetadata(run: ArcRun, setRun: ArcRun -> unit) = RunMetadata.RunMetadata(run, setRun)
+    static member LazyRunMetadata(run: ArcRun, setRun: ArcRun -> unit) =
+        RunMetadata.RunMetadata(run = run, setRun = setRun)
 
     [<ReactLazyComponent>]
     static member LazyWorkflowMetadata(workflow: ArcWorkflow, setWorkflow: ArcWorkflow -> unit) =
-        WorkflowMetadata.WorkflowMetadata(workflow, setWorkflow)
+        WorkflowMetadata.WorkflowMetadata(workflow = workflow, setWorkflow = setWorkflow)
 
     [<ReactLazyComponent>]
     static member LazyDataMapMetadata(datamap: DataMap) =
-        DataMapMetadata.DataMapMetadata(datamap)
+        DataMapMetadata.DataMapMetadata(datamap = datamap)
 
     [<ReactLazyComponent>]
     static member LazyTemplateMetadata(template: ARCtrl.Template, setTemplate: ARCtrl.Template -> unit) =
-        TemplateMetadata.TemplateMetadata(template, setTemplate)
+        TemplateMetadata.TemplateMetadata(template = template, setTemplate = setTemplate)
 
 open Fable.Core
 

--- a/src/Components/src/Metadata/AssayMetadata.fs
+++ b/src/Components/src/Metadata/AssayMetadata.fs
@@ -4,6 +4,7 @@ open System
 open Fable.Core
 open Feliz
 open ARCtrl
+open Swate.Components
 open Swate.Components.Metadata
 
 [<Erase; Mangle(false)>]
@@ -13,8 +14,8 @@ type AssayMetadata =
     static member AssayMetadata
         // 👀 If you rename these variables, ensure that the names are forwarded for lazy loading in `src\Components\src\Metadata\ArcFileMetadata.fs` as well!
         (assay: ArcAssay, setAssay: ArcAssay -> unit) =
-        Generic.Section [
-            Generic.BoxedField(
+        LayoutComponents.Section [
+            LayoutComponents.BoxedField(
                 "Assay Metadata",
                 content = [
                     FormComponents.TextInput(assay.Identifier, (fun _ -> ()), label = "Identifier", disabled = true)

--- a/src/Components/src/Metadata/DataMapMetadata.fs
+++ b/src/Components/src/Metadata/DataMapMetadata.fs
@@ -3,7 +3,7 @@ namespace Swate.Components.Metadata
 open Fable.Core
 open Feliz
 open ARCtrl
-open Swate.Components.Metadata
+open Swate.Components
 
 [<Erase; Mangle(false)>]
 type DataMapMetadata =
@@ -13,6 +13,6 @@ type DataMapMetadata =
         // 👀 If you rename these variables, ensure that the names are forwarded for lazy loading in `src\Components\src\Metadata\ArcFileMetadata.fs` as well!
         (datamap: DataMap)
         =
-        Generic.Section [
-            Generic.BoxedField("DataMap", description = $"Data Contexts: {datamap.DataContexts.Count}")
+        LayoutComponents.Section [
+            LayoutComponents.BoxedField("DataMap", description = $"Data Contexts: {datamap.DataContexts.Count}")
         ]

--- a/src/Components/src/Metadata/FormComponents.fs
+++ b/src/Components/src/Metadata/FormComponents.fs
@@ -11,16 +11,16 @@ open Swate.Components
 open Swate.Components.JsBindings
 
 [<RequireQualifiedAccess>]
-type AsyncState<'T> =
+type private AsyncState<'T> =
     | Idle
     | Loading
     | Ok of 'T
     | Error of exn
 
-module Helper =
+type FormComponents =
 
     [<ReactComponent>]
-    let AddButton (clickEvent: MouseEvent -> unit) =
+    static member private AddButton(clickEvent: MouseEvent -> unit) =
         Html.button [
             prop.className "swt:btn swt:btn-info"
             prop.text "+"
@@ -28,7 +28,7 @@ module Helper =
         ]
 
     [<ReactComponent>]
-    let DeleteButton (clickEvent: MouseEvent -> unit) =
+    static member private DeleteButton(clickEvent: MouseEvent -> unit) =
         Html.button [
             prop.className "swt:btn swt:btn-error swt:grow-0"
             prop.text "Delete"
@@ -36,13 +36,12 @@ module Helper =
         ]
 
     [<ReactComponent>]
-    let CardFormGroup (content: ReactElement list) =
+    static member private CardFormGroup(content: ReactElement list) =
         Html.div [
             prop.className "swt:grid swt:@md/main:grid-cols-2 swt:@xl/main:grid-flow-col swt:gap-4 not-prose"
             prop.children content
         ]
 
-type FormComponents =
 
     [<ReactComponent>]
     static member InputSequenceElement(key: string, id: string, listComponent: ReactElement) =
@@ -174,7 +173,7 @@ type FormComponents =
                 Html.div [
                     prop.className "swt:flex swt:justify-center swt:w-full swt:mt-2"
                     prop.children [
-                        Helper.AddButton(fun _ ->
+                        FormComponents.AddButton(fun _ ->
                             inputs.Add(constructor ())
                             validateSetter inputs
                         )
@@ -263,7 +262,7 @@ type FormComponents =
                             classNames = TermSearchStyle(Fable.Core.U2.Case1 "swt:w-full")
                         )
                         if rmv.IsSome then
-                            Helper.DeleteButton rmv.Value
+                            FormComponents.DeleteButton rmv.Value
                     ]
                 ]
             ]
@@ -338,7 +337,7 @@ type FormComponents =
         LayoutComponents.Collapse [
             LayoutComponents.CollapseTitle(nameText, orcid, countFilledFieldsString input)
         ] [
-            Helper.CardFormGroup [
+            FormComponents.CardFormGroup [
                 createPersonFieldTextInput (
                     input.FirstName,
                     "First Name",
@@ -346,7 +345,7 @@ type FormComponents =
                 )
                 createPersonFieldTextInput (input.LastName, "Last Name", fun person value -> person.LastName <- value)
             ]
-            Helper.CardFormGroup [
+            FormComponents.CardFormGroup [
                 createPersonFieldTextInput (
                     input.MidInitials,
                     "Mid Initials",
@@ -354,7 +353,7 @@ type FormComponents =
                 )
                 createPersonFieldTextInput (input.ORCID, "ORCID", fun person value -> person.ORCID <- value)
             ]
-            Helper.CardFormGroup [
+            FormComponents.CardFormGroup [
                 createPersonFieldTextInput (
                     input.Affiliation,
                     "Affiliation",
@@ -363,7 +362,7 @@ type FormComponents =
                 createPersonFieldTextInput (input.Address, "Address", fun person value -> person.Address <- value)
             ]
             createPersonFieldTextInput (input.EMail, "Email", fun person value -> person.EMail <- value)
-            Helper.CardFormGroup [
+            FormComponents.CardFormGroup [
                 createPersonFieldTextInput (input.Phone, "Phone", fun person value -> person.Phone <- value)
                 createPersonFieldTextInput (input.Fax, "Fax", fun person value -> person.Fax <- value)
             ]
@@ -377,7 +376,7 @@ type FormComponents =
                 parent = TermCollection.PersonRoleWithinExperiment
             )
             if rmv.IsSome then
-                Helper.DeleteButton rmv.Value
+                FormComponents.DeleteButton rmv.Value
         ]
 
     [<ReactComponent>]
@@ -519,7 +518,7 @@ type FormComponents =
                             placeholder = "comment"
                         )
                         if rmv.IsSome then
-                            Helper.DeleteButton rmv.Value
+                            FormComponents.DeleteButton rmv.Value
                     ]
                 ]
             ]
@@ -588,7 +587,7 @@ type FormComponents =
             LayoutComponents.CollapseTitle(title, doi, countFilledFieldsString ())
         ] [
             createFieldTextInput (publication.Title, "Title", fun value -> publication.Title <- value)
-            Helper.CardFormGroup [
+            FormComponents.CardFormGroup [
                 createFieldTextInput (publication.PubMedID, "PubMed ID", fun value -> publication.PubMedID <- value)
                 createFieldTextInput (publication.DOI, "DOI", fun value -> publication.DOI <- value)
             ]
@@ -611,7 +610,7 @@ type FormComponents =
                 "Comments"
             )
             if rmv.IsSome then
-                Helper.DeleteButton rmv.Value
+                FormComponents.DeleteButton rmv.Value
         ]
 
     static member PublicationsInput
@@ -662,7 +661,7 @@ type FormComponents =
             LayoutComponents.CollapseTitle(name, version, countFilledFieldsString ())
         ] [
             createFieldTextInput (input.Name, "Name", fun value -> input.Name <- value)
-            Helper.CardFormGroup [
+            FormComponents.CardFormGroup [
                 createFieldTextInput (input.Version, "Version", fun value -> input.Version <- value)
                 createFieldTextInput (input.File, "File", fun value -> input.File <- value)
             ]
@@ -684,7 +683,7 @@ type FormComponents =
                 "Comments"
             )
             if deleteButton.IsSome then
-                Helper.DeleteButton deleteButton.Value
+                FormComponents.DeleteButton deleteButton.Value
         ]
 
     static member OntologySourceReferencesInput

--- a/src/Components/src/Metadata/Forms.fs
+++ b/src/Components/src/Metadata/Forms.fs
@@ -19,21 +19,24 @@ type AsyncState<'T> =
 
 module Helper =
 
-    let addButton (clickEvent: MouseEvent -> unit) =
+    [<ReactComponent>]
+    let AddButton (clickEvent: MouseEvent -> unit) =
         Html.button [
             prop.className "swt:btn swt:btn-info"
             prop.text "+"
             prop.onClick clickEvent
         ]
 
-    let deleteButton (clickEvent: MouseEvent -> unit) =
+    [<ReactComponent>]
+    let DeleteButton (clickEvent: MouseEvent -> unit) =
         Html.button [
             prop.className "swt:btn swt:btn-error swt:grow-0"
             prop.text "Delete"
             prop.onClick clickEvent
         ]
 
-    let cardFormGroup (content: ReactElement list) =
+    [<ReactComponent>]
+    let CardFormGroup (content: ReactElement list) =
         Html.div [
             prop.className "swt:grid swt:@md/main:grid-cols-2 swt:@xl/main:grid-flow-col swt:gap-4 not-prose"
             prop.children content
@@ -130,7 +133,7 @@ type FormComponents =
             prop.children [
                 BaseModal.ErrorModalObsolete(error.IsSome, (fun _ -> setError None), error |> Option.defaultValue "")
                 if label.IsSome then
-                    Generic.FieldTitle label.Value
+                    LayoutComponents.FieldTitle label.Value
                 if extendedElements.IsSome then
                     extendedElements.Value
                 DndKit.DndContext(
@@ -171,7 +174,7 @@ type FormComponents =
                 Html.div [
                     prop.className "swt:flex swt:justify-center swt:w-full swt:mt-2"
                     prop.children [
-                        Helper.addButton (fun _ ->
+                        Helper.AddButton(fun _ ->
                             inputs.Add(constructor ())
                             validateSetter inputs
                         )
@@ -249,7 +252,7 @@ type FormComponents =
             prop.className "swt:space-y-2 swt:grow"
             prop.children [
                 if label.IsSome then
-                    Generic.FieldTitle label.Value
+                    LayoutComponents.FieldTitle label.Value
                 Html.div [
                     prop.className "swt:w-full swt:flex swt:gap-2 swt:relative"
                     prop.children [
@@ -260,7 +263,7 @@ type FormComponents =
                             classNames = TermSearchStyle(Fable.Core.U2.Case1 "swt:w-full")
                         )
                         if rmv.IsSome then
-                            Helper.deleteButton rmv.Value
+                            Helper.DeleteButton rmv.Value
                     ]
                 ]
             ]
@@ -332,10 +335,10 @@ type FormComponents =
             let filled = fields |> List.choose id |> List.length
             $"{filled}/{total}"
 
-        Generic.Collapse [
-            Generic.CollapseTitle(nameText, orcid, countFilledFieldsString input)
+        LayoutComponents.Collapse [
+            LayoutComponents.CollapseTitle(nameText, orcid, countFilledFieldsString input)
         ] [
-            Helper.cardFormGroup [
+            Helper.CardFormGroup [
                 createPersonFieldTextInput (
                     input.FirstName,
                     "First Name",
@@ -343,7 +346,7 @@ type FormComponents =
                 )
                 createPersonFieldTextInput (input.LastName, "Last Name", fun person value -> person.LastName <- value)
             ]
-            Helper.cardFormGroup [
+            Helper.CardFormGroup [
                 createPersonFieldTextInput (
                     input.MidInitials,
                     "Mid Initials",
@@ -351,7 +354,7 @@ type FormComponents =
                 )
                 createPersonFieldTextInput (input.ORCID, "ORCID", fun person value -> person.ORCID <- value)
             ]
-            Helper.cardFormGroup [
+            Helper.CardFormGroup [
                 createPersonFieldTextInput (
                     input.Affiliation,
                     "Affiliation",
@@ -360,7 +363,7 @@ type FormComponents =
                 createPersonFieldTextInput (input.Address, "Address", fun person value -> person.Address <- value)
             ]
             createPersonFieldTextInput (input.EMail, "Email", fun person value -> person.EMail <- value)
-            Helper.cardFormGroup [
+            Helper.CardFormGroup [
                 createPersonFieldTextInput (input.Phone, "Phone", fun person value -> person.Phone <- value)
                 createPersonFieldTextInput (input.Fax, "Fax", fun person value -> person.Fax <- value)
             ]
@@ -374,7 +377,7 @@ type FormComponents =
                 parent = TermCollection.PersonRoleWithinExperiment
             )
             if rmv.IsSome then
-                Helper.deleteButton rmv.Value
+                Helper.DeleteButton rmv.Value
         ]
 
     [<ReactComponent>]
@@ -464,7 +467,7 @@ type FormComponents =
             prop.className "swt:grow"
             prop.children [
                 if label.IsSome then
-                    Generic.FieldTitle label.Value
+                    LayoutComponents.FieldTitle label.Value
                 Html.input [
                     prop.className "swt:input"
                     prop.type'.dateTimeLocal
@@ -516,7 +519,7 @@ type FormComponents =
                             placeholder = "comment"
                         )
                         if rmv.IsSome then
-                            Helper.deleteButton rmv.Value
+                            Helper.DeleteButton rmv.Value
                     ]
                 ]
             ]
@@ -581,11 +584,11 @@ type FormComponents =
             let filled = fields |> List.choose id |> List.length
             $"{filled}/{total}"
 
-        Generic.Collapse [
-            Generic.CollapseTitle(title, doi, countFilledFieldsString ())
+        LayoutComponents.Collapse [
+            LayoutComponents.CollapseTitle(title, doi, countFilledFieldsString ())
         ] [
             createFieldTextInput (publication.Title, "Title", fun value -> publication.Title <- value)
-            Helper.cardFormGroup [
+            Helper.CardFormGroup [
                 createFieldTextInput (publication.PubMedID, "PubMed ID", fun value -> publication.PubMedID <- value)
                 createFieldTextInput (publication.DOI, "DOI", fun value -> publication.DOI <- value)
             ]
@@ -608,7 +611,7 @@ type FormComponents =
                 "Comments"
             )
             if rmv.IsSome then
-                Helper.deleteButton rmv.Value
+                Helper.DeleteButton rmv.Value
         ]
 
     static member PublicationsInput
@@ -655,11 +658,11 @@ type FormComponents =
             let filled = fields |> List.choose id |> List.length
             $"{filled}/{total}"
 
-        Generic.Collapse [
-            Generic.CollapseTitle(name, version, countFilledFieldsString ())
+        LayoutComponents.Collapse [
+            LayoutComponents.CollapseTitle(name, version, countFilledFieldsString ())
         ] [
             createFieldTextInput (input.Name, "Name", fun value -> input.Name <- value)
-            Helper.cardFormGroup [
+            Helper.CardFormGroup [
                 createFieldTextInput (input.Version, "Version", fun value -> input.Version <- value)
                 createFieldTextInput (input.File, "File", fun value -> input.File <- value)
             ]
@@ -681,7 +684,7 @@ type FormComponents =
                 "Comments"
             )
             if deleteButton.IsSome then
-                Helper.deleteButton deleteButton.Value
+                Helper.DeleteButton deleteButton.Value
         ]
 
     static member OntologySourceReferencesInput

--- a/src/Components/src/Metadata/InvestigationMetadata.fs
+++ b/src/Components/src/Metadata/InvestigationMetadata.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Feliz
 open ARCtrl
-open Swate.Components.Metadata
+open Swate.Components
 
 [<Erase; Mangle(false)>]
 type InvestigationMetadata =
@@ -13,8 +13,8 @@ type InvestigationMetadata =
     static member InvestigationMetadata
         // 👀 If you rename these variables, ensure that the names are forwarded for lazy loading in `src\Components\src\Metadata\ArcFileMetadata.fs` as well!
         (investigation: ArcInvestigation, setInvestigation: ArcInvestigation -> unit) =
-        Generic.Section [
-            Generic.BoxedField(
+        LayoutComponents.Section [
+            LayoutComponents.BoxedField(
                 "Investigation Metadata",
                 content = [
                     FormComponents.TextInput(

--- a/src/Components/src/Metadata/RunMetadata.fs
+++ b/src/Components/src/Metadata/RunMetadata.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Feliz
 open ARCtrl
-open Swate.Components.Metadata
+open Swate.Components
 
 [<Erase; Mangle(false)>]
 type RunMetadata =
@@ -13,8 +13,8 @@ type RunMetadata =
     static member RunMetadata
         // 👀 If you rename these variables, ensure that the names are forwarded for lazy loading in `src\Components\src\Metadata\ArcFileMetadata.fs` as well!
         (run: ArcRun, setRun: ArcRun -> unit) =
-        Generic.Section [
-            Generic.BoxedField(
+        LayoutComponents.Section [
+            LayoutComponents.BoxedField(
                 "Run Metadata",
                 content = [
                     FormComponents.TextInput(run.Identifier, (fun _ -> ()), label = "Identifier", disabled = true)

--- a/src/Components/src/Metadata/StudyMetadata.fs
+++ b/src/Components/src/Metadata/StudyMetadata.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Feliz
 open ARCtrl
-open Swate.Components.Metadata
+open Swate.Components
 
 [<Erase; Mangle(false)>]
 type StudyMetadata =
@@ -13,8 +13,8 @@ type StudyMetadata =
     static member StudyMetadata
         // 👀 If you rename these variables, ensure that the names are forwarded for lazy loading in `src\Components\src\Metadata\ArcFileMetadata.fs` as well!
         (study: ArcStudy, setStudy: ArcStudy -> unit) =
-        Generic.Section [
-            Generic.BoxedField(
+        LayoutComponents.Section [
+            LayoutComponents.BoxedField(
                 "Study Metadata",
                 content = [
                     FormComponents.TextInput(study.Identifier, (fun _ -> ()), label = "Identifier", disabled = true)

--- a/src/Components/src/Metadata/TemplateMetadata.fs
+++ b/src/Components/src/Metadata/TemplateMetadata.fs
@@ -3,7 +3,7 @@ namespace Swate.Components.Metadata
 open Fable.Core
 open Feliz
 open ARCtrl
-open Swate.Components.Metadata
+open Swate.Components
 
 [<Erase; Mangle(false)>]
 type TemplateMetadata =
@@ -12,8 +12,8 @@ type TemplateMetadata =
     static member TemplateMetadata
         // 👀 If you rename these variables, ensure that the names are forwarded for lazy loading in `src\Components\src\Metadata\ArcFileMetadata.fs` as well!
         (template: ARCtrl.Template, setTemplate: ARCtrl.Template -> unit) =
-        Generic.Section [
-            Generic.BoxedField(
+        LayoutComponents.Section [
+            LayoutComponents.BoxedField(
                 "Template Metadata",
                 content = [
                     FormComponents.TextInput(

--- a/src/Components/src/Metadata/TextInput.fs
+++ b/src/Components/src/Metadata/TextInput.fs
@@ -74,7 +74,7 @@ type TextInput =
             )
             prop.children [
                 if label.IsSome && not isJoin then
-                    Generic.FieldTitle label.Value
+                    LayoutComponents.FieldTitle label.Value
                 if isArea then
                     Html.textarea [
                         prop.className [

--- a/src/Components/src/Metadata/WorkflowMetadata.fs
+++ b/src/Components/src/Metadata/WorkflowMetadata.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Feliz
 open ARCtrl
-open Swate.Components.Metadata
+open Swate.Components
 
 [<Erase; Mangle(false)>]
 type WorkflowMetadata =
@@ -13,8 +13,8 @@ type WorkflowMetadata =
     static member WorkflowMetadata
         // 👀 If you rename these variables, ensure that the names are forwarded for lazy loading in `src\Components\src\Metadata\ArcFileMetadata.fs` as well!
         (workflow: ArcWorkflow, setWorkflow: ArcWorkflow -> unit) =
-        Generic.Section [
-            Generic.BoxedField(
+        LayoutComponents.Section [
+            LayoutComponents.BoxedField(
                 "Workflow Metadata",
                 content = [
                     FormComponents.TextInput(workflow.Identifier, (fun _ -> ()), label = "Identifier", disabled = true)

--- a/src/Components/src/Notes/Editor/NoteFormFields.fs
+++ b/src/Components/src/Notes/Editor/NoteFormFields.fs
@@ -4,7 +4,6 @@ open System
 open ARCtrl
 open Feliz
 open Swate.Components
-open Swate.Components.Metadata
 open Swate.Components.MarkdownText
 
 [<RequireQualifiedAccess>]
@@ -58,7 +57,8 @@ module NoteFormFields =
         let addTagFromKeyboardEvent (keyboardEvent: Browser.Types.KeyboardEvent) =
             let termFromInput =
                 match keyboardEvent.target with
-                | :? Browser.Types.HTMLInputElement as inputElement when not (String.IsNullOrWhiteSpace inputElement.value)
+                | :? Browser.Types.HTMLInputElement as inputElement when
+                    not (String.IsNullOrWhiteSpace inputElement.value)
                     ->
                     Some(Term(inputElement.value.Trim()))
                 | _ -> None
@@ -93,7 +93,7 @@ module NoteFormFields =
                 prop.testId "notes-title-field"
                 prop.className "swt:fieldset swt:grow"
                 prop.children [
-                    Generic.FieldTitle "Title (Required)"
+                    LayoutComponents.FieldTitle "Title (Required)"
                     Html.input [
                         prop.className "swt:input swt:input-bordered swt:w-full"
                         prop.type'.text
@@ -107,14 +107,15 @@ module NoteFormFields =
                 prop.testId "notes-date-field"
                 prop.className "swt:fieldset swt:w-full swt:max-w-[9rem]"
                 prop.children [
-                    Generic.FieldTitle "Date Created (Required)"
+                    LayoutComponents.FieldTitle "Date Created (Required)"
                     Html.input [
                         prop.className "swt:input swt:input-bordered swt:w-full"
                         prop.type'.date
                         prop.valueOrDefault dateInputValue
                         prop.onChange (fun value ->
                             let parsedDate = Validation.tryParseDateCreated value
-                            setDraft { draft with DateCreated = parsedDate })
+                            setDraft { draft with DateCreated = parsedDate }
+                        )
                     ]
                 ]
             ]
@@ -122,7 +123,7 @@ module NoteFormFields =
                 prop.testId "notes-tags-field"
                 prop.className "swt:fieldset swt:space-y-2"
                 prop.children [
-                    Generic.FieldTitle "Tags (Optional)"
+                    LayoutComponents.FieldTitle "Tags (Optional)"
                     Html.div [
                         prop.className "swt:w-full swt:relative"
                         prop.children [
@@ -153,7 +154,8 @@ module NoteFormFields =
                                 for index, tag in draft.Tags |> Seq.indexed do
                                     Html.li [
                                         prop.key $"note-tag-{tagKey tag}"
-                                        prop.className "swt:flex swt:items-center swt:gap-2 swt:rounded-box swt:border swt:border-base-300 swt:px-2 swt:py-1"
+                                        prop.className
+                                            "swt:flex swt:items-center swt:gap-2 swt:rounded-box swt:border swt:border-base-300 swt:px-2 swt:py-1"
                                         prop.children [
                                             Html.span [
                                                 prop.className "swt:grow swt:text-sm swt:break-all"

--- a/src/Components/src/PageComponents/SettingsPage/SettingsPage.fs
+++ b/src/Components/src/PageComponents/SettingsPage/SettingsPage.fs
@@ -1,0 +1,77 @@
+namespace Swate.Components.PageComponents.SettingsPage
+
+open Feliz
+open Fable.Core
+open Fable.Core.JsInterop
+open Swate.Components
+open Swate.Components.Theme.Context
+
+[<Erase; Mangle(false)>]
+type SettingsPage =
+
+    [<ReactComponent>]
+    static member private SettingColumnElement
+        (title: string, settingElement: ReactElement, ?description: ReactElement)
+        =
+        Html.div [
+            prop.className "swt:grid swt:grid-cols-1 swt:md:grid-cols-2 swt:gap-2 swt:py-2"
+            prop.children [
+                Html.p [ prop.className "swt:text-xl not-prose"; prop.text title ]
+                Html.div [
+                    prop.className "not-prose"
+                    prop.children [ settingElement ]
+                ]
+                if description.IsSome then
+                    Html.div [
+                        prop.className "swt:text-sm swt:text-base-content/70 swt:md:col-span-2 swt:prose"
+                        prop.children description.Value
+                    ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member private General() =
+        LayoutComponents.BoxedField(
+            "General",
+            content = [
+                SettingsPage.SettingColumnElement(
+                    "Theme",
+                    Theme.ThemeSelector.ThemeSelector(),
+                    description =
+                        Html.p [
+                            prop.className "swt:mt-1 swt:text-sm swt:text-base-content/70"
+                            prop.text
+                                "Select the theme for the application. The 'Auto' option will use the system's theme settings."
+                        ]
+                )
+            ]
+        )
+
+    [<ReactComponent>]
+    static member private SearchConfig() =
+        LayoutComponents.BoxedField(
+            "Term Search Configuration",
+            content = [
+                Swate.Components.TermSearch.TermSearchConfigSetter.TermSearchConfigSetter(fun props ->
+                    SettingsPage.SettingColumnElement(
+                        props.title,
+                        props.settingElement,
+                        description = props.description
+                    )
+                )
+            ]
+        )
+
+    static member SettingsPage() =
+        LayoutComponents.Section [
+            SettingsPage.General()
+
+            SettingsPage.SearchConfig()
+
+        ]
+
+    [<ReactComponent>]
+    static member Entry() =
+        Theme.ThemeProvider.ThemeProvider(
+            TermSearch.TermSearchConfigProvider.TIBQueryProvider(SettingsPage.SettingsPage())
+        )

--- a/src/Components/src/PageComponents/SettingsPage/SettingsPage.fs
+++ b/src/Components/src/PageComponents/SettingsPage/SettingsPage.fs
@@ -62,6 +62,7 @@ type SettingsPage =
             ]
         )
 
+    [<ReactComponent>]
     static member SettingsPage() =
         LayoutComponents.Section [
             SettingsPage.General()

--- a/src/Components/src/PageComponents/SettingsPage/SettingsPage.stories.tsx
+++ b/src/Components/src/PageComponents/SettingsPage/SettingsPage.stories.tsx
@@ -5,7 +5,7 @@ import { Entry as SettingsPage } from './SettingsPage.fs.js';
 
 
 const meta = {
-  title: 'PageComponents/SettingsPage',
+  title: 'Page Components/SettingsPage',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/src/Components/src/PageComponents/SettingsPage/SettingsPage.stories.tsx
+++ b/src/Components/src/PageComponents/SettingsPage/SettingsPage.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect, userEvent, waitFor } from 'storybook/test';
+import { Entry as SettingsPage } from './SettingsPage.fs.js';
+
+
+const meta = {
+  title: 'PageComponents/SettingsPage',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  component: SettingsPage,
+} satisfies Meta<typeof SettingsPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -79,6 +79,7 @@
     <Compile Include="Api\TIBApi.fs" />
     <Compile Include="GenericComponents\Icons.fs" />
     <Compile Include="GenericComponents\GenericComponents.fs" />
+    <Compile Include="GenericComponents\LayoutComponents.fs" />
     <Compile Include="GenericComponents\Popover\Context.fs" />
     <Compile Include="GenericComponents\Popover\Popover.fs" />
     <Compile Include="GenericComponents\ContextMenu.fs" />
@@ -106,8 +107,9 @@
     <Compile Include="GitComparison\GitMergeConflictViewer.fs" />
     <Compile Include="GitSidebar\Types.fs" />
     <Compile Include="GitSidebar\GitSidebar.fs" />
-    <Compile Include="ThemeProvider\Context.fs" />
-    <Compile Include="ThemeProvider\ThemeProvider.fs" />
+    <Compile Include="Theme\Context.fs" />
+    <Compile Include="Theme\ThemeProvider.fs" />
+    <Compile Include="Theme\ThemeSelector.fs" />
     <Compile Include="QuickAccessButton\QuickAccessButton.fs" />
     <Compile Include="TermSearch\TermSearchActiveKeysContext.fs" />
     <Compile Include="TermSearch\TermSearchConfigContext.fs" />
@@ -115,7 +117,6 @@
     <Compile Include="TermSearch\TermSearchConfigProvider.fs" />
     <Compile Include="TermSearch\TermSearchConfigSetter.fs" />
     <Compile Include="TermSearch\TermSearch.fs" />
-    <Compile Include="Metadata\Generic.fs" />
     <Compile Include="Metadata\TextInput.fs" />
     <Compile Include="Metadata\Forms.fs" />
     <Compile Include="Metadata\InvestigationMetadata.fs" />
@@ -229,8 +230,8 @@
     <Compile Include="DataHub\GenericComponents.fs" />
     <Compile Include="DataHub\DataHubBrowserModel.fs" />
     <Compile Include="DataHub\DataHubBrowser.fs" />
+    <Compile Include="PageComponents\SettingsPage\SettingsPage.fs" />
     <Compile Include="Style.fs" />
-    <None Include="GitSidebar\GitSidebar.stories.tsx" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -118,7 +118,7 @@
     <Compile Include="TermSearch\TermSearchConfigSetter.fs" />
     <Compile Include="TermSearch\TermSearch.fs" />
     <Compile Include="Metadata\TextInput.fs" />
-    <Compile Include="Metadata\Forms.fs" />
+    <Compile Include="Metadata\FormComponents.fs" />
     <Compile Include="Metadata\InvestigationMetadata.fs" />
     <Compile Include="Metadata\StudyMetadata.fs" />
     <Compile Include="Metadata\AssayMetadata.fs" />

--- a/src/Components/src/TermSearch/TermSearchActiveKeysContext.fs
+++ b/src/Components/src/TermSearch/TermSearchActiveKeysContext.fs
@@ -3,23 +3,29 @@ module Swate.Components.TermSearch.TermSearchActiveKeysContext
 open Feliz
 open Swate.Components.Types
 
-type TermSearchConfigLocalStorageActiveKeysContext = {
+type TermSearchActiveKeysContext = {|
     disableDefault: bool
     activeKeys: string[]
-} with
+|}
 
-    static member init(?defaultActive: Set<string>) = {
+module TermSearchActiveKeysContext =
+
+    let init (defaultActive: Set<string>) : TermSearchActiveKeysContext = {|
         disableDefault = false
-        activeKeys = defaultActive |> Option.map Set.toArray |> Option.defaultValue [||]
-    }
+        activeKeys = Set.toArray defaultActive
+    |}
 
 let TermSearchActiveKeysCtx =
-    React.createContext<StateContext<TermSearchConfigLocalStorageActiveKeysContext>> (
+    React.createContext<StateContext<TermSearchActiveKeysContext>> (
         {
-            state = TermSearchConfigLocalStorageActiveKeysContext.init ()
+            state = TermSearchActiveKeysContext.init (Set.empty)
             setState = fun keys -> printfn "Setting active keys not given: %A" keys
         }
     )
 
+/// This context is used to track the active keys for the term search queries, and whether the default search is disabled. It is used by the TermSearchConfigProvider and TermSearchConfigSetter components.
+///
+/// It is stored in local storage, therefore all types related to this must be serializable to JSON by native JavaScript function ``JSON.stringify``. This means that it should not contain any functions or complex types that cannot be serialized to JSON.
 [<Hook>]
-let useTermSearchActiveKeysCtx () = React.useContext TermSearchActiveKeysCtx
+let useTermSearchActiveKeysCtx () =
+    React.useContext TermSearchActiveKeysCtx

--- a/src/Components/src/TermSearch/TermSearchConfigProvider.fs
+++ b/src/Components/src/TermSearch/TermSearchConfigProvider.fs
@@ -140,7 +140,10 @@ type TermSearchConfigProvider =
             )
 
         /// This is used for memoization
-        let activeKeysString = activeKeys.activeKeys |> Array.sort |> String.concat "; "
+        let activeKeysString =
+            match activeKeys.activeKeys with
+            | [||] -> ""
+            | keys -> keys |> Array.sort |> String.concat "; "
 
         let queries =
             React.useMemo (
@@ -187,8 +190,5 @@ type TermSearchConfigProvider =
                 state = activeKeys
                 setState = setActiveKeys
             },
-            TermSearchConfigCtx.Provider(
-                queries,
-                TermSearchAllKeysCtx.Provider(allKeys, children)
-            )
+            TermSearchConfigCtx.Provider(queries, TermSearchAllKeysCtx.Provider(allKeys, children))
         )

--- a/src/Components/src/TermSearch/TermSearchConfigProvider.fs
+++ b/src/Components/src/TermSearch/TermSearchConfigProvider.fs
@@ -11,88 +11,11 @@ open Swate.Components.TermSearch.TermSearchActiveKeysContext
 
 module private TermSearchConfigProviderHelper =
 
-    [<Emit("Array.isArray($0)")>]
-    let isJsArray (value: obj) : bool = jsNative
-
     [<Literal>]
     let TIB_PREFIX = "TIB_"
 
     [<Literal>]
     let TIB_DATAPLANT_COLLECTION_KEY = "DataPLANT"
-
-    let sanitizeStringArray (arr: string[]) =
-        if isNullOrUndefined (box arr) || not (isJsArray (box arr)) then
-            [||]
-        else
-            arr
-            |> Array.choose (fun item ->
-                if isNullOrUndefined (box item) then
-                    None
-                else
-                    let value = string item
-
-                    if System.String.IsNullOrWhiteSpace value then
-                        None
-                    else
-                        Some value
-            )
-
-    let sanitizeQueryList<'T> (queries: ResizeArray<string * 'T>) =
-        if isNullOrUndefined (box queries) || not (isJsArray (box queries)) then
-            ResizeArray()
-        else
-            queries
-            |> Seq.choose (fun entry ->
-                if isNullOrUndefined (box entry) || not (isJsArray (box entry)) then
-                    None
-                else
-                    let key, value = entry
-
-                    if isNullOrUndefined (box key) || isNullOrUndefined (box value) then
-                        None
-                    else
-                        let key = string key
-
-                        if System.String.IsNullOrWhiteSpace key then
-                            None
-                        else
-                            Some(key, value)
-            )
-            |> ResizeArray
-
-    let sanitizeActiveKeysState
-        (fallbackState: TermSearchConfigLocalStorageActiveKeysContext)
-        (state: TermSearchConfigLocalStorageActiveKeysContext)
-        : TermSearchConfigLocalStorageActiveKeysContext * bool =
-        if isNullOrUndefined (box state) then
-            fallbackState, true
-        else
-            let hasDisableDefault = not (isNullOrUndefined (box state.disableDefault))
-
-            let disableDefault =
-                if hasDisableDefault then
-                    state.disableDefault
-                else
-                    fallbackState.disableDefault
-
-            let activeKeysRaw = state.activeKeys
-
-            let hasActiveKeys =
-                not (isNullOrUndefined (box activeKeysRaw)) && isJsArray (box activeKeysRaw)
-
-            let activeKeys =
-                if hasActiveKeys then
-                    sanitizeStringArray activeKeysRaw
-                else
-                    fallbackState.activeKeys
-
-            let wasFiltered = hasActiveKeys && activeKeys.Length <> activeKeysRaw.Length
-
-            {
-                disableDefault = disableDefault
-                activeKeys = activeKeys
-            },
-            (not hasDisableDefault || not hasActiveKeys || wasFiltered)
 
     let mkTIBQueries (collections: Set<string>) = {|
         TermSearch =
@@ -150,10 +73,11 @@ type TermSearchConfigProvider =
             (fun _ -> // get all currently supported catalogues
                 promise {
                     try
-                        let! collections = Api.TIBApi.TIBApi.getCollections ()
+                        let! collections =
+                            Api.TIBApi.TIBApi.getCollections ()
+                            |> Promise.catch (fun ex -> console.error "Error fetching TIB collections:" ex)
 
-                        let collectionSet =
-                            collections.content |> Option.ofObj |> Option.defaultValue [||] |> Set.ofArray
+                        let collectionSet = Set.ofArray collections.content
 
                         let tibQueries = TermSearchConfigProviderHelper.mkTIBQueries collectionSet
                         setAllTermSearchQueries (ResizeArray tibQueries.TermSearch)
@@ -187,39 +111,10 @@ type TermSearchConfigProvider =
             ?localStorageKey: string
         ) =
         let localStorageKey = defaultArg localStorageKey "swate-termsearchconfig-ctx"
+        let defaultActive = defaultArg defaultActive Set.empty
 
-        let (activeKeys: TermSearchConfigLocalStorageActiveKeysContext), setActiveKeys =
-            React.useLocalStorage (
-                localStorageKey,
-                TermSearchConfigLocalStorageActiveKeysContext.init (?defaultActive = defaultActive)
-            )
-
-        let defaultActiveKeysState =
-            TermSearchConfigLocalStorageActiveKeysContext.init (?defaultActive = defaultActive)
-
-        let sanitizedActiveKeys, shouldRepairActiveKeysState =
-            TermSearchConfigProviderHelper.sanitizeActiveKeysState defaultActiveKeysState activeKeys
-
-        React.useEffect (
-            (fun () ->
-                if shouldRepairActiveKeysState then
-                    setActiveKeys sanitizedActiveKeys
-            ),
-            [|
-                box shouldRepairActiveKeysState
-                box sanitizedActiveKeys.disableDefault
-                box (sanitizedActiveKeys.activeKeys |> String.concat ";")
-            |]
-        )
-
-        let allTermSearchQueries =
-            TermSearchConfigProviderHelper.sanitizeQueryList allTermSearchQueries
-
-        let allParentSearchQueries =
-            TermSearchConfigProviderHelper.sanitizeQueryList allParentSearchQueries
-
-        let allAllChildrenSearchQueries =
-            TermSearchConfigProviderHelper.sanitizeQueryList allAllChildrenSearchQueries
+        let (activeKeys: TermSearchActiveKeysContext), setActiveKeys =
+            React.useLocalStorage (localStorageKey, TermSearchActiveKeysContext.init (defaultActive))
 
         let allKeys =
             React.useMemo (
@@ -243,34 +138,34 @@ type TermSearchConfigProvider =
             )
 
         /// This is used for memoization
-        let activeKeysString =
-            match sanitizedActiveKeys.activeKeys with
-            | [||] -> ""
-            | keys -> keys |> Array.sort |> String.concat "; "
+        let activeKeysString = activeKeys.activeKeys |> Array.sort |> String.concat "; "
 
         let queries =
             React.useMemo (
                 (fun () ->
-                    let activeKeysSet = sanitizedActiveKeys.activeKeys |> Set.ofSeq
 
                     let termSearchQueries =
                         allTermSearchQueries
-                        |> Seq.filter (fun (key, _) -> activeKeysSet |> Set.contains key)
+                        |> Seq.filter (fun (key, _) ->
+                            let isActive = activeKeys.activeKeys |> Set.ofSeq |> Set.contains key
+
+                            isActive
+                        )
                         |> ResizeArray
 
                     let parentSearchQueries =
                         allParentSearchQueries
-                        |> Seq.filter (fun (key, _) -> activeKeysSet |> Set.contains key)
+                        |> Seq.filter (fun (key, _) -> activeKeys.activeKeys |> Set.ofSeq |> Set.contains key)
                         |> ResizeArray
 
                     let allChildrenSearchQueries =
                         allAllChildrenSearchQueries
-                        |> Seq.filter (fun (key, _) -> activeKeysSet |> Set.contains key)
+                        |> Seq.filter (fun (key, _) -> activeKeys.activeKeys |> Set.ofSeq |> Set.contains key)
                         |> ResizeArray
 
                     {
                         hasProvider = true
-                        disableDefault = sanitizedActiveKeys.disableDefault
+                        disableDefault = activeKeys.disableDefault
                         termSearchQueries = termSearchQueries
                         parentSearchQueries = parentSearchQueries
                         allChildrenSearchQueries = allChildrenSearchQueries
@@ -278,7 +173,7 @@ type TermSearchConfigProvider =
                 ),
                 [|
                     activeKeysString
-                    sanitizedActiveKeys.disableDefault
+                    activeKeys.disableDefault
                     allTermSearchQueries
                     allParentSearchQueries
                     allAllChildrenSearchQueries
@@ -287,7 +182,7 @@ type TermSearchConfigProvider =
 
         TermSearchActiveKeysContext.TermSearchActiveKeysCtx.Provider(
             {
-                state = sanitizedActiveKeys
+                state = activeKeys
                 setState = setActiveKeys
             },
             TermSearchConfigCtx.Provider(queries, TermSearchAllKeysCtx.Provider(allKeys, children))

--- a/src/Components/src/TermSearch/TermSearchConfigProvider.fs
+++ b/src/Components/src/TermSearch/TermSearchConfigProvider.fs
@@ -2,6 +2,7 @@ namespace Swate.Components.TermSearch
 
 open Swate.Components
 open Fable.Core
+open Fable.Core.JsInterop
 open Feliz
 open Swate.Components.TermSearch.TermSearchConfigContext
 open Swate.Components.TermSearch.TermSearchAllKeysContext
@@ -10,11 +11,88 @@ open Swate.Components.TermSearch.TermSearchActiveKeysContext
 
 module private TermSearchConfigProviderHelper =
 
+    [<Emit("Array.isArray($0)")>]
+    let isJsArray (value: obj) : bool = jsNative
+
     [<Literal>]
     let TIB_PREFIX = "TIB_"
 
     [<Literal>]
     let TIB_DATAPLANT_COLLECTION_KEY = "DataPLANT"
+
+    let sanitizeStringArray (arr: string[]) =
+        if isNullOrUndefined (box arr) || not (isJsArray (box arr)) then
+            [||]
+        else
+            arr
+            |> Array.choose (fun item ->
+                if isNullOrUndefined (box item) then
+                    None
+                else
+                    let value = string item
+
+                    if System.String.IsNullOrWhiteSpace value then
+                        None
+                    else
+                        Some value
+            )
+
+    let sanitizeQueryList<'T> (queries: ResizeArray<string * 'T>) =
+        if isNullOrUndefined (box queries) || not (isJsArray (box queries)) then
+            ResizeArray()
+        else
+            queries
+            |> Seq.choose (fun entry ->
+                if isNullOrUndefined (box entry) || not (isJsArray (box entry)) then
+                    None
+                else
+                    let key, value = entry
+
+                    if isNullOrUndefined (box key) || isNullOrUndefined (box value) then
+                        None
+                    else
+                        let key = string key
+
+                        if System.String.IsNullOrWhiteSpace key then
+                            None
+                        else
+                            Some(key, value)
+            )
+            |> ResizeArray
+
+    let sanitizeActiveKeysState
+        (fallbackState: TermSearchConfigLocalStorageActiveKeysContext)
+        (state: TermSearchConfigLocalStorageActiveKeysContext)
+        : TermSearchConfigLocalStorageActiveKeysContext * bool =
+        if isNullOrUndefined (box state) then
+            fallbackState, true
+        else
+            let hasDisableDefault = not (isNullOrUndefined (box state.disableDefault))
+
+            let disableDefault =
+                if hasDisableDefault then
+                    state.disableDefault
+                else
+                    fallbackState.disableDefault
+
+            let activeKeysRaw = state.activeKeys
+
+            let hasActiveKeys =
+                not (isNullOrUndefined (box activeKeysRaw)) && isJsArray (box activeKeysRaw)
+
+            let activeKeys =
+                if hasActiveKeys then
+                    sanitizeStringArray activeKeysRaw
+                else
+                    fallbackState.activeKeys
+
+            let wasFiltered = hasActiveKeys && activeKeys.Length <> activeKeysRaw.Length
+
+            {
+                disableDefault = disableDefault
+                activeKeys = activeKeys
+            },
+            (not hasDisableDefault || not hasActiveKeys || wasFiltered)
 
     let mkTIBQueries (collections: Set<string>) = {|
         TermSearch =
@@ -71,20 +149,18 @@ type TermSearchConfigProvider =
         React.useEffect (
             (fun _ -> // get all currently supported catalogues
                 promise {
+                    try
+                        let! collections = Api.TIBApi.TIBApi.getCollections ()
 
-                    let! collections =
-                        Api.TIBApi.TIBApi.getCollections ()
-                        |> Promise.catch (fun ex -> console.error "Error fetching TIB collections:" ex)
+                        let collectionSet =
+                            collections.content |> Option.ofObj |> Option.defaultValue [||] |> Set.ofArray
 
-                    let collectionSet = Set.ofArray collections.content
-                    let tibQueries = TermSearchConfigProviderHelper.mkTIBQueries collectionSet
-                    setAllTermSearchQueries (ResizeArray(Seq.append allTermSearchQueries tibQueries.TermSearch))
-
-                    setAllParentSearchQueries (ResizeArray(Seq.append allParentSearchQueries tibQueries.ParentSearch))
-
-                    setAllAllChildrenSearchQueries (
-                        ResizeArray(Seq.append allAllChildrenSearchQueries tibQueries.AllChildrenSearch)
-                    )
+                        let tibQueries = TermSearchConfigProviderHelper.mkTIBQueries collectionSet
+                        setAllTermSearchQueries (ResizeArray tibQueries.TermSearch)
+                        setAllParentSearchQueries (ResizeArray tibQueries.ParentSearch)
+                        setAllAllChildrenSearchQueries (ResizeArray tibQueries.AllChildrenSearch)
+                    with ex ->
+                        console.error ("Error fetching TIB collections:", ex)
                 }
                 |> Promise.start
             ),
@@ -118,6 +194,33 @@ type TermSearchConfigProvider =
                 TermSearchConfigLocalStorageActiveKeysContext.init (?defaultActive = defaultActive)
             )
 
+        let defaultActiveKeysState =
+            TermSearchConfigLocalStorageActiveKeysContext.init (?defaultActive = defaultActive)
+
+        let sanitizedActiveKeys, shouldRepairActiveKeysState =
+            TermSearchConfigProviderHelper.sanitizeActiveKeysState defaultActiveKeysState activeKeys
+
+        React.useEffect (
+            (fun () ->
+                if shouldRepairActiveKeysState then
+                    setActiveKeys sanitizedActiveKeys
+            ),
+            [|
+                box shouldRepairActiveKeysState
+                box sanitizedActiveKeys.disableDefault
+                box (sanitizedActiveKeys.activeKeys |> String.concat ";")
+            |]
+        )
+
+        let allTermSearchQueries =
+            TermSearchConfigProviderHelper.sanitizeQueryList allTermSearchQueries
+
+        let allParentSearchQueries =
+            TermSearchConfigProviderHelper.sanitizeQueryList allParentSearchQueries
+
+        let allAllChildrenSearchQueries =
+            TermSearchConfigProviderHelper.sanitizeQueryList allAllChildrenSearchQueries
+
         let allKeys =
             React.useMemo (
                 (fun () ->
@@ -141,36 +244,33 @@ type TermSearchConfigProvider =
 
         /// This is used for memoization
         let activeKeysString =
-            match activeKeys.activeKeys with
+            match sanitizedActiveKeys.activeKeys with
             | [||] -> ""
             | keys -> keys |> Array.sort |> String.concat "; "
 
         let queries =
             React.useMemo (
                 (fun () ->
+                    let activeKeysSet = sanitizedActiveKeys.activeKeys |> Set.ofSeq
 
                     let termSearchQueries =
                         allTermSearchQueries
-                        |> Seq.filter (fun (key, _) ->
-                            let isActive = activeKeys.activeKeys |> Set.ofSeq |> Set.contains key
-
-                            isActive
-                        )
+                        |> Seq.filter (fun (key, _) -> activeKeysSet |> Set.contains key)
                         |> ResizeArray
 
                     let parentSearchQueries =
                         allParentSearchQueries
-                        |> Seq.filter (fun (key, _) -> activeKeys.activeKeys |> Set.ofSeq |> Set.contains key)
+                        |> Seq.filter (fun (key, _) -> activeKeysSet |> Set.contains key)
                         |> ResizeArray
 
                     let allChildrenSearchQueries =
                         allAllChildrenSearchQueries
-                        |> Seq.filter (fun (key, _) -> activeKeys.activeKeys |> Set.ofSeq |> Set.contains key)
+                        |> Seq.filter (fun (key, _) -> activeKeysSet |> Set.contains key)
                         |> ResizeArray
 
                     {
                         hasProvider = true
-                        disableDefault = activeKeys.disableDefault
+                        disableDefault = sanitizedActiveKeys.disableDefault
                         termSearchQueries = termSearchQueries
                         parentSearchQueries = parentSearchQueries
                         allChildrenSearchQueries = allChildrenSearchQueries
@@ -178,7 +278,7 @@ type TermSearchConfigProvider =
                 ),
                 [|
                     activeKeysString
-                    activeKeys.disableDefault
+                    sanitizedActiveKeys.disableDefault
                     allTermSearchQueries
                     allParentSearchQueries
                     allAllChildrenSearchQueries
@@ -187,7 +287,7 @@ type TermSearchConfigProvider =
 
         TermSearchActiveKeysContext.TermSearchActiveKeysCtx.Provider(
             {
-                state = activeKeys
+                state = sanitizedActiveKeys
                 setState = setActiveKeys
             },
             TermSearchConfigCtx.Provider(queries, TermSearchAllKeysCtx.Provider(allKeys, children))

--- a/src/Components/src/TermSearch/TermSearchConfigSetter.fs
+++ b/src/Components/src/TermSearch/TermSearchConfigSetter.fs
@@ -11,6 +11,7 @@ open Swate.Components.TermSearch.TermSearchActiveKeysContext
 [<Erase; Mangle(false)>]
 type TermSearchConfigSetter =
 
+    [<ReactComponent>]
     static member private TriggerRender(activeKeys: string[]) =
         Html.button [
             prop.testId "term-search-config-setter-tib-trigger"
@@ -46,7 +47,7 @@ type TermSearchConfigSetter =
 
         let activeKeysState =
             if isNullOrUndefined (box activeKeysCtx.state) then
-                TermSearchConfigLocalStorageActiveKeysContext.init ()
+                TermSearchActiveKeysContext.init (Set.empty)
             else
                 activeKeysCtx.state
 
@@ -65,10 +66,10 @@ type TermSearchConfigSetter =
             fun selectedIndices ->
                 let nextActiveKeys = selectedIndices |> Seq.map (fun i -> allKeysCtx |> Seq.item i)
 
-                activeKeysCtx.setState {
+                activeKeysCtx.setState {|
                     activeKeysState with
                         activeKeys = Array.ofSeq nextActiveKeys
-                }
+                |}
 
         let defaultSearchActive = not activeKeysState.disableDefault
 
@@ -98,10 +99,10 @@ type TermSearchConfigSetter =
                         prop.type'.checkbox
                         prop.isChecked defaultSearchActive
                         prop.onChange (fun (b: bool) ->
-                            activeKeysCtx.setState {
+                            activeKeysCtx.setState {|
                                 activeKeysState with
                                     disableDefault = not b
-                            }
+                            |}
                         )
                     ]
                 description = Html.p "When you deactivate this, the default search will not be used."

--- a/src/Components/src/TermSearch/TermSearchConfigSetter.fs
+++ b/src/Components/src/TermSearch/TermSearchConfigSetter.fs
@@ -2,6 +2,7 @@ namespace Swate.Components.TermSearch
 
 open Swate.Components
 open Fable.Core
+open Fable.Core.JsInterop
 open Feliz
 open Swate.Components.TermSearch.TermSearchAllKeysContext
 open Swate.Components.TermSearch.TermSearchActiveKeysContext
@@ -43,8 +44,17 @@ type TermSearchConfigSetter =
         let activeKeysCtx = useTermSearchActiveKeysCtx ()
         let allKeysCtx = useTermSearchAllKeysCtx ()
 
+        let activeKeysState =
+            if isNullOrUndefined (box activeKeysCtx.state) then
+                TermSearchConfigLocalStorageActiveKeysContext.init ()
+            else
+                activeKeysCtx.state
+
+        let activeKeys =
+            activeKeysState.activeKeys |> Option.ofObj |> Option.defaultValue [||]
+
         let selectedIndices =
-            activeKeysCtx.state.activeKeys
+            activeKeys
             |> Array.choose (fun key -> allKeysCtx |> Seq.tryFindIndex (fun activeKey -> activeKey = key))
             |> Set
 
@@ -56,14 +66,13 @@ type TermSearchConfigSetter =
                 let nextActiveKeys = selectedIndices |> Seq.map (fun i -> allKeysCtx |> Seq.item i)
 
                 activeKeysCtx.setState {
-                    activeKeysCtx.state with
+                    activeKeysState with
                         activeKeys = Array.ofSeq nextActiveKeys
                 }
 
-        let defaultSearchActive = not activeKeysCtx.state.disableDefault
+        let defaultSearchActive = not activeKeysState.disableDefault
 
-        let TriggerRender =
-            fun _ -> TermSearchConfigSetter.TriggerRender(activeKeysCtx.state.activeKeys)
+        let TriggerRender = fun _ -> TermSearchConfigSetter.TriggerRender(activeKeys)
 
         React.Fragment [
 
@@ -72,9 +81,9 @@ type TermSearchConfigSetter =
                 prop.className "swt:hidden"
                 prop.ariaHidden true
                 prop.testId "term-search-config-setter"
-                prop.custom ("data-activekeyscount", activeKeysCtx.state.activeKeys.Length)
-                prop.custom ("data-defaultdisables", activeKeysCtx.state.disableDefault)
-                prop.custom ("data-activekeys", activeKeysCtx.state.activeKeys |> Array.sort |> String.concat "; ")
+                prop.custom ("data-activekeyscount", activeKeys.Length)
+                prop.custom ("data-defaultdisables", activeKeysState.disableDefault)
+                prop.custom ("data-activekeys", activeKeys |> Array.sort |> String.concat "; ")
             ]
 
             renderer {|
@@ -90,7 +99,7 @@ type TermSearchConfigSetter =
                         prop.isChecked defaultSearchActive
                         prop.onChange (fun (b: bool) ->
                             activeKeysCtx.setState {
-                                activeKeysCtx.state with
+                                activeKeysState with
                                     disableDefault = not b
                             }
                         )

--- a/src/Components/src/Theme/Context.fs
+++ b/src/Components/src/Theme/Context.fs
@@ -1,4 +1,4 @@
-module Swate.Components.ThemeProvider.Context
+module Swate.Components.Theme.Context
 
 open Feliz
 open Swate.Components

--- a/src/Components/src/Theme/ThemeProvider.fs
+++ b/src/Components/src/Theme/ThemeProvider.fs
@@ -1,4 +1,4 @@
-namespace Swate.Components.ThemeProvider
+namespace Swate.Components.Theme
 
 open Feliz
 open Fable.Core
@@ -11,13 +11,8 @@ type ThemeProvider =
 
     [<ReactComponent(true)>]
     static member ThemeProvider
-        (
-            reactContext: ReactContext<StateContext<Theme>>,
-            children: ReactElement,
-            ?dataAttribute: string,
-            ?localStorageKey: string,
-            ?enforceTheme: Theme
-        ) =
+        (children: ReactElement, ?dataAttribute: string, ?localStorageKey: string, ?enforceTheme: Theme)
+        =
         let localStorageKey = defaultArg localStorageKey "swate-theme-ctx"
         let dataAttribute = defaultArg dataAttribute "data-theme"
         let (theme, setTheme) = React.useLocalStorage (localStorageKey, Theme.Auto)
@@ -43,4 +38,4 @@ type ThemeProvider =
             [| box enforceTheme |]
         )
 
-        reactContext.Provider({ state = theme; setState = setTheme }, children)
+        Context.ThemeCtx.Provider({ state = theme; setState = setTheme }, children)

--- a/src/Components/src/Theme/ThemeSelector.fs
+++ b/src/Components/src/Theme/ThemeSelector.fs
@@ -1,0 +1,115 @@
+namespace Swate.Components.Theme
+
+open Feliz
+open Fable.Core
+open Fable.Core.JsInterop
+
+module private ThemeSelectorHelper =
+    [<Literal>]
+    let Browser =
+        """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+	<rect width="24" height="24" fill="none" />
+	<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm4-2v4" />
+</svg>"""
+
+    [<Literal>]
+    let AnimatedMoon =
+        """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <g fill="currentColor" fill-opacity="0"><path d="M15.22 6.03l2.53-1.94L14.56 4L13.5 1l-1.06 3l-3.19.09l2.53 1.94l-.91 3.06l2.63-1.81l2.63 1.81z">
+            <animate id="lineMdMoonRisingLoop0" fill="freeze" attributeName="fill-opacity" begin="0.7s;lineMdMoonRisingLoop0.begin+6s" dur="0.4s" values="0;1"/>
+            <animate fill="freeze" attributeName="fill-opacity" begin="lineMdMoonRisingLoop0.begin+2.2s" dur="0.4s" values="1;0"/></path><path d="M13.61 5.25L15.25 4l-2.06-.05L12.5 2l-.69 1.95L9.75 4l1.64 1.25l-.59 1.98l1.7-1.17l1.7 1.17z"><animate fill="freeze" attributeName="fill-opacity" begin="lineMdMoonRisingLoop0.begin+3s" dur="0.4s" values="0;1"/>
+            <animate fill="freeze" attributeName="fill-opacity" begin="lineMdMoonRisingLoop0.begin+5.2s" dur="0.4s" values="1;0"/></path><path d="M19.61 12.25L21.25 11l-2.06-.05L18.5 9l-.69 1.95l-2.06.05l1.64 1.25l-.59 1.98l1.7-1.17l1.7 1.17z">
+            <animate fill="freeze" attributeName="fill-opacity" begin="lineMdMoonRisingLoop0.begin+0.4s" dur="0.4s" values="0;1"/><animate fill="freeze" attributeName="fill-opacity" begin="lineMdMoonRisingLoop0.begin+2.8s" dur="0.4s" values="1;0"/></path><path d="M20.828 9.731l1.876-1.439l-2.366-.067L19.552 6l-.786 2.225l-2.366.067l1.876 1.439L17.601 12l1.951-1.342L21.503 12z">
+            <animate fill="freeze" attributeName="fill-opacity" begin="lineMdMoonRisingLoop0.begin+3.4s" dur="0.4s" values="0;1"/><animate fill="freeze" attributeName="fill-opacity" begin="lineMdMoonRisingLoop0.begin+5.6s" dur="0.4s" values="1;0"/></path></g><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M7 6 C7 12.08 11.92 17 18 17 C18.53 17 19.05 16.96 19.56 16.89 C17.95 19.36 15.17 21 12 21 C7.03 21 3 16.97 3 12 C3 8.83 4.64 6.05 7.11 4.44 C7.04 4.95 7 5.47 7 6 Z" transform="translate(0 22)" stroke-width="1"><animateMotion fill="freeze" calcMode="linear" dur="0.6s" path="M0 0v-22"/>
+            </path></svg>"""
+
+    [<Literal>]
+    let AnimatedSun =
+        """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <rect width="24" height="24" fill="none" />
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <circle cx="12" cy="32" r="6">
+            <animate fill="freeze" attributeName="cy" dur="0.6s" values="32;12" />
+        </circle>
+        <g>
+            <path stroke-dasharray="2" stroke-dashoffset="2" d="M12 19v1M19 12h1M12 5v-1M5 12h-1">
+                <animate fill="freeze" attributeName="d" begin="0.7s" dur="0.2s" values="M12 19v1M19 12h1M12 5v-1M5 12h-1;M12 21v1M21 12h1M12 3v-1M3 12h-1" />
+                <animate fill="freeze" attributeName="stroke-dashoffset" begin="0.7s" dur="0.2s" values="2;0" />
+            </path>
+            <path stroke-dasharray="2" stroke-dashoffset="2" d="M17 17l0.5 0.5M17 7l0.5 -0.5M7 7l-0.5 -0.5M7 17l-0.5 0.5">
+                <animate fill="freeze" attributeName="d" begin="0.9s" dur="0.2s" values="M17 17l0.5 0.5M17 7l0.5 -0.5M7 7l-0.5 -0.5M7 17l-0.5 0.5;M18.5 18.5l0.5 0.5M18.5 5.5l0.5 -0.5M5.5 5.5l-0.5 -0.5M5.5 18.5l-0.5 0.5" />
+                <animate fill="freeze" attributeName="stroke-dashoffset" begin="0.9s" dur="0.2s" values="2;0" />
+            </path>
+            <animateTransform attributeName="transform" dur="30s" repeatCount="indefinite" type="rotate" values="0 12 12;360 12 12" />
+        </g>
+    </g>
+</svg>"""
+
+    [<Literal>]
+    let Planti =
+        """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+	<rect width="24" height="24" fill="none" />
+	<path fill="currentColor" d="M23 4.1V2.3l-1.8-.2c-.1 0-.7-.1-1.7-.1c-4.1 0-7.1 1.2-8.8 3.3C9.4 4.5 7.6 4 5.5 4c-1 0-1.7.1-1.7.1l-1.9.3l.1 1.7c.1 3 1.6 8.7 6.8 8.7H9v3.4c-3.8.5-7 1.8-7 1.8v2h20v-2s-3.2-1.3-7-1.8V15c6.3-.1 8-7.2 8-10.9M12 18h-1v-5.6S10.8 9 8 9c0 0 1.5.8 1.9 3.7c-.4.1-.8.1-1.1.1C4.2 12.8 4 6.1 4 6.1S4.6 6 5.5 6c1.9 0 5 .4 5.9 3.1C11.9 4.6 17 4 19.5 4c.9 0 1.5.1 1.5.1s0 9-6.3 9H14c0-2 2-5 2-5c-3 1-3 4.9-3 4.9v5z" />
+</svg>"""
+
+    [<Literal>]
+    let Viola =
+        """<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+	<rect width="32" height="32" fill="none" />
+	<path fill="currentColor" d="M16 1C7.716 1 1 7.716 1 16s6.716 15 15 15s15-6.716 15-15S24.284 1 16 1m1.5 2.086L3.086 17.5a13 13 0 0 1-.072-2.1L15.4 3.015a13 13 0 0 1 2.1.072m2.338.49q.81.25 1.572.6L4.176 21.41a13 13 0 0 1-.6-1.572zM5.19 23.224L23.224 5.19q.645.433 1.234.938l-18.33 18.33q-.505-.588-.938-1.234m2.352 2.648l18.33-18.33q.506.588.938 1.234L8.776 26.81q-.646-.432-1.234-.938m3.048 1.952L27.824 10.59q.35.761.6 1.572L12.162 28.424a13 13 0 0 1-1.572-.6m3.91 1.09L28.914 14.5a13 13 0 0 1 .072 2.1L16.6 28.985a13 13 0 0 1-2.1-.072m5.561-.56l8.292-8.293a13.03 13.03 0 0 1-8.292 8.292M3.647 11.938a13.03 13.03 0 0 1 8.292-8.292z" />
+</svg>"""
+
+open ThemeSelectorHelper
+
+[<Erase; Mangle(false)>]
+type ThemeSelector =
+
+    [<ReactComponent>]
+    static member private SelectItem(theme: Swate.Components.Types.Theme) =
+        let txt = Swate.Components.Types.Theme.toString theme
+        Html.option [ prop.value txt; prop.text txt ]
+
+    [<ReactComponent(true)>]
+    static member ThemeSelector() =
+
+        let themeCtx = Context.useThemeCtx ()
+
+        let iconRef = React.useElementRef ()
+
+        React.useLayoutEffect (
+            (fun () ->
+                let icon =
+                    match themeCtx.state with
+                    | Swate.Components.Types.Theme.Sunrise -> AnimatedSun
+                    | Swate.Components.Types.Finster -> AnimatedMoon
+                    | Swate.Components.Types.Planti -> Planti
+                    | Swate.Components.Types.Viola -> Viola
+                    | Swate.Components.Types.Auto -> Browser
+
+                iconRef.current?innerHTML <- icon
+                ()
+            ),
+            [| box themeCtx.state |]
+        )
+
+        Html.label [
+            prop.className "swt:select"
+            prop.children [
+                Html.label [ prop.className "swt:label"; prop.ref iconRef ]
+                Html.select [
+                    prop.defaultValue (Swate.Components.Types.Theme.toString themeCtx.state)
+                    prop.onChange (fun (e: string) -> themeCtx.setState (Swate.Components.Types.Theme.fromString e))
+                    prop.children [
+                        ThemeSelector.SelectItem Swate.Components.Types.Theme.Sunrise
+                        ThemeSelector.SelectItem Swate.Components.Types.Theme.Finster
+                        ThemeSelector.SelectItem Swate.Components.Types.Theme.Planti
+                        ThemeSelector.SelectItem Swate.Components.Types.Theme.Viola
+                        ThemeSelector.SelectItem Swate.Components.Types.Theme.Auto
+                    ]
+                ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member Entry() =
+        ThemeProvider.ThemeProvider(ThemeSelector.ThemeSelector())

--- a/src/Components/src/Theme/ThemeSelector.fs
+++ b/src/Components/src/Theme/ThemeSelector.fs
@@ -95,9 +95,9 @@ type ThemeSelector =
         Html.label [
             prop.className "swt:select"
             prop.children [
-                Html.label [ prop.className "swt:label"; prop.ref iconRef ]
+                Html.span [ prop.className "swt:label"; prop.ref iconRef ]
                 Html.select [
-                    prop.defaultValue (Swate.Components.Types.Theme.toString themeCtx.state)
+                    prop.value (Swate.Components.Types.Theme.toString themeCtx.state)
                     prop.onChange (fun (e: string) -> themeCtx.setState (Swate.Components.Types.Theme.fromString e))
                     prop.children [
                         ThemeSelector.SelectItem Swate.Components.Types.Theme.Sunrise

--- a/src/Components/src/Theme/ThemeSelector.stories.tsx
+++ b/src/Components/src/Theme/ThemeSelector.stories.tsx
@@ -5,7 +5,7 @@ import { Entry as ThemeSelector } from './ThemeSelector.fs.js';
 
 
 const meta = {
-  title: 'CompositeComponents/ThemeSelector',
+  title: 'Composite Components/ThemeSelector',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/src/Components/src/Theme/ThemeSelector.stories.tsx
+++ b/src/Components/src/Theme/ThemeSelector.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect, userEvent, waitFor } from 'storybook/test';
+import { Entry as ThemeSelector } from './ThemeSelector.fs.js';
+
+
+const meta = {
+  title: 'CompositeComponents/ThemeSelector',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  component: ThemeSelector,
+} satisfies Meta<typeof ThemeSelector>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/Electron/src/Renderer/Components/Navbar.fs
+++ b/src/Electron/src/Renderer/Components/Navbar.fs
@@ -100,8 +100,7 @@ type private Selector =
                 dependencies = [||]
             }
 
-        let selectorControlRef =
-            React.useRef ({ toggle = ignore }: SelectorRef)
+        let selectorControlRef = React.useRef ({ toggle = ignore }: SelectorRef)
 
         let onOpen =
             fun (isOpen: bool) ->
@@ -207,7 +206,7 @@ type Navbar =
                 prop.children [
                     Authentication.UserAvatar()
                     Html.div [ prop.className "swt:divider swt:divider-horizontal" ]
-                    Layout.LeftSidebarToggleBtn(activeBorderStyle = false)
+                    Layout.LeftSidebarToggleBtn()
                 ]
             ]
 


### PR DESCRIPTION
- Increase robustness of TermSearchQueryProvider
- Move `Components/**/Metadata/Generic.fs` with generic layout helper components to: `src\Components\src\GenericComponents\LayoutComponents.fs`
  - I have used the namespace `Swate.Components`, instead of design docs `Swate.Components.GenericComponents` in respect of possible changes due to #1073. As i thought it might be a good idea to keep all "primitives" in root namespace? @caroott @Etschbeijer 
- Rename `ThemeProvider` namespace to `Theme` namespace and add `ThemeSelector` Component (implementation taken from Client/** and cleaned)
- add PageComponents/** namespace and add `SettingsPage` component taking minimal logic from Client/** and cleaned.
- Add storybook examples in respect to #1073 in new namespaces: "'Page Components/SettingsPage'" and "'Composite Components/ThemeSelector'"
- Fix sidebar toggle icon to correctly display left and right
- Increase lazy component robustness by calling explicit argument names, to provoke compile time errors on argument rename