### PR TITLE
Git LFS storage-management actions

### DIFF
--- a/docs/GitFunctionalityUserGuide.md
+++ b/docs/GitFunctionalityUserGuide.md
@@ -45,6 +45,9 @@ gitDiscardPaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, str
 gitCommit: GitCommitRequest -> JS.Promise<Result<GitOperationResult, string>>
 setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, string>>
 confirmGitMergeResolution: GitConfirmMergeResolutionRequest -> JS.Promise<Result<GitConfirmMergeResolutionResult, string>>
+gitLfsPrune: unit -> JS.Promise<Result<GitOperationResult, string>>
+gitLfsDedup: unit -> JS.Promise<Result<GitOperationResult, string>>
+gitLfsFreeLocalCopy: GitLfsFreeLocalCopyRequest -> JS.Promise<Result<GitOperationResult, string>>
 ```
 
 Most app code should access these through `GitWorkflow.GitDependencies`, which is populated in `GitStateContext.fs`. That dependency layer maps diff and merge page-load DTOs to `PageState`.
@@ -214,6 +217,7 @@ promise {
 - Remote sync: `fetch`, `previewPull`, `pull`, `push`
 - Local writes: `stagePaths`, `unstagePaths`, `discardPaths`, `commit`, `createBranch`, `checkoutBranch`, `addRemote`
 - LFS settings: `getLfsSettings`, `setLfsSettings`
+- LFS storage maintenance: `pruneLfsCache`, `dedupLfsStorage`, `freeLocalLfsCopy`
 - Merge resolution: `confirmMergeResolution`
 
 `GitProvisioningService.fs` owns path-driven operations that do not require an active ARC:
@@ -225,6 +229,7 @@ promise {
 
 - System install/probe: `installSystem`, `isSystemInstalled`
 - Tracking: `track`, `isTrackedByAttributes`
+- Storage helpers: `storagePruneArgs`, `storageDedupArgs`, `buildFetchRefetchArgs`, `buildLsFilesJsonArgs`, `tryFindListingForPath`
 - Push support: `planOutboundPush`, `uploadObjects`, `collectPushDiagnostics`
 
 `GitAuthAdapter.fs` builds scoped auth config and redacts secrets. `GitTokenProvider.fs` is the process-wide token lookup hook installed by `AuthService`.
@@ -286,6 +291,12 @@ Pull applies `GIT_LFS_SKIP_SMUDGE` when large-file download is disabled. When en
 
 Push uses `GitLfsService.planOutboundPush` to detect outbound LFS pointer objects. If needed, `GitLfsService.uploadObjects` uploads exact object IDs before the git push; if exact upload is unsupported by the installed git-lfs, it falls back to refspec upload.
 
+Additional LFS storage actions:
+
+- "Clean LFS Cache" requires a clean working tree, rejects repositories with custom `lfs.storage`, and runs `git lfs prune --verify-remote --verify-unreachable --when-unverified=halt` through the active ARC. This removes hidden local LFS cache objects only after Git LFS can verify the configured origin remote.
+- "Reduce LFS Storage" requires a clean working tree and runs `git lfs dedup`. It may fail on file systems without copy-on-write support or when Git LFS extensions are configured; this is expected and should be shown to users.
+- "Free local LFS copy" is available from LFS-tracked file context menus. It verifies the file is clean, confirms Git LFS can fetch it from the remote, then replaces the visible full file with the small LFS pointer. The file can be downloaded again with Git LFS pull.
+
 ## 9. Branches and Pull Workflow
 
 `getGitBranches` returns local branches and remote branch refs. The renderer maps remote branch switches to:
@@ -337,6 +348,9 @@ Operations wrapped in `withBusyWriting`:
 - `createBranch`
 - `checkoutBranch`
 - `confirmGitMergeResolution`
+- `gitLfsPrune`
+- `gitLfsDedup`
+- `gitLfsFreeLocalCopy`
 
 Operations not wrapped:
 

--- a/src/Components/src/ARCObjectExplorer/ARCExplorer.fs
+++ b/src/Components/src/ARCObjectExplorer/ARCExplorer.fs
@@ -180,7 +180,7 @@ module ARCExplorer =
             Swate.Components.FileExplorer.FileExplorerGitLfsHelper.toggleLfsMark services.setStatusMessage (services.runToggleLfsMark rootRepoPath)
 
         let contextMenuItems (item: FileItem) =
-            Swate.Components.FileExplorer.FileExplorerGitLfsHelper.contextMenuItems item toggleLfsMark
+            Swate.Components.FileExplorer.FileExplorerGitLfsHelper.contextMenuItems item toggleLfsMark None
 
         let openView item = promise { createOpenPreviewHandler setSelection services item |> Promise.start } |> Promise.start
 

--- a/src/Components/src/FileExplorer/FileExplorer.stories.tsx
+++ b/src/Components/src/FileExplorer/FileExplorer.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { screen, within, expect, userEvent, waitFor, fireEvent } from "storybook/test";
 import { FileExplorer, FileExplorerExample_Example as FileExplorerExample } from "./FileExplorer.fs.js";
+import { contextMenuItems as fileExplorerGitLfsContextMenuItems } from "./FileExplorerGitLfsHelper.fs.js";
 import {
   ContextMenuItem,
   FileItemIcon_Document$,
@@ -105,6 +106,42 @@ const DestructiveContextMenuFileExplorer = () => {
         }
       />
       <div data-testid="context-click-count">Context clicks: {clickCount}</div>
+    </div>
+  );
+};
+
+const LfsContextMenuFileExplorer = () => {
+  const items = React.useMemo(
+    () =>
+      ofArray([
+        Object.assign(
+          FileTree_createFile("Downloaded LFS", "data/downloaded.bin", FileItemIcon_Document$()),
+          { IsLFS: true, Downloaded: true, IsLFSPointer: false },
+        ),
+        Object.assign(
+          FileTree_createFile("Pointer LFS", "data/pointer.bin", FileItemIcon_Document$()),
+          { IsLFS: true, Downloaded: false, IsLFSPointer: true },
+        ),
+        Object.assign(
+          FileTree_createFile("Plain File", "data/plain.txt", FileItemIcon_Document$()),
+          { IsLFS: false, Downloaded: false, IsLFSPointer: false },
+        ),
+      ]),
+    [],
+  );
+
+  return (
+    <div className="swt:p-4">
+      <FileExplorer
+        initialItems={items}
+        onContextMenu={(item) =>
+          fileExplorerGitLfsContextMenuItems(
+            item,
+            () => {},
+            () => {},
+          )
+        }
+      />
     </div>
   );
 };
@@ -215,5 +252,54 @@ export const ContextMenuItemDispatchesAction: StoryObj<typeof DestructiveContext
     await waitFor(() =>
       expect(canvas.getByTestId("context-click-count")).toHaveTextContent("Context clicks: 1"),
     );
+  },
+};
+
+export const LfsContextMenuStates: StoryObj<typeof LfsContextMenuFileExplorer> = {
+  render: () => <LfsContextMenuFileExplorer />,
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const downloadedFile = await canvas.findByText("Downloaded LFS");
+    const downloadedItem = downloadedFile.closest("[data-file-item-id]");
+    await waitFor(() => expect(downloadedItem).toBeTruthy());
+
+    if (!downloadedItem) {
+      throw new Error("Expected downloaded LFS file item.");
+    }
+
+    fireEvent.contextMenu(downloadedItem, { clientX: 30, clientY: 30, bubbles: true });
+    const enabledMenuItem = await screen.findByText("Free local LFS copy");
+    await expect(enabledMenuItem).toBeVisible();
+    await expect(enabledMenuItem).not.toHaveClass("swt:opacity-50");
+
+    await userEvent.click(document.body);
+
+    const pointerFile = await canvas.findByText("Pointer LFS");
+    const pointerItem = pointerFile.closest("[data-file-item-id]");
+    await waitFor(() => expect(pointerItem).toBeTruthy());
+
+    if (!pointerItem) {
+      throw new Error("Expected pointer LFS file item.");
+    }
+
+    fireEvent.contextMenu(pointerItem, { clientX: 30, clientY: 30, bubbles: true });
+    const disabledMenuItem = await screen.findByText("Free local LFS copy");
+    await expect(disabledMenuItem).toBeVisible();
+    await expect(disabledMenuItem).toHaveClass("swt:opacity-50");
+
+    await userEvent.click(document.body);
+
+    const plainFile = await canvas.findByText("Plain File");
+    const plainItem = plainFile.closest("[data-file-item-id]");
+    await waitFor(() => expect(plainItem).toBeTruthy());
+
+    if (!plainItem) {
+      throw new Error("Expected plain file item.");
+    }
+
+    fireEvent.contextMenu(plainItem, { clientX: 30, clientY: 30, bubbles: true });
+    await expect(screen.queryByText("Free local LFS copy")).toBeNull();
   },
 };

--- a/src/Components/src/FileExplorer/FileExplorerGitLfsHelper.fs
+++ b/src/Components/src/FileExplorer/FileExplorerGitLfsHelper.fs
@@ -75,7 +75,7 @@ let contextMenuItems
                     [
                         {
                             Label = "Free local LFS copy"
-                            Icon = "swt:fluent--document-arrow-up-24-regular"
+                            Icon = "swt:fluent--document-arrow-up-20-regular"
                             OnClick = fun () -> freeLocalCopy item
                             Disabled = None
                         }
@@ -84,7 +84,7 @@ let contextMenuItems
                     [
                         {
                             Label = "Free local LFS copy"
-                            Icon = "swt:fluent--document-arrow-up-24-regular"
+                            Icon = "swt:fluent--document-arrow-up-20-regular"
                             OnClick = fun () -> ()
                             Disabled = Some true
                         }

--- a/src/Components/src/FileExplorer/FileExplorerGitLfsHelper.fs
+++ b/src/Components/src/FileExplorer/FileExplorerGitLfsHelper.fs
@@ -23,11 +23,40 @@ let toggleLfsMark
         }
         |> Promise.start
 
-let contextMenuItems (item: FileItem) (onToggleLfsMark: FileItem -> bool -> unit) : ContextMenuItem list =
+let freeLocalLfsCopy
+        (setError: string option -> unit)
+        (runCleanup: string -> JS.Promise<Result<unit, string>>)
+    : (FileItem -> unit) =
+    fun item ->
+        promise {
+            match item.Path with
+            | None -> ()
+            | Some relativePath ->
+                if System.String.IsNullOrWhiteSpace relativePath then
+                    setError (Some "Cannot free the ARC root as a Git LFS file.")
+                elif item.IsLFS <> Some true then
+                    setError (Some $"'{item.Name}' is not marked as a Git LFS file.")
+                elif item.Downloaded <> Some true || item.IsLFSPointer = Some true then
+                    setError (Some $"'{item.Name}' is already stored locally as an LFS pointer.")
+                else
+                    let! result = runCleanup relativePath
+
+                    match result with
+                    | Ok _ -> setError None
+                    | Error msg -> setError (Some $"Git LFS cleanup failed for '{item.Name}': {msg}")
+        }
+        |> Promise.start
+
+let contextMenuItems
+    (item: FileItem)
+    (onToggleLfsMark: FileItem -> bool -> unit)
+    (onFreeLocalLfsCopy: (FileItem -> unit) option)
+    : ContextMenuItem list =
     if item.IsDirectory then
         []
     else
         let isMarked = item.IsLFS = Some true
+        let hasLocalLfsCopy = isMarked && item.Downloaded = Some true && item.IsLFSPointer <> Some true
 
         [
             {
@@ -40,6 +69,27 @@ let contextMenuItems (item: FileItem) (onToggleLfsMark: FileItem -> bool -> unit
                 OnClick = fun () -> onToggleLfsMark item (not isMarked)
                 Disabled = None
             }
+            yield!
+                match onFreeLocalLfsCopy with
+                | Some freeLocalCopy when hasLocalLfsCopy ->
+                    [
+                        {
+                            Label = "Free local LFS copy"
+                            Icon = "swt:fluent--document-arrow-up-24-regular"
+                            OnClick = fun () -> freeLocalCopy item
+                            Disabled = None
+                        }
+                    ]
+                | Some _ when isMarked ->
+                    [
+                        {
+                            Label = "Free local LFS copy"
+                            Icon = "swt:fluent--document-arrow-up-24-regular"
+                            OnClick = fun () -> ()
+                            Disabled = Some true
+                        }
+                    ]
+                | _ -> []
             {
                 Label =
                     if isMarked then

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -782,14 +782,17 @@ type GitSidebar =
                                     "swt:fluent--broom-24-regular",
                                     props.IsBusy,
                                     props.SubmitPruneLfsCache,
-                                    testId = "GitSidebarLfsPruneButton"
+                                    testId = "GitSidebarLfsPruneButton",
+                                    tooltipText =
+                                        "Clean LFS Cache:\n- git lfs prune --verify-remote --verify-unreachable --when-unverified=halt"
                                 )
                                 GitSidebar.ActionButton(
                                     "Reduce LFS Storage",
                                     "swt:fluent--folder-sync-24-regular",
                                     props.IsBusy,
                                     props.SubmitDedupLfsStorage,
-                                    testId = "GitSidebarLfsDedupButton"
+                                    testId = "GitSidebarLfsDedupButton",
+                                    tooltipText = "Reduce LFS Storage:\n- git lfs dedup"
                                 )
                             ]
                         ]

--- a/src/Components/src/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/GitSidebar/GitSidebar.fs
@@ -156,6 +156,8 @@ type private AdvancedActionsProps = {
     OpenSwitchBranchModal: unit -> unit
     CanSwitchBranch: bool
     LfsSettings: LfsSettingsSectionProps
+    SubmitPruneLfsCache: unit -> unit
+    SubmitDedupLfsStorage: unit -> unit
 }
 
 type private CommitSectionProps = {
@@ -774,6 +776,20 @@ type GitSidebar =
                                     props.OpenSwitchBranchModal,
                                     testId = "GitSidebarSwitchBranchButton",
                                     tooltipText = "Switch To Work Copy:\n- git checkout <branch>"
+                                )
+                                GitSidebar.ActionButton(
+                                    "Clean LFS Cache",
+                                    "swt:fluent--broom-24-regular",
+                                    props.IsBusy,
+                                    props.SubmitPruneLfsCache,
+                                    testId = "GitSidebarLfsPruneButton"
+                                )
+                                GitSidebar.ActionButton(
+                                    "Reduce LFS Storage",
+                                    "swt:fluent--folder-sync-24-regular",
+                                    props.IsBusy,
+                                    props.SubmitDedupLfsStorage,
+                                    testId = "GitSidebarLfsDedupButton"
                                 )
                             ]
                         ]
@@ -1728,6 +1744,14 @@ type GitSidebar =
                 onSwitchBranch branchName
                 setActiveDialog ActiveDialog.None
 
+        let submitPruneLfsCache () =
+            setLocalError None
+            callbacks.OnPruneLfsCache()
+
+        let submitDedupLfsStorage () =
+            setLocalError None
+            callbacks.OnDedupLfsStorage()
+
         let hasConflicts = GitSidebarInternal.hasConflicts status changedFiles
         let canEditCommit = not status.IsClean && not hasConflicts && not isBusy
         let markedCount = Set.count markedPaths
@@ -1801,6 +1825,8 @@ type GitSidebar =
                         OpenCreateBranchModal = openCreateBranchModal
                         OpenSwitchBranchModal = openSwitchBranchModal
                         CanSwitchBranch = canSwitchBranch
+                        SubmitPruneLfsCache = submitPruneLfsCache
+                        SubmitDedupLfsStorage = submitDedupLfsStorage
                         LfsSettings = {
                             IsBusy = isBusy
                             LfsThresholdInput = lfsThresholdInput

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -35,6 +35,8 @@ const baseCallbacks = {
   OnCreateBranch: noopWithArg,
   OnSwitchBranch: noopWithBranch,
   OnSelectChange: noopSelectChange,
+  OnPruneLfsCache: noop,
+  OnDedupLfsStorage: noop,
 };
 
 const buildCallbacks = (
@@ -295,6 +297,8 @@ export const AdvancedActions: Story = {
     await expect(canvas.getByTestId("GitSidebarFetchButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPullButton")).toBeInTheDocument();
     await expect(canvas.getByTestId("GitSidebarPushButton")).toBeInTheDocument();
+    await expect(canvas.getByTestId("GitSidebarLfsPruneButton")).toBeVisible();
+    await expect(canvas.getByTestId("GitSidebarLfsDedupButton")).toBeVisible();
     const downloadLargeFilesCheckbox = canvas.getByTestId("GitSidebarDownloadLargeFilesCheckbox");
     const lfsThresholdInput = canvas.getByTestId("GitSidebarLfsThresholdInput");
 

--- a/src/Components/src/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/GitSidebar/GitSidebar.stories.tsx
@@ -347,6 +347,14 @@ export const ActionTooltipsAndResponsiveLabels: Story = {
       "title",
       "Upload Changes:\n- git push origin",
     );
+    await expect(canvas.getByTestId("GitSidebarLfsPruneButton")).toHaveAttribute(
+      "title",
+      "Clean LFS Cache:\n- git lfs prune --verify-remote --verify-unreachable --when-unverified=halt",
+    );
+    await expect(canvas.getByTestId("GitSidebarLfsDedupButton")).toHaveAttribute(
+      "title",
+      "Reduce LFS Storage:\n- git lfs dedup",
+    );
   },
 };
 

--- a/src/Components/src/GitSidebar/Types.fs
+++ b/src/Components/src/GitSidebar/Types.fs
@@ -77,6 +77,8 @@ type GitSidebarCallbacks = {
     OnCreateBranch: GitSidebarCreateBranchRequest -> unit
     OnSwitchBranch: string -> unit
     OnSelectChange: GitSidebarChange -> JS.Promise<Result<unit, string>>
+    OnPruneLfsCache: unit -> unit
+    OnDedupLfsStorage: unit -> unit
 }
 
 [<RequireQualifiedAccess>]

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -73,45 +73,35 @@ module ArcVaultExtensions =
                                     do! this.LoadArc()
                                     sendMsgApi.IsLoadingChanges false
 
-                                    let pathUpdater (path: string) =
-                                        $"{this.path.Value}\{path}"
-                                            .Replace(ArcPathHelper.PathSeperatorWindows, ArcPathHelper.PathSeperator)
+                                    match this.path with
+                                    | None -> ()
+                                    | Some arcPath ->
+                                        let eventPath =
+                                            $"{arcPath}\{path}"
+                                                .Replace(ArcPathHelper.PathSeperatorWindows, ArcPathHelper.PathSeperator)
 
-                                    match eventName.ToLower() with
-                                    | name when name = Chokidar.Events.Add.ToString() ->
-                                        if this.path.IsSome then
-                                            let newPath = pathUpdater path
-                                            let! addedFile = getFileEntryWithLfsMetadata this.path.Value newPath
-                                            let newFileTree = this.fileTree
-                                            newFileTree.Add(addedFile.path, addedFile)
-                                            this.SetFileTree(newFileTree)
-                                    | name when name = Chokidar.Events.AddDir.ToString() ->
-                                        if this.path.IsSome then
-                                            let newPath = pathUpdater path
-                                            let! addedFile = getFileEntry (newPath)
-                                            let newFileTree = this.fileTree
-                                            newFileTree.Add(addedFile.path, addedFile)
-                                            this.SetFileTree(newFileTree)
-                                    | name when name = Chokidar.Events.Unlink.ToString() ->
-                                        let newPath = pathUpdater path
-
-                                        if this.path.IsSome then
-                                            let nextFileTree = removePathAndDescendants newPath this.fileTree
+                                        match eventName.ToLowerInvariant() with
+                                        | name when name = Chokidar.Events.Add.ToString().ToLowerInvariant()
+                                                    || name = Chokidar.Events.Change.ToString().ToLowerInvariant() ->
+                                            let! changedFile = getFileEntryWithLfsMetadata arcPath eventPath
+                                            let nextFileTree = upsertFileEntry changedFile this.fileTree
                                             this.SetFileTree(nextFileTree)
-                                    | name when name = Chokidar.Events.UnlinkDir.ToString() ->
-                                        let newPath = pathUpdater path
-
-                                        if this.path.IsSome then
-                                            let nextFileTree = removePathAndDescendants newPath this.fileTree
+                                        | name when name = Chokidar.Events.AddDir.ToString().ToLowerInvariant() ->
+                                            let! addedDirectory = getFileEntry eventPath
+                                            let nextFileTree = upsertFileEntry addedDirectory this.fileTree
                                             this.SetFileTree(nextFileTree)
-                                    | _ ->
-                                        if this.path.IsSome then
-                                            let! fileEntries = getFileEntries this.path.Value
-                                            let fileTree = createFileEntryTree fileEntries
-                                            this.SetFileTree(fileTree)
+                                        | name when name = Chokidar.Events.Unlink.ToString().ToLowerInvariant()
+                                                    || name = Chokidar.Events.UnlinkDir.ToString().ToLowerInvariant() ->
+                                            let nextFileTree = removePathAndDescendants eventPath this.fileTree
+                                            this.SetFileTree(nextFileTree)
+                                        | _ -> ()
 
                                     this.fileWatcherReloadArcTimeout <- None
                                 }
+                                |> Promise.catch (fun ex ->
+                                    swatelogfn this.window.id "Scheduled ARC reload failed: %s" ex.Message
+                                    sendMsgApi.IsLoadingChanges false
+                                    this.fileWatcherReloadArcTimeout <- None)
                                 |> Promise.start
                             )
                             500

--- a/src/Electron/src/Main/FileTreeCreator.fs
+++ b/src/Electron/src/Main/FileTreeCreator.fs
@@ -78,6 +78,12 @@ let removePathAndDescendants (targetPath: string) (fileTree: Dictionary<string, 
         keysToRemove |> Array.iter (fun path -> nextTree.Remove(path) |> ignore)
         nextTree
 
+/// Add or replace a single file tree entry without mutating the current snapshot.
+let upsertFileEntry (entry: FileEntry) (fileTree: Dictionary<string, FileEntry>) : Dictionary<string, FileEntry> =
+    let nextTree = Dictionary<string, FileEntry>(fileTree)
+    nextTree.[entry.path] <- entry
+    nextTree
+
 let getFileEntry (path: string) = promise {
     let! stats = fs?promises?stat (path)
     return FileEntry.create (pathMod?basename (path), path, stats?isDirectory (), None)

--- a/src/Electron/src/Main/Git/GitLfsService.fs
+++ b/src/Electron/src/Main/Git/GitLfsService.fs
@@ -211,6 +211,39 @@ let tryGetLsFilesByRelativePath (repoRoot: string) : JS.Promise<Dictionary<strin
             return Dictionary<string, GitLfsLsFileInfo>()
     }
 
+let storagePruneArgs =
+    [| "lfs"; "prune"; "--verify-remote"; "--verify-unreachable"; "--when-unverified=halt" |]
+
+let storageDedupArgs = [| "lfs"; "dedup" |]
+
+let buildFetchRefetchArgs (relativePath: string) =
+    [|
+        "lfs"
+        "fetch"
+        "--refetch"
+        $"--include={relativePath}"
+        "origin"
+        "HEAD"
+    |]
+
+let buildLsFilesJsonArgs (relativePath: string) =
+    [| "lfs"; "ls-files"; "-l"; "--size"; "--json"; $"--include={relativePath}" |]
+
+let tryFindListingForPath (relativePath: string) (listingJson: string) : Result<GitLfsLsFileInfo, string> =
+    try
+        let normalizedPath = PathHelpers.normalizeSeparators relativePath
+
+        match
+            listingJson
+            |> parseLsFiles
+            |> Array.tryFind (fun file ->
+                String.Equals(PathHelpers.normalizeSeparators file.name, normalizedPath, StringComparison.Ordinal))
+        with
+        | None -> Error "The file is not listed by Git LFS in the current checkout."
+        | Some file -> Ok { file with name = PathHelpers.normalizeSeparators file.name }
+    with error ->
+        Error $"Could not read Git LFS file metadata: {error.Message}"
+
 let private formatDiagnosticsSection (title: string) (content: string option) =
     match content |> Option.map _.Trim() with
     | Some value when not (String.IsNullOrWhiteSpace value) -> Some $"{title}:\n{redactDiagnosticText value}"

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -424,6 +424,36 @@ let private tryResolveArcRelativePath (arcPath: string) (requestedPath: string) 
         else
             Ok(safeRelativePath, absolutePath)
 
+let private createTemporaryLfsBackupPath (absolutePath: string) =
+    $"{absolutePath}.swate-lfs-backup-{Guid.NewGuid():N}"
+
+let private isPathCleanInStatus (status: StatusResult) (relativePath: string) =
+    valueOrEmptyArray status.files
+    |> Array.exists (fun fileStatus ->
+        String.Equals(fileStatus.path, relativePath, StringComparison.Ordinal)
+        || (fileStatus.``from`` |> Option.exists (fun original -> String.Equals(original, relativePath, StringComparison.Ordinal))))
+    |> not
+
+let private ensureBackupMatchesLfsOid (backupPath: string) (listing: Swate.Electron.Shared.FileIOTypes.GitLfsLsFileInfo) =
+    promise {
+        let! pointerTextResult =
+            runGitCaptured {
+                WorkingDirectory = None
+                Arguments = [| "lfs"; "pointer"; "--file"; backupPath |]
+                Environment = None
+                StandardInput = None
+                TimeoutMs = Some 30000
+            }
+
+        let generatedPointer = $"{pointerTextResult.StdoutText}\n{pointerTextResult.StderrText}"
+
+        return
+            if pointerTextResult.ExitCode = 0 && generatedPointer.Contains($"oid sha256:{listing.oid}") then
+                Ok()
+            else
+                Error(exn "The temporary LFS backup did not match the expected object. The original file was restored.")
+    }
+
 let private isMergeInProgress (arcPath: string) =
     let mergeHeadPath = pathDynamic?resolve (arcPath, ".git", "MERGE_HEAD") |> unbox<string>
     existsSync mergeHeadPath
@@ -1011,6 +1041,38 @@ let private createAuthenticatedGitSession
                             }
     }
 
+let private createOriginLfsRemoteGit
+    (arcPath: string)
+    (progressCallback: GitProgressCallback option)
+    : JS.Promise<GitResult<ISimpleGit>> =
+    promise {
+        let remoteName = "origin"
+        let probeOptions = createOptions arcPath standardTimeout None
+        let probeGit = createGit probeOptions
+
+        let! remoteResult =
+            runSimpleGit
+                (fun git -> promise {
+                    let! remoteUrl = git.raw [| "config"; "--get"; $"remote.{remoteName}.url" |]
+                    return remoteUrl.Trim()
+                })
+                probeGit
+
+        match remoteResult with
+        | Error failure -> return Error failure
+        | Ok remoteUrl ->
+            match ensureAllowedRemoteUrl remoteUrl with
+            | Ok _ ->
+                let! sessionResult = createAuthenticatedGitSession arcPath remoteName progressCallback
+                return sessionResult |> Result.map _.Git
+            | Error _ when remoteUrl.StartsWith("file://", StringComparison.OrdinalIgnoreCase)
+                           || (pathDynamic?isAbsolute(remoteUrl) |> unbox<bool>) ->
+                let options = createOptions arcPath syncTimeout progressCallback
+                return Ok(createGit options)
+            | Error validationError ->
+                return errorResult validationError
+    }
+
 let private ensureRepo (git: ISimpleGit) = promise {
     let! isRepo = git.checkIsRepo ()
 
@@ -1043,6 +1105,31 @@ let private withAuthenticatedGit
         match gitResult with
         | Error failure -> return Error failure
         | Ok session -> return! runSimpleGit operation session.Git
+    }
+
+let private requireCleanWorkingTreeForLfsStorageAction (actionLabel: string) (git: ISimpleGit) =
+    promise {
+        let! status = git.status ()
+
+        return
+            if status.isClean () then
+                Ok()
+            else
+                Error(exn $"{actionLabel} requires a clean working tree. Save, discard, or commit local changes first.")
+    }
+
+let private rejectCustomLfsStorageForPrune (git: ISimpleGit) =
+    promise {
+        let! storageResult =
+            runSimpleGit
+                (fun currentGit -> currentGit.raw [| "config"; "--get"; "lfs.storage" |])
+                git
+
+        return
+            match storageResult with
+            | Ok value when not (String.IsNullOrWhiteSpace(value.Trim())) ->
+                Error(exn "Git LFS prune is disabled because this repository uses a custom lfs.storage directory.")
+            | _ -> Ok()
     }
 
 /// Reads status for the active ARC repository, including conflict metadata used by the sidebar and merge UI.
@@ -1635,6 +1722,43 @@ let setLfsSettings (arcPath: string) (settings: GitLfsSettingsDto) : JS.Promise<
                     })
     }
 
+let pruneLfsCache (arcPath: string) : JS.Promise<GitResult<string>> =
+    promise {
+        let! localValidationResult =
+            withLocalGit
+                arcPath
+                (fun git -> promise {
+                    match! requireCleanWorkingTreeForLfsStorageAction "Cleaning the Git LFS cache" git with
+                    | Error validationError -> return abortGitPromiseWith validationError
+                    | Ok() ->
+                        match! rejectCustomLfsStorageForPrune git with
+                        | Error validationError -> return abortGitPromiseWith validationError
+                        | Ok() -> return ()
+                })
+
+        match localValidationResult with
+        | Error failure -> return Error failure
+        | Ok() ->
+            let! gitResult = createOriginLfsRemoteGit arcPath None
+
+            match gitResult with
+            | Error failure -> return Error failure
+            | Ok git ->
+                let! result = runSimpleGit (fun currentGit -> currentGit.raw GitLfsService.storagePruneArgs) git
+                return result
+    }
+
+let dedupLfsStorage (arcPath: string) : JS.Promise<GitResult<string>> =
+    withLocalGit
+        arcPath
+        (fun git -> promise {
+            match! requireCleanWorkingTreeForLfsStorageAction "Reducing Git LFS duplicate storage" git with
+            | Error validationError -> return abortGitPromiseWith validationError
+            | Ok() ->
+                let! output = git.raw GitLfsService.storageDedupArgs
+                return output
+        })
+
 /// Stages validated pathspecs and auto-tracks oversized selected files in Git LFS before restaging.
 let stagePaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<unit>> = promise {
     match validatePathspecs pathSpecs with
@@ -1711,6 +1835,105 @@ let private discardPathspecsWithOriginals (arcPath: string) (status: StatusResul
 
     Array.append safePathSpecs originalPaths
     |> Array.distinct
+
+let freeLocalLfsCopy
+    (arcPath: string)
+    (requestedPath: string)
+    : JS.Promise<GitResult<unit>> =
+    promise {
+        match tryResolveArcRelativePath arcPath requestedPath with
+        | Error validationError -> return errorResult validationError
+        | Ok(safePath, absolutePath) ->
+            if not (isTrackedByAttributes arcPath safePath) then
+                return errorResult (exn $"'{safePath}' is not tracked by Git LFS.")
+            else
+                let! gitResult = createOriginLfsRemoteGit arcPath None
+
+                match gitResult with
+                | Error failure -> return Error failure
+                | Ok git ->
+                    let! statusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
+
+                    match statusResult with
+                    | Error failure -> return Error failure
+                    | Ok status when not (isPathCleanInStatus status safePath) ->
+                        return
+                            errorResult (
+                                exn $"'{safePath}' has local changes. Save, discard, or commit them before freeing the local LFS copy."
+                            )
+                    | Ok _ ->
+                        let! listingResult =
+                            runSimpleGit
+                                (fun currentGit -> currentGit.raw (GitLfsService.buildLsFilesJsonArgs safePath))
+                                git
+
+                        match listingResult with
+                        | Error failure -> return Error failure
+                        | Ok listingJson ->
+                            match GitLfsService.tryFindListingForPath safePath listingJson with
+                            | Error message -> return errorResult (exn $"'{safePath}' {message}")
+                            | Ok listing when not listing.checkout -> return Ok()
+                            | Ok listing ->
+                                let! fetchResult =
+                                    runSimpleGit
+                                        (fun currentGit -> currentGit.raw (GitLfsService.buildFetchRefetchArgs safePath))
+                                        git
+
+                                match fetchResult with
+                                | Error failure -> return Error failure
+                                | Ok _ ->
+                                    let backupPath = createTemporaryLfsBackupPath absolutePath
+
+                                    try
+                                        renameSync absolutePath backupPath
+
+                                        match! ensureBackupMatchesLfsOid backupPath listing with
+                                        | Error validationError ->
+                                            if existsSync backupPath then
+                                                renameSync backupPath absolutePath
+
+                                            return errorResult validationError
+                                        | Ok() ->
+                                            let pointerGit = git.env (GitLfsSkipSmudgeEnvKey, "1")
+                                            let! checkoutResult =
+                                                runSimpleGit
+                                                    (fun currentGit -> currentGit.raw [| "checkout"; "HEAD"; "--"; safePath |])
+                                                    pointerGit
+
+                                            match checkoutResult with
+                                            | Error failure ->
+                                                if existsSync backupPath then
+                                                    renameSync backupPath absolutePath
+
+                                                return Error failure
+                                            | Ok _ ->
+                                                let! finalStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
+
+                                                match finalStatusResult with
+                                                | Error failure ->
+                                                    if existsSync backupPath then
+                                                        renameSync backupPath absolutePath
+
+                                                    return Error failure
+                                                | Ok finalStatus when not (isPathCleanInStatus finalStatus safePath) ->
+                                                    if existsSync backupPath then
+                                                        renameSync backupPath absolutePath
+
+                                                    return
+                                                        errorResult (
+                                                            exn $"Could not replace '{safePath}' with an LFS pointer without changing Git status."
+                                                        )
+                                                | Ok _ ->
+                                                    if existsSync backupPath then
+                                                        unlinkSync backupPath
+
+                                                    return Ok()
+                                    with ex ->
+                                        if existsSync backupPath then
+                                            renameSync backupPath absolutePath
+
+                                        return errorResult ex
+    }
 
 /// Discards validated pathspecs by restoring tracked paths from HEAD and cleaning selected untracked files.
 let discardPaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<unit>> = promise {

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -377,6 +377,47 @@ let api (event: IpcMainInvokeEvent) : IGitApi = {
 
                 return toGitOperationResult (fun () -> Some "Git LFS settings updated.") None None result
         }
+    gitLfsPrune =
+        fun () -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(vault, arcPath) ->
+                return!
+                    withBusyWriting
+                        vault
+                        (fun () -> promise {
+                            let! result = GitService.pruneLfsCache arcPath
+                            return toGitOperationResult (fun _ -> Some "Hidden Git LFS cache cleaned.") None None result
+                        })
+        }
+    gitLfsDedup =
+        fun () -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(vault, arcPath) ->
+                return!
+                    withBusyWriting
+                        vault
+                        (fun () -> promise {
+                            let! result = GitService.dedupLfsStorage arcPath
+                            return toGitOperationResult (fun _ -> Some "Git LFS deduplication completed.") None None result
+                        })
+        }
+    gitLfsFreeLocalCopy =
+        fun (request: GitLfsFreeLocalCopyRequest) -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(vault, arcPath) ->
+                return!
+                    withBusyWriting
+                        vault
+                        (fun () -> promise {
+                            let! result = GitService.freeLocalLfsCopy arcPath request.Path
+                            if Result.isOk result then
+                                do! vault.RefreshFileTree()
+                            return toGitOperationResult (fun () -> Some $"Freed local LFS copy for '{request.Path}'.") None None result
+                        })
+        }
     createBranch =
         fun (request: GitCreateBranchRequest) -> promise {
             match tryGetVaultAndArcPath event with

--- a/src/Electron/src/Renderer/Components/ARCHelper.fs
+++ b/src/Electron/src/Renderer/Components/ARCHelper.fs
@@ -55,6 +55,20 @@ let runToggleLfsMark (relativePath: string) (markAsLfs: bool) = promise {
         | Error exn -> Error exn.Message
 }
 
+let runFreeLocalLfsCopy (relativePath: string) = promise {
+    let request: GitLfsFreeLocalCopyRequest = {
+        Path = relativePath
+    }
+
+    let! result = Renderer.GitApiClient.gitLfsFreeLocalCopy request
+
+    return
+        match result with
+        | Ok operation when operation.Success -> Ok()
+        | Ok operation -> Error(operation.Message |> Option.defaultValue "Git LFS cleanup failed.")
+        | Error message -> Error message
+}
+
 let private loadViewResult (previewPath: string) = promise {
     let! result = Api.ipcArcVaultApi.openFile previewPath
 

--- a/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
+++ b/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
@@ -2,6 +2,7 @@ module Renderer.Components.FileExplorerDeleteHelper
 
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOHelper
+open Swate.Electron.Shared.FileIOTypes
 
 [<RequireQualifiedAccess>]
 module FileExplorerDeleteHelper =
@@ -30,6 +31,32 @@ module FileExplorerDeleteHelper =
         | Some Renderer.Types.PageState.UnknownPage
         | Some(Renderer.Types.PageState.ErrorPage _) -> true
         | _ -> false
+
+    let private shouldReloadPageStateAfterSelectedFileUpdate (pageState: Renderer.Types.PageState option) =
+        match pageState with
+        | Some(Renderer.Types.PageState.TextPage _)
+        | Some Renderer.Types.PageState.UnknownPage
+        | Some(Renderer.Types.PageState.ErrorPage _) -> true
+        | _ -> false
+
+    let tryGetReloadableSelectedFilePath
+        (fileTree: FileEntry[])
+        (selectionPath: string option)
+        (pageState: Renderer.Types.PageState option)
+        =
+        if shouldReloadPageStateAfterSelectedFileUpdate pageState |> not then
+            None
+        else
+            selectionPath
+            |> Option.map PathHelpers.normalizePath
+            |> Option.bind (fun selectedPath ->
+                fileTree
+                |> Array.tryFind (fun entry ->
+                    not entry.isDirectory
+                    && PathHelpers.pathsEqual (PathHelpers.normalizePath entry.path) selectedPath
+                )
+                |> Option.map (fun entry -> PathHelpers.normalizePath entry.path)
+            )
 
     let isPendingPathAffectedByDelete (deletedPath: string) (pendingPath: string option) =
         let normalizedDeletedPath = normalizeRelativePath deletedPath

--- a/src/Electron/src/Renderer/Components/FileExplorerLfs.fs
+++ b/src/Electron/src/Renderer/Components/FileExplorerLfs.fs
@@ -53,13 +53,27 @@ let createToggleLfsMark
 
     Swate.Components.FileExplorer.FileExplorerGitLfsHelper.toggleLfsMark setError runToggle
 
+let createFreeLocalLfsCopy
+    (enqueueErrorModal: ErrorModalRequest -> unit)
+    (arcScopeId: string option)
+    (runCleanup: string -> JS.Promise<Result<unit, string>>)
+    : (FileItem -> unit) =
+    let setError (errorMsg: string option) =
+        match errorMsg with
+        | Some msg ->
+            enqueueErrorModal (ErrorModalRequest.create(msg, title = "Git LFS cleanup failed", ?scopeId = arcScopeId))
+        | None -> ()
+
+    Swate.Components.FileExplorer.FileExplorerGitLfsHelper.freeLocalLfsCopy setError runCleanup
+
 let withLfsContextMenuItems
     (item: FileItem)
     (toggleLfsMark: FileItem -> bool -> unit)
+    (freeLocalLfsCopy: FileItem -> unit)
     (baseItems: ContextMenuItem list)
     : ContextMenuItem list =
     baseItems
-    @ Swate.Components.FileExplorer.FileExplorerGitLfsHelper.contextMenuItems item toggleLfsMark
+    @ Swate.Components.FileExplorer.FileExplorerGitLfsHelper.contextMenuItems item toggleLfsMark (Some freeLocalLfsCopy)
 
 let createContextMenuItems
     (enqueueErrorModal: ErrorModalRequest -> unit)
@@ -69,4 +83,7 @@ let createContextMenuItems
     let toggleLfsMark =
         createToggleLfsMark enqueueErrorModal arcScopeId Renderer.Components.ARCHelper.runToggleLfsMark
 
-    fun item -> withLfsContextMenuItems item toggleLfsMark (baseItems item)
+    let freeLocalLfsCopy =
+        createFreeLocalLfsCopy enqueueErrorModal arcScopeId Renderer.Components.ARCHelper.runFreeLocalLfsCopy
+
+    fun item -> withLfsContextMenuItems item toggleLfsMark freeLocalLfsCopy (baseItems item)

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
@@ -58,6 +58,7 @@ type FileTree =
         let pendingArcFileSave, setPendingArcFileSave = React.useState<ArcFiles option> None
         let pendingDeleteItem, setPendingDeleteItem = React.useState<FileItem option> None
         let isDeleting, setIsDeleting = React.useState false
+        let hasObservedFileTreeUpdateRef = React.useRef false
 
         let effectiveFileTree =
             React.useMemo (
@@ -179,6 +180,40 @@ type FileTree =
                             Renderer.Components.ARCHelper.applyViewError pageStateCtx.setState fullErrorMessage
             }
             |> Promise.start
+
+        let reloadSelectedPreviewAfterFileTreeUpdate () =
+            match
+                FileExplorerDeleteHelper.tryGetReloadableSelectedFilePath
+                    fileStateCtx.state.FileTree
+                    fileStateCtx.state.Selection.TreePath
+                    pageStateCtx.state
+            with
+            | None -> ()
+            | Some selectedPath ->
+                promise {
+                    let! result = Renderer.Components.ARCHelper.openView selectedPath
+
+                    match result with
+                    | Ok loaded -> Renderer.Components.ARCHelper.applyLoadedView pageStateCtx.setState loaded
+                    | Error errorMessage ->
+                        Renderer.Components.ARCHelper.applyViewError
+                            pageStateCtx.setState
+                            $"Could not reload preview for '{selectedPath}': {errorMessage}"
+                }
+                |> Promise.catch (fun exn ->
+                    Renderer.Components.ARCHelper.applyViewError
+                        pageStateCtx.setState
+                        $"Could not reload preview for '{selectedPath}': {exn.Message}")
+                |> Promise.start
+
+        React.useEffect (
+            (fun () ->
+                if hasObservedFileTreeUpdateRef.current then
+                    reloadSelectedPreviewAfterFileTreeUpdate ()
+                else
+                    hasObservedFileTreeUpdateRef.current <- true),
+            [| box fileStateCtx.state.FileTree |]
+        )
 
         let handleDirectoryArrowToggle (item: FileItem) (willExpand: bool) =
             if willExpand then

--- a/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/GitSidebarPanel.fs
@@ -136,6 +136,8 @@ let Main () =
                 OnCreateBranch = gitStateCtx.createBranch
                 OnSwitchBranch = gitStateCtx.switchBranch
                 OnSelectChange = gitStateCtx.selectChange
+                OnPruneLfsCache = gitStateCtx.pruneLfsCache
+                OnDedupLfsStorage = gitStateCtx.dedupLfsStorage
             },
             downloadLargeFiles = gitStateCtx.state.DownloadLargeFiles,
             lfsAutoTrackThresholdMb = gitStateCtx.state.LfsAutoTrackThresholdMb,

--- a/src/Electron/src/Renderer/Context/GitStateContext.fs
+++ b/src/Electron/src/Renderer/Context/GitStateContext.fs
@@ -34,6 +34,8 @@ type GitStateController = {
     switchBranch: string -> unit
     selectChange: GitSidebarChange -> JS.Promise<Result<unit, string>>
     confirmMergeResolution: GitConfirmMergeResolutionRequest -> unit
+    pruneLfsCache: unit -> unit
+    dedupLfsStorage: unit -> unit
 }
 
 module private Helper =
@@ -84,7 +86,10 @@ module private Helper =
         gitDiscardPaths = Renderer.GitApiClient.gitDiscardPaths
         gitCommit = Renderer.GitApiClient.gitCommit
         setGitLfsSettings = Renderer.GitApiClient.setGitLfsSettings
+        gitLfsPrune = Renderer.GitApiClient.gitLfsPrune
+        gitLfsDedup = Renderer.GitApiClient.gitLfsDedup
         confirmGitMergeResolution = Renderer.GitApiClient.confirmGitMergeResolution
+        confirmLfsPrune = fun message -> window.confirm message
         confirmInstall = fun message -> window.confirm message
     }
 
@@ -112,6 +117,8 @@ let GitStateCtx =
             switchBranch = fun _ -> ()
             selectChange = fun _ -> promise { return Ok() }
             confirmMergeResolution = fun _ -> ()
+            pruneLfsCache = fun () -> ()
+            dedupLfsStorage = fun () -> ()
         }
     )
 
@@ -181,6 +188,12 @@ let GitStateCtxProvider (children: ReactElement) =
     let confirmMergeResolutionAction request =
         dispatch (ConfirmMergeResolutionRequested request)
 
+    let pruneLfsCache () =
+        dispatch PruneLfsCacheRequested
+
+    let dedupLfsStorage () =
+        dispatch DedupLfsStorageRequested
+
     React.useEffect ((fun () -> dispatch (ArcPathChanged appStateCtx)), [| box appStateCtx |])
 
     let gitStateController: GitStateController =
@@ -207,6 +220,8 @@ let GitStateCtxProvider (children: ReactElement) =
                 switchBranch = switchBranchTo
                 selectChange = selectChange
                 confirmMergeResolution = confirmMergeResolutionAction
+                pruneLfsCache = pruneLfsCache
+                dedupLfsStorage = dedupLfsStorage
             }),
             [| box gitState |]
         )

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -32,6 +32,8 @@ type GitBusyOperation =
     | CreatingBranch
     | SwitchingBranch
     | InstallingGitLfs
+    | PruningGitLfsCache
+    | DeduplicatingGitLfsStorage
     | ConfirmingMergeResolution of path: string
 
 [<RequireQualifiedAccess>]
@@ -155,6 +157,8 @@ type WriteRequest =
     | CommitAll of PreparedCommitOperation
     | DiscardSelection of string[]
     | SaveLfsSettings of GitBusyOperation * GitLfsSettingsDto
+    | PruneLfsCache
+    | DedupLfsStorage
     | CreateBranch of GitCreateBranchRequest
     | SwitchBranch of GitCheckoutBranchRequest
 
@@ -205,6 +209,8 @@ type Msg =
     | CancelPendingRemoteActionRequested
     | CreateBranchRequested of GitSidebarCreateBranchRequest
     | SwitchBranchRequested of string
+    | PruneLfsCacheRequested
+    | DedupLfsStorageRequested
     | WriteRequested of WriteRequest
     | WriteCompleted of sessionId: int * WriteRequest * Result<WriteAttemptOutcome, string>
     | WriteInstallPromptAnswered of sessionId: int * WriteRequest * bool
@@ -232,8 +238,11 @@ type GitDependencies = {
     gitDiscardPaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitCommit: GitCommitRequest -> JS.Promise<Result<GitOperationResult, string>>
     setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, string>>
+    gitLfsPrune: unit -> JS.Promise<Result<GitOperationResult, string>>
+    gitLfsDedup: unit -> JS.Promise<Result<GitOperationResult, string>>
     confirmGitMergeResolution:
         GitConfirmMergeResolutionRequest -> JS.Promise<Result<GitConfirmMergeResolutionResult, string>>
+    confirmLfsPrune: string -> bool
     confirmInstall: string -> bool
 }
 
@@ -270,6 +279,8 @@ let busyNoticeFromOperation =
     | GitBusyOperation.CreatingBranch -> Some "Creating branch"
     | GitBusyOperation.SwitchingBranch -> Some "Switching branch"
     | GitBusyOperation.InstallingGitLfs -> Some "Installing Git LFS"
+    | GitBusyOperation.PruningGitLfsCache -> Some "Cleaning Git LFS cache"
+    | GitBusyOperation.DeduplicatingGitLfsStorage -> Some "Reducing Git LFS duplicate storage"
     | GitBusyOperation.ConfirmingMergeResolution _ -> Some "Confirming merge resolution"
 
 let currentRunStatus (model: GitState) =
@@ -572,6 +583,8 @@ let private busyOperationForWriteRequest =
     | CommitAll prepared -> prepared.BusyOperation
     | DiscardSelection _ -> GitBusyOperation.DiscardingSelectedChanges
     | SaveLfsSettings(busyOperation, _) -> busyOperation
+    | PruneLfsCache -> GitBusyOperation.PruningGitLfsCache
+    | DedupLfsStorage -> GitBusyOperation.DeduplicatingGitLfsStorage
     | CreateBranch _ -> GitBusyOperation.CreatingBranch
     | SwitchBranch _ -> GitBusyOperation.SwitchingBranch
 
@@ -868,6 +881,18 @@ let private executeWriteAttempt (deps: GitDependencies) (state: GitState) (reque
     | CommitAll prepared -> return! runCommitAttemptAsync deps prepared
     | DiscardSelection paths -> return! runDiscardAttemptAsync deps paths
     | SaveLfsSettings(busyOperation, settings) -> return! runSaveLfsSettingsAttemptAsync deps busyOperation settings
+    | PruneLfsCache ->
+        return!
+            runSimpleWriteAttemptAsync
+                deps
+                GitBusyOperation.PruningGitLfsCache
+                deps.gitLfsPrune
+    | DedupLfsStorage ->
+        return!
+            runSimpleWriteAttemptAsync
+                deps
+                GitBusyOperation.DeduplicatingGitLfsStorage
+                deps.gitLfsDedup
     | CreateBranch request ->
         return! runSimpleWriteAttemptAsync deps GitBusyOperation.CreatingBranch (fun () -> deps.createBranch request)
     | SwitchBranch request ->
@@ -1323,6 +1348,16 @@ let update
                 | _ -> None, normalizedBranchName
 
             model, Cmd.ofMsg (WriteRequested(SwitchBranch { Name = localName; StartPoint = startPoint }))
+    | PruneLfsCacheRequested ->
+        let message =
+            "This cleans hidden Git LFS cache files for the current ARC. Files that are still needed can be downloaded again from the remote. Continue?"
+
+        if deps.confirmLfsPrune message then
+            model, Cmd.ofMsg (WriteRequested PruneLfsCache)
+        else
+            model, Cmd.none
+    | DedupLfsStorageRequested ->
+        model, Cmd.ofMsg (WriteRequested DedupLfsStorage)
     | WriteRequested request when requiresArcForWriteRequest request && model.CurrentArcPath.IsNone -> model, Cmd.none
     | WriteRequested request ->
         let nextModel =

--- a/src/Electron/src/Renderer/GitApiClient.fs
+++ b/src/Electron/src/Renderer/GitApiClient.fs
@@ -100,3 +100,12 @@ let setGitLfsSettings (settings: GitLfsSettingsDto) =
 
 let confirmGitMergeResolution (request: GitConfirmMergeResolutionRequest) =
     callIpcWith request (gitApi.confirmGitMergeResolution)
+
+let gitLfsPrune () =
+    callIpc (fun () -> gitApi.gitLfsPrune ())
+
+let gitLfsDedup () =
+    callIpc (fun () -> gitApi.gitLfsDedup ())
+
+let gitLfsFreeLocalCopy (request: GitLfsFreeLocalCopyRequest) =
+    callIpcWith request (gitApi.gitLfsFreeLocalCopy)

--- a/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
@@ -149,6 +149,8 @@ type GitCloneRepositoryRequest = {
 
 type GitPathspecRequest = { Pathspecs: string[] }
 
+type GitLfsFreeLocalCopyRequest = { Path: string }
+
 type GitCommitRequest = { Message: string }
 
 type GitLfsSettingsDto = {

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -78,6 +78,9 @@ type IGitApi = {
     gitDiscardPaths: GitPathspecRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitCommit: GitCommitRequest -> JS.Promise<Result<GitOperationResult, exn>>
     setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, exn>>
+    gitLfsPrune: unit -> JS.Promise<Result<GitOperationResult, exn>>
+    gitLfsDedup: unit -> JS.Promise<Result<GitOperationResult, exn>>
+    gitLfsFreeLocalCopy: GitLfsFreeLocalCopyRequest -> JS.Promise<Result<GitOperationResult, exn>>
     createBranch: GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, exn>>
     checkoutBranch: GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, exn>>
     confirmGitMergeResolution:

--- a/tests/Electron.Core/FileTreeCompaction.test.fs
+++ b/tests/Electron.Core/FileTreeCompaction.test.fs
@@ -147,3 +147,53 @@ Vitest.describe("FileTreeCreator.removePathAndDescendants", fun () ->
         Vitest.expect(updatedTree.ContainsKey("C:/arc/assays/AB/isa.assay.xlsx")).toBe(true)
     )
 )
+
+Vitest.describe("FileTreeCreator.upsertFileEntry", fun () ->
+    let createFileEntry path isDirectory lfs = {
+        name =
+            path
+            |> Swate.Components.Shared.PathHelpers.normalizePath
+            |> Swate.Components.Shared.PathHelpers.getFileName
+        isDirectory = isDirectory
+        path = path
+        lfs = lfs
+    }
+
+    let pointerInfo: GitLfsLsFileInfo = {
+        name = "data.bin"
+        size = 128.0
+        checkout = false
+        downloaded = false
+        ``oid_type`` = "sha256"
+        oid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        version = "https://git-lfs.github.com/spec/v1"
+    }
+
+    Vitest.test("replaces an existing file entry without throwing", fun () ->
+        let tree = Dictionary<string, FileEntry>()
+        tree.Add("C:/arc/data.bin", createFileEntry "C:/arc/data.bin" false None)
+        tree.Add("C:/arc/other.bin", createFileEntry "C:/arc/other.bin" false None)
+
+        let updatedTree =
+            FileTreeCreator.upsertFileEntry
+                (createFileEntry "C:/arc/data.bin" false (Some pointerInfo))
+                tree
+
+        Vitest.expect(updatedTree.Count).toBe(2)
+        Vitest.expect(updatedTree.["C:/arc/data.bin"].lfs).toEqual(Some pointerInfo)
+        Vitest.expect(updatedTree.ContainsKey("C:/arc/other.bin")).toBe(true)
+    )
+
+    Vitest.test("returns a new dictionary instead of mutating the current file tree", fun () ->
+        let tree = Dictionary<string, FileEntry>()
+        tree.Add("C:/arc/data.bin", createFileEntry "C:/arc/data.bin" false None)
+
+        let updatedTree =
+            FileTreeCreator.upsertFileEntry
+                (createFileEntry "C:/arc/data.bin" false (Some pointerInfo))
+                tree
+
+        Vitest.expect(tree.["C:/arc/data.bin"].lfs).toEqual(None)
+        Vitest.expect(updatedTree.["C:/arc/data.bin"].lfs).toEqual(Some pointerInfo)
+    )
+)

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -325,6 +325,37 @@ let private withTempRepository (testBody: TempRepositoryContext -> JS.Promise<un
         return raise error
 }
 
+let private setupCommittedPushedLfsFile
+    (context: TempRepositoryContext)
+    (fileName: string)
+    (content: string)
+    : JS.Promise<string> =
+    promise {
+        let remotePath = join [| context.RootPath; "remote-lfs.git" |]
+        let filePath = join [| context.RepoPath; fileName |]
+
+        let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
+        let! _ = context.Git.raw [| "remote"; "add"; "origin"; remotePath |]
+        let! _ = context.Git.raw [| "lfs"; "install"; "--local" |]
+        let! _ = context.Git.raw [| "lfs"; "track"; "*.bin" |]
+
+        do!
+            writeUtf8FileAsync
+                (join [| context.RepoPath; ".gitattributes" |])
+                "*.bin filter=lfs diff=lfs merge=lfs -text\n"
+
+        do! writeUtf8FileAsync filePath content
+
+        let! _ = context.Git.raw [| "add"; ".gitattributes"; fileName |]
+        let! _ = context.Git.raw [| "commit"; "-m"; "test: add lfs file" |]
+
+        let! currentBranch = context.Git.raw [| "branch"; "--show-current" |]
+        let branchName = currentBranch.Trim()
+        let! _ = context.Git.raw [| "push"; "-u"; "origin"; branchName |]
+
+        return remotePath
+    }
+
 let private commitWorkflowFilePath = "notes/workflow.txt"
 let private featureBranchName = "feature/local-workflow"
 let private initialCommitMessage = "test: initial commit"
@@ -2060,6 +2091,204 @@ Vitest.describe (
                         | Error _ -> ()
                     })
             }
+        )
+
+        Vitest.describe ("GitService.freeLocalLfsCopy", fun () ->
+            Vitest.test (
+                "freeLocalLfsCopy replaces a clean checked-out LFS file with a pointer",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            let! _ = setupCommittedPushedLfsFile context "data.bin" (String.replicate 4096 "x")
+
+                            let! result = GitService.freeLocalLfsCopy context.RepoPath "data.bin"
+                            expectOk "free local lfs copy" result |> ignore
+
+                            let! statusAfterCleanup =
+                                unwrapResultAsync
+                                    (GitService.getStatus context.RepoPath)
+                                    (expectOk "git status after lfs cleanup")
+
+                            Vitest.expect(statusAfterCleanup.Files.Length).toBe(0)
+
+                            let! listing =
+                                context.Git.raw [| "lfs"; "ls-files"; "-l"; "--size"; "--json"; "--include=data.bin" |]
+
+                            Vitest.expect(listing.Contains("\"checkout\": false")).toBe(true)
+                        })
+                }
+            )
+
+            Vitest.test (
+                "freeLocalLfsCopy rejects dirty files and keeps the full local file",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            let filePath = join [| context.RepoPath; "data.bin" |]
+                            let! _ = setupCommittedPushedLfsFile context "data.bin" (String.replicate 4096 "x")
+
+                            do! writeUtf8FileAsync filePath "changed locally\n"
+
+                            let! result = GitService.freeLocalLfsCopy context.RepoPath "data.bin"
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("local changes")).toBe(true)
+
+                            let! statusAfterFailure =
+                                unwrapResultAsync
+                                    (GitService.getStatus context.RepoPath)
+                                    (expectOk "git status after failed lfs cleanup")
+
+                            Vitest.expect(statusAfterFailure.Files.Length).toBeGreaterThan(0)
+                        })
+                }
+            )
+
+            Vitest.test (
+                "freeLocalLfsCopy rejects staged changes and keeps the staged file content",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            let filePath = join [| context.RepoPath; "data.bin" |]
+                            let! _ = setupCommittedPushedLfsFile context "data.bin" (String.replicate 4096 "x")
+
+                            do! writeUtf8FileAsync filePath "staged change\n"
+                            let! _ = context.Git.raw [| "add"; "data.bin" |]
+
+                            let! result = GitService.freeLocalLfsCopy context.RepoPath "data.bin"
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("local changes")).toBe(true)
+
+                            let! contentAfter =
+                                fsPromisesDynamic?readFile (filePath, "utf8")
+                                |> unbox<JS.Promise<string>>
+
+                            Vitest.expect(contentAfter).toBe("staged change\n")
+                        })
+                }
+            )
+
+            Vitest.test (
+                "freeLocalLfsCopy rejects an invalid path traversal request",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            let! result = GitService.freeLocalLfsCopy context.RepoPath "../outside.bin"
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("traversal")).toBe(true)
+                        })
+                }
+            )
+
+            Vitest.test (
+                "freeLocalLfsCopy rejects a file that is not tracked by LFS",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            let plainPath = join [| context.RepoPath; "plain.txt" |]
+                            do! writeUtf8FileAsync plainPath "plain text\n"
+                            let! _ = context.Git.raw [| "add"; "plain.txt" |]
+                            let! _ = context.Git.raw [| "commit"; "-m"; "test: add plain file" |]
+
+                            let! result = GitService.freeLocalLfsCopy context.RepoPath "plain.txt"
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("not tracked")).toBe(true)
+                        })
+                }
+            )
+        )
+
+        Vitest.describe ("GitService LFS storage maintenance", fun () ->
+            Vitest.test (
+                "pruneLfsCache rejects a dirty working tree",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            do! writeUtf8FileAsync (join [| context.RepoPath; "untracked.txt" |]) "dirty\n"
+
+                            let! result = GitService.pruneLfsCache context.RepoPath
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("clean working tree")).toBe(true)
+                        })
+                }
+            )
+
+            Vitest.test (
+                "pruneLfsCache rejects repositories with custom lfs.storage",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            do! writeUtf8FileAsync (join [| context.RepoPath; "file.txt" |]) "content\n"
+                            let! _ = context.Git.raw [| "add"; "file.txt" |]
+                            let! _ = context.Git.raw [| "commit"; "-m"; "test: initial" |]
+                            let! _ = context.Git.raw [| "config"; "lfs.storage"; "custom-lfs" |]
+
+                            let! result = GitService.pruneLfsCache context.RepoPath
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("lfs.storage")).toBe(true)
+                        })
+                }
+            )
+
+            Vitest.test (
+                "pruneLfsCache reports origin verification failures",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            do! writeUtf8FileAsync (join [| context.RepoPath; "file.txt" |]) "content\n"
+                            let! _ = context.Git.raw [| "add"; "file.txt" |]
+                            let! _ = context.Git.raw [| "commit"; "-m"; "test: initial" |]
+
+                            let! result = GitService.pruneLfsCache context.RepoPath
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("Remote URL is empty.")).toBe(true)
+                        })
+                }
+            )
+
+            Vitest.test (
+                "dedupLfsStorage rejects a dirty working tree",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            do! writeUtf8FileAsync (join [| context.RepoPath; "untracked.txt" |]) "dirty\n"
+
+                            let! result = GitService.dedupLfsStorage context.RepoPath
+                            let failure = expectError result
+                            Vitest.expect(failure.Message.Contains("clean working tree")).toBe(true)
+                        })
+                }
+            )
+
+            Vitest.test (
+                "dedupLfsStorage returns either success or an Unknown failure with a message",
+                gitLfsIntegrationTestOptions,
+                fun () -> promise {
+                    do!
+                        withTempRepository (fun context -> promise {
+                            do! writeUtf8FileAsync (join [| context.RepoPath; "file.txt" |]) "content\n"
+                            let! _ = context.Git.raw [| "add"; "file.txt" |]
+                            let! _ = context.Git.raw [| "commit"; "-m"; "test: initial" |]
+                            let! _ = context.Git.raw [| "lfs"; "install"; "--local" |]
+
+                            let! result = GitService.dedupLfsStorage context.RepoPath
+
+                            match result with
+                            | Ok _ -> Vitest.expect(true).toBe(true)
+                            | Error failure ->
+                                Vitest.expect(failure.Kind).toEqual(GitFailureKind.Unknown)
+                                Vitest.expect(String.IsNullOrWhiteSpace(failure.Message)).toBe(false)
+                        })
+                }
+            )
         )
 
         Vitest.test (

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -107,6 +107,20 @@ Vitest.describe("IPC architecture review fixes", fun () ->
                     "ArcDeleteHelper.mergeReloadedArcAfterDelete"
                 |]
         })
+
+    Vitest.test("Git LFS storage management is exposed through IGitApi only", fun () ->
+        promise {
+            let! ipcTypesSource = sourcePath [| "Swate.Electron.Shared"; "IPCTypes.fs" |] |> readUtf8FileAsync
+
+            expectSourceContainsInOrder
+                ipcTypesSource
+                [|
+                    "setGitLfsSettings: GitLfsSettingsDto -> JS.Promise<Result<GitOperationResult, exn>>"
+                    "gitLfsPrune: unit -> JS.Promise<Result<GitOperationResult, exn>>"
+                    "gitLfsDedup: unit -> JS.Promise<Result<GitOperationResult, exn>>"
+                    "gitLfsFreeLocalCopy: GitLfsFreeLocalCopyRequest -> JS.Promise<Result<GitOperationResult, exn>>"
+                |]
+        })
 )
 
 Vitest.describe("ArcDeleteHelper merge and validation", fun () ->

--- a/tests/Electron.Renderer/FileStateContextReload.test.fs
+++ b/tests/Electron.Renderer/FileStateContextReload.test.fs
@@ -145,4 +145,51 @@ Vitest.describe("FileExplorer delete helpers", fun () ->
         Vitest.expect(FileExplorerDeleteHelper.isPendingPathAffectedByDelete "assays/AssayA" (Some "assays/AssayB/isa.assay.xlsx")).toBe(false)
         Vitest.expect(FileExplorerDeleteHelper.isPendingPathAffectedByDelete "assays/AssayA" None).toBe(false)
     )
+
+    Vitest.test("tryGetReloadableSelectedFilePath returns selected text previews after file-tree updates", fun () ->
+        let fileTree = [|
+            FileEntry.create("data.quant", "data.quant", false, None)
+            FileEntry.create("assays", "assays", true, None)
+        |]
+
+        let reloadPath =
+            FileExplorerDeleteHelper.tryGetReloadableSelectedFilePath
+                fileTree
+                (Some "data.quant")
+                (Some(PageState.TextPage "old content"))
+
+        Vitest.expect(reloadPath).toEqual(Some "data.quant")
+    )
+
+    Vitest.test("tryGetReloadableSelectedFilePath skips directories, missing selections, and editable ARC previews", fun () ->
+        let assay =
+            ArcAssay.init "SelectedAssay"
+            |> Swate.Components.Shared.ARCtrlHelper.ArcFiles.Assay
+
+        let fileTree = [|
+            FileEntry.create("isa.assay.xlsx", "assays/SelectedAssay/isa.assay.xlsx", false, None)
+            FileEntry.create("assays", "assays", true, None)
+        |]
+
+        Vitest.expect(
+            FileExplorerDeleteHelper.tryGetReloadableSelectedFilePath
+                fileTree
+                (Some "assays")
+                (Some(PageState.TextPage "old content"))
+        ).toEqual(None)
+
+        Vitest.expect(
+            FileExplorerDeleteHelper.tryGetReloadableSelectedFilePath
+                fileTree
+                (Some "missing.txt")
+                (Some(PageState.TextPage "old content"))
+        ).toEqual(None)
+
+        Vitest.expect(
+            FileExplorerDeleteHelper.tryGetReloadableSelectedFilePath
+                fileTree
+                (Some "assays/SelectedAssay/isa.assay.xlsx")
+                (Some(PageState.ArcFilePage assay))
+        ).toEqual(None)
+    )
 )

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -298,6 +298,8 @@ let private noopCallbacks: GitSidebarCallbacks = {
     OnCreateBranch = fun _ -> ()
     OnSwitchBranch = fun _ -> ()
     OnSelectChange = fun _ -> promise { return Ok() }
+    OnPruneLfsCache = fun () -> ()
+    OnDedupLfsStorage = fun () -> ()
 }
 
 Vitest.afterEach (fun () -> document.body.innerHTML <- "")
@@ -1986,6 +1988,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2064,6 +2068,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5,
@@ -2118,6 +2124,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2168,6 +2176,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2221,6 +2231,8 @@ Vitest.describe (
                                         OnCreateBranch = fun _ -> ()
                                         OnSwitchBranch = fun _ -> ()
                                         OnSelectChange = fun _ -> promise { return Ok() }
+                                        OnPruneLfsCache = fun () -> ()
+                                        OnDedupLfsStorage = fun () -> ()
                                     },
                                     downloadLargeFiles = true,
                                     lfsAutoTrackThresholdMb = 5
@@ -2303,6 +2315,8 @@ Vitest.describe (
                                         OnCreateBranch = fun _ -> ()
                                         OnSwitchBranch = fun _ -> ()
                                         OnSelectChange = fun _ -> promise { return Ok() }
+                                        OnPruneLfsCache = fun () -> ()
+                                        OnDedupLfsStorage = fun () -> ()
                                     },
                                     downloadLargeFiles = true,
                                     lfsAutoTrackThresholdMb = 5
@@ -2388,6 +2402,8 @@ Vitest.describe (
                                                         OnCreateBranch = fun _ -> ()
                                                         OnSwitchBranch = fun _ -> ()
                                                         OnSelectChange = fun _ -> promise { return Ok() }
+                                                        OnPruneLfsCache = fun () -> ()
+                                                        OnDedupLfsStorage = fun () -> ()
                                                     },
                                                     downloadLargeFiles = true,
                                                     lfsAutoTrackThresholdMb = 5
@@ -2452,6 +2468,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2509,6 +2527,8 @@ Vitest.describe (
                                         OnCreateBranch = fun _ -> ()
                                         OnSwitchBranch = fun _ -> ()
                                         OnSelectChange = fun _ -> promise { return Ok() }
+                                        OnPruneLfsCache = fun () -> ()
+                                        OnDedupLfsStorage = fun () -> ()
                                     },
                                     downloadLargeFiles = true,
                                     lfsAutoTrackThresholdMb = 5
@@ -2559,6 +2579,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2678,6 +2700,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2755,6 +2779,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2832,6 +2858,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Error "Diff failed to load." }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2886,6 +2914,8 @@ Vitest.describe (
                                 OnCreateBranch = fun _ -> ()
                                 OnSwitchBranch = fun _ -> ()
                                 OnSelectChange = fun _ -> promise { return Ok() }
+                                OnPruneLfsCache = fun () -> ()
+                                OnDedupLfsStorage = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -251,6 +251,9 @@ let private defaultDependencies: GitDependencies = {
     gitCommit = fun _ -> unexpectedPromise "gitCommit"
     setGitLfsSettings = fun _ -> unexpectedPromise "setGitLfsSettings"
     confirmGitMergeResolution = fun _ -> unexpectedPromise "confirmGitMergeResolution"
+    gitLfsPrune = fun () -> unexpectedPromise "gitLfsPrune"
+    gitLfsDedup = fun () -> unexpectedPromise "gitLfsDedup"
+    confirmLfsPrune = fun message -> failwith $"Unexpected LFS prune confirmation: {message}"
     confirmInstall = fun message -> failwith $"Unexpected install prompt: {message}"
 }
 
@@ -421,6 +424,53 @@ Vitest.describe (
                     Vitest.expect(hasOwnProperty body "path").toBe(false)
                 finally
                     cleanupGitLabCreateProjectFetchSpy ()
+            }
+        )
+)
+
+Vitest.describe (
+    "GitWorkflow LFS storage maintenance",
+    fun () ->
+        Vitest.test (
+            "PruneLfsCacheRequested asks for confirmation before running prune",
+            fun () -> promise {
+                let mutable confirmedMessage = None
+
+                let deps = {
+                    defaultDependencies with
+                        confirmLfsPrune =
+                            fun message ->
+                                confirmedMessage <- Some message
+                                true
+                        gitLfsPrune = fun () -> promise { return Ok okOperationResult }
+                }
+
+                let model = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        ArcSessionId = 1
+                }
+
+                let nextModel, cmd = update deps ignore PruneLfsCacheRequested model
+                let! _ = collectMessages cmd
+
+                Vitest.expect(confirmedMessage.IsSome).toBe(true)
+                Vitest.expect(nextModel.BusyOperation).toBe(None)
+            }
+        )
+
+        Vitest.test (
+            "DedupLfsStorageRequested starts dedup write operation",
+            fun () -> promise {
+                let model = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        ArcSessionId = 1
+                }
+
+                let nextModel, _cmd = update defaultDependencies ignore (WriteRequested DedupLfsStorage) model
+
+                Vitest.expect(nextModel.BusyOperation).toEqual(Some GitBusyOperation.DeduplicatingGitLfsStorage)
             }
         )
 )


### PR DESCRIPTION
## Summary

Solves issue https://github.com/nfdi4plants/Swate/issues/1074.
Adds Git LFS storage-management actions to the Electron app:

- repository-wide `git lfs prune` support from the Git sidebar
- repository-wide `git lfs dedup` support from the Git sidebar
  - <img width="497" height="232" alt="image" src="https://github.com/user-attachments/assets/48a9ce3b-dd2a-4971-a0e9-34b551579a95" />
- per-file "Free local LFS copy" from the left file-tree context menu
  - <img width="592" height="161" alt="image" src="https://github.com/user-attachments/assets/3cabf5d4-890f-40bc-b2eb-29034455eae1" />

The implementation keeps all Git/LFS execution in Electron Main, exposes the new actions through `IGitApi`, and wires them into the existing renderer workflow and reusable component helpers.

## What Changed

### Shared and IPC contracts

- Added `GitLfsFreeLocalCopyRequest`
- Added new `IGitApi` endpoints:
  - `gitLfsPrune`
  - `gitLfsDedup`
  - `gitLfsFreeLocalCopy`

### Main Git/LFS services

- Added LFS storage command helpers in `GitLfsService`
- Reused the existing typed `git lfs ls-files --json` parsing path
- Added `GitService` orchestration for:
  - `pruneLfsCache`
  - `dedupLfsStorage`
  - `freeLocalLfsCopy`

### Safety and validation

- Prune and dedup require a clean working tree
- Dedup verifies that the OS supports the command
  - <img width="494" height="551" alt="image" src="https://github.com/user-attachments/assets/81843306-ab4a-46c3-ba96-9b3ba148feca" />
- Prune rejects repos with a custom `lfs.storage`
- Prune verifies against configured `origin`
- Per-file cleanup:
  - validates the requested path
  - rejects dirty/staged/conflicted paths
  - confirms the file is LFS-tracked
  - verifies the local backup matches the expected LFS object
  - restores the original file on failure
  - replaces the working file with the LFS pointer using `GIT_LFS_SKIP_SMUDGE=1`

### Renderer workflow and UI

- Added renderer workflow messages and busy states for prune/dedup
- Exposed new actions through `GitStateContext`
- Added Git sidebar actions under "More Git Actions":
  - `Clean LFS Cache`
  - `Reduce LFS Storage`
- Added reusable file-tree context-menu support for:
  - `Free local LFS copy`

### Documentation

- Updated `docs/GitFunctionalityUserGuide.md` to describe the new renderer API, Main service ownership, LFS behavior, and busy-write coverage


## Notes

- The per-file cleanup action is wired through `Renderer.Components.FileExplorerLfs`, which matches the current left-sidebar composition on this branch.
- `ARCExplorer.fs` was updated only to satisfy the helper signature change without changing its behavior.