### PR TITLE
Remove pure in-memory addition and deletion

### DIFF
--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -22,8 +22,6 @@ type ArcVault(window: BrowserWindow) =
     member val window: BrowserWindow = window with get
     member val path: string option = None with get, set
     member val arc: ARC option = None with get, set
-    /// Optional staged ARC file draft used by file-explorer pending-save/delete flows.
-    member val pendingArcFileSave: FileContentDTO option = None with get, set
     /// Dirty marker for unsaved in-memory ARC mutations.
     /// This flag is intentionally coarse and can remain true even if later edits restore the previous logical state.
     ///Good workaround, for a missing member 👍 Might even be more performant, than calculating a isDirty flag. On the other hand, it is unable to detect if changes are removed again. For example:

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -153,6 +153,34 @@ module ArcVaultExtensions =
             | _ -> return Error(exn "ARC is not loaded.")
         }
 
+        /// Applies an ARC file request on a copy and persists it.
+        /// The in-memory ARC is only replaced after successful persistence.
+        member this.ApplyArcFileAndSave(request: FileContentDTO) : Fable.Core.JS.Promise<Result<unit, exn>> = promise {
+            match this.path, this.arc with
+            | Some arcPath, Some arc ->
+                let normalizedRequest =
+                    Swate.Electron.Shared.FileIOHelper.FileContentDTO.normalizeArcFileRequestPath request
+
+                let workingArc = arc.Copy()
+
+                match updateARCByFileContentDTO workingArc normalizedRequest with
+                | Error updateError -> return Error updateError
+                | Ok updatedArc ->
+                    this.isBusyWriting <- true
+
+                    try
+                        try
+                            do! updatedArc.UpdateAsync(arcPath)
+                            this.SetArc(updatedArc)
+                            this.hasUnsavedArcChanges <- false
+                            return Ok()
+                        with e ->
+                            return Error(exn $"Failed to persist ARC to disk: {e.Message}")
+                    finally
+                        this.isBusyWriting <- false
+            | _ -> return Error(exn "ARC is not loaded.")
+        }
+
         member this.SetFileTree(fileTree: Dictionary<string, FileEntry>) =
             this.fileTree <- fileTree
 

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -143,34 +143,48 @@ let private isSameOrDescendantPathForComparison (path: string) (ancestorPath: st
 module ArcDeleteHelper =
 
 
-    let isPendingPathAffectedByDelete (deletedPath: string) (pendingArcFileSave: FileContentDTO option) =
-        pendingArcFileSave
-        |> Option.exists (fun pendingArcFileSave ->
-            isSameOrDescendantPathForComparison pendingArcFileSave.path deletedPath
-        )
-
     let private tryGetNodeErrorCode (error: exn) : string option =
         try
             error?code |> unbox<string> |> Option.ofObj
         with _ ->
             None
 
-    let shouldIgnoreMissingDiskDeleteError
-        (deletedPath: string)
-        (pendingArcFileSave: FileContentDTO option)
-        (deleteError: exn)
-        =
-        let isMissingPathError =
-            match tryGetNodeErrorCode deleteError with
-            | Some "ENOENT" -> true
-            | _ -> false
+    let private isMissingPathError (deleteError: exn) =
+        match tryGetNodeErrorCode deleteError with
+        | Some "ENOENT" -> true
+        | _ -> false
 
-        isMissingPathError
-        && isPendingPathAffectedByDelete deletedPath pendingArcFileSave
+    let private canonicalTargetExistsInMemory (arcLocal: ARC) (target: ArcDeletePathRules.CanonicalArcFileTarget) =
+        match target with
+        | ArcDeletePathRules.CanonicalArcFileTarget.InvestigationFile -> true
+        | ArcDeletePathRules.CanonicalArcFileTarget.EntityFile(zone, identifier) ->
+            match zone with
+            | ArcDeletePathRules.AddZone.Assays -> arcLocal.ContainsAssay(identifier)
+            | ArcDeletePathRules.AddZone.Studies -> arcLocal.ContainsStudy(identifier)
+            | ArcDeletePathRules.AddZone.Workflows -> arcLocal.ContainsWorkflow(identifier)
+            | ArcDeletePathRules.AddZone.Runs -> arcLocal.ContainsRun(identifier)
+        | ArcDeletePathRules.CanonicalArcFileTarget.DataMapFile(zone, identifier) ->
+            match zone with
+            | ArcDeletePathRules.AddZone.Assays ->
+                arcLocal.TryGetAssay(identifier) |> Option.exists (fun assay -> assay.DataMap.IsSome)
+            | ArcDeletePathRules.AddZone.Studies ->
+                arcLocal.TryGetStudy(identifier) |> Option.exists (fun study -> study.DataMap.IsSome)
+            | ArcDeletePathRules.AddZone.Workflows ->
+                arcLocal.TryGetWorkflow(identifier) |> Option.exists (fun workflow -> workflow.DataMap.IsSome)
+            | ArcDeletePathRules.AddZone.Runs ->
+                arcLocal.TryGetRun(identifier) |> Option.exists (fun run -> run.DataMap.IsSome)
+
+    let tryCreateMemoryOnlyDeleteError (deletedPath: string) (arcLocal: ARC) (deleteError: exn) =
+        if isMissingPathError deleteError then
+            match ArcDeletePathRules.tryParseCanonicalArcFileTarget deletedPath with
+            | Some target when canonicalTargetExistsInMemory arcLocal target ->
+                Some(exn $"Target '{deletedPath}' exists only in memory and is not written to disk yet.")
+            | _ -> None
+        else
+            None
 
     type MergeResult = {
         Arc: ARC
-        PendingArcFileSave: FileContentDTO option
     }
 
     let private normalizeRelativePathForMerge (path: string) =
@@ -222,35 +236,12 @@ module ArcDeleteHelper =
         (preDeleteFileRelativePaths: string seq)
         (arcLocal: ARC)
         (reloadedArc: ARC)
-        (pendingArcFileSave: FileContentDTO option)
         : Result<MergeResult, exn> =
-        let shouldDropPendingArcFileSave =
-            isPendingPathAffectedByDelete deletedPath pendingArcFileSave
-
-        let pendingForMerge =
-            if shouldDropPendingArcFileSave then
-                None
-            else
-                pendingArcFileSave
-
         let arcLocalForMerge = arcLocal.Copy()
+        let unlinkEvents = buildDeleteUnlinkEvents deletedPath preDeleteFileRelativePaths
+        let mergedArc = ARC.merge arcLocalForMerge reloadedArc unlinkEvents
 
-        let arcLocalForMergeResult =
-            match pendingForMerge with
-            | None -> Ok arcLocalForMerge
-            | Some pendingArcFileSave ->
-                Main.ArcVaultHelper.updateARCByFileContentDTO arcLocalForMerge pendingArcFileSave
-
-        match arcLocalForMergeResult with
-        | Error mergeError -> Error mergeError
-        | Ok arcLocalForMerge ->
-            let unlinkEvents = buildDeleteUnlinkEvents deletedPath preDeleteFileRelativePaths
-            let mergedArc = ARC.merge arcLocalForMerge reloadedArc unlinkEvents
-
-            Ok {
-                Arc = mergedArc
-                PendingArcFileSave = pendingForMerge
-            }
+        Ok { Arc = mergedArc }
 
 
 /// This depends on the types in this file, but the types on this file must call this to bind IPC calls :/
@@ -507,7 +498,16 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
     saveArcFile =
         fun () -> promise {
             try
-                return! withLoadedArcVault event (fun vault -> vault.WriteArc())
+                return!
+                    withLoadedArcVault event (fun vault ->
+                        promise {
+                            match! vault.WriteArc() with
+                            | Error saveError -> return Error saveError
+                            | Ok() ->
+                                do! vault.RefreshFileTree()
+                                return Ok()
+                        }
+                    )
             with e ->
                 return Error e
         }
@@ -522,19 +522,6 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                             | Ok() -> return Ok()
                         }
                     )
-            with e ->
-                return Error e
-        }
-    setPendingArcFileSave =
-        fun (pendingArcFileSave: FileContentDTO option) -> promise {
-            try
-                let windowId = windowIdFromIpcEvent event
-
-                match ARC_VAULTS.TryGetVault(windowId) with
-                | None -> return Error(exn $"The ARC for window id {windowId} should exist")
-                | Some vault ->
-                    vault.pendingArcFileSave <- pendingArcFileSave
-                    return Ok()
             with e ->
                 return Error e
         }
@@ -568,8 +555,6 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                 vault.isBusyWriting <- true
 
                                 try
-                                    let pendingArcFileSave = vault.pendingArcFileSave
-
                                     let! deleteResult =
                                         promise {
                                             try
@@ -582,15 +567,14 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
 
                                                 return Ok()
                                             with deleteError ->
-                                                if
-                                                    ArcDeleteHelper.shouldIgnoreMissingDiskDeleteError
+                                                match
+                                                    ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
                                                         normalizedRelativePath
-                                                        pendingArcFileSave
+                                                        arcLocal
                                                         deleteError
-                                                then
-                                                    return Ok()
-                                                else
-                                                    return Error deleteError
+                                                with
+                                                | Some memoryOnlyError -> return Error memoryOnlyError
+                                                | None -> return Error deleteError
                                         }
 
                                     match deleteResult with
@@ -608,12 +592,10 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                     preDeleteFileRelativePaths
                                                     arcLocal
                                                     reloadedArc
-                                                    pendingArcFileSave
                                             with
                                             | Error mergeError -> return Error mergeError
                                             | Ok mergeResult ->
                                                 vault.arc <- Some mergeResult.Arc
-                                                vault.pendingArcFileSave <- mergeResult.PendingArcFileSave
                                                 vault.window.title <- mergeResult.Arc.Identifier
                                                 return Ok()
                                 finally

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -484,6 +484,22 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
             with e ->
                 return Error e
         }
+    applyArcFileAndSave =
+        fun (request: FileContentDTO) -> promise {
+            try
+                return!
+                    withLoadedArcVault event (fun vault ->
+                        promise {
+                            match! vault.ApplyArcFileAndSave(request) with
+                            | Error saveError -> return Error saveError
+                            | Ok() ->
+                                do! vault.RefreshFileTree()
+                                return Ok()
+                        }
+                    )
+            with e ->
+                return Error e
+        }
     deletePath =
         fun (relativePath: string) -> promise {
             try

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -154,30 +154,45 @@ module ArcDeleteHelper =
         | Some "ENOENT" -> true
         | _ -> false
 
-    let private canonicalTargetExistsInMemory (arcLocal: ARC) (target: ArcDeletePathRules.CanonicalArcFileTarget) =
-        match target with
-        | ArcDeletePathRules.CanonicalArcFileTarget.InvestigationFile -> true
-        | ArcDeletePathRules.CanonicalArcFileTarget.EntityFile(zone, identifier) ->
-            match zone with
-            | ArcDeletePathRules.AddZone.Assays -> arcLocal.ContainsAssay(identifier)
-            | ArcDeletePathRules.AddZone.Studies -> arcLocal.ContainsStudy(identifier)
-            | ArcDeletePathRules.AddZone.Workflows -> arcLocal.ContainsWorkflow(identifier)
-            | ArcDeletePathRules.AddZone.Runs -> arcLocal.ContainsRun(identifier)
-        | ArcDeletePathRules.CanonicalArcFileTarget.DataMapFile(zone, identifier) ->
-            match zone with
-            | ArcDeletePathRules.AddZone.Assays ->
-                arcLocal.TryGetAssay(identifier) |> Option.exists (fun assay -> assay.DataMap.IsSome)
-            | ArcDeletePathRules.AddZone.Studies ->
-                arcLocal.TryGetStudy(identifier) |> Option.exists (fun study -> study.DataMap.IsSome)
-            | ArcDeletePathRules.AddZone.Workflows ->
-                arcLocal.TryGetWorkflow(identifier) |> Option.exists (fun workflow -> workflow.DataMap.IsSome)
-            | ArcDeletePathRules.AddZone.Runs ->
-                arcLocal.TryGetRun(identifier) |> Option.exists (fun run -> run.DataMap.IsSome)
+    let private entityExistsInMemory (arcLocal: ARC) (zone: ArcDeletePathRules.AddZone) (identifier: string) =
+        match zone with
+        | ArcDeletePathRules.AddZone.Assays -> arcLocal.ContainsAssay(identifier)
+        | ArcDeletePathRules.AddZone.Studies -> arcLocal.ContainsStudy(identifier)
+        | ArcDeletePathRules.AddZone.Workflows -> arcLocal.ContainsWorkflow(identifier)
+        | ArcDeletePathRules.AddZone.Runs -> arcLocal.ContainsRun(identifier)
+
+    let private dataMapExistsInMemory (arcLocal: ARC) (zone: ArcDeletePathRules.AddZone) (identifier: string) =
+        match zone with
+        | ArcDeletePathRules.AddZone.Assays ->
+            arcLocal.TryGetAssay(identifier) |> Option.exists (fun assay -> assay.DataMap.IsSome)
+        | ArcDeletePathRules.AddZone.Studies ->
+            arcLocal.TryGetStudy(identifier) |> Option.exists (fun study -> study.DataMap.IsSome)
+        | ArcDeletePathRules.AddZone.Workflows ->
+            arcLocal.TryGetWorkflow(identifier) |> Option.exists (fun workflow -> workflow.DataMap.IsSome)
+        | ArcDeletePathRules.AddZone.Runs ->
+            arcLocal.TryGetRun(identifier) |> Option.exists (fun run -> run.DataMap.IsSome)
+
+    let private isMemoryOnlyDeleteTarget
+        (arcLocal: ARC)
+        (targetClassification: ArcDeletePathRules.DeletePathClassification)
+        =
+        match targetClassification with
+        | ArcDeletePathRules.DeletePathClassification.CanonicalFileTarget(
+            ArcDeletePathRules.CanonicalArcFileTarget.EntityFile(zone, identifier),
+            _
+          ) -> entityExistsInMemory arcLocal zone identifier
+        | ArcDeletePathRules.DeletePathClassification.CanonicalFileTarget(
+            ArcDeletePathRules.CanonicalArcFileTarget.DataMapFile(zone, identifier),
+            _
+          ) -> dataMapExistsInMemory arcLocal zone identifier
+        | ArcDeletePathRules.DeletePathClassification.EntityFolderTarget(zone, identifier, _) ->
+            entityExistsInMemory arcLocal zone identifier
+        | _ -> false
 
     let tryCreateMemoryOnlyDeleteError (deletedPath: string) (arcLocal: ARC) (deleteError: exn) =
         if isMissingPathError deleteError then
-            match ArcDeletePathRules.tryParseCanonicalArcFileTarget deletedPath with
-            | Some target when canonicalTargetExistsInMemory arcLocal target ->
+            match ArcDeletePathRules.classifyDeleteTarget deletedPath with
+            | targetClassification when isMemoryOnlyDeleteTarget arcLocal targetClassification ->
                 Some(exn $"Target '{deletedPath}' exists only in memory and is not written to disk yet.")
             | _ -> None
         else

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -142,62 +142,6 @@ let private isSameOrDescendantPathForComparison (path: string) (ancestorPath: st
 [<RequireQualifiedAccess>]
 module ArcDeleteHelper =
 
-
-    let private tryGetNodeErrorCode (error: exn) : string option =
-        try
-            error?code |> unbox<string> |> Option.ofObj
-        with _ ->
-            None
-
-    let private isMissingPathError (deleteError: exn) =
-        match tryGetNodeErrorCode deleteError with
-        | Some "ENOENT" -> true
-        | _ -> false
-
-    let private entityExistsInMemory (arcLocal: ARC) (zone: ArcDeletePathRules.AddZone) (identifier: string) =
-        match zone with
-        | ArcDeletePathRules.AddZone.Assays -> arcLocal.ContainsAssay(identifier)
-        | ArcDeletePathRules.AddZone.Studies -> arcLocal.ContainsStudy(identifier)
-        | ArcDeletePathRules.AddZone.Workflows -> arcLocal.ContainsWorkflow(identifier)
-        | ArcDeletePathRules.AddZone.Runs -> arcLocal.ContainsRun(identifier)
-
-    let private dataMapExistsInMemory (arcLocal: ARC) (zone: ArcDeletePathRules.AddZone) (identifier: string) =
-        match zone with
-        | ArcDeletePathRules.AddZone.Assays ->
-            arcLocal.TryGetAssay(identifier) |> Option.exists (fun assay -> assay.DataMap.IsSome)
-        | ArcDeletePathRules.AddZone.Studies ->
-            arcLocal.TryGetStudy(identifier) |> Option.exists (fun study -> study.DataMap.IsSome)
-        | ArcDeletePathRules.AddZone.Workflows ->
-            arcLocal.TryGetWorkflow(identifier) |> Option.exists (fun workflow -> workflow.DataMap.IsSome)
-        | ArcDeletePathRules.AddZone.Runs ->
-            arcLocal.TryGetRun(identifier) |> Option.exists (fun run -> run.DataMap.IsSome)
-
-    let private isMemoryOnlyDeleteTarget
-        (arcLocal: ARC)
-        (targetClassification: ArcDeletePathRules.DeletePathClassification)
-        =
-        match targetClassification with
-        | ArcDeletePathRules.DeletePathClassification.CanonicalFileTarget(
-            ArcDeletePathRules.CanonicalArcFileTarget.EntityFile(zone, identifier),
-            _
-          ) -> entityExistsInMemory arcLocal zone identifier
-        | ArcDeletePathRules.DeletePathClassification.CanonicalFileTarget(
-            ArcDeletePathRules.CanonicalArcFileTarget.DataMapFile(zone, identifier),
-            _
-          ) -> dataMapExistsInMemory arcLocal zone identifier
-        | ArcDeletePathRules.DeletePathClassification.EntityFolderTarget(zone, identifier, _) ->
-            entityExistsInMemory arcLocal zone identifier
-        | _ -> false
-
-    let tryCreateMemoryOnlyDeleteError (deletedPath: string) (arcLocal: ARC) (deleteError: exn) =
-        if isMissingPathError deleteError then
-            match ArcDeletePathRules.classifyDeleteTarget deletedPath with
-            | targetClassification when isMemoryOnlyDeleteTarget arcLocal targetClassification ->
-                Some(exn $"Target '{deletedPath}' exists only in memory and is not written to disk yet.")
-            | _ -> None
-        else
-            None
-
     type MergeResult = {
         Arc: ARC
     }
@@ -570,31 +514,14 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                 vault.isBusyWriting <- true
 
                                 try
-                                    let! deleteResult =
-                                        promise {
-                                            try
-                                                let! _ =
-                                                    fsPromisesDynamic?rm (
-                                                        absolutePath,
-                                                        createObj [ "recursive" ==> true; "force" ==> false ]
-                                                    )
-                                                    |> unbox<JS.Promise<obj>>
+                                    try
+                                        let! _ =
+                                            fsPromisesDynamic?rm (
+                                                absolutePath,
+                                                createObj [ "recursive" ==> true; "force" ==> false ]
+                                            )
+                                            |> unbox<JS.Promise<obj>>
 
-                                                return Ok()
-                                            with deleteError ->
-                                                match
-                                                    ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
-                                                        normalizedRelativePath
-                                                        arcLocal
-                                                        deleteError
-                                                with
-                                                | Some memoryOnlyError -> return Error memoryOnlyError
-                                                | None -> return Error deleteError
-                                        }
-
-                                    match deleteResult with
-                                    | Error deleteError -> return Error deleteError
-                                    | Ok() ->
                                         do! vault.RefreshFileTree()
 
                                         match! ARC.tryLoadAsync arcPath with
@@ -613,6 +540,8 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                 vault.arc <- Some mergeResult.Arc
                                                 vault.window.title <- mergeResult.Arc.Identifier
                                                 return Ok()
+                                    with deleteError ->
+                                        return Error deleteError
                                 finally
                                     vault.isBusyWriting <- false
             with e ->

--- a/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
+++ b/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
@@ -6,12 +6,6 @@ open Swate.Electron.Shared.FileIOHelper
 [<RequireQualifiedAccess>]
 module FileExplorerDeleteHelper =
 
-    let private normalizeRelativePath (path: string) =
-        path
-        |> PathHelpers.normalizeRelativePath
-        |> PathHelpers.normalizePath
-
-
     let containsPath (paths: string seq) (relativePath: string) =
         let normalizedTargetPath = PathHelpers.normalizePath relativePath
 
@@ -30,12 +24,3 @@ module FileExplorerDeleteHelper =
         | Some Renderer.Types.PageState.UnknownPage
         | Some(Renderer.Types.PageState.ErrorPage _) -> true
         | _ -> false
-
-    let isPendingPathAffectedByDelete (deletedPath: string) (pendingPath: string option) =
-        let normalizedDeletedPath = normalizeRelativePath deletedPath
-
-        pendingPath
-        |> Option.map normalizeRelativePath
-        |> Option.exists (fun normalizedPendingPath ->
-            isSameOrDescendantPath normalizedPendingPath normalizedDeletedPath
-        )

--- a/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
+++ b/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
@@ -25,3 +25,29 @@ module FileExplorerDeleteHelper =
         | Some Renderer.Types.PageState.UnknownPage
         | Some(Renderer.Types.PageState.ErrorPage _) -> true
         | _ -> false
+
+    let private shouldReloadPageStateAfterSelectedFileUpdate (pageState: Renderer.Types.PageState option) =
+        match pageState with
+        | Some(Renderer.Types.PageState.TextPage _)
+        | Some Renderer.Types.PageState.UnknownPage
+        | Some(Renderer.Types.PageState.ErrorPage _) -> true
+        | _ -> false
+
+    let tryGetReloadableSelectedFilePath
+        (fileTree: FileEntry[])
+        (selectionPath: string option)
+        (pageState: Renderer.Types.PageState option)
+        =
+        if shouldReloadPageStateAfterSelectedFileUpdate pageState |> not then
+            None
+        else
+            selectionPath
+            |> Option.map PathHelpers.normalizePath
+            |> Option.bind (fun selectedPath ->
+                fileTree
+                |> Array.tryFind (fun entry ->
+                    not entry.isDirectory
+                    && PathHelpers.pathsEqual (PathHelpers.normalizePath entry.path) selectedPath
+                )
+                |> Option.map (fun entry -> PathHelpers.normalizePath entry.path)
+            )

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
@@ -16,20 +16,17 @@ open Types
 open Helper
 
 module private FileTreeHelper =
-    let stagePendingArcFileSave (arcFile: ArcFiles option) : JS.Promise<Result<unit, exn>> = promise {
-        let pendingSaveRequestResult =
-            match arcFile with
-            | None -> Ok None
-            | Some nextArcFile ->
-                match FileContentDTO.fromArcFile nextArcFile with
-                | Some request -> Ok(Some request)
-                | None -> Error(exn "Saving this file type is not supported in Electron yet.")
 
-        match pendingSaveRequestResult with
-        | Error saveError -> return Error saveError
-        | Ok pendingSaveRequest ->
-            let! result = Api.ipcArcVaultApi.setPendingArcFileSave pendingSaveRequest
-            return result
+    let saveArcFileAndOpen (arcFile: ArcFiles) : JS.Promise<Result<FileContentDTO, exn>> = promise {
+        match FileContentDTO.fromArcFile arcFile with
+        | None -> return Error(exn "Saving this file type is not supported in Electron yet.")
+        | Some request ->
+            match! Api.ipcArcVaultApi.setArcFileInMemory request with
+            | Error setError -> return Error setError
+            | Ok() ->
+                match! Api.ipcArcVaultApi.saveArcFile() with
+                | Error saveError -> return Error saveError
+                | Ok() -> return! Api.ipcArcVaultApi.openFile request.path
     }
 
 open FileTreeHelper
@@ -55,18 +52,11 @@ type FileTree =
         let pendingCreateKind, setPendingCreateKind =
             React.useState<ArcExplorerNodeKind option> None
 
-        let pendingArcFileSave, setPendingArcFileSave = React.useState<ArcFiles option> None
         let pendingDeleteItem, setPendingDeleteItem = React.useState<FileItem option> None
         let isDeleting, setIsDeleting = React.useState false
 
         let effectiveFileTree =
-            React.useMemo (
-                (fun () -> withPendingArcFileEntry fileStateCtx.state.FileTree pendingArcFileSave),
-                [|
-                    box fileStateCtx.state.FileTree
-                    box pendingArcFileSave
-                |]
-            )
+            React.useMemo ((fun () -> fileStateCtx.state.FileTree), [| box fileStateCtx.state.FileTree |])
 
         React.useEffect (
             (fun () ->
@@ -162,21 +152,16 @@ type FileTree =
                 | Some path ->
                     let selectedPath = PathHelpers.normalizePath path
                     fileStateCtx.setSelection (ArcSelection.forTreePath (Some selectedPath))
+                    let! result = Renderer.Components.ARCHelper.openView selectedPath
 
-                    match tryFindPendingArcFileByPath selectedPath pendingArcFileSave with
-                    | Some pendingArcFile ->
-                        pageStateCtx.setState (Some(Renderer.Types.PageState.ArcFilePage pendingArcFile))
-                    | None ->
-                        let! result = Renderer.Components.ARCHelper.openView selectedPath
-
-                        match result with
-                        | Ok loaded ->
-                            console.log ("[Renderer] Received data, processing...")
-                            Renderer.Components.ARCHelper.applyLoadedView pageStateCtx.setState loaded
-                        | Error errorMessage ->
-                            let fullErrorMessage = $"Could not open preview for '{item.Name}': {errorMessage}"
-                            console.log ($"[Renderer] Error: {fullErrorMessage}")
-                            Renderer.Components.ARCHelper.applyViewError pageStateCtx.setState fullErrorMessage
+                    match result with
+                    | Ok loaded ->
+                        console.log ("[Renderer] Received data, processing...")
+                        Renderer.Components.ARCHelper.applyLoadedView pageStateCtx.setState loaded
+                    | Error errorMessage ->
+                        let fullErrorMessage = $"Could not open preview for '{item.Name}': {errorMessage}"
+                        console.log ($"[Renderer] Error: {fullErrorMessage}")
+                        Renderer.Components.ARCHelper.applyViewError pageStateCtx.setState fullErrorMessage
             }
             |> Promise.start
 
@@ -218,16 +203,13 @@ type FileTree =
             inlineCreateKindForItem item |> Option.iter openCreateModal
 
         let applyCreateError errorMessage =
-            Renderer.Components.ARCHelper.applyViewError pageStateCtx.setState errorMessage
+            errorModal.enqueue (ErrorModalRequest.create (errorMessage, title = "Could not create ARC file", ?scopeId = arcScopeId))
 
         let confirmDeleteItem () =
             FileTreeDeleteWorkflow.confirmDeleteItem {
                 pendingDeleteItem = pendingDeleteItem
-                pendingArcFileSave = pendingArcFileSave
                 closeDeleteModal = closeDeleteModal
                 setIsDeleting = setIsDeleting
-                setPendingArcFileSave = setPendingArcFileSave
-                stagePendingArcFileSave = stagePendingArcFileSave
                 enqueueError = errorModal.enqueue
                 arcScopeId = arcScopeId
             }
@@ -238,25 +220,23 @@ type FileTree =
             match tryBuildArcCreateDraft kind identifier existingPaths with
             | Error errorMessage -> applyCreateError errorMessage
             | Ok draft ->
-                fileStateCtx.setSelection (ArcSelection.forTreePath (Some draft.Path))
-                setPendingArcFileSave (Some draft.ArcFile)
-                pageStateCtx.setState (Some(Renderer.Types.PageState.ArcFilePage draft.ArcFile))
-
                 promise {
-                    match! stagePendingArcFileSave (Some draft.ArcFile) with
-                    | Ok() -> ()
-                    | Error exn ->
-                        errorModal.enqueue (
-                            ErrorModalRequest.create (
-                                exn.Message,
-                                title = "Could not stage ARC file save",
-                                ?scopeId = arcScopeId
-                            )
-                        )
-                }
-                |> Promise.start
+                    let! createResult = saveArcFileAndOpen draft.ArcFile
 
-                closeCreateModal ()
+                    match createResult with
+                    | Error exn -> applyCreateError exn.Message
+                    | Ok createdArcFileDto ->
+                        let selectedPath = PathHelpers.normalizePath createdArcFileDto.path
+                        fileStateCtx.setSelection (ArcSelection.forTreePath (Some selectedPath))
+
+                        createdArcFileDto
+                        |> Renderer.Components.ARCHelper.viewLoadResultOfDto
+                        |> Renderer.Components.ARCHelper.applyLoadedView pageStateCtx.setState
+
+                        closeCreateModal ()
+                }
+                |> Promise.catch (fun exn -> applyCreateError exn.Message)
+                |> Promise.start
 
         let arcCreateContextMenuItems (item: FileItem) =
             if item.IsDirectory then

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
@@ -21,12 +21,10 @@ module private FileTreeHelper =
         match FileContentDTO.fromArcFile arcFile with
         | None -> return Error(exn "Saving this file type is not supported in Electron yet.")
         | Some request ->
-            match! Api.ipcArcVaultApi.setArcFileInMemory request with
-            | Error setError -> return Error setError
+            match! Api.ipcArcVaultApi.applyArcFileAndSave request with
+            | Error saveError -> return Error saveError
             | Ok() ->
-                match! Api.ipcArcVaultApi.saveArcFile() with
-                | Error saveError -> return Error saveError
-                | Ok() -> return! Api.ipcArcVaultApi.openFile request.path
+                return! Api.ipcArcVaultApi.openFile request.path
     }
 
 open FileTreeHelper

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeDelete.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeDelete.fs
@@ -1,6 +1,5 @@
 namespace Renderer.Components.LeftSidebar.FileExplorer
 
-open Renderer.Components.FileExplorerDeleteHelper
 open Swate.Components
 open Swate.Components.ErrorModal
 open Swate.Components.FileExplorer.Types
@@ -14,11 +13,8 @@ module FileTreeDeleteWorkflow =
 
     type ConfirmDeleteConfig = {
         pendingDeleteItem: FileItem option
-        pendingArcFileSave: ArcFiles option
         closeDeleteModal: unit -> unit
         setIsDeleting: bool -> unit
-        setPendingArcFileSave: ArcFiles option -> unit
-        stagePendingArcFileSave: ArcFiles option -> JS.Promise<Result<unit, exn>>
         enqueueError: ErrorModalRequest -> unit
         arcScopeId: string option
     }
@@ -45,23 +41,10 @@ module FileTreeDeleteWorkflow =
             config.setIsDeleting true
 
             promise {
-                let pendingPath = tryGetArcFilePendingPath config.pendingArcFileSave
-
-                let shouldClearPendingDraft =
-                    FileExplorerDeleteHelper.isPendingPathAffectedByDelete deletePath pendingPath
-
                 let! deleteResult = Api.ipcArcVaultApi.deletePath deletePath
 
                 match deleteResult with
-                | Ok() ->
-                    if shouldClearPendingDraft then
-                        config.setPendingArcFileSave None
-
-                        match! config.stagePendingArcFileSave None with
-                        | Ok() -> ()
-                        | Error exn -> applyDeleteError config exn.Message
-
-                    config.closeDeleteModal ()
+                | Ok() -> config.closeDeleteModal ()
                 | Error exn -> applyDeleteError config exn.Message
             }
             |> Promise.catch (fun exn -> applyDeleteError config exn.Message)

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/Helper.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/Helper.fs
@@ -9,33 +9,6 @@ open ARCtrl
 open Types
 
 
-let tryGetArcFileRelativePath (arcFile: ArcFiles) =
-    arcFile.TryGetRelativePath() |> Option.map PathHelpers.normalizePath
-
-let tryGetArcFilePendingPath (pendingArcFile: ArcFiles option) =
-    pendingArcFile |> Option.bind tryGetArcFileRelativePath
-
-let tryPendingArcFileEntry (arcFile: ArcFiles) =
-    tryGetArcFileRelativePath arcFile
-    |> Option.map (fun path -> FileEntry.create (PathHelpers.getFileName path, path, false))
-
-let withPendingArcFileEntry (fileTree: FileEntry[]) (pendingArcFile: ArcFiles option) =
-    match pendingArcFile |> Option.bind tryPendingArcFileEntry with
-    | Some pendingEntry when
-        fileTree
-        |> Array.exists (fun entry -> PathHelpers.pathsEqual entry.path pendingEntry.path)
-        |> not
-        ->
-        Array.append fileTree [| pendingEntry |]
-    | _ -> fileTree
-
-let tryFindPendingArcFileByPath (path: string) (pendingArcFile: ArcFiles option) =
-    pendingArcFile
-    |> Option.filter (fun arcFile ->
-        tryGetArcFileRelativePath arcFile
-        |> Option.exists (fun pendingPath -> PathHelpers.pathsEqual pendingPath path)
-    )
-
 let tryGetItemRelativePath (item: FileItem) =
     item.Path
     |> Option.map PathHelpers.normalizeRelativePath

--- a/src/Electron/src/Renderer/Components/MainContent/Helper.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/Helper.fs
@@ -40,17 +40,12 @@ module MainContentHelper =
     let saveArcFileAndOpen (arcFile: ArcFiles) =
         withArcFileRequest arcFile (fun request ->
             promise {
-                let! setResult = Api.ipcArcVaultApi.setArcFileInMemory request
+                let! saveResult = Api.ipcArcVaultApi.applyArcFileAndSave request
 
-                match setResult with
+                match saveResult with
                 | Error exn -> return Error exn
                 | Ok() ->
-                    let! saveResult = Api.ipcArcVaultApi.saveArcFile ()
-
-                    match saveResult with
-                    | Error exn -> return Error exn
-                    | Ok() ->
-                        let! openResult = Api.ipcArcVaultApi.openFile request.path
-                        return openResult
+                    let! openResult = Api.ipcArcVaultApi.openFile request.path
+                    return openResult
             }
         )

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -46,6 +46,8 @@ type IArcVaultsApi = {
     saveArcFile: unit -> JS.Promise<Result<unit, exn>>
     /// Applies ARC file changes to the active vault's in-memory ARC without writing to disk.
     setArcFileInMemory: FileContentDTO -> JS.Promise<Result<unit, exn>>
+    /// Applies ARC file changes and persists to disk atomically. In-memory ARC is only committed on successful save.
+    applyArcFileAndSave: FileContentDTO -> JS.Promise<Result<unit, exn>>
     deletePath: string -> JS.Promise<Result<unit, exn>>
     writeFile: FileContentDTO -> JS.Promise<Result<unit, exn>>
     runGitLfs: GitLfsRequest -> JS.Promise<Result<GitLfsResult, exn>>

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -46,8 +46,6 @@ type IArcVaultsApi = {
     saveArcFile: unit -> JS.Promise<Result<unit, exn>>
     /// Applies ARC file changes to the active vault's in-memory ARC without writing to disk.
     setArcFileInMemory: FileContentDTO -> JS.Promise<Result<unit, exn>>
-    /// Stores or clears the currently pending ARC file save draft for the active vault window.
-    setPendingArcFileSave: FileContentDTO option -> JS.Promise<Result<unit, exn>>
     deletePath: string -> JS.Promise<Result<unit, exn>>
     writeFile: FileContentDTO -> JS.Promise<Result<unit, exn>>
     runGitLfs: GitLfsRequest -> JS.Promise<Result<GitLfsResult, exn>>

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -36,13 +36,6 @@ let private expectSourceContainsInOrder (sourceText: string) (snippets: string[]
         Vitest.expect(snippetIndex >= 0, $"Expected source to contain (in order): {snippet}").toBe(true)
         searchStartIndex <- snippetIndex + snippet.Length
 
-let private createNodeLikeError (code: string) (message: string) : exn =
-    createObj [
-        "message" ==> message
-        "code" ==> code
-    ]
-    |> unbox<exn>
-
 Vitest.describe("IPC architecture review fixes", fun () ->
     Vitest.test("Arc vault dialogs consistently use a centralized IPC dialog parent helper", fun () ->
         promise {
@@ -120,58 +113,6 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
         Vitest.expect(ArcDeletePathRules.isDeletePathAllowed "studies").toBe(false)
         Vitest.expect(ArcDeletePathRules.isDeletePathAllowed "README.md").toBe(false)
         Vitest.expect(ArcDeletePathRules.isDeletePathAllowed "../studies/StudyA/isa.study.xlsx").toBe(false)
-    )
-
-    Vitest.test("maps ENOENT to explicit memory-only delete error for canonical targets present in memory", fun () ->
-        let arcLocal = ARC("MemoryOnlyArc")
-        arcLocal.InitAssay("PendingAssay") |> ignore
-
-        let missingPathError = createNodeLikeError "ENOENT" "missing path"
-
-        let memoryOnlyError =
-            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
-                "assays/PendingAssay/isa.assay.xlsx"
-                arcLocal
-                missingPathError
-
-        Vitest.expect(memoryOnlyError.IsSome).toBe(true)
-        Vitest.expect(memoryOnlyError.Value.Message.Contains("exists only in memory and is not written to disk yet.")).toBe(true)
-    )
-
-    Vitest.test("does not map ENOENT to memory-only error when canonical target is not present in memory", fun () ->
-        let arcLocal = ARC("MemoryOnlyArc")
-        let missingPathError = createNodeLikeError "ENOENT" "missing path"
-
-        let memoryOnlyError =
-            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
-                "assays/PendingAssay/isa.assay.xlsx"
-                arcLocal
-                missingPathError
-
-        Vitest.expect(memoryOnlyError).toEqual(None)
-    )
-
-    Vitest.test("does not map non-canonical or non-ENOENT delete errors to memory-only error", fun () ->
-        let arcLocal = ARC("MemoryOnlyArc")
-        arcLocal.InitAssay("PendingAssay") |> ignore
-
-        let missingPathError = createNodeLikeError "ENOENT" "missing path"
-        let accessError = createNodeLikeError "EACCES" "permission denied"
-
-        let canonicalWithNonEnoent =
-            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
-                "assays/PendingAssay/isa.assay.xlsx"
-                arcLocal
-                accessError
-
-        let nonCanonicalWithEnoent =
-            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
-                "assays/PendingAssay/readme.md"
-                arcLocal
-                missingPathError
-
-        Vitest.expect(canonicalWithNonEnoent).toEqual(None)
-        Vitest.expect(nonCanonicalWithEnoent).toEqual(None)
     )
 
     Vitest.test("mergeReloadedArcAfterDelete preserves unrelated local in-memory entities", fun () ->

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -122,55 +122,64 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
         Vitest.expect(ArcDeletePathRules.isDeletePathAllowed "../studies/StudyA/isa.study.xlsx").toBe(false)
     )
 
-    Vitest.test("ignore missing disk delete error when target is an affected pending draft", fun () ->
-        let pendingAssay = ArcAssay.init "PendingAssay"
-        let pendingDto = ArcFiles.Assay pendingAssay |> FileContentDTO.fromArcFile |> Option.get
+    Vitest.test("maps ENOENT to explicit memory-only delete error for canonical targets present in memory", fun () ->
+        let arcLocal = ARC("MemoryOnlyArc")
+        arcLocal.InitAssay("PendingAssay") |> ignore
+
         let missingPathError = createNodeLikeError "ENOENT" "missing path"
 
-        let shouldIgnore =
-            ArcDeleteHelper.shouldIgnoreMissingDiskDeleteError
+        let memoryOnlyError =
+            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
                 "assays/PendingAssay/isa.assay.xlsx"
-                (Some pendingDto)
+                arcLocal
                 missingPathError
 
-        Vitest.expect(shouldIgnore).toBe(true)
+        Vitest.expect(memoryOnlyError.IsSome).toBe(true)
+        Vitest.expect(memoryOnlyError.Value.Message.Contains("exists only in memory and is not written to disk yet.")).toBe(true)
     )
 
-    Vitest.test("do not ignore missing disk delete error when pending draft is unrelated", fun () ->
-        let pendingAssay = ArcAssay.init "PendingAssay"
-        let pendingDto = ArcFiles.Assay pendingAssay |> FileContentDTO.fromArcFile |> Option.get
+    Vitest.test("does not map ENOENT to memory-only error when canonical target is not present in memory", fun () ->
+        let arcLocal = ARC("MemoryOnlyArc")
         let missingPathError = createNodeLikeError "ENOENT" "missing path"
 
-        let shouldIgnore =
-            ArcDeleteHelper.shouldIgnoreMissingDiskDeleteError
-                "assays/OtherAssay/isa.assay.xlsx"
-                (Some pendingDto)
+        let memoryOnlyError =
+            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
+                "assays/PendingAssay/isa.assay.xlsx"
+                arcLocal
                 missingPathError
 
-        Vitest.expect(shouldIgnore).toBe(false)
+        Vitest.expect(memoryOnlyError).toEqual(None)
     )
 
-    Vitest.test("do not ignore non-ENOENT delete errors even when pending draft is affected", fun () ->
-        let pendingAssay = ArcAssay.init "PendingAssay"
-        let pendingDto = ArcFiles.Assay pendingAssay |> FileContentDTO.fromArcFile |> Option.get
+    Vitest.test("does not map non-canonical or non-ENOENT delete errors to memory-only error", fun () ->
+        let arcLocal = ARC("MemoryOnlyArc")
+        arcLocal.InitAssay("PendingAssay") |> ignore
+
+        let missingPathError = createNodeLikeError "ENOENT" "missing path"
         let accessError = createNodeLikeError "EACCES" "permission denied"
 
-        let shouldIgnore =
-            ArcDeleteHelper.shouldIgnoreMissingDiskDeleteError
+        let canonicalWithNonEnoent =
+            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
                 "assays/PendingAssay/isa.assay.xlsx"
-                (Some pendingDto)
+                arcLocal
                 accessError
 
-        Vitest.expect(shouldIgnore).toBe(false)
+        let nonCanonicalWithEnoent =
+            ArcDeleteHelper.tryCreateMemoryOnlyDeleteError
+                "assays/PendingAssay/readme.md"
+                arcLocal
+                missingPathError
+
+        Vitest.expect(canonicalWithNonEnoent).toEqual(None)
+        Vitest.expect(nonCanonicalWithEnoent).toEqual(None)
     )
 
-    Vitest.test("mergeReloadedArcAfterDelete preserves unrelated pending drafts and applies them", fun () ->
+    Vitest.test("mergeReloadedArcAfterDelete preserves unrelated local in-memory entities", fun () ->
         let localArc = ARC("MergeArc")
         localArc.Title <- Some "Dirty local title"
+        localArc.InitAssay("AssayMergeA") |> ignore
 
         let reloadedArc = ARC("MergeArc")
-        let pendingAssay = ArcAssay.init "AssayMergeA"
-        let pendingDto = ArcFiles.Assay pendingAssay |> FileContentDTO.fromArcFile |> Option.get
 
         let result =
             ArcDeleteHelper.mergeReloadedArcAfterDelete
@@ -178,36 +187,11 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
                 [ "studies/StudyA/isa.study.xlsx" ]
                 localArc
                 reloadedArc
-                (Some pendingDto)
 
         match result with
         | Error error -> failwith error.Message
         | Ok mergeResult ->
-            Vitest.expect(mergeResult.PendingArcFileSave.IsSome).toBe(true)
             Vitest.expect(mergeResult.Arc.TryGetAssay "AssayMergeA" |> Option.isSome).toBe(true)
-    )
-
-    Vitest.test("mergeReloadedArcAfterDelete drops pending drafts affected by deletion targets", fun () ->
-        let localArc = ARC("MergeArc")
-        localArc.Title <- Some "Dirty local title"
-
-        let reloadedArc = ARC("MergeArc")
-        let pendingAssay = ArcAssay.init "AssayMergeB"
-        let pendingDto = ArcFiles.Assay pendingAssay |> FileContentDTO.fromArcFile |> Option.get
-
-        let result =
-            ArcDeleteHelper.mergeReloadedArcAfterDelete
-                "assays/AssayMergeB"
-                [ "assays/AssayMergeB/isa.assay.xlsx" ]
-                localArc
-                reloadedArc
-                (Some pendingDto)
-
-        match result with
-        | Error error -> failwith error.Message
-        | Ok mergeResult ->
-            Vitest.expect(mergeResult.PendingArcFileSave).toEqual(None)
-            Vitest.expect(mergeResult.Arc.TryGetAssay "AssayMergeB" |> Option.isSome).toBe(false)
     )
 
     Vitest.test("entity unlink event removes the targeted entity", fun () ->
@@ -222,7 +206,6 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
                 [ "assays/My Assay/isa.assay.xlsx" ]
                 localArc
                 reloadedArc
-                None
 
         match result with
         | Error error -> failwith error.Message
@@ -246,7 +229,6 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
                 [ "assays/My Assay/isa.datamap.xlsx" ]
                 localArc
                 reloadedArc
-                None
 
         match result with
         | Error error -> failwith error.Message
@@ -264,7 +246,7 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
         let reloadedArc = localArc.Copy()
 
         let result =
-            ArcDeleteHelper.mergeReloadedArcAfterDelete "assays/My Assay" [] localArc reloadedArc None
+            ArcDeleteHelper.mergeReloadedArcAfterDelete "assays/My Assay" [] localArc reloadedArc
 
         match result with
         | Error error -> failwith error.Message

--- a/tests/Electron.Renderer/FileStateContextReload.test.fs
+++ b/tests/Electron.Renderer/FileStateContextReload.test.fs
@@ -140,9 +140,4 @@ Vitest.describe("FileExplorer delete helpers", fun () ->
         Vitest.expect(FileExplorerDeleteHelper.shouldResetPageStateAfterSelectionRemoval None).toBe(false)
     )
 
-    Vitest.test("isPendingPathAffectedByDelete only clears pending drafts inside deleted targets", fun () ->
-        Vitest.expect(FileExplorerDeleteHelper.isPendingPathAffectedByDelete "assays/AssayA" (Some "assays/AssayA/isa.assay.xlsx")).toBe(true)
-        Vitest.expect(FileExplorerDeleteHelper.isPendingPathAffectedByDelete "assays/AssayA" (Some "assays/AssayB/isa.assay.xlsx")).toBe(false)
-        Vitest.expect(FileExplorerDeleteHelper.isPendingPathAffectedByDelete "assays/AssayA" None).toBe(false)
-    )
 )


### PR DESCRIPTION
- Add of the filetree no longer adds only in-memory. 
- An added target must be written directly onto the disk.
- Delete of the filetree must delete only targets on disk.