### PR TITLE
Add rename button to context menu filetree and filetree row

### DIFF
--- a/src/Components/src/FileExplorer/FileExplorer.fs
+++ b/src/Components/src/FileExplorer/FileExplorer.fs
@@ -114,6 +114,8 @@ type FileExplorer =
             ?onContextMenu: FileItem -> Swate.Components.FileExplorer.Types.ContextMenuItem list,
             ?canCreateItem: FileItem -> bool,
             ?onCreateItem: FileItem -> unit,
+            ?canRenameItem: FileItem -> bool,
+            ?onRenameItem: FileItem -> unit,
             ?canDeleteItem: FileItem -> bool,
             ?onDeleteItem: FileItem -> unit,
             ?selectedItemId: string option,
@@ -131,6 +133,7 @@ type FileExplorer =
         let showBreadcrumbs = defaultArg showBreadcrumbs true
         let getItemIconClass = defaultArg getItemIconClass (fun _ -> None)
         let canCreateItem = defaultArg canCreateItem (fun (_: FileItem) -> false)
+        let canRenameItem = defaultArg canRenameItem (fun (_: FileItem) -> false)
         let canDeleteItem = defaultArg canDeleteItem (fun (_: FileItem) -> false)
         let includeSelectedDirectoryInVisiblePath =
             directoryInteractionMode = DirectoryInteractionMode.SingleClickToggle
@@ -253,6 +256,8 @@ type FileExplorer =
                     ),
                     ?onCreateItem = onCreateItem,
                     canCreateItem = canCreateItem,
+                    ?onRenameItem = onRenameItem,
+                    canRenameItem = canRenameItem,
                     ?onDeleteItem = onDeleteItem,
                     canDeleteItem = canDeleteItem,
                     ?children = childrenTree
@@ -264,6 +269,8 @@ type FileExplorer =
                     selectedNameClass,
                     getItemIconClass,
                     (fun () -> Swate.Components.FileExplorer.Helper.handleItemClick item onItemClick dispatch),
+                    ?onRenameItem = onRenameItem,
+                    canRenameItem = canRenameItem,
                     ?onDeleteItem = onDeleteItem,
                     canDeleteItem = canDeleteItem
                 )

--- a/src/Components/src/FileExplorer/FileExplorer.fs
+++ b/src/Components/src/FileExplorer/FileExplorer.fs
@@ -114,8 +114,7 @@ type FileExplorer =
             ?onContextMenu: FileItem -> Swate.Components.FileExplorer.Types.ContextMenuItem list,
             ?canCreateItem: FileItem -> bool,
             ?onCreateItem: FileItem -> unit,
-            ?canRenameItem: FileItem -> bool,
-            ?onRenameItem: FileItem -> unit,
+            ?getItemActions: FileItem -> Swate.Components.FileExplorer.Types.ContextMenuItem list,
             ?canDeleteItem: FileItem -> bool,
             ?onDeleteItem: FileItem -> unit,
             ?selectedItemId: string option,
@@ -133,7 +132,7 @@ type FileExplorer =
         let showBreadcrumbs = defaultArg showBreadcrumbs true
         let getItemIconClass = defaultArg getItemIconClass (fun _ -> None)
         let canCreateItem = defaultArg canCreateItem (fun (_: FileItem) -> false)
-        let canRenameItem = defaultArg canRenameItem (fun (_: FileItem) -> false)
+        let getItemActions = defaultArg getItemActions (fun (_: FileItem) -> [])
         let canDeleteItem = defaultArg canDeleteItem (fun (_: FileItem) -> false)
         let includeSelectedDirectoryInVisiblePath =
             directoryInteractionMode = DirectoryInteractionMode.SingleClickToggle
@@ -225,6 +224,8 @@ type FileExplorer =
                 | Some children -> not (List.isEmpty children)
                 | None -> true
 
+            let itemActions = getItemActions item
+
             if item.IsDirectory then
                 let childrenTree =
                     if isExpanded then
@@ -256,8 +257,7 @@ type FileExplorer =
                     ),
                     ?onCreateItem = onCreateItem,
                     canCreateItem = canCreateItem,
-                    ?onRenameItem = onRenameItem,
-                    canRenameItem = canRenameItem,
+                    itemActions = itemActions,
                     ?onDeleteItem = onDeleteItem,
                     canDeleteItem = canDeleteItem,
                     ?children = childrenTree
@@ -269,8 +269,7 @@ type FileExplorer =
                     selectedNameClass,
                     getItemIconClass,
                     (fun () -> Swate.Components.FileExplorer.Helper.handleItemClick item onItemClick dispatch),
-                    ?onRenameItem = onRenameItem,
-                    canRenameItem = canRenameItem,
+                    itemActions = itemActions,
                     ?onDeleteItem = onDeleteItem,
                     canDeleteItem = canDeleteItem
                 )

--- a/src/Components/src/FileExplorer/FileExplorer.stories.tsx
+++ b/src/Components/src/FileExplorer/FileExplorer.stories.tsx
@@ -64,6 +64,7 @@ const InMemoryCreateFileExplorer = () => {
 
 const DeleteActionFileExplorer = () => {
   const [lastDeleted, setLastDeleted] = React.useState<string>("none");
+  const [lastAction, setLastAction] = React.useState<string>("none");
 
   const items = React.useMemo(
     () =>
@@ -80,8 +81,12 @@ const DeleteActionFileExplorer = () => {
         initialItems={items}
         canDeleteItem={() => true}
         onDeleteItem={(item) => setLastDeleted(item.Name)}
+        getItemActions={(item) =>
+          ofArray([new ContextMenuItem("Mark", "swt:fluent--star-24-regular", () => setLastAction(item.Name), undefined)])
+        }
       />
       <div data-testid="last-deleted">Last deleted: {lastDeleted}</div>
+      <div data-testid="last-row-action">Last action: {lastAction}</div>
     </div>
   );
 };
@@ -216,19 +221,17 @@ export const InlineDeleteDispatchesForFileAndDirectory: StoryObj<typeof DeleteAc
 
     const deletableDirectory = await canvas.findByText("Deletable Folder");
     await userEvent.hover(deletableDirectory);
+    await userEvent.click(await canvas.findByRole("button", { name: "Mark Deletable Folder" }));
+    await waitFor(() => expect(canvas.getByTestId("last-row-action")).toHaveTextContent("Last action: Deletable Folder"));
     await userEvent.click(await canvas.findByRole("button", { name: "Delete Deletable Folder" }));
-
-    await waitFor(() =>
-      expect(canvas.getByTestId("last-deleted")).toHaveTextContent("Last deleted: Deletable Folder"),
-    );
+    await waitFor(() => expect(canvas.getByTestId("last-deleted")).toHaveTextContent("Last deleted: Deletable Folder"));
 
     const deletableFile = await canvas.findByText("Deletable File");
     await userEvent.hover(deletableFile);
+    await userEvent.click(await canvas.findByRole("button", { name: "Mark Deletable File" }));
+    await waitFor(() => expect(canvas.getByTestId("last-row-action")).toHaveTextContent("Last action: Deletable File"));
     await userEvent.click(await canvas.findByRole("button", { name: "Delete Deletable File" }));
-
-    await waitFor(() =>
-      expect(canvas.getByTestId("last-deleted")).toHaveTextContent("Last deleted: Deletable File"),
-    );
+    await waitFor(() => expect(canvas.getByTestId("last-deleted")).toHaveTextContent("Last deleted: Deletable File"));
   },
 };
 

--- a/src/Components/src/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/FileExplorer/FileExplorerItem.fs
@@ -34,6 +34,32 @@ type FileExplorerItem =
             Html.none
 
     [<ReactComponent>]
+    static member private RenameItemButton
+        (item: FileItem, onRenameItem: (FileItem -> unit) option, canRenameItem: FileItem -> bool)
+        =
+        let handleRenameItem (ev: Browser.Types.MouseEvent) =
+            ev.preventDefault ()
+            ev.stopPropagation ()
+            onRenameItem |> Option.iter (fun fn -> fn item)
+
+        if canRenameItem item && onRenameItem.IsSome then
+            Html.button [
+                prop.type'.button
+                prop.className
+                    "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
+                prop.ariaLabel $"Rename {item.Name}"
+                prop.title $"Rename {item.Name}"
+                prop.onClick handleRenameItem
+                prop.children [
+                    Html.i [
+                        prop.className "swt:iconify swt:fluent--edit-24-regular swt:size-4"
+                    ]
+                ]
+            ]
+        else
+            Html.none
+
+    [<ReactComponent>]
     static member private DeleteItemButton
         (item: FileItem, onDeleteItem: (FileItem -> unit) option, canDeleteItem: FileItem -> bool)
         =
@@ -150,13 +176,17 @@ type FileExplorerItem =
             onDirectoryArrowToggle: Browser.Types.MouseEvent -> unit,
             ?onCreateItem: FileItem -> unit,
             ?canCreateItem: FileItem -> bool,
+            ?onRenameItem: FileItem -> unit,
+            ?canRenameItem: FileItem -> bool,
             ?onDeleteItem: FileItem -> unit,
             ?canDeleteItem: FileItem -> bool,
             ?children: ReactElement
         ) =
         let canCreateItem = defaultArg canCreateItem (fun (_: FileItem) -> false)
+        let canRenameItem = defaultArg canRenameItem (fun (_: FileItem) -> false)
         let canDeleteItem = defaultArg canDeleteItem (fun (_: FileItem) -> false)
         let canCreateFromDirectory = canCreateItem item && onCreateItem.IsSome
+        let canRenameFromDirectory = canRenameItem item && onRenameItem.IsSome
         let canDeleteFromDirectory = canDeleteItem item && onDeleteItem.IsSome
 
         let directoryToggleIconClass =
@@ -212,6 +242,7 @@ type FileExplorerItem =
                                 if item.IsLFS = Some true
                                    || canExpandDirectory
                                    || canCreateFromDirectory
+                                   || canRenameFromDirectory
                                    || canDeleteFromDirectory then
                                     Html.div [
                                         prop.className "swt:ml-auto swt:shrink-0 swt:flex swt:items-center swt:gap-2"
@@ -220,6 +251,12 @@ type FileExplorerItem =
                                                 item,
                                                 onCreateItem,
                                                 canCreateItem
+                                            )
+
+                                            FileExplorerItem.RenameItemButton (
+                                                item,
+                                                onRenameItem,
+                                                canRenameItem
                                             )
 
                                             FileExplorerItem.DeleteItemButton (
@@ -279,10 +316,14 @@ type FileExplorerItem =
             selectedNameClass: string,
             getItemIconClass: FileItem -> string option,
             onSelect: unit -> unit,
+            ?onRenameItem: FileItem -> unit,
+            ?canRenameItem: FileItem -> bool,
             ?onDeleteItem: FileItem -> unit,
             ?canDeleteItem: FileItem -> bool
         ) =
+        let canRenameItem = defaultArg canRenameItem (fun (_: FileItem) -> false)
         let canDeleteItem = defaultArg canDeleteItem (fun (_: FileItem) -> false)
+        let canRenameFromFile = canRenameItem item && onRenameItem.IsSome
         let canDeleteFromFile = canDeleteItem item && onDeleteItem.IsSome
 
         Html.li [
@@ -318,10 +359,16 @@ type FileExplorerItem =
                             ]
                         ]
 
-                        if item.IsLFS = Some true || canDeleteFromFile then
+                        if item.IsLFS = Some true || canRenameFromFile || canDeleteFromFile then
                             Html.div [
                                 prop.className "swt:flex swt:items-center swt:gap-2"
                                 prop.children [
+                                    FileExplorerItem.RenameItemButton (
+                                        item,
+                                        onRenameItem,
+                                        canRenameItem
+                                    )
+
                                     FileExplorerItem.DeleteItemButton (
                                         item,
                                         onDeleteItem,

--- a/src/Components/src/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/FileExplorer/FileExplorerItem.fs
@@ -8,54 +8,66 @@ open Swate.Components.FileExplorer.Types
 type FileExplorerItem =
 
     [<ReactComponent>]
+    static member private RowActionButton
+        (label: string, icon: string, onClick: unit -> unit, ?className: string, ?disabled: bool, ?buttonKey: string)
+        =
+        let disabled = defaultArg disabled false
+
+        Html.button [
+            match buttonKey with
+            | Some key -> prop.key key
+            | None -> ()
+
+            prop.type'.button
+            prop.className [
+                "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
+
+                match className with
+                | Some className -> className
+                | None -> ()
+
+                if disabled then
+                    "swt:opacity-50"
+            ]
+            prop.disabled disabled
+            prop.ariaLabel label
+            prop.title label
+            prop.onClick (fun ev ->
+                ev.preventDefault ()
+                ev.stopPropagation ()
+
+                if not disabled then
+                    onClick()
+            )
+            prop.children [
+                Html.i [
+                    prop.className $"swt:iconify {icon} swt:size-4"
+                ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member private ItemActionButton (item: FileItem, action: ContextMenuItem) =
+        let label = $"{action.Label} {item.Name}"
+
+        FileExplorerItem.RowActionButton(
+            label,
+            action.Icon,
+            action.OnClick,
+            ?disabled = action.Disabled,
+            buttonKey = $"{item.Id}-{action.Label}"
+        )
+
+    [<ReactComponent>]
     static member private CreateItemButton
         (item: FileItem, onCreateItem: (FileItem -> unit) option, canCreateItem: FileItem -> bool)
         =
-        let handleCreateItem (ev: Browser.Types.MouseEvent) =
-            ev.preventDefault ()
-            ev.stopPropagation ()
-            onCreateItem |> Option.iter (fun fn -> fn item)
-
         if item.IsDirectory && canCreateItem item && onCreateItem.IsSome then
-            Html.button [
-                prop.type'.button
-                prop.className
-                    "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
-                prop.ariaLabel $"Create new item in {item.Name}"
-                prop.title $"Create new item in {item.Name}"
-                prop.onClick handleCreateItem
-                prop.children [
-                    Html.i [
-                        prop.className "swt:iconify swt:fluent--add-24-regular swt:size-4"
-                    ]
-                ]
-            ]
-        else
-            Html.none
-
-    [<ReactComponent>]
-    static member private RenameItemButton
-        (item: FileItem, onRenameItem: (FileItem -> unit) option, canRenameItem: FileItem -> bool)
-        =
-        let handleRenameItem (ev: Browser.Types.MouseEvent) =
-            ev.preventDefault ()
-            ev.stopPropagation ()
-            onRenameItem |> Option.iter (fun fn -> fn item)
-
-        if canRenameItem item && onRenameItem.IsSome then
-            Html.button [
-                prop.type'.button
-                prop.className
-                    "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
-                prop.ariaLabel $"Rename {item.Name}"
-                prop.title $"Rename {item.Name}"
-                prop.onClick handleRenameItem
-                prop.children [
-                    Html.i [
-                        prop.className "swt:iconify swt:fluent--edit-24-regular swt:size-4"
-                    ]
-                ]
-            ]
+            FileExplorerItem.RowActionButton(
+                $"Create new item in {item.Name}",
+                "swt:fluent--add-24-regular",
+                (fun () -> onCreateItem |> Option.iter (fun fn -> fn item))
+            )
         else
             Html.none
 
@@ -63,25 +75,13 @@ type FileExplorerItem =
     static member private DeleteItemButton
         (item: FileItem, onDeleteItem: (FileItem -> unit) option, canDeleteItem: FileItem -> bool)
         =
-        let handleDeleteItem (ev: Browser.Types.MouseEvent) =
-            ev.preventDefault ()
-            ev.stopPropagation ()
-            onDeleteItem |> Option.iter (fun fn -> fn item)
-
         if canDeleteItem item && onDeleteItem.IsSome then
-            Html.button [
-                prop.type'.button
-                prop.className
-                    "swt:btn swt:btn-ghost swt:btn-square swt:btn-xs swt:text-error swt:opacity-0 swt:transition-opacity swt:group-hover:opacity-100 swt:focus:opacity-100"
-                prop.ariaLabel $"Delete {item.Name}"
-                prop.title $"Delete {item.Name}"
-                prop.onClick handleDeleteItem
-                prop.children [
-                    Html.i [
-                        prop.className "swt:iconify swt:fluent--delete-24-regular swt:size-4"
-                    ]
-                ]
-            ]
+            FileExplorerItem.RowActionButton(
+                $"Delete {item.Name}",
+                "swt:fluent--delete-24-regular",
+                (fun () -> onDeleteItem |> Option.iter (fun fn -> fn item)),
+                className = "swt:text-error"
+            )
         else
             Html.none
 
@@ -176,17 +176,16 @@ type FileExplorerItem =
             onDirectoryArrowToggle: Browser.Types.MouseEvent -> unit,
             ?onCreateItem: FileItem -> unit,
             ?canCreateItem: FileItem -> bool,
-            ?onRenameItem: FileItem -> unit,
-            ?canRenameItem: FileItem -> bool,
+            ?itemActions: ContextMenuItem list,
             ?onDeleteItem: FileItem -> unit,
             ?canDeleteItem: FileItem -> bool,
             ?children: ReactElement
         ) =
         let canCreateItem = defaultArg canCreateItem (fun (_: FileItem) -> false)
-        let canRenameItem = defaultArg canRenameItem (fun (_: FileItem) -> false)
+        let itemActions = defaultArg itemActions []
         let canDeleteItem = defaultArg canDeleteItem (fun (_: FileItem) -> false)
         let canCreateFromDirectory = canCreateItem item && onCreateItem.IsSome
-        let canRenameFromDirectory = canRenameItem item && onRenameItem.IsSome
+        let hasItemActions = itemActions |> List.isEmpty |> not
         let canDeleteFromDirectory = canDeleteItem item && onDeleteItem.IsSome
 
         let directoryToggleIconClass =
@@ -242,7 +241,7 @@ type FileExplorerItem =
                                 if item.IsLFS = Some true
                                    || canExpandDirectory
                                    || canCreateFromDirectory
-                                   || canRenameFromDirectory
+                                   || hasItemActions
                                    || canDeleteFromDirectory then
                                     Html.div [
                                         prop.className "swt:ml-auto swt:shrink-0 swt:flex swt:items-center swt:gap-2"
@@ -253,11 +252,9 @@ type FileExplorerItem =
                                                 canCreateItem
                                             )
 
-                                            FileExplorerItem.RenameItemButton (
-                                                item,
-                                                onRenameItem,
-                                                canRenameItem
-                                            )
+                                            yield!
+                                                itemActions
+                                                |> List.map (fun action -> FileExplorerItem.ItemActionButton(item, action))
 
                                             FileExplorerItem.DeleteItemButton (
                                                 item,
@@ -316,14 +313,13 @@ type FileExplorerItem =
             selectedNameClass: string,
             getItemIconClass: FileItem -> string option,
             onSelect: unit -> unit,
-            ?onRenameItem: FileItem -> unit,
-            ?canRenameItem: FileItem -> bool,
+            ?itemActions: ContextMenuItem list,
             ?onDeleteItem: FileItem -> unit,
             ?canDeleteItem: FileItem -> bool
         ) =
-        let canRenameItem = defaultArg canRenameItem (fun (_: FileItem) -> false)
+        let itemActions = defaultArg itemActions []
         let canDeleteItem = defaultArg canDeleteItem (fun (_: FileItem) -> false)
-        let canRenameFromFile = canRenameItem item && onRenameItem.IsSome
+        let hasItemActions = itemActions |> List.isEmpty |> not
         let canDeleteFromFile = canDeleteItem item && onDeleteItem.IsSome
 
         Html.li [
@@ -359,15 +355,13 @@ type FileExplorerItem =
                             ]
                         ]
 
-                        if item.IsLFS = Some true || canRenameFromFile || canDeleteFromFile then
+                        if item.IsLFS = Some true || hasItemActions || canDeleteFromFile then
                             Html.div [
                                 prop.className "swt:flex swt:items-center swt:gap-2"
                                 prop.children [
-                                    FileExplorerItem.RenameItemButton (
-                                        item,
-                                        onRenameItem,
-                                        canRenameItem
-                                    )
+                                    yield!
+                                        itemActions
+                                        |> List.map (fun action -> FileExplorerItem.ItemActionButton(item, action))
 
                                     FileExplorerItem.DeleteItemButton (
                                         item,

--- a/src/Electron/src/Main/ArcMerge/ArcAddExtensions.fs
+++ b/src/Electron/src/Main/ArcMerge/ArcAddExtensions.fs
@@ -1,0 +1,71 @@
+namespace Main.ArcMerge
+
+open ARCtrl
+open ARCtrl.Contract
+open CrossAsync
+open Swate.Components.Shared
+
+[<AutoOpen>]
+module ArcAddExtensions =
+
+    let private formatContractErrors (errors: string[]) =
+        errors |> Array.map string |> String.concat "\n"
+
+    let private failIfEntityExists (entityKind: string) (identifier: string) (exists: bool) =
+        if exists then
+            failwith $"ARC already contains {entityKind} with identifier '{identifier}'."
+
+    type ARC with
+
+        member this.GetAssayAddContracts(assay: ArcAssay) =
+            failIfEntityExists "assay" assay.Identifier (this.ContainsAssay assay.Identifier)
+            this.AddAssay(assay)
+            this.UpdateFileSystem()
+            this.GetUpdateContracts(skipUpdateFS = true)
+
+        member this.GetStudyAddContracts(study: ArcStudy) =
+            failIfEntityExists "study" study.Identifier (this.ContainsStudy study.Identifier)
+            this.AddStudy(study)
+            this.UpdateFileSystem()
+            this.GetUpdateContracts(skipUpdateFS = true)
+
+        member this.GetRunAddContracts(run: ArcRun) =
+            failIfEntityExists "run" run.Identifier (this.ContainsRun run.Identifier)
+            this.AddRun(run)
+            this.UpdateFileSystem()
+            this.GetUpdateContracts(skipUpdateFS = true)
+
+        member this.GetWorkflowAddContracts(workflow: ArcWorkflow) =
+            failIfEntityExists "workflow" workflow.Identifier (this.ContainsWorkflow workflow.Identifier)
+            this.AddWorkflow(workflow)
+            this.UpdateFileSystem()
+            this.GetUpdateContracts(skipUpdateFS = true)
+
+        member this.GetAddContracts(arcFile: ArcFiles) =
+            match arcFile with
+            | ArcFiles.Assay assay -> this.GetAssayAddContracts assay
+            | ArcFiles.Study(study, _) -> this.GetStudyAddContracts study
+            | ArcFiles.Run run -> this.GetRunAddContracts run
+            | ArcFiles.Workflow workflow -> this.GetWorkflowAddContracts workflow
+            | ArcFiles.Investigation _ -> failwith "Adding investigation files is not supported."
+            | ArcFiles.DataMap _ -> failwith "Adding datamap files is not supported."
+            | ArcFiles.Template _ -> failwith "Adding template files is not supported."
+
+        member this.TryAddAsync(arcPath: string, arcFile: ArcFiles) =
+            crossAsync {
+                try
+                    let contracts = this.GetAddContracts arcFile
+                    return! fullFillContractBatchAsync arcPath contracts
+                with error ->
+                    return Error [| error.Message |]
+            }
+
+        member this.AddAsync(arcPath: string, arcFile: ArcFiles) =
+            crossAsync {
+                let! result = this.TryAddAsync(arcPath, arcFile)
+
+                match result with
+                | Ok _ -> ()
+                | Error errors ->
+                    failwithf "Could not add ARC file, failed with the following errors %s" (formatContractErrors errors)
+            }

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -6,6 +6,7 @@ open Fable.Electron
 open Fable.Electron.Remoting.Main
 open Main
 open Main.Bindings
+open Main.ArcMerge
 open Main.ArcVaultHelper
 open Swate.Electron.Shared.IPCTypes
 open Swate.Electron.Shared.IPCTypes.IPCTypesHelper
@@ -151,23 +152,51 @@ module ArcVaultExtensions =
                 let normalizedRequest =
                     Swate.Electron.Shared.FileIOHelper.FileContentDTO.normalizeArcFileRequestPath request
 
-                let workingArc = arc.Copy()
+                let newTopLevelArcFile = tryGetNewTopLevelArcFile arc normalizedRequest
 
-                match updateARCByFileContentDTO workingArc normalizedRequest with
-                | Error updateError -> return Error updateError
-                | Ok updatedArc ->
+                match newTopLevelArcFile with
+                | Some arcFile ->
+                    let hadUnsavedArcChanges = this.hasUnsavedArcChanges
                     this.isBusyWriting <- true
 
                     try
-                        try
-                            do! updatedArc.UpdateAsync(arcPath)
-                            this.SetArc(updatedArc)
-                            this.hasUnsavedArcChanges <- false
-                            return Ok()
-                        with e ->
-                            return Error(exn $"Failed to persist ARC to disk: {e.Message}")
+                        match! ARC.tryLoadAsync arcPath with
+                        | Error loadErrors ->
+                            let loadErrorMessage = String.concat "\n" loadErrors
+                            return Error(exn $"Unable to reload ARC before add: {loadErrorMessage}")
+                        | Ok arcFromDisk ->
+                            let arcForDiskPersistence = arcFromDisk
+                            let addEvents = getAddArcFileEvents arcFile
+
+                            try
+                                do! arcForDiskPersistence.AddAsync(arcPath, arcFile)
+                                let mergedArc = ARC.merge arc arcForDiskPersistence addEvents
+                                syncArcStaticHashes arcForDiskPersistence mergedArc
+                                this.SetArc(mergedArc)
+                                this.hasUnsavedArcChanges <- hadUnsavedArcChanges || mergedArc.hasInMemoryChanges()
+                                return Ok()
+                            with e ->
+                                return Error(exn $"Failed to persist ARC to disk: {e.Message}")
                     finally
                         this.isBusyWriting <- false
+                | None ->
+                    let workingArc = arc.Copy()
+
+                    match updateARCByFileContentDTO workingArc normalizedRequest with
+                    | Error updateError -> return Error updateError
+                    | Ok updatedArc ->
+                        this.isBusyWriting <- true
+
+                        try
+                            try
+                                do! updatedArc.UpdateAsync(arcPath)
+                                this.SetArc(updatedArc)
+                                this.hasUnsavedArcChanges <- false
+                                return Ok()
+                            with e ->
+                                return Error(exn $"Failed to persist ARC to disk: {e.Message}")
+                        finally
+                            this.isBusyWriting <- false
             | _ -> return Error(exn "ARC is not loaded.")
         }
 

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -192,12 +192,12 @@ module ArcVaultExtensions =
                 swatefailfn this.window.id $"No path set for StartFileWatcher."
         }
 
-        member this.StartFileWatcher() =
+        member this.StartFileWatcher(?usePolling: bool) =
             if this.path.IsSome then
                 match this.watcher with
                 | Some _ -> ()
                 | None ->
-                    let watcher = createFileWatcher this.path.Value
+                    let watcher = createFileWatcher this.path.Value usePolling
 
                     let sendMsgApi =
                         Remoting.createIpc ()

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -194,16 +194,32 @@ module ArcVaultExtensions =
 
         member this.StartFileWatcher() =
             if this.path.IsSome then
-                let watcher = createFileWatcher this.path.Value
+                match this.watcher with
+                | Some _ -> ()
+                | None ->
+                    let watcher = createFileWatcher this.path.Value
 
-                let sendMsgApi =
-                    Remoting.createIpc ()
-                    |> Remoting.withWindow this.window
-                    |> Remoting.buildProxySender<IArcFileWatcherApi>
+                    let sendMsgApi =
+                        Remoting.createIpc ()
+                        |> Remoting.withWindow this.window
+                        |> Remoting.buildProxySender<IArcFileWatcherApi>
 
-                watcher.on (Chokidar.Events.All, this._ScheduleReloadArc sendMsgApi) |> ignore
+                    watcher.on (Chokidar.Events.All, this._ScheduleReloadArc sendMsgApi) |> ignore
+                    this.watcher <- Some watcher
             else
                 swatefailfn this.window.id $"No path set for StartFileWatcher."
+
+        member this.StopFileWatcher() = promise {
+            match this.watcher with
+            | None -> return ()
+            | Some watcher ->
+                try
+                    do! watcher.close ()
+                with _ ->
+                    ()
+
+                this.watcher <- None
+        }
 
         /// This functions should be called once, when an vault is first started with a path
         member this.Startup() = promise {
@@ -312,7 +328,7 @@ type ArcVaults() =
         match this.Vaults.TryGetValue(id) with
         | false, _ -> swatefailfn id $"Failed to remove vault."
         | true, vault ->
-            vault.watcher |> Option.iter (fun watcher -> watcher.close () |> Promise.start)
+            vault.StopFileWatcher() |> Promise.start
             this.Vaults.Remove(id) |> ignore
             vault.path |> Option.iter (fun p -> RECENT_ARCS.Inactivate(p) |> ignore)
             this.BroadcastRecentARCs()

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -11,6 +11,43 @@ open Main
 open Main.Bindings
 open Node.Api
 
+let private processDynamic: obj = emitJsExpr () "process"
+
+let private isWindowsPlatform () =
+    try
+        let platform = processDynamic?platform |> unbox<string>
+        platform = "win32"
+    with _ ->
+        false
+
+type private FileWatcherProfile = {
+    AwaitWriteFinish: bool
+    IgnoreInitial: bool
+    UsePolling: bool option
+    Interval: int option
+    BinaryInterval: int option
+}
+
+let private defaultWatcherProfile = {
+    AwaitWriteFinish = true
+    IgnoreInitial = true
+    UsePolling = None
+    Interval = None
+    BinaryInterval = None
+}
+
+// Polling on Windows increases event reliability for external xlsx edits at the cost of more filesystem polling.
+let private windowsWatcherProfile = {
+    AwaitWriteFinish = true
+    IgnoreInitial = true
+    UsePolling = Some true
+    Interval = Some 200
+    BinaryInterval = Some 400
+}
+
+let private activeWatcherProfile () =
+    if isWindowsPlatform () then windowsWatcherProfile else defaultWatcherProfile
+
 
 /// This function mutably sets the datamap on the correct parent based on the datamap parent info included in the file content DTO.
 /// It also ensures that the static hash is preserved to avoid unnecessary changes to the ARC when saving a datamap.
@@ -182,11 +219,20 @@ let createFileWatcher (path: string) =
             else
                 false
 
-    let watcher =
-        Chokidar.Chokidar.watch (
-            path,
-            Chokidar.WatchOptions(cwd = path, awaitWriteFinish = true, ignored = !^ignoreFn, ignoreInitial = true)
+    let watcherProfile = activeWatcherProfile ()
+
+    let watcherOptions =
+        Chokidar.WatchOptions(
+            cwd = path,
+            awaitWriteFinish = watcherProfile.AwaitWriteFinish,
+            ignored = !^ignoreFn,
+            ignoreInitial = watcherProfile.IgnoreInitial,
+            ?usePolling = watcherProfile.UsePolling,
+            ?interval = watcherProfile.Interval,
+            ?binaryInterval = watcherProfile.BinaryInterval
         )
+
+    let watcher = Chokidar.Chokidar.watch (path, watcherOptions)
 
     watcher
 

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -11,44 +11,6 @@ open Main
 open Main.Bindings
 open Node.Api
 
-let private processDynamic: obj = emitJsExpr () "process"
-
-let private isWindowsPlatform () =
-    try
-        let platform = processDynamic?platform |> unbox<string>
-        platform = "win32"
-    with _ ->
-        false
-
-type private FileWatcherProfile = {
-    AwaitWriteFinish: bool
-    IgnoreInitial: bool
-    UsePolling: bool option
-    Interval: int option
-    BinaryInterval: int option
-}
-
-let private defaultWatcherProfile = {
-    AwaitWriteFinish = true
-    IgnoreInitial = true
-    UsePolling = None
-    Interval = None
-    BinaryInterval = None
-}
-
-// Polling on Windows increases event reliability for external xlsx edits at the cost of more filesystem polling.
-let private windowsWatcherProfile = {
-    AwaitWriteFinish = true
-    IgnoreInitial = true
-    UsePolling = Some true
-    Interval = Some 200
-    BinaryInterval = Some 400
-}
-
-let private activeWatcherProfile () =
-    if isWindowsPlatform () then windowsWatcherProfile else defaultWatcherProfile
-
-
 /// This function mutably sets the datamap on the correct parent based on the datamap parent info included in the file content DTO.
 /// It also ensures that the static hash is preserved to avoid unnecessary changes to the ARC when saving a datamap.
 let private setDataMapByParentInfo (arc: ARC) (dmpi: DatamapParentInfo) (dm: DataMap) : Result<unit, exn> =
@@ -199,7 +161,7 @@ let createWindow () = promise {
     return window
 }
 
-let createFileWatcher (path: string) =
+let createFileWatcher (path: string) (usePolling: bool option) =
 
     let ignoreFn =
         fun (path: string) ->
@@ -219,18 +181,26 @@ let createFileWatcher (path: string) =
             else
                 false
 
-    let watcherProfile = activeWatcherProfile ()
+    let usePolling = defaultArg usePolling false
 
     let watcherOptions =
-        Chokidar.WatchOptions(
-            cwd = path,
-            awaitWriteFinish = watcherProfile.AwaitWriteFinish,
-            ignored = !^ignoreFn,
-            ignoreInitial = watcherProfile.IgnoreInitial,
-            ?usePolling = watcherProfile.UsePolling,
-            ?interval = watcherProfile.Interval,
-            ?binaryInterval = watcherProfile.BinaryInterval
-        )
+        if usePolling then
+            Chokidar.WatchOptions(
+                cwd = path,
+                awaitWriteFinish = true,
+                ignored = !^ignoreFn,
+                ignoreInitial = true,
+                usePolling = true,
+                interval = 200,
+                binaryInterval = 400
+            )
+        else
+            Chokidar.WatchOptions(
+                cwd = path,
+                awaitWriteFinish = true,
+                ignored = !^ignoreFn,
+                ignoreInitial = true
+            )
 
     let watcher = Chokidar.Chokidar.watch (path, watcherOptions)
 

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -8,6 +8,7 @@ open ARCtrl
 open Fable.Electron
 open Fable.Core.JsInterop
 open Main
+open Main.ArcMerge
 open Main.Bindings
 open Node.Api
 
@@ -58,6 +59,61 @@ let private setDataMapByParentInfo (arc: ARC) (dmpi: DatamapParentInfo) (dm: Dat
             Ok()
     with e ->
         Error(exn $"Failed to set datamap on ARC: {e.Message}")
+
+let private syncDataMapStaticHash (sourceDataMap: DataMap option) (targetDataMap: DataMap option) =
+    match sourceDataMap, targetDataMap with
+    | Some sourceDataMap, Some targetDataMap -> targetDataMap.StaticHash <- sourceDataMap.StaticHash
+    | _ -> ()
+
+/// Syncs static hashes from source ARC to target ARC for matching entities.
+/// This keeps ARCtrl update contract generation scoped to actual changes.
+let syncArcStaticHashes (source: ARC) (target: ARC) : unit =
+    target.StaticHash <- source.StaticHash
+
+    match source.License, target.License with
+    | Some sourceLicense, Some targetLicense -> targetLicense.StaticHash <- sourceLicense.StaticHash
+    | _ -> ()
+
+    for targetStudy in target.Studies do
+        match source.TryGetStudy targetStudy.Identifier with
+        | Some sourceStudy ->
+            targetStudy.StaticHash <- sourceStudy.StaticHash
+            syncDataMapStaticHash sourceStudy.DataMap targetStudy.DataMap
+        | None -> ()
+
+    for targetAssay in target.Assays do
+        match source.TryGetAssay targetAssay.Identifier with
+        | Some sourceAssay ->
+            targetAssay.StaticHash <- sourceAssay.StaticHash
+            syncDataMapStaticHash sourceAssay.DataMap targetAssay.DataMap
+        | None -> ()
+
+    for targetWorkflow in target.Workflows do
+        match source.TryGetWorkflow targetWorkflow.Identifier with
+        | Some sourceWorkflow ->
+            targetWorkflow.StaticHash <- sourceWorkflow.StaticHash
+            syncDataMapStaticHash sourceWorkflow.DataMap targetWorkflow.DataMap
+        | None -> ()
+
+    for targetRun in target.Runs do
+        match source.TryGetRun targetRun.Identifier with
+        | Some sourceRun ->
+            targetRun.StaticHash <- sourceRun.StaticHash
+            syncDataMapStaticHash sourceRun.DataMap targetRun.DataMap
+        | None -> ()
+
+let tryGetNewTopLevelArcFile (arc: ARC) (dto: FileContentDTO) : ArcFiles option =
+    match FileContentDTO.toArcFile dto with
+    | Some(ArcFiles.Assay assay as arcFile) when arc.ContainsAssay assay.Identifier |> not -> Some arcFile
+    | Some(ArcFiles.Study(study, _) as arcFile) when arc.ContainsStudy study.Identifier |> not -> Some arcFile
+    | Some(ArcFiles.Run run as arcFile) when arc.ContainsRun run.Identifier |> not -> Some arcFile
+    | Some(ArcFiles.Workflow workflow as arcFile) when arc.ContainsWorkflow workflow.Identifier |> not -> Some arcFile
+    | _ -> None
+
+let getAddArcFileEvents (arcFile: ArcFiles) : FileEvent list =
+    arcFile.TryGetRelativePath()
+    |> Option.map (fun path -> [ { EventName = EventName.Add; Path = path } ])
+    |> Option.defaultValue []
 
 /// This function should only be used for partial updates to an ARC based on a file content DTO.
 let updateARCByFileContentDTO (oldArc: ARC) (dto: FileContentDTO) : Result<ARC, exn> =

--- a/src/Electron/src/Main/Bindings/Chokidar.fs
+++ b/src/Electron/src/Main/Bindings/Chokidar.fs
@@ -25,7 +25,10 @@ type WatchOptions
         ?ignoreInitial: bool,
         ?followSimlinks: bool,
         ?cwd: string,
-        ?awaitWriteFinish: bool
+        ?awaitWriteFinish: bool,
+        ?usePolling: bool,
+        ?interval: int,
+        ?binaryInterval: int
     ) =
     member val persistent: bool option = persistent with get, set
     member val ignored = ignored with get, set
@@ -33,6 +36,9 @@ type WatchOptions
     member val followSimlinks: bool option = followSimlinks with get, set
     member val cwd: string option = cwd with get, set
     member val awaitWriteFinish: bool option = awaitWriteFinish with get, set
+    member val usePolling: bool option = usePolling with get, set
+    member val interval: int option = interval with get, set
+    member val binaryInterval: int option = binaryInterval with get, set
 
 type IWatched =
     [<EmitIndexerAttribute>]

--- a/src/Electron/src/Main/FileTreeCreator.fs
+++ b/src/Electron/src/Main/FileTreeCreator.fs
@@ -72,7 +72,7 @@ let removePathAndDescendants (targetPath: string) (fileTree: Dictionary<string, 
     else
         let keysToRemove =
             nextTree.Keys
-            |> Seq.filter (fun path -> isSameOrDescendantPath path normalizedTargetPath)
+            |> Seq.filter (fun path -> PathHelpers.isSameOrDescendantPath path normalizedTargetPath)
             |> Seq.toArray
 
         keysToRemove |> Array.iter (fun path -> nextTree.Remove(path) |> ignore)

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -197,10 +197,14 @@ let private applyArcMutationMergeResult (vault: ArcVault) (mergeResult: ArcMutat
     vault.arc <- Some mergeResult.Arc
     vault.window.title <- mergeResult.Arc.Identifier
 
+let private passthroughReloadedArc (reloadedArc: ARC) : JS.Promise<Result<ARC, exn>> =
+    promise { return Ok reloadedArc }
+
 let private runArcDiskMutation
     (vault: ArcVault)
     (reloadErrorContext: string)
     (diskMutation: unit -> JS.Promise<Result<unit, exn>>)
+    (postReloadArcMutation: ARC -> JS.Promise<Result<ARC, exn>>)
     (mergeReloadedArc: ARC -> Result<ArcMutationMergeResult, exn>)
     : JS.Promise<Result<unit, exn>> =
     promise {
@@ -217,13 +221,26 @@ let private runArcDiskMutation
                 match! ARC.tryLoadAsync vault.path.Value with
                 | Error loadError -> return Error(exn $"Unable to reload ARC after {reloadErrorContext}: {loadError}")
                 | Ok reloadedArc ->
-                    match mergeReloadedArc reloadedArc with
-                    | Error mergeError -> return Error mergeError
-                    | Ok mergeResult ->
-                        applyArcMutationMergeResult vault mergeResult
-                        return Ok()
+                    match! postReloadArcMutation reloadedArc with
+                    | Error postReloadError -> return Error postReloadError
+                    | Ok postMutationArc ->
+                        match mergeReloadedArc postMutationArc with
+                        | Error mergeError -> return Error mergeError
+                        | Ok mergeResult ->
+                            applyArcMutationMergeResult vault mergeResult
+                            return Ok()
         finally
             vault.isBusyWriting <- false
+    }
+
+let private runRenameOperationSafely
+    (operation: unit -> JS.Promise<Result<unit, exn>>)
+    : JS.Promise<Result<unit, exn>> =
+    promise {
+        try
+            return! operation ()
+        with operationError ->
+            return Error operationError
     }
 
 let private runWithRenameScopedPolling
@@ -233,23 +250,18 @@ let private runWithRenameScopedPolling
     promise {
         let useScopedPolling = isWindowsPlatform () && vault.watcher.IsSome
 
-        if useScopedPolling then
+        if useScopedPolling |> not then
+            return! runRenameOperationSafely operation
+        else
             do! vault.StopFileWatcher()
             vault.StartFileWatcher(usePolling = true)
 
-        let! operationResult =
-            promise {
-                try
-                    return! operation ()
-                with e ->
-                    return Error e
-            }
+            let! operationResult = runRenameOperationSafely operation
 
-        if useScopedPolling then
             do! vault.StopFileWatcher()
             vault.StartFileWatcher()
 
-        return operationResult
+            return operationResult
     }
 
 [<RequireQualifiedAccess>]
@@ -374,6 +386,24 @@ module ArcRenameHelper =
                             exn
                                 $"Renamed folder from '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}', but failed to sync ARC identifier from '{renamePlan.SyncPlan.OldIdentifier}' to '{renamePlan.SyncPlan.NewIdentifier}': {syncError.Message}"
                         )
+        }
+
+    let syncRenamedEntityIdentifierOnLoadedArc
+        (arcPath: string)
+        (renamePlan: RenamePlan)
+        (reloadedArc: ARC)
+        : JS.Promise<Result<ARC, exn>> =
+        promise {
+            try
+                applyIdentifierRenameSyncPlan reloadedArc renamePlan.SyncPlan
+                do! reloadedArc.UpdateAsync arcPath
+                return Ok reloadedArc
+            with syncError ->
+                return
+                    Error(
+                        exn
+                            $"Renamed folder from '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}', but failed to sync ARC identifier from '{renamePlan.SyncPlan.OldIdentifier}' to '{renamePlan.SyncPlan.NewIdentifier}': {syncError.Message}"
+                    )
         }
 
     let mapRenameDiskError (sourcePath: string) (targetPath: string) (renameError: exn) =
@@ -822,6 +852,7 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                             vault
                                             $"deleting '{normalizedRelativePath}'"
                                             deleteDiskMutation
+                                            passthroughReloadedArc
                                             (fun reloadedArc ->
                                                 ArcDeleteHelper.mergeReloadedArcAfterDelete
                                                     normalizedRelativePath
@@ -859,13 +890,7 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                 renameWithRetriesAsync sourceAbsolutePath targetAbsolutePath
 
                                             match renameResult with
-                                            | Ok() ->
-                                                let! syncResult =
-                                                    ArcRenameHelper.syncRenamedEntityIdentifierOnDisk
-                                                        arcPath
-                                                        renamePlan
-
-                                                return syncResult
+                                            | Ok() -> return Ok()
                                             | Error renameError ->
                                                 return
                                                     Error(
@@ -884,6 +909,7 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                     vault
                                                     $"renaming '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}'"
                                                     renameDiskMutation
+                                                    (ArcRenameHelper.syncRenamedEntityIdentifierOnLoadedArc arcPath renamePlan)
                                                     (fun reloadedArc ->
                                                         ArcRenameHelper.mergeReloadedArcAfterRename
                                                             renamePlan

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -325,6 +325,12 @@ module ArcRenameHelper =
         TargetPath: string
     }
 
+    type IdentifierRenameSyncPlan = {
+        Zone: ArcDeletePathRules.AddZone
+        OldIdentifier: string
+        NewIdentifier: string
+    }
+
     type MergeResult = {
         Arc: ARC
     }
@@ -341,6 +347,80 @@ module ArcRenameHelper =
             event.EventName
         )
         |> Seq.toList
+
+    let tryBuildIdentifierRenameSyncPlan
+        (sourcePath: string)
+        (targetPath: string)
+        : Result<IdentifierRenameSyncPlan, exn> =
+        let normalizedSourcePath = normalizeRelativePathForComparison sourcePath
+        let normalizedTargetPath = normalizeRelativePathForComparison targetPath
+
+        match
+            ArcDeletePathRules.tryGetRenameEntityFolderTarget normalizedSourcePath,
+            ArcDeletePathRules.tryGetRenameEntityFolderTarget normalizedTargetPath
+        with
+        | Some(sourceZone, sourceIdentifier), Some(targetZone, targetIdentifier) ->
+            if sourceZone <> targetZone then
+                Error(
+                    exn
+                        $"Renamed folder from '{sourcePath}' to '{targetPath}', but ARC identifier sync only supports renames within the same entity zone."
+                )
+            elif PathHelpers.pathsEqual sourceIdentifier targetIdentifier then
+                Error(
+                    exn
+                        $"Renamed folder from '{sourcePath}' to '{targetPath}', but no ARC identifier change was detected for content sync."
+                )
+            else
+                Ok {
+                    Zone = sourceZone
+                    OldIdentifier = sourceIdentifier
+                    NewIdentifier = targetIdentifier
+                }
+        | _ ->
+            Error(
+                exn
+                    $"Renamed folder from '{sourcePath}' to '{targetPath}', but ARC identifier sync requires ARC entity folder paths under studies/, assays/, workflows/, or runs/."
+            )
+
+    let private applyIdentifierRenameSyncPlan (arc: ARC) (syncPlan: IdentifierRenameSyncPlan) =
+        match syncPlan.Zone with
+        | ArcDeletePathRules.AddZone.Assays ->
+            arc.RenameAssay(syncPlan.OldIdentifier, syncPlan.NewIdentifier)
+        | ArcDeletePathRules.AddZone.Studies ->
+            arc.RenameStudy(syncPlan.OldIdentifier, syncPlan.NewIdentifier)
+        | ArcDeletePathRules.AddZone.Workflows ->
+            arc.RenameWorkflow(syncPlan.OldIdentifier, syncPlan.NewIdentifier)
+        | ArcDeletePathRules.AddZone.Runs ->
+            arc.RenameRun(syncPlan.OldIdentifier, syncPlan.NewIdentifier)
+
+    let syncRenamedEntityIdentifierOnDisk
+        (arcPath: string)
+        (sourcePath: string)
+        (targetPath: string)
+        : JS.Promise<Result<unit, exn>> =
+        promise {
+            match tryBuildIdentifierRenameSyncPlan sourcePath targetPath with
+            | Error planError -> return Error planError
+            | Ok syncPlan ->
+                match! ARC.tryLoadAsync arcPath with
+                | Error loadError ->
+                    return
+                        Error(
+                            exn
+                                $"Renamed folder from '{sourcePath}' to '{targetPath}', but could not reload ARC for identifier sync: {loadError}"
+                        )
+                | Ok reloadedArc ->
+                    try
+                        applyIdentifierRenameSyncPlan reloadedArc syncPlan
+                        do! reloadedArc.UpdateAsync arcPath
+                        return Ok()
+                    with syncError ->
+                        return
+                            Error(
+                                exn
+                                    $"Renamed folder from '{sourcePath}' to '{targetPath}', but failed to sync ARC identifier from '{syncPlan.OldIdentifier}' to '{syncPlan.NewIdentifier}': {syncError.Message}"
+                            )
+        }
 
     let mapRenameDiskError (sourcePath: string) (targetPath: string) (renameError: exn) =
         match tryGetNodeErrorCode renameError with
@@ -816,7 +896,14 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                 renameWithRetriesAsync sourceAbsolutePath targetAbsolutePath
 
                                             match renameResult with
-                                            | Ok() -> return Ok()
+                                            | Ok() ->
+                                                let! syncResult =
+                                                    ArcRenameHelper.syncRenamedEntityIdentifierOnDisk
+                                                        arcPath
+                                                        renamePlan.SourcePath
+                                                        renamePlan.TargetPath
+
+                                                return syncResult
                                             | Error renameError ->
                                                 return
                                                     Error(

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -7,6 +7,7 @@ open Swate.Electron.Shared.IPCTypes
 open Swate.Electron.Shared.GitTypes
 open Swate.Electron.Shared.FileIOTypes
 open Swate.Electron.Shared.FileIOHelper
+open Swate.Electron.Shared.RenamePathRules
 open Fable.Core
 open Fable.Electron
 open Fable.Electron.Main
@@ -25,11 +26,10 @@ let private pathDynamic: obj = importAll "path"
 module ArcPathValidation =
 
     let normalizePathForComparison (pathValue: string) =
-        pathValue.Replace("\\", "/").Trim().TrimEnd('/').ToLowerInvariant()
+        PathHelpers.normalizePathForFsComparison pathValue
 
     let containsTraversalSegments (pathValue: string) =
-        pathValue.Split('/')
-        |> Array.exists (fun segment -> segment = "." || segment = "..")
+        PathHelpers.containsPathTraversalSegments pathValue
 
     let isSafeRelativePathCandidate (pathValue: string) =
         let normalizedPath = PathHelpers.normalizePath pathValue
@@ -113,6 +113,58 @@ let private readUtf8FileAsync (absolutePath: string) : JS.Promise<string> =
     fsPromisesDynamic?readFile (absolutePath, "utf8")
     |> unbox<JS.Promise<string>>
 
+let private tryGetNodeErrorCode (error: exn) : string option =
+    try
+        error?code |> unbox<string> |> Option.ofObj
+    with _ ->
+        None
+
+type private RenameRetryStrategy = {
+    DelaysMs: int[]
+    IsTransientErrorCode: string option -> bool
+}
+
+// Windows file APIs can briefly return lock/contention errors while external processes still hold handles.
+// Retry with short backoff to avoid surfacing transient rename failures.
+let private renameRetryStrategy = {
+    DelaysMs = [| 0; 75; 200; 500 |]
+    IsTransientErrorCode =
+        function
+        | Some "EPERM"
+        | Some "EACCES"
+        | Some "EBUSY"
+        | Some "ENOTEMPTY" -> true
+        | _ -> false
+}
+
+let private renameWithRetriesAsync
+    (sourceAbsolutePath: string)
+    (targetAbsolutePath: string)
+    : JS.Promise<Result<unit, exn>> =
+    let rec attempt (attemptIndex: int) = promise {
+        if attemptIndex > 0 then
+            do! Promise.sleep renameRetryStrategy.DelaysMs.[attemptIndex]
+
+        try
+            let! _ =
+                fsPromisesDynamic?rename (sourceAbsolutePath, targetAbsolutePath)
+                |> unbox<JS.Promise<obj>>
+
+            return Ok()
+        with renameError ->
+            let errorCode = tryGetNodeErrorCode renameError
+
+            if
+                attemptIndex < renameRetryStrategy.DelaysMs.Length - 1
+                && renameRetryStrategy.IsTransientErrorCode errorCode
+            then
+                return! attempt (attemptIndex + 1)
+            else
+                return Error renameError
+    }
+
+    attempt 0
+
 open ARCtrl.Contract
 
 let private withLoadedArcVault<'T>
@@ -130,14 +182,44 @@ let private withLoadedArcVault<'T>
             | _ -> return Error(exn "ARC is not loaded.")
     }
 
-let private isSameOrDescendantPathForComparison (path: string) (ancestorPath: string) =
-    let normalize = PathHelpers.normalizePath >> ArcPathValidation.normalizePathForComparison
-    let normalizedPath = normalize path
-    let normalizedAncestorPath = normalize ancestorPath
+type private ArcMutationMergeResult = {
+    Arc: ARC
+    PendingArcFileSave: FileContentDTO option
+}
 
-    not (String.IsNullOrWhiteSpace normalizedPath)
-    && not (String.IsNullOrWhiteSpace normalizedAncestorPath)
-    && (normalizedPath = normalizedAncestorPath || normalizedPath.StartsWith(normalizedAncestorPath + "/"))
+let private applyArcMutationMergeResult (vault: ArcVault) (mergeResult: ArcMutationMergeResult) =
+    vault.arc <- Some mergeResult.Arc
+    vault.pendingArcFileSave <- mergeResult.PendingArcFileSave
+    vault.window.title <- mergeResult.Arc.Identifier
+
+let private runArcDiskMutation
+    (vault: ArcVault)
+    (reloadErrorContext: string)
+    (diskMutation: unit -> JS.Promise<Result<unit, exn>>)
+    (mergeReloadedArc: ARC -> Result<ArcMutationMergeResult, exn>)
+    : JS.Promise<Result<unit, exn>> =
+    promise {
+        vault.isBusyWriting <- true
+
+        try
+            let! diskMutationResult = diskMutation ()
+
+            match diskMutationResult with
+            | Error diskMutationError -> return Error diskMutationError
+            | Ok() ->
+                do! vault.RefreshFileTree()
+
+                match! ARC.tryLoadAsync vault.path.Value with
+                | Error loadError -> return Error(exn $"Unable to reload ARC after {reloadErrorContext}: {loadError}")
+                | Ok reloadedArc ->
+                    match mergeReloadedArc reloadedArc with
+                    | Error mergeError -> return Error mergeError
+                    | Ok mergeResult ->
+                        applyArcMutationMergeResult vault mergeResult
+                        return Ok()
+        finally
+            vault.isBusyWriting <- false
+    }
 
 [<RequireQualifiedAccess>]
 module ArcDeleteHelper =
@@ -146,14 +228,8 @@ module ArcDeleteHelper =
     let isPendingPathAffectedByDelete (deletedPath: string) (pendingArcFileSave: FileContentDTO option) =
         pendingArcFileSave
         |> Option.exists (fun pendingArcFileSave ->
-            isSameOrDescendantPathForComparison pendingArcFileSave.path deletedPath
+            PathHelpers.isSameOrDescendantPathForFsComparison pendingArcFileSave.path deletedPath
         )
-
-    let private tryGetNodeErrorCode (error: exn) : string option =
-        try
-            error?code |> unbox<string> |> Option.ofObj
-        with _ ->
-            None
 
     let shouldIgnoreMissingDiskDeleteError
         (deletedPath: string)
@@ -188,7 +264,9 @@ module ArcDeleteHelper =
 
         preDeleteFileRelativePaths
         |> Seq.map normalizeRelativePathForMerge
-        |> Seq.filter (fun relativePath -> isSameOrDescendantPathForComparison relativePath normalizedDeletedPath)
+        |> Seq.filter (fun relativePath ->
+            PathHelpers.isSameOrDescendantPathForFsComparison relativePath normalizedDeletedPath
+        )
         |> deduplicateEventPaths
 
     let buildDeleteUnlinkEvents (deletedPath: string) (preDeleteFileRelativePaths: string seq) : FileEvent list =
@@ -250,6 +328,140 @@ module ArcDeleteHelper =
             Ok {
                 Arc = mergedArc
                 PendingArcFileSave = pendingForMerge
+            }
+
+[<RequireQualifiedAccess>]
+module ArcRenameHelper =
+
+    type RenamePlan = {
+        SourcePath: string
+        TargetPath: string
+    }
+
+    type MergeResult = {
+        Arc: ARC
+        PendingArcFileSave: FileContentDTO option
+    }
+
+    let private normalizeRelativePathForComparison (path: string) =
+        path
+        |> PathHelpers.normalizeRelativePath
+        |> PathHelpers.normalizePath
+
+    let private deduplicateEvents (events: FileEvent list) =
+        events
+        |> Seq.distinctBy (fun event ->
+            ArcPathValidation.normalizePathForComparison event.Path,
+            event.EventName
+        )
+        |> Seq.toList
+
+    let mapRenameDiskError (sourcePath: string) (targetPath: string) (renameError: exn) =
+        match tryGetNodeErrorCode renameError with
+        | Some "EPERM"
+        | Some "EACCES" ->
+            exn
+                $"Cannot rename '{sourcePath}' to '{targetPath}'. Windows reported a permission or file-lock conflict. If the destination already exists, choose a different name and close apps that may be using these paths."
+        | Some "ENOTEMPTY"
+        | Some "EEXIST" ->
+            exn
+                $"Cannot rename '{sourcePath}' to '{targetPath}' because the destination already exists."
+        | Some "ENOENT" ->
+            exn
+                $"Cannot rename '{sourcePath}' because the source path no longer exists on disk."
+        | _ -> renameError
+
+    let private validateRenamePathClassification (classification: ArcDeletePathRules.RenamePathClassification) =
+        match classification with
+        | ArcDeletePathRules.RenamePathClassification.RootTarget ->
+            Error(exn "Renaming the ARC root is not allowed.")
+        | ArcDeletePathRules.RenamePathClassification.DisallowedTarget _ ->
+            Error(exn "Rename path must not contain path traversal segments.")
+        | ArcDeletePathRules.RenamePathClassification.ProtectedTarget _ ->
+            Error(exn "Renaming protected files (for example .gitkeep or readme.md) is not allowed.")
+        | ArcDeletePathRules.RenamePathClassification.InvestigationFileTarget _ ->
+            Error(exn "Renaming the investigation file is not supported.")
+        | ArcDeletePathRules.RenamePathClassification.AddZoneRootTarget _ ->
+            Error(exn "Renaming add-zone root folders (studies/, assays/, workflows/, runs/) is not allowed.")
+        | ArcDeletePathRules.RenamePathClassification.EntityFolderTarget _
+        | ArcDeletePathRules.RenamePathClassification.CanonicalEntityFileTarget _
+        | ArcDeletePathRules.RenamePathClassification.CanonicalDataMapFileTarget _
+        | ArcDeletePathRules.RenamePathClassification.GenericTarget _ -> Ok()
+
+    let tryBuildRenamePlan (request: RenamePathRequest) : Result<RenamePlan, exn> =
+        let requestedRelativePath = normalizeRelativePathForComparison request.relativePath
+        let sourceClassification = ArcDeletePathRules.classifyRenameTarget requestedRelativePath
+
+        match validateRenamePathClassification sourceClassification with
+        | Error validationError -> Error validationError
+        | Ok() ->
+            let resolvedSourcePath = ArcDeletePathRules.resolveRenameSourcePath requestedRelativePath
+
+            match tryBuildRenameTargetPath resolvedSourcePath request.newName with
+            | Error targetPathError -> Error(exn targetPathError)
+            | Ok targetPath ->
+                let targetClassification = ArcDeletePathRules.classifyRenameTarget targetPath
+
+                match validateRenamePathClassification targetClassification with
+                | Error validationError -> Error validationError
+                | Ok() ->
+                    Ok {
+                        SourcePath = resolvedSourcePath
+                        TargetPath = targetPath
+                    }
+
+    let buildRenameEvents (sourcePath: string) (targetPath: string) : FileEvent list =
+        match
+            ArcDeletePathRules.tryGetRenameEntityFolderTarget sourcePath,
+            ArcDeletePathRules.tryGetRenameEntityFolderTarget targetPath
+        with
+        | Some(sourceZone, sourceIdentifier), Some(targetZone, targetIdentifier) ->
+            let oldCanonicalPaths =
+                ArcDeletePathRules.buildCanonicalEntityPaths sourceZone sourceIdentifier
+
+            let newCanonicalPaths =
+                ArcDeletePathRules.buildCanonicalEntityPaths targetZone targetIdentifier
+
+            [
+                for oldPath in oldCanonicalPaths do
+                    {
+                        EventName = EventName.Unlink
+                        Path = oldPath
+                    }
+
+                for newPath in newCanonicalPaths do
+                    {
+                        EventName = EventName.Add
+                        Path = newPath
+                    }
+            ]
+            |> deduplicateEvents
+        | _ -> []
+
+    let mergeReloadedArcAfterRename
+        (sourcePath: string)
+        (targetPath: string)
+        (arcLocal: ARC)
+        (reloadedArc: ARC)
+        (pendingArcFileSave: FileContentDTO option)
+        : Result<MergeResult, exn> =
+        let arcLocalForMerge = arcLocal.Copy()
+
+        let arcLocalForMergeResult =
+            match pendingArcFileSave with
+            | None -> Ok arcLocalForMerge
+            | Some pendingArcFileSave ->
+                Main.ArcVaultHelper.updateARCByFileContentDTO arcLocalForMerge pendingArcFileSave
+
+        match arcLocalForMergeResult with
+        | Error mergeError -> Error mergeError
+        | Ok arcLocalForMerge ->
+            let renameEvents = buildRenameEvents sourcePath targetPath
+            let mergedArc = ARC.merge arcLocalForMerge reloadedArc renameEvents
+
+            Ok {
+                Arc = mergedArc
+                PendingArcFileSave = pendingArcFileSave
             }
 
 
@@ -541,36 +753,29 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
     deletePath =
         fun (relativePath: string) -> promise {
             try
-                let windowId = windowIdFromIpcEvent event
+                return!
+                    withLoadedArcVault event (fun vault ->
+                        promise {
+                            let arcPath = vault.path.Value
+                            let arcLocal = vault.arc.Value
+                            let normalizedRelativePath = PathHelpers.normalizeRelativePath relativePath
 
-                match ARC_VAULTS.TryGetVault(windowId) with
-                | None -> return Error(exn $"The ARC for window id {windowId} should exist")
-                | Some vault ->
-                    match vault.path, vault.arc with
-                    | None, _
-                    | _, None -> return Error(exn "ARC is not loaded.")
-                    | Some arcPath, Some arcLocal ->
-                        let normalizedRelativePath = PathHelpers.normalizeRelativePath relativePath
+                            if ArcDeletePathRules.isDeletePathAllowed normalizedRelativePath |> not then
+                                return
+                                    Error(
+                                        exn
+                                            "Deletion is only allowed for descendants under studies/, assays/, workflows/, or runs/."
+                                    )
+                            else
+                                match tryResolveArcRelativePath arcPath normalizedRelativePath with
+                                | Error pathError -> return Error pathError
+                                | Ok absolutePath ->
+                                    let preDeleteFileRelativePaths =
+                                        ArcDeleteHelper.getPreDeleteFileRelativePaths arcPath vault.fileTree.Values
 
-                        if ArcDeletePathRules.isDeletePathAllowed normalizedRelativePath |> not then
-                            return
-                                Error(
-                                    exn
-                                        "Deletion is only allowed for descendants under studies/, assays/, workflows/, or runs/."
-                                )
-                        else
-                            match tryResolveArcRelativePath arcPath normalizedRelativePath with
-                            | Error pathError -> return Error pathError
-                            | Ok absolutePath ->
-                                let preDeleteFileRelativePaths =
-                                    ArcDeleteHelper.getPreDeleteFileRelativePaths arcPath vault.fileTree.Values
-
-                                vault.isBusyWriting <- true
-
-                                try
                                     let pendingArcFileSave = vault.pendingArcFileSave
 
-                                    let! deleteResult =
+                                    let deleteDiskMutation () =
                                         promise {
                                             try
                                                 let! _ =
@@ -593,31 +798,83 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                     return Error deleteError
                                         }
 
-                                    match deleteResult with
-                                    | Error deleteError -> return Error deleteError
-                                    | Ok() ->
-                                        do! vault.RefreshFileTree()
-
-                                        match! ARC.tryLoadAsync arcPath with
-                                        | Error loadError ->
-                                            return Error(exn $"Unable to reload ARC after deleting '{normalizedRelativePath}': {loadError}")
-                                        | Ok reloadedArc ->
-                                            match
+                                    return!
+                                        runArcDiskMutation
+                                            vault
+                                            $"deleting '{normalizedRelativePath}'"
+                                            deleteDiskMutation
+                                            (fun reloadedArc ->
                                                 ArcDeleteHelper.mergeReloadedArcAfterDelete
                                                     normalizedRelativePath
                                                     preDeleteFileRelativePaths
                                                     arcLocal
                                                     reloadedArc
                                                     pendingArcFileSave
-                                            with
-                                            | Error mergeError -> return Error mergeError
-                                            | Ok mergeResult ->
-                                                vault.arc <- Some mergeResult.Arc
-                                                vault.pendingArcFileSave <- mergeResult.PendingArcFileSave
-                                                vault.window.title <- mergeResult.Arc.Identifier
-                                                return Ok()
-                                finally
-                                    vault.isBusyWriting <- false
+                                                |> Result.map (fun mergeResult -> {
+                                                    Arc = mergeResult.Arc
+                                                    PendingArcFileSave = mergeResult.PendingArcFileSave
+                                                })
+                                            )
+                        }
+                    )
+            with e ->
+                return Error e
+        }
+    renamePath =
+        fun (request: RenamePathRequest) -> promise {
+            try
+                return!
+                    withLoadedArcVault event (fun vault ->
+                        promise {
+                            let arcPath = vault.path.Value
+                            let arcLocal = vault.arc.Value
+
+                            match ArcRenameHelper.tryBuildRenamePlan request with
+                            | Error validationError -> return Error validationError
+                            | Ok renamePlan ->
+                                match
+                                    tryResolveArcRelativePath arcPath renamePlan.SourcePath,
+                                    tryResolveArcRelativePath arcPath renamePlan.TargetPath
+                                with
+                                | Error pathError, _
+                                | _, Error pathError -> return Error pathError
+                                | Ok sourceAbsolutePath, Ok targetAbsolutePath ->
+                                    let renameDiskMutation () =
+                                        promise {
+                                            let! renameResult =
+                                                renameWithRetriesAsync sourceAbsolutePath targetAbsolutePath
+
+                                            match renameResult with
+                                            | Ok() -> return Ok()
+                                            | Error renameError ->
+                                                return
+                                                    Error(
+                                                        ArcRenameHelper.mapRenameDiskError
+                                                            renamePlan.SourcePath
+                                                            renamePlan.TargetPath
+                                                            renameError
+                                                    )
+                                        }
+
+                                    return!
+                                        runArcDiskMutation
+                                            vault
+                                            $"renaming '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}'"
+                                            renameDiskMutation
+                                            (fun reloadedArc ->
+                                                ArcRenameHelper.mergeReloadedArcAfterRename
+                                                    renamePlan.SourcePath
+                                                    renamePlan.TargetPath
+                                                    arcLocal
+                                                    reloadedArc
+                                                    vault.pendingArcFileSave
+                                                |> Result.map (fun mergeResult -> {
+                                                    Arc = mergeResult.Arc
+                                                    PendingArcFileSave = mergeResult.PendingArcFileSave
+                                                })
+                                            )
+                        }
+                    )
             with e ->
                 return Error e
         }

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -320,15 +320,16 @@ module ArcDeleteHelper =
 [<RequireQualifiedAccess>]
 module ArcRenameHelper =
 
-    type RenamePlan = {
-        SourcePath: string
-        TargetPath: string
-    }
-
     type IdentifierRenameSyncPlan = {
         Zone: ArcDeletePathRules.AddZone
         OldIdentifier: string
         NewIdentifier: string
+    }
+
+    type RenamePlan = {
+        SourcePath: string
+        TargetPath: string
+        SyncPlan: IdentifierRenameSyncPlan
     }
 
     type MergeResult = {
@@ -339,48 +340,6 @@ module ArcRenameHelper =
         path
         |> PathHelpers.normalizeRelativePath
         |> PathHelpers.normalizePath
-
-    let private deduplicateEvents (events: FileEvent list) =
-        events
-        |> Seq.distinctBy (fun event ->
-            ArcPathValidation.normalizePathForComparison event.Path,
-            event.EventName
-        )
-        |> Seq.toList
-
-    let tryBuildIdentifierRenameSyncPlan
-        (sourcePath: string)
-        (targetPath: string)
-        : Result<IdentifierRenameSyncPlan, exn> =
-        let normalizedSourcePath = normalizeRelativePathForComparison sourcePath
-        let normalizedTargetPath = normalizeRelativePathForComparison targetPath
-
-        match
-            ArcDeletePathRules.tryGetRenameEntityFolderTarget normalizedSourcePath,
-            ArcDeletePathRules.tryGetRenameEntityFolderTarget normalizedTargetPath
-        with
-        | Some(sourceZone, sourceIdentifier), Some(targetZone, targetIdentifier) ->
-            if sourceZone <> targetZone then
-                Error(
-                    exn
-                        $"Renamed folder from '{sourcePath}' to '{targetPath}', but ARC identifier sync only supports renames within the same entity zone."
-                )
-            elif PathHelpers.pathsEqual sourceIdentifier targetIdentifier then
-                Error(
-                    exn
-                        $"Renamed folder from '{sourcePath}' to '{targetPath}', but no ARC identifier change was detected for content sync."
-                )
-            else
-                Ok {
-                    Zone = sourceZone
-                    OldIdentifier = sourceIdentifier
-                    NewIdentifier = targetIdentifier
-                }
-        | _ ->
-            Error(
-                exn
-                    $"Renamed folder from '{sourcePath}' to '{targetPath}', but ARC identifier sync requires ARC entity folder paths under studies/, assays/, workflows/, or runs/."
-            )
 
     let private applyIdentifierRenameSyncPlan (arc: ARC) (syncPlan: IdentifierRenameSyncPlan) =
         match syncPlan.Zone with
@@ -395,31 +354,27 @@ module ArcRenameHelper =
 
     let syncRenamedEntityIdentifierOnDisk
         (arcPath: string)
-        (sourcePath: string)
-        (targetPath: string)
+        (renamePlan: RenamePlan)
         : JS.Promise<Result<unit, exn>> =
         promise {
-            match tryBuildIdentifierRenameSyncPlan sourcePath targetPath with
-            | Error planError -> return Error planError
-            | Ok syncPlan ->
-                match! ARC.tryLoadAsync arcPath with
-                | Error loadError ->
+            match! ARC.tryLoadAsync arcPath with
+            | Error loadError ->
+                return
+                    Error(
+                        exn
+                            $"Renamed folder from '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}', but could not reload ARC for identifier sync: {loadError}"
+                    )
+            | Ok reloadedArc ->
+                try
+                    applyIdentifierRenameSyncPlan reloadedArc renamePlan.SyncPlan
+                    do! reloadedArc.UpdateAsync arcPath
+                    return Ok()
+                with syncError ->
                     return
                         Error(
                             exn
-                                $"Renamed folder from '{sourcePath}' to '{targetPath}', but could not reload ARC for identifier sync: {loadError}"
+                                $"Renamed folder from '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}', but failed to sync ARC identifier from '{renamePlan.SyncPlan.OldIdentifier}' to '{renamePlan.SyncPlan.NewIdentifier}': {syncError.Message}"
                         )
-                | Ok reloadedArc ->
-                    try
-                        applyIdentifierRenameSyncPlan reloadedArc syncPlan
-                        do! reloadedArc.UpdateAsync arcPath
-                        return Ok()
-                    with syncError ->
-                        return
-                            Error(
-                                exn
-                                    $"Renamed folder from '{sourcePath}' to '{targetPath}', but failed to sync ARC identifier from '{syncPlan.OldIdentifier}' to '{syncPlan.NewIdentifier}': {syncError.Message}"
-                            )
         }
 
     let mapRenameDiskError (sourcePath: string) (targetPath: string) (renameError: exn) =
@@ -456,6 +411,12 @@ module ArcRenameHelper =
         | ArcDeletePathRules.RenamePathClassification.GenericTarget _ ->
             Error(exn "Renaming generic files or folders is not supported from the ARC file tree.")
 
+    let private tryGetEntityFolderRenameTarget (classification: ArcDeletePathRules.RenamePathClassification) =
+        match classification with
+        | ArcDeletePathRules.RenamePathClassification.EntityFolderTarget(zone, identifier, normalizedRelativePath) ->
+            Some(zone, identifier, normalizedRelativePath)
+        | _ -> None
+
     let tryBuildRenamePlan (request: RenamePathRequest) : Result<RenamePlan, exn> =
         let requestedRelativePath = normalizeRelativePathForComparison request.relativePath
         let sourceClassification = ArcDeletePathRules.classifyRenameTarget requestedRelativePath
@@ -473,50 +434,49 @@ module ArcRenameHelper =
                 match validateRenamePathClassification targetClassification with
                 | Error validationError -> Error validationError
                 | Ok() ->
-                    Ok {
-                        SourcePath = resolvedSourcePath
-                        TargetPath = targetPath
-                    }
-
-    let buildRenameEvents (sourcePath: string) (targetPath: string) : FileEvent list =
-        match
-            ArcDeletePathRules.tryGetRenameEntityFolderTarget sourcePath,
-            ArcDeletePathRules.tryGetRenameEntityFolderTarget targetPath
-        with
-        | Some(sourceZone, sourceIdentifier), Some(targetZone, targetIdentifier) ->
-            let oldCanonicalPaths =
-                ArcDeletePathRules.buildCanonicalEntityPaths sourceZone sourceIdentifier
-
-            let newCanonicalPaths =
-                ArcDeletePathRules.buildCanonicalEntityPaths targetZone targetIdentifier
-
-            [
-                for oldPath in oldCanonicalPaths do
-                    {
-                        EventName = EventName.Unlink
-                        Path = oldPath
-                    }
-
-                for newPath in newCanonicalPaths do
-                    {
-                        EventName = EventName.Add
-                        Path = newPath
-                    }
-            ]
-            |> deduplicateEvents
-        | _ -> []
+                    match
+                        tryGetEntityFolderRenameTarget sourceClassification,
+                        tryGetEntityFolderRenameTarget targetClassification
+                    with
+                    | Some(sourceZone, sourceIdentifier, sourcePath), Some(targetZone, targetIdentifier, targetPath) ->
+                        if sourceZone <> targetZone then
+                            Error(
+                                exn
+                                    $"Renamed folder from '{sourcePath}' to '{targetPath}', but ARC identifier sync only supports renames within the same entity zone."
+                            )
+                        else
+                            Ok {
+                                SourcePath = sourcePath
+                                TargetPath = targetPath
+                                SyncPlan = {
+                                    Zone = sourceZone
+                                    OldIdentifier = sourceIdentifier
+                                    NewIdentifier = targetIdentifier
+                                }
+                            }
+                    | _ ->
+                        Error(
+                            exn
+                                $"Renamed folder from '{resolvedSourcePath}' to '{targetPath}', but ARC identifier sync requires validated ARC entity folder paths."
+                        )
 
     let mergeReloadedArcAfterRename
-        (sourcePath: string)
-        (targetPath: string)
+        (renamePlan: RenamePlan)
         (arcLocal: ARC)
         (reloadedArc: ARC)
         : Result<MergeResult, exn> =
-        let arcLocalForMerge = arcLocal.Copy()
-        let renameEvents = buildRenameEvents sourcePath targetPath
-        let mergedArc = ARC.merge arcLocalForMerge reloadedArc renameEvents
-
-        Ok { Arc = mergedArc }
+        if not (arcLocal.hasInMemoryChanges()) then
+            Ok { Arc = reloadedArc.Copy() }
+        else
+            try
+                let mergedArc = arcLocal.Copy()
+                applyIdentifierRenameSyncPlan mergedArc renamePlan.SyncPlan
+                Ok { Arc = mergedArc }
+            with mergeError ->
+                Error(
+                    exn
+                        $"Unable to merge renamed ARC entity from '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}': {mergeError.Message}"
+                )
 
 
 /// This depends on the types in this file, but the types on this file must call this to bind IPC calls :/
@@ -900,8 +860,7 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                 let! syncResult =
                                                     ArcRenameHelper.syncRenamedEntityIdentifierOnDisk
                                                         arcPath
-                                                        renamePlan.SourcePath
-                                                        renamePlan.TargetPath
+                                                        renamePlan
 
                                                 return syncResult
                                             | Error renameError ->
@@ -924,8 +883,7 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                     renameDiskMutation
                                                     (fun reloadedArc ->
                                                         ArcRenameHelper.mergeReloadedArcAfterRename
-                                                            renamePlan.SourcePath
-                                                            renamePlan.TargetPath
+                                                            renamePlan
                                                             arcLocal
                                                             reloadedArc
                                                         |> Result.map (fun mergeResult -> { Arc = mergeResult.Arc })))

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -21,6 +21,14 @@ open Swate.Electron.Shared.DTOs.NoteSearchDto
 
 let private fsPromisesDynamic: obj = importAll "fs/promises"
 let private pathDynamic: obj = importAll "path"
+let private processDynamic: obj = emitJsExpr () "process"
+
+let private isWindowsPlatform () =
+    try
+        let platform = processDynamic?platform |> unbox<string>
+        platform = "win32"
+    with _ ->
+        false
 
 [<RequireQualifiedAccess>]
 module ArcPathValidation =
@@ -132,8 +140,7 @@ let private renameRetryStrategy = {
         function
         | Some "EPERM"
         | Some "EACCES"
-        | Some "EBUSY"
-        | Some "ENOTEMPTY" -> true
+        | Some "EBUSY" -> true
         | _ -> false
 }
 
@@ -219,6 +226,32 @@ let private runArcDiskMutation
                         return Ok()
         finally
             vault.isBusyWriting <- false
+    }
+
+let private runWithRenameScopedPolling
+    (vault: ArcVault)
+    (operation: unit -> JS.Promise<Result<unit, exn>>)
+    : JS.Promise<Result<unit, exn>> =
+    promise {
+        let useScopedPolling = isWindowsPlatform () && vault.watcher.IsSome
+
+        if useScopedPolling then
+            do! vault.StopFileWatcher()
+            vault.StartFileWatcher(usePolling = true)
+
+        let! operationResult =
+            promise {
+                try
+                    return! operation ()
+                with e ->
+                    return Error e
+            }
+
+        if useScopedPolling then
+            do! vault.StopFileWatcher()
+            vault.StartFileWatcher()
+
+        return operationResult
     }
 
 [<RequireQualifiedAccess>]
@@ -373,6 +406,7 @@ module ArcRenameHelper =
 
     let private validateRenamePathClassification (classification: ArcDeletePathRules.RenamePathClassification) =
         match classification with
+        | ArcDeletePathRules.RenamePathClassification.EntityFolderTarget _ -> Ok()
         | ArcDeletePathRules.RenamePathClassification.RootTarget ->
             Error(exn "Renaming the ARC root is not allowed.")
         | ArcDeletePathRules.RenamePathClassification.DisallowedTarget _ ->
@@ -383,10 +417,11 @@ module ArcRenameHelper =
             Error(exn "Renaming the investigation file is not supported.")
         | ArcDeletePathRules.RenamePathClassification.AddZoneRootTarget _ ->
             Error(exn "Renaming add-zone root folders (studies/, assays/, workflows/, runs/) is not allowed.")
-        | ArcDeletePathRules.RenamePathClassification.EntityFolderTarget _
         | ArcDeletePathRules.RenamePathClassification.CanonicalEntityFileTarget _
-        | ArcDeletePathRules.RenamePathClassification.CanonicalDataMapFileTarget _
-        | ArcDeletePathRules.RenamePathClassification.GenericTarget _ -> Ok()
+        | ArcDeletePathRules.RenamePathClassification.CanonicalDataMapFileTarget _ ->
+            Error(exn "Renaming canonical ARC files is not supported. Rename the containing ARC entity folder instead.")
+        | ArcDeletePathRules.RenamePathClassification.GenericTarget _ ->
+            Error(exn "Renaming generic files or folders is not supported from the ARC file tree.")
 
     let tryBuildRenamePlan (request: RenamePathRequest) : Result<RenamePlan, exn> =
         let requestedRelativePath = normalizeRelativePathForComparison request.relativePath
@@ -857,22 +892,25 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                         }
 
                                     return!
-                                        runArcDiskMutation
+                                        runWithRenameScopedPolling
                                             vault
-                                            $"renaming '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}'"
-                                            renameDiskMutation
-                                            (fun reloadedArc ->
-                                                ArcRenameHelper.mergeReloadedArcAfterRename
-                                                    renamePlan.SourcePath
-                                                    renamePlan.TargetPath
-                                                    arcLocal
-                                                    reloadedArc
-                                                    vault.pendingArcFileSave
-                                                |> Result.map (fun mergeResult -> {
-                                                    Arc = mergeResult.Arc
-                                                    PendingArcFileSave = mergeResult.PendingArcFileSave
-                                                })
-                                            )
+                                            (fun () ->
+                                                runArcDiskMutation
+                                                    vault
+                                                    $"renaming '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}'"
+                                                    renameDiskMutation
+                                                    (fun reloadedArc ->
+                                                        ArcRenameHelper.mergeReloadedArcAfterRename
+                                                            renamePlan.SourcePath
+                                                            renamePlan.TargetPath
+                                                            arcLocal
+                                                            reloadedArc
+                                                            vault.pendingArcFileSave
+                                                        |> Result.map (fun mergeResult -> {
+                                                            Arc = mergeResult.Arc
+                                                            PendingArcFileSave = mergeResult.PendingArcFileSave
+                                                        })
+                                                    ))
                         }
                     )
             with e ->

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -338,8 +338,7 @@ module ArcRenameHelper =
 
     let private normalizeRelativePathForComparison (path: string) =
         path
-        |> PathHelpers.normalizeRelativePath
-        |> PathHelpers.normalizePath
+        |> PathHelpers.normalizeCanonicalRelativePath
 
     let private applyIdentifierRenameSyncPlan (arc: ARC) (syncPlan: IdentifierRenameSyncPlan) =
         match syncPlan.Zone with
@@ -465,18 +464,22 @@ module ArcRenameHelper =
         (arcLocal: ARC)
         (reloadedArc: ARC)
         : Result<MergeResult, exn> =
-        if not (arcLocal.hasInMemoryChanges()) then
-            Ok { Arc = reloadedArc.Copy() }
-        else
-            try
-                let mergedArc = arcLocal.Copy()
-                applyIdentifierRenameSyncPlan mergedArc renamePlan.SyncPlan
-                Ok { Arc = mergedArc }
-            with mergeError ->
-                Error(
-                    exn
-                        $"Unable to merge renamed ARC entity from '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}': {mergeError.Message}"
-                )
+        try
+            let arcLocalForMerge =
+                if arcLocal.hasInMemoryChanges() then
+                    let renamedLocalArc = arcLocal.Copy()
+                    applyIdentifierRenameSyncPlan renamedLocalArc renamePlan.SyncPlan
+                    renamedLocalArc
+                else
+                    arcLocal
+
+            let mergedArc = ARC.merge arcLocalForMerge reloadedArc []
+            Ok { Arc = mergedArc }
+        with mergeError ->
+            Error(
+                exn
+                    $"Unable to merge renamed ARC entity from '{renamePlan.SourcePath}' to '{renamePlan.TargetPath}': {mergeError.Message}"
+            )
 
 
 /// This depends on the types in this file, but the types on this file must call this to bind IPC calls :/

--- a/src/Electron/src/Main/Main.fsproj
+++ b/src/Electron/src/Main/Main.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="ArcMerge\Extensions.fs" />
     <Compile Include="ArcMerge\ArcEntityRefHelper.fs" />
     <Compile Include="ArcMerge\ArcMergeLibraryExtensions.fs" />
+    <Compile Include="ArcMerge\ArcAddExtensions.fs" />
     <Compile Include="Git\GitTokenProvider.fs" />
     <Compile Include="Git\GitInternals.fs" />
     <Compile Include="Git\GitService.fs" />

--- a/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
+++ b/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
@@ -37,5 +37,5 @@ module FileExplorerDeleteHelper =
         pendingPath
         |> Option.map normalizeRelativePath
         |> Option.exists (fun normalizedPendingPath ->
-            isSameOrDescendantPath normalizedPendingPath normalizedDeletedPath
+            PathHelpers.isSameOrDescendantPathForFsComparison normalizedPendingPath normalizedDeletedPath
         )

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
@@ -228,10 +228,21 @@ type FileTree =
             inlineCreateKindForItem item |> Option.iter openCreateModal
 
         let canRenameFromItem (item: FileItem) =
-            item.IsDirectory && FileTreeRenameHelper.canRenameItem item
+            FileTreeRenameHelper.canRenameItem item
 
         let applyCreateError errorMessage =
             Renderer.Components.ARCHelper.applyViewError pageStateCtx.setState errorMessage
+
+        let reloadPreviewByPath (path: string) : JS.Promise<Result<unit, string>> =
+            promise {
+                let! openResult = Renderer.Components.ARCHelper.openView path
+
+                match openResult with
+                | Ok loaded ->
+                    Renderer.Components.ARCHelper.applyLoadedView pageStateCtx.setState loaded
+                    return Ok()
+                | Error errorMessage -> return Error errorMessage
+            }
 
         let confirmDeleteItem () =
             FileTreeDeleteWorkflow.confirmDeleteItem {
@@ -304,10 +315,12 @@ type FileTree =
                 {
                     pendingRenameDraft = pendingRenameDraft
                     selectedTreePath = fileStateCtx.state.Selection.TreePath
+                    pageState = pageStateCtx.state
                     closeRenameModal = closeRenameModal
                     setIsRenaming = setIsRenaming
                     setSelection = fileStateCtx.setSelection
                     refreshGitStatus = gitStateCtx.refresh
+                    reloadPreviewByPath = reloadPreviewByPath
                     renamePath = Api.ipcArcVaultApi.renamePath
                     enqueueError = errorModal.enqueue
                     arcScopeId = arcScopeId

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
@@ -14,6 +14,7 @@ open Fable.Core.JsInterop
 open ARCtrl
 open Types
 open Helper
+open FileTreeRenameHelper
 
 module private FileTreeHelper =
     let stagePendingArcFileSave (arcFile: ArcFiles option) : JS.Promise<Result<unit, exn>> = promise {
@@ -49,6 +50,7 @@ type FileTree =
 
         let pageStateCtx = Renderer.Context.PageStateContext.usePageStateCtx ()
         let fileStateCtx = Renderer.Context.FileStateContext.useFileStateCtx ()
+        let gitStateCtx = Renderer.Context.GitStateContext.useGitStateCtx ()
         let errorModal = ErrorModal.Context.useErrorModalCtx ()
         let arcScopeId = useCurrentArcScopeId ()
 
@@ -56,6 +58,8 @@ type FileTree =
             React.useState<ArcExplorerNodeKind option> None
 
         let pendingArcFileSave, setPendingArcFileSave = React.useState<ArcFiles option> None
+        let pendingRenameDraft, setPendingRenameDraft = React.useState<ArcRenameDraft option> None
+        let isRenaming, setIsRenaming = React.useState false
         let pendingDeleteItem, setPendingDeleteItem = React.useState<FileItem option> None
         let isDeleting, setIsDeleting = React.useState false
 
@@ -201,8 +205,14 @@ type FileTree =
         let closeDeleteModal () =
             setPendingDeleteItem None
 
+        let closeRenameModal () =
+            setPendingRenameDraft None
+
         let requestDeleteItem =
             FileTreeDeleteWorkflow.requestDeleteItem setPendingDeleteItem
+
+        let requestRenameItem =
+            FileTreeRenameWorkflow.requestRenameItem setPendingRenameDraft errorModal.enqueue arcScopeId
 
         let rootPath = fileTree |> Option.map (fun tree -> tree.path)
 
@@ -216,6 +226,9 @@ type FileTree =
 
         let createFromItem item =
             inlineCreateKindForItem item |> Option.iter openCreateModal
+
+        let canRenameFromItem (item: FileItem) =
+            item.IsDirectory && FileTreeRenameHelper.canRenameItem item
 
         let applyCreateError errorMessage =
             Renderer.Components.ARCHelper.applyViewError pageStateCtx.setState errorMessage
@@ -274,14 +287,32 @@ type FileTree =
         let deleteContextMenuItems =
             FileTreeDeleteWorkflow.deleteContextMenuItems requestDeleteItem
 
+        let renameContextMenuItems =
+            FileTreeRenameWorkflow.renameContextMenuItems requestRenameItem
+
         let baseContextMenuItems (item: FileItem) =
-            arcCreateContextMenuItems item @ deleteContextMenuItems item
+            arcCreateContextMenuItems item @ renameContextMenuItems item @ deleteContextMenuItems item
 
         let createContextMenuItems =
             Renderer.Components.FileExplorerLfs.createContextMenuItems
                 errorModal.enqueue
                 arcScopeId
                 baseContextMenuItems
+
+        let confirmRenameItem (newName: string) =
+            FileTreeRenameWorkflow.confirmRenameItem
+                {
+                    pendingRenameDraft = pendingRenameDraft
+                    selectedTreePath = fileStateCtx.state.Selection.TreePath
+                    closeRenameModal = closeRenameModal
+                    setIsRenaming = setIsRenaming
+                    setSelection = fileStateCtx.setSelection
+                    refreshGitStatus = gitStateCtx.refresh
+                    renamePath = Api.ipcArcVaultApi.renamePath
+                    enqueueError = errorModal.enqueue
+                    arcScopeId = arcScopeId
+                }
+                newName
 
         let activeCreateKind =
             pendingCreateKind |> Option.defaultValue ArcExplorerNodeKind.Study
@@ -303,6 +334,16 @@ type FileTree =
                 isDeleting = isDeleting
             )
 
+        let renameModal =
+            FileTreeRename.RenameModal(
+                isOpen = pendingRenameDraft.IsSome,
+                itemName = (pendingRenameDraft |> Option.map (fun draft -> draft.Item.Name)),
+                initialName = (pendingRenameDraft |> Option.map _.InitialName),
+                close = closeRenameModal,
+                submit = confirmRenameItem,
+                isRenaming = isRenaming
+            )
+
         match fileItem with
         | Some rootItem ->
             let visibleItems = rootItem.Children |> Option.defaultValue []
@@ -318,6 +359,8 @@ type FileTree =
                             onContextMenu = createContextMenuItems,
                             canCreateItem = canCreateFromItem,
                             onCreateItem = createFromItem,
+                            canRenameItem = canRenameFromItem,
+                            onRenameItem = requestRenameItem,
                             canDeleteItem = canDeleteItem,
                             onDeleteItem = requestDeleteItem,
                             selectedItemId = fileStateCtx.state.Selection.TreePath,
@@ -326,11 +369,13 @@ type FileTree =
                     ]
                 ]
                 arcCreateModal
+                renameModal
                 deleteConfirmModal
             ]
         | None ->
             React.Fragment [
                 FileTree.EmptyFileTreePlaceholder()
                 arcCreateModal
+                renameModal
                 deleteConfirmModal
             ]

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
@@ -245,9 +245,6 @@ type FileTree =
         let createFromItem item =
             inlineCreateKindForItem item |> Option.iter openCreateModal
 
-        let canRenameFromItem (item: FileItem) =
-            FileTreeRenameHelper.canRenameItem item
-
         let applyCreateError errorMessage =
             errorModal.enqueue (ErrorModalRequest.create (errorMessage, title = "Could not create ARC file", ?scopeId = arcScopeId))
 
@@ -386,8 +383,7 @@ type FileTree =
                             getItemIconClass = getItemIconClass,
                             canCreateItem = canCreateFromItem,
                             onCreateItem = createFromItem,
-                            canRenameItem = canRenameFromItem,
-                            onRenameItem = requestRenameItem,
+                            getItemActions = renameContextMenuItems,
                             canDeleteItem = canDeleteItem,
                             onDeleteItem = requestDeleteItem,
                             selectedItemId = fileStateCtx.state.Selection.TreePath,

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRename.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRename.fs
@@ -1,0 +1,197 @@
+namespace Renderer.Components.LeftSidebar.FileExplorer
+
+open Fable.Core
+open Feliz
+open Swate.Components
+open Swate.Components.ErrorModal
+open Swate.Components.FileExplorer.Types
+open Swate.Components.Shared
+open Swate.Electron.Shared.FileIOTypes
+open Renderer.Components.LeftSidebar.FileExplorer.Types
+open Renderer.Components.LeftSidebar.FileExplorer.FileTreeRenameHelper
+
+module FileTreeRenameWorkflow =
+
+    type ConfirmRenameConfig = {
+        pendingRenameDraft: ArcRenameDraft option
+        selectedTreePath: string option
+        closeRenameModal: unit -> unit
+        setIsRenaming: bool -> unit
+        setSelection: ArcSelection -> unit
+        refreshGitStatus: unit -> unit
+        renamePath: RenamePathRequest -> JS.Promise<Result<unit, exn>>
+        enqueueError: ErrorModalRequest -> unit
+        arcScopeId: string option
+    }
+
+    let private enqueueRenameError
+        (enqueueError: ErrorModalRequest -> unit)
+        (arcScopeId: string option)
+        (errorMessage: string)
+        =
+        enqueueError (
+            ErrorModalRequest.create (
+                errorMessage,
+                title = "Could not rename item",
+                ?scopeId = arcScopeId
+            )
+        )
+
+    let private applyRenameError (config: ConfirmRenameConfig) (errorMessage: string) =
+        enqueueRenameError config.enqueueError config.arcScopeId errorMessage
+
+    let requestRenameItem
+        (setPendingRenameDraft: ArcRenameDraft option -> unit)
+        (enqueueError: ErrorModalRequest -> unit)
+        (arcScopeId: string option)
+        (item: FileItem)
+        =
+        match tryBuildRenameDraft item with
+        | Ok renameDraft -> setPendingRenameDraft (Some renameDraft)
+        | Error validationError -> enqueueRenameError enqueueError arcScopeId validationError
+
+    let renameContextMenuItems (requestRenameItem: FileItem -> unit) (item: FileItem) =
+        if canRenameItem item then
+            [
+                {
+                    Label = "Rename"
+                    Icon = "swt:fluent--edit-24-regular"
+                    OnClick = fun () -> requestRenameItem item
+                    Disabled = None
+                }
+            ]
+        else
+            []
+
+    let confirmRenameItem (config: ConfirmRenameConfig) (newName: string) =
+        match config.pendingRenameDraft with
+        | None -> config.closeRenameModal ()
+        | Some renameDraft ->
+            match normalizeRenameName newName with
+            | Error validationError -> applyRenameError config validationError
+            | Ok normalizedNewName ->
+                let targetPath = buildRenamedPath renameDraft.SourcePath normalizedNewName
+
+                if PathHelpers.pathsEqual targetPath renameDraft.SourcePath then
+                    config.closeRenameModal ()
+                else
+                    config.setIsRenaming true
+
+                    promise {
+                        let! renameResult =
+                            config.renamePath {
+                                relativePath = renameDraft.SourcePath
+                                newName = normalizedNewName
+                            }
+
+                        match renameResult with
+                        | Ok() ->
+                            tryRemapSelectionPath renameDraft.SourcePath targetPath config.selectedTreePath
+                            |> Option.iter (fun remappedSelectionPath ->
+                                config.setSelection (ArcSelection.forTreePath (Some remappedSelectionPath))
+                            )
+
+                            config.refreshGitStatus ()
+                            config.closeRenameModal ()
+                        | Error renameError -> applyRenameError config renameError.Message
+                    }
+                    |> Promise.catch (fun promiseError -> applyRenameError config promiseError.Message)
+                    |> Promise.map (fun _ -> config.setIsRenaming false)
+                    |> Promise.start
+
+[<Erase; Mangle(false)>]
+type FileTreeRename =
+
+    [<ReactComponent>]
+    static member RenameModal
+        (
+            isOpen: bool,
+            itemName: string option,
+            initialName: string option,
+            close: unit -> unit,
+            submit: string -> unit,
+            ?isRenaming: bool
+        ) =
+
+        let renameName, setRenameName = React.useState (initialName |> Option.defaultValue "")
+        let isRenaming = defaultArg isRenaming false
+
+        React.useEffect (
+            (fun () -> setRenameName (initialName |> Option.defaultValue "")),
+            [| box initialName; box isOpen |]
+        )
+
+        let setIsOpen isOpen =
+            if not isOpen then
+                close ()
+
+        let displayName = itemName |> Option.defaultValue "this item"
+        let normalizedNameResult = normalizeRenameName renameName
+        let isValid = normalizedNameResult |> Result.isOk
+
+        let submitIfValid () =
+            match normalizeRenameName renameName with
+            | Ok normalizedName -> submit normalizedName
+            | Error _ -> ()
+
+        let footer =
+            Html.div [
+                prop.className "swt:flex swt:gap-2 swt:justify-end swt:w-full"
+                prop.children [
+                    Html.button [
+                        prop.className "swt:btn swt:btn-ghost"
+                        prop.disabled isRenaming
+                        prop.onClick (fun _ -> close ())
+                        prop.text "Cancel"
+                    ]
+                    Html.button [
+                        prop.className "swt:btn swt:btn-primary"
+                        prop.disabled ((not isValid) || isRenaming)
+                        prop.onClick (fun _ -> submitIfValid ())
+                        prop.children [
+                            if isRenaming then
+                                Html.span [ prop.text "Renaming..." ]
+                            else
+                                Html.span [ prop.text "Rename" ]
+                        ]
+                    ]
+                ]
+            ]
+
+        let content =
+            Html.fieldSet [
+                prop.className "swt:fieldset"
+                prop.children [
+                    Html.legend [
+                        prop.className "swt:fieldset-legend"
+                        prop.text "New name"
+                    ]
+                    Html.label [
+                        prop.className "swt:input swt:w-full"
+                        prop.children [
+                            Html.input [
+                                prop.autoFocus true
+                                prop.disabled isRenaming
+                                prop.value renameName
+                                prop.onChange setRenameName
+                                prop.onKeyDown (key.enter, fun _ -> submitIfValid ())
+                            ]
+                        ]
+                    ]
+                    Html.p [
+                        prop.hidden isValid
+                        prop.className "swt:text-error swt:text-sm"
+                        prop.text "Name is required and must not contain path separators."
+                    ]
+                ]
+            ]
+
+        BaseModal.Modal(
+            isOpen = isOpen,
+            setIsOpen = setIsOpen,
+            header = Html.text "Rename Item",
+            description = Html.text $"Rename '{displayName}' in the current ARC.",
+            children = content,
+            footer = footer,
+            debug = "arc-rename"
+        )

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRename.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRename.fs
@@ -15,10 +15,12 @@ module FileTreeRenameWorkflow =
     type ConfirmRenameConfig = {
         pendingRenameDraft: ArcRenameDraft option
         selectedTreePath: string option
+        pageState: Renderer.Types.PageState option
         closeRenameModal: unit -> unit
         setIsRenaming: bool -> unit
         setSelection: ArcSelection -> unit
         refreshGitStatus: unit -> unit
+        reloadPreviewByPath: string -> JS.Promise<Result<unit, string>>
         renamePath: RenamePathRequest -> JS.Promise<Result<unit, exn>>
         enqueueError: ErrorModalRequest -> unit
         arcScopeId: string option
@@ -39,6 +41,19 @@ module FileTreeRenameWorkflow =
 
     let private applyRenameError (config: ConfirmRenameConfig) (errorMessage: string) =
         enqueueRenameError config.enqueueError config.arcScopeId errorMessage
+
+    let private tryRemapActiveArcFilePath
+        (sourcePath: string)
+        (targetPath: string)
+        (pageState: Renderer.Types.PageState option)
+        =
+        match pageState with
+        | Some(Renderer.Types.PageState.ArcFilePage arcFile) ->
+            arcFile.TryGetRelativePath()
+            |> Option.bind (fun arcFilePath ->
+                tryRemapSelectionPath sourcePath targetPath (Some arcFilePath)
+            )
+        | _ -> None
 
     let requestRenameItem
         (setPendingRenameDraft: ArcRenameDraft option -> unit)
@@ -90,6 +105,18 @@ module FileTreeRenameWorkflow =
                             |> Option.iter (fun remappedSelectionPath ->
                                 config.setSelection (ArcSelection.forTreePath (Some remappedSelectionPath))
                             )
+
+                            match tryRemapActiveArcFilePath renameDraft.SourcePath targetPath config.pageState with
+                            | Some remappedArcFilePath ->
+                                let! reloadResult = config.reloadPreviewByPath remappedArcFilePath
+
+                                match reloadResult with
+                                | Ok() -> ()
+                                | Error reloadError ->
+                                    applyRenameError
+                                        config
+                                        $"Renamed item, but could not refresh the open ARC file preview: {reloadError}"
+                            | None -> ()
 
                             config.refreshGitStatus ()
                             config.closeRenameModal ()

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
@@ -8,13 +8,11 @@ open Renderer.Components.LeftSidebar.FileExplorer.Types
 
 let private tryGetItemRelativePath (item: FileItem) =
     item.Path
-    |> Option.map PathHelpers.normalizeRelativePath
-    |> Option.map PathHelpers.normalizePath
+    |> Option.map PathHelpers.normalizeCanonicalRelativePath
 
 let private normalizeRelativePath (path: string) =
     path
-    |> PathHelpers.normalizeRelativePath
-    |> PathHelpers.normalizePath
+    |> PathHelpers.normalizeCanonicalRelativePath
 
 let normalizeRenameName (newName: string) =
     validateRenameName newName

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
@@ -4,8 +4,12 @@ open Swate.Components.FileExplorer.Types
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOHelper
 open Swate.Electron.Shared.RenamePathRules
-open Renderer.Components.LeftSidebar.FileExplorer.Helper
 open Renderer.Components.LeftSidebar.FileExplorer.Types
+
+let private tryGetItemRelativePath (item: FileItem) =
+    item.Path
+    |> Option.map PathHelpers.normalizeRelativePath
+    |> Option.map PathHelpers.normalizePath
 
 let private normalizeRelativePath (path: string) =
     path

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
@@ -23,11 +23,7 @@ let buildRenamedPath (sourcePath: string) (newName: string) =
     buildRenamedSiblingPath sourcePath newName
 
 let private isRenameContextMenuTarget (relativePath: string) =
-    match ArcDeletePathRules.classifyRenameTarget relativePath with
-    | ArcDeletePathRules.RenamePathClassification.EntityFolderTarget _
-    | ArcDeletePathRules.RenamePathClassification.CanonicalEntityFileTarget _
-    | ArcDeletePathRules.RenamePathClassification.CanonicalDataMapFileTarget _ -> true
-    | _ -> false
+    ArcDeletePathRules.isRenamePathAllowed relativePath
 
 let canRenameItem (item: FileItem) =
     tryGetItemRelativePath item
@@ -42,10 +38,7 @@ let tryBuildRenameDraft (item: FileItem) : Result<ArcRenameDraft, string> =
         if ArcDeletePathRules.isRenamePathAllowed normalizedRelativePath |> not then
             Error "Renaming this item is not allowed."
         else
-            let sourcePath =
-                normalizedRelativePath
-                |> ArcDeletePathRules.resolveRenameSourcePath
-                |> normalizeRelativePath
+            let sourcePath = normalizedRelativePath
 
             let initialName = PathHelpers.getNameFromPath sourcePath
 

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRenameHelper.fs
@@ -1,0 +1,88 @@
+module Renderer.Components.LeftSidebar.FileExplorer.FileTreeRenameHelper
+
+open Swate.Components.FileExplorer.Types
+open Swate.Components.Shared
+open Swate.Electron.Shared.FileIOHelper
+open Swate.Electron.Shared.RenamePathRules
+open Renderer.Components.LeftSidebar.FileExplorer.Helper
+open Renderer.Components.LeftSidebar.FileExplorer.Types
+
+let private normalizeRelativePath (path: string) =
+    path
+    |> PathHelpers.normalizeRelativePath
+    |> PathHelpers.normalizePath
+
+let normalizeRenameName (newName: string) =
+    validateRenameName newName
+
+let buildRenamedPath (sourcePath: string) (newName: string) =
+    buildRenamedSiblingPath sourcePath newName
+
+let private isRenameContextMenuTarget (relativePath: string) =
+    match ArcDeletePathRules.classifyRenameTarget relativePath with
+    | ArcDeletePathRules.RenamePathClassification.EntityFolderTarget _
+    | ArcDeletePathRules.RenamePathClassification.CanonicalEntityFileTarget _
+    | ArcDeletePathRules.RenamePathClassification.CanonicalDataMapFileTarget _ -> true
+    | _ -> false
+
+let canRenameItem (item: FileItem) =
+    tryGetItemRelativePath item
+    |> Option.exists isRenameContextMenuTarget
+
+let tryBuildRenameDraft (item: FileItem) : Result<ArcRenameDraft, string> =
+    match tryGetItemRelativePath item with
+    | None -> Error "Could not resolve the selected item path for rename."
+    | Some relativePath ->
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        if ArcDeletePathRules.isRenamePathAllowed normalizedRelativePath |> not then
+            Error "Renaming this item is not allowed."
+        else
+            let sourcePath =
+                normalizedRelativePath
+                |> ArcDeletePathRules.resolveRenameSourcePath
+                |> normalizeRelativePath
+
+            let initialName = PathHelpers.getNameFromPath sourcePath
+
+            Ok {
+                Item = item
+                SourcePath = sourcePath
+                InitialName = initialName
+            }
+
+let tryRemapSelectionPath (sourcePath: string) (targetPath: string) (selectedPath: string option) =
+    let normalizedSourcePath = normalizeRelativePath sourcePath
+    let normalizedTargetPath = normalizeRelativePath targetPath
+
+    selectedPath
+    |> Option.map normalizeRelativePath
+    |> Option.bind (fun normalizedSelectedPath ->
+        if PathHelpers.isSameOrDescendantPath normalizedSelectedPath normalizedSourcePath |> not then
+            None
+        else
+            let selectedSegments = getNonEmptyPathParts normalizedSelectedPath
+            let sourceSegments = getNonEmptyPathParts normalizedSourcePath
+            let targetSegments = getNonEmptyPathParts normalizedTargetPath
+
+            if selectedSegments.Length < sourceSegments.Length then
+                None
+            else
+                let samePrefix =
+                    sourceSegments
+                    |> Array.mapi (fun index segment ->
+                        PathHelpers.pathsEqual segment selectedSegments.[index]
+                    )
+                    |> Array.forall id
+
+                if samePrefix |> not then
+                    None
+                else
+                    let suffixSegments =
+                        selectedSegments
+                        |> Array.skip sourceSegments.Length
+
+                    Array.append targetSegments suffixSegments
+                    |> String.concat "/"
+                    |> Some
+    )

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/Helper.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/Helper.fs
@@ -54,7 +54,7 @@ let rec private collectSelectedDirectoryPathChain
 
     let isInSelectedPathChain =
         selectedTreeItemPath
-        |> Option.exists (fun focusedPath -> isSameOrDescendantPath focusedPath normalizedNodePath)
+        |> Option.exists (fun focusedPath -> PathHelpers.isSameOrDescendantPath focusedPath normalizedNodePath)
 
     if node.isDirectory then
         let nextLoadedPaths =
@@ -107,7 +107,7 @@ let rec loopPaths (loadedDirectoryPaths: Set<string>) (selectedTreeItemPath: str
                 Id = parent.path
                 IsExpanded =
                     selectedTreeItemPath
-                    |> Option.exists (fun focusedPath -> isSameOrDescendantPath focusedPath parent.path)
+                    |> Option.exists (fun focusedPath -> PathHelpers.isSameOrDescendantPath focusedPath parent.path)
                 Children = children
         }
         |> Renderer.Components.FileExplorerLfs.withFileTreeNodeLfsState parent

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/Types.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/Types.fs
@@ -1,5 +1,12 @@
 module Renderer.Components.LeftSidebar.FileExplorer.Types
 
+open Swate.Components.FileExplorer.Types
 open Swate.Components.Shared
 
 type ArcCreateDraft = { ArcFile: ArcFiles; Path: string }
+
+type ArcRenameDraft = {
+    Item: FileItem
+    SourcePath: string
+    InitialName: string
+}

--- a/src/Electron/src/Renderer/Renderer.fsproj
+++ b/src/Electron/src/Renderer/Renderer.fsproj
@@ -24,7 +24,9 @@
     <Compile Include="Components\FileExplorerDeleteHelper.fs" />
     <Compile Include="Components\LeftSidebar\FileExplorer\Types.fs" />
     <Compile Include="Components\LeftSidebar\FileExplorer\Helper.fs" />
+    <Compile Include="Components\LeftSidebar\FileExplorer\FileTreeRenameHelper.fs" />
     <Compile Include="Components\LeftSidebar\FileExplorer\CreateArcFileModal.fs" />
+    <Compile Include="Components\LeftSidebar\FileExplorer\FileTreeRename.fs" />
     <Compile Include="Components\LeftSidebar\FileExplorer\FileTreeDelete.fs" />
     <Compile Include="Components\LeftSidebar\FileExplorer\FileTree.fs" />
     <Compile Include="Components\LeftSidebar\FileExplorer\Main.fs" />

--- a/src/Electron/src/Swate.Electron.Shared/FileIOHelper.fs
+++ b/src/Electron/src/Swate.Electron.Shared/FileIOHelper.fs
@@ -17,16 +17,6 @@ let getPathDepth (path: string) =
 let pathsEqual (left: string) (right: string) =
     PathHelpers.normalizePath left = PathHelpers.normalizePath right
 
-let isSameOrDescendantPath (path: string) (ancestorPath: string) =
-    let normalizedPath = PathHelpers.normalizePath path
-    let normalizedAncestorPath = PathHelpers.normalizePath ancestorPath
-    String.IsNullOrWhiteSpace normalizedAncestorPath
-    || normalizedPath = normalizedAncestorPath
-    || normalizedPath.StartsWith(normalizedAncestorPath + "/", StringComparison.OrdinalIgnoreCase)
-
-let private containsTraversalSegments (path: string) =
-    path.Split('/') |> Array.exists (fun segment -> segment = "." || segment = "..")
-
 let private tryGetRepoRelativePathCore (repoRoot: string) (absolutePath: string) (allowRoot: bool) =
     let normalizedRoot = PathHelpers.normalizePath repoRoot
     let normalizedAbsolutePath = PathHelpers.normalizePath absolutePath
@@ -35,13 +25,13 @@ let private tryGetRepoRelativePathCore (repoRoot: string) (absolutePath: string)
         None
     elif pathsEqual normalizedAbsolutePath normalizedRoot then
         if allowRoot then Some "" else None
-    elif isSameOrDescendantPath normalizedAbsolutePath normalizedRoot then
+    elif PathHelpers.isSameOrDescendantPath normalizedAbsolutePath normalizedRoot then
         let prefix = normalizedRoot + "/"
 
         if normalizedAbsolutePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) then
             let relativePath = normalizedAbsolutePath.Substring(prefix.Length)
 
-            if String.IsNullOrWhiteSpace relativePath || containsTraversalSegments relativePath then
+            if String.IsNullOrWhiteSpace relativePath || PathHelpers.containsPathTraversalSegments relativePath then
                 None
             else
                 Some relativePath

--- a/src/Electron/src/Swate.Electron.Shared/FileIOTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/FileIOTypes.fs
@@ -83,3 +83,8 @@ type NoteTarget =
     | Assay of string
     | Workflow of string
     | Run of string
+
+type RenamePathRequest = {
+    relativePath: string
+    newName: string
+}

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -49,6 +49,7 @@ type IArcVaultsApi = {
     /// Stores or clears the currently pending ARC file save draft for the active vault window.
     setPendingArcFileSave: FileContentDTO option -> JS.Promise<Result<unit, exn>>
     deletePath: string -> JS.Promise<Result<unit, exn>>
+    renamePath: RenamePathRequest -> JS.Promise<Result<unit, exn>>
     writeFile: FileContentDTO -> JS.Promise<Result<unit, exn>>
     runGitLfs: GitLfsRequest -> JS.Promise<Result<GitLfsResult, exn>>
     cancelGitLfs: string -> JS.Promise<Result<string, exn>>

--- a/src/Electron/src/Swate.Electron.Shared/RenamePathRules.fs
+++ b/src/Electron/src/Swate.Electron.Shared/RenamePathRules.fs
@@ -5,8 +5,7 @@ open Swate.Components.Shared
 
 let private normalizeRelativePath (path: string) =
     path
-    |> PathHelpers.normalizeRelativePath
-    |> PathHelpers.normalizePath
+    |> PathHelpers.normalizeCanonicalRelativePath
 
 let private tryGetParentPath (path: string) =
     let normalizedPath = PathHelpers.normalizePath path

--- a/src/Electron/src/Swate.Electron.Shared/RenamePathRules.fs
+++ b/src/Electron/src/Swate.Electron.Shared/RenamePathRules.fs
@@ -1,0 +1,58 @@
+module Swate.Electron.Shared.RenamePathRules
+
+open System
+open Swate.Components.Shared
+
+let private normalizeRelativePath (path: string) =
+    path
+    |> PathHelpers.normalizeRelativePath
+    |> PathHelpers.normalizePath
+
+let private tryGetParentPath (path: string) =
+    let normalizedPath = PathHelpers.normalizePath path
+    let separatorIndex = normalizedPath.LastIndexOf('/')
+
+    if separatorIndex < 0 then
+        None
+    else
+        Some(normalizedPath.Substring(0, separatorIndex))
+
+let validateRenameName (newName: string) =
+    let normalizedNewName = newName.Trim()
+
+    if String.IsNullOrWhiteSpace normalizedNewName then
+        Error "A new name is required."
+    elif normalizedNewName = "." || normalizedNewName = ".." then
+        Error "The new name must not be '.' or '..'."
+    elif
+        normalizedNewName.Contains("/")
+        || normalizedNewName.Contains("\\")
+        || normalizedNewName.Contains("\u0000")
+    then
+        Error "The new name must not contain path separators or null characters."
+    else
+        Ok normalizedNewName
+
+let buildRenamedSiblingPath (sourcePath: string) (newName: string) =
+    let normalizedSourcePath = normalizeRelativePath sourcePath
+    let normalizedNewName = newName.Trim()
+
+    match tryGetParentPath normalizedSourcePath with
+    | Some parentPath when String.IsNullOrWhiteSpace parentPath |> not -> $"{parentPath}/{normalizedNewName}"
+    | _ -> normalizedNewName
+
+let tryBuildRenameTargetPath (sourcePath: string) (newName: string) =
+    let normalizedSourcePath = normalizeRelativePath sourcePath
+
+    if String.IsNullOrWhiteSpace normalizedSourcePath then
+        Error "Rename source path is required."
+    else
+        match validateRenameName newName with
+        | Error validationError -> Error validationError
+        | Ok normalizedNewName ->
+            let targetPath = buildRenamedSiblingPath normalizedSourcePath normalizedNewName
+
+            if PathHelpers.pathsEqual normalizedSourcePath targetPath then
+                Error "Rename target is identical to the current path."
+            else
+                Ok targetPath

--- a/src/Electron/src/Swate.Electron.Shared/Swate.Electron.Shared.fsproj
+++ b/src/Electron/src/Swate.Electron.Shared/Swate.Electron.Shared.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="GitTypes.fs" />
     <Compile Include="IPCTypes.fs" />
     <Compile Include="Types.fs" />
+    <Compile Include="RenamePathRules.fs" />
     <Compile Include="FileIOHelper.fs" />
   </ItemGroup>
 

--- a/src/Shared/PathHelpers.fs
+++ b/src/Shared/PathHelpers.fs
@@ -323,10 +323,7 @@ module ArcDeletePathRules =
 
     let isRenamePathAllowed (relativePath: string) =
         match classifyRenameTarget relativePath with
-        | RenamePathClassification.EntityFolderTarget _
-        | RenamePathClassification.CanonicalEntityFileTarget _
-        | RenamePathClassification.CanonicalDataMapFileTarget _
-        | RenamePathClassification.GenericTarget _ -> true
+        | RenamePathClassification.EntityFolderTarget _ -> true
         | _ -> false
 
     let resolveRenameSourcePath (relativePath: string) =

--- a/src/Shared/PathHelpers.fs
+++ b/src/Shared/PathHelpers.fs
@@ -20,6 +20,32 @@ module PathHelpers =
         normalizeSeparators path
         |> fun normalized -> normalized.Trim().TrimEnd('/').ToLowerInvariant()
 
+    let normalizePathForFsComparison (path: string) =
+        path
+        |> normalizePath
+        |> normalizeForComparison
+
+    let isSameOrDescendantPath (path: string) (ancestorPath: string) =
+        let normalizedPath = normalizePath path
+        let normalizedAncestorPath = normalizePath ancestorPath
+
+        String.IsNullOrWhiteSpace normalizedAncestorPath
+        || normalizedPath = normalizedAncestorPath
+        || normalizedPath.StartsWith(normalizedAncestorPath + "/", StringComparison.OrdinalIgnoreCase)
+
+    let isSameOrDescendantPathForFsComparison (path: string) (ancestorPath: string) =
+        let normalizedPath = normalizePathForFsComparison path
+        let normalizedAncestorPath = normalizePathForFsComparison ancestorPath
+
+        not (String.IsNullOrWhiteSpace normalizedPath)
+        && not (String.IsNullOrWhiteSpace normalizedAncestorPath)
+        && (normalizedPath = normalizedAncestorPath || normalizedPath.StartsWith(normalizedAncestorPath + "/"))
+
+    let containsPathTraversalSegments (path: string) =
+        normalizeSeparators path
+        |> fun normalized -> normalized.Split([| '/' |], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.exists (fun segment -> segment = "." || segment = "..")
+
     let pathsEqual (left: string) (right: string) =
         normalizeForComparison left = normalizeForComparison right
 
@@ -99,6 +125,17 @@ module ArcDeletePathRules =
         | EntityFolderTarget of zone: AddZone * identifier: string * normalizedRelativePath: string
         | AddZoneDescendantTarget of zone: AddZone * normalizedRelativePath: string
         | DisallowedTarget of normalizedRelativePath: string
+
+    type RenamePathClassification =
+        | RootTarget
+        | DisallowedTarget of normalizedRelativePath: string
+        | ProtectedTarget of normalizedRelativePath: string
+        | InvestigationFileTarget of normalizedRelativePath: string
+        | AddZoneRootTarget of zone: AddZone * normalizedRelativePath: string
+        | EntityFolderTarget of zone: AddZone * identifier: string * normalizedRelativePath: string
+        | CanonicalEntityFileTarget of zone: AddZone * identifier: string * normalizedRelativePath: string
+        | CanonicalDataMapFileTarget of zone: AddZone * identifier: string * normalizedRelativePath: string
+        | GenericTarget of normalizedRelativePath: string
 
     let private protectedDeleteTargetNames = [ ".gitkeep"; "readme.md" ]
 
@@ -226,6 +263,10 @@ module ArcDeletePathRules =
         let zoneFolder = zoneFolderName zone
         $"{zoneFolder}/{identifier}/{ARCtrl.ArcPathHelper.DataMapFileName}"
 
+    let private canonicalEntityFolderPath zone identifier =
+        let zoneFolder = zoneFolderName zone
+        $"{zoneFolder}/{identifier}"
+
     let buildFallbackUnlinkPaths (relativePath: string) =
         let fallbackPaths =
             match classifyDeleteTarget relativePath with
@@ -242,3 +283,74 @@ module ArcDeletePathRules =
         fallbackPaths
         |> Seq.distinctBy PathHelpers.normalizeForComparison
         |> Seq.toList
+
+    let classifyRenameTarget (relativePath: string) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        if String.IsNullOrWhiteSpace normalizedRelativePath then
+            RenamePathClassification.RootTarget
+        else
+            let segments = normalizedRelativePath |> splitPathSegments
+
+            if PathHelpers.containsPathTraversalSegments normalizedRelativePath then
+                RenamePathClassification.DisallowedTarget normalizedRelativePath
+            elif PathHelpers.isProtectedDeleteTarget protectedDeleteTargetNames normalizedRelativePath then
+                RenamePathClassification.ProtectedTarget normalizedRelativePath
+            else
+                match segments with
+                | [| singleSegment |] ->
+                    match tryParseZone singleSegment with
+                    | Some zone -> RenamePathClassification.AddZoneRootTarget(zone, normalizedRelativePath)
+                    | None when PathHelpers.pathsEqual singleSegment ARCtrl.ArcPathHelper.InvestigationFileName ->
+                        RenamePathClassification.InvestigationFileTarget normalizedRelativePath
+                    | None -> RenamePathClassification.GenericTarget normalizedRelativePath
+                | [| zoneSegment; identifier |] ->
+                    match tryParseZone zoneSegment with
+                    | Some zone -> RenamePathClassification.EntityFolderTarget(zone, identifier, normalizedRelativePath)
+                    | None -> RenamePathClassification.GenericTarget normalizedRelativePath
+                | [| zoneSegment; identifier; fileName |] ->
+                    match tryParseZone zoneSegment with
+                    | Some zone when PathHelpers.pathsEqual fileName (zoneEntityFileName zone) ->
+                        RenamePathClassification.CanonicalEntityFileTarget(zone, identifier, normalizedRelativePath)
+                    | Some zone when PathHelpers.pathsEqual fileName ARCtrl.ArcPathHelper.DataMapFileName ->
+                        RenamePathClassification.CanonicalDataMapFileTarget(zone, identifier, normalizedRelativePath)
+                    | _ -> RenamePathClassification.GenericTarget normalizedRelativePath
+                | _ ->
+                    if PathHelpers.pathsEqual normalizedRelativePath ARCtrl.ArcPathHelper.InvestigationFileName then
+                        RenamePathClassification.InvestigationFileTarget normalizedRelativePath
+                    else
+                        RenamePathClassification.GenericTarget normalizedRelativePath
+
+    let isRenamePathAllowed (relativePath: string) =
+        match classifyRenameTarget relativePath with
+        | RenamePathClassification.EntityFolderTarget _
+        | RenamePathClassification.CanonicalEntityFileTarget _
+        | RenamePathClassification.CanonicalDataMapFileTarget _
+        | RenamePathClassification.GenericTarget _ -> true
+        | _ -> false
+
+    let resolveRenameSourcePath (relativePath: string) =
+        match classifyRenameTarget relativePath with
+        | RenamePathClassification.CanonicalEntityFileTarget(zone, identifier, _)
+        | RenamePathClassification.CanonicalDataMapFileTarget(zone, identifier, _) ->
+            canonicalEntityFolderPath zone identifier
+        | RenamePathClassification.EntityFolderTarget(_, _, normalizedRelativePath)
+        | RenamePathClassification.GenericTarget normalizedRelativePath
+        | RenamePathClassification.AddZoneRootTarget(_, normalizedRelativePath)
+        | RenamePathClassification.InvestigationFileTarget normalizedRelativePath
+        | RenamePathClassification.DisallowedTarget normalizedRelativePath
+        | RenamePathClassification.ProtectedTarget normalizedRelativePath -> normalizedRelativePath
+        | RenamePathClassification.RootTarget -> ""
+
+    let tryGetRenameEntityFolderTarget (relativePath: string) =
+        match classifyRenameTarget relativePath with
+        | RenamePathClassification.EntityFolderTarget(zone, identifier, _)
+        | RenamePathClassification.CanonicalEntityFileTarget(zone, identifier, _)
+        | RenamePathClassification.CanonicalDataMapFileTarget(zone, identifier, _) -> Some(zone, identifier)
+        | _ -> None
+
+    let buildCanonicalEntityPaths zone identifier =
+        [
+            canonicalEntityFilePath zone identifier
+            canonicalDataMapFilePath zone identifier
+        ]

--- a/src/Shared/PathHelpers.fs
+++ b/src/Shared/PathHelpers.fs
@@ -16,6 +16,11 @@ module PathHelpers =
     let normalizeRelativePath (path: string) =
         normalizeSeparators path |> fun normalized -> normalized.Trim('/').Trim()
 
+    let normalizeCanonicalRelativePath (path: string) =
+        path
+        |> normalizeRelativePath
+        |> normalizePath
+
     let normalizeForComparison (path: string) =
         normalizeSeparators path
         |> fun normalized -> normalized.Trim().TrimEnd('/').ToLowerInvariant()
@@ -141,8 +146,7 @@ module ArcDeletePathRules =
 
     let private normalizeRelativePath (path: string) =
         path
-        |> PathHelpers.normalizeRelativePath
-        |> PathHelpers.normalizePath
+        |> PathHelpers.normalizeCanonicalRelativePath
 
     let private splitPathSegments (path: string) =
         path.Split([| '/' |], StringSplitOptions.RemoveEmptyEntries)

--- a/tests/Electron.Core/ArcAddExtensions.test.fs
+++ b/tests/Electron.Core/ArcAddExtensions.test.fs
@@ -1,0 +1,212 @@
+module ElectronCore.ArcAddExtensionsTests
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Electron
+open Fable.Electron.Main
+open Main.ArcMerge
+open Main.ArcVault
+open Main.Bindings.Path
+open Swate.Components.Shared
+open Swate.Electron.Shared.FileIOHelper
+open ARCtrl
+open ARCtrl.Contract
+open Vitest
+
+let private fsPromisesDynamic: obj = importAll "fs/promises"
+let private osDynamic: obj = importAll "os"
+
+let private expectLoadedArc (result: Result<ARC, string[]>) =
+    match result with
+    | Ok arc -> arc
+    | Error errors -> failwith (errors |> String.concat "\n")
+
+let private expectSome (value: 'T option) (message: string) : 'T =
+    match value with
+    | Some value -> value
+    | None -> failwith message
+
+let private createTempDirectoryAsync () : JS.Promise<string> =
+    let prefix =
+        join [|
+            osDynamic?tmpdir () |> unbox<string>
+            "swate-addasync-"
+        |]
+
+    fsPromisesDynamic?mkdtemp (prefix) |> unbox<JS.Promise<string>>
+
+let private removeDirectoryAsync (path: string) : JS.Promise<unit> = promise {
+    let! _ =
+        fsPromisesDynamic?rm (path, createObj [ "recursive" ==> true; "force" ==> true ])
+        |> unbox<JS.Promise<obj>>
+
+    return ()
+}
+
+let private pathExistsAsync (path: string) : JS.Promise<bool> = promise {
+    try
+        let! _ = fsPromisesDynamic?access (path) |> unbox<JS.Promise<obj>>
+        return true
+    with _ ->
+        return false
+}
+
+let private withTempArc (seedArc: ARC -> unit) (testBody: string -> JS.Promise<unit>) : JS.Promise<unit> = promise {
+    let! rootPath = createTempDirectoryAsync ()
+    let arcPath = join [| rootPath; "arc" |]
+
+    try
+        let arc = ARC("AddAsyncArc")
+        seedArc arc
+        do! arc.WriteAsync arcPath
+        do! testBody arcPath
+        do! removeDirectoryAsync rootPath
+    with error ->
+        do! removeDirectoryAsync rootPath
+        return raise error
+}
+
+let private loadArcAsync (arcPath: string) : JS.Promise<ARC> = promise {
+    let! loaded = ARC.tryLoadAsync arcPath
+    return expectLoadedArc loaded
+}
+
+let private testWindow () =
+    createObj [
+        "id" ==> 0
+        "title" ==> ""
+    ]
+    |> unbox<BrowserWindow>
+
+Vitest.describe("ARC AddAsync", fun () ->
+    Vitest.test("adds an assay and creates the canonical assay file", fun () ->
+        withTempArc ignore (fun arcPath -> promise {
+            let! arc = loadArcAsync arcPath
+            do! arc.AddAsync(arcPath, ArcFiles.Assay(ArcAssay("NewAssay")))
+
+            let canonicalPath = join [| arcPath; "assays"; "NewAssay"; "isa.assay.xlsx" |]
+            let! exists = pathExistsAsync canonicalPath
+            Vitest.expect(exists).toBe(true)
+
+            let! reloadedArc = loadArcAsync arcPath
+            Vitest.expect(reloadedArc.ContainsAssay("NewAssay")).toBe(true)
+        }))
+
+    Vitest.test("adds a study and creates the canonical study file", fun () ->
+        withTempArc ignore (fun arcPath -> promise {
+            let! arc = loadArcAsync arcPath
+            do! arc.AddAsync(arcPath, ArcFiles.Study(ArcStudy("NewStudy"), []))
+
+            let canonicalPath = join [| arcPath; "studies"; "NewStudy"; "isa.study.xlsx" |]
+            let! exists = pathExistsAsync canonicalPath
+            Vitest.expect(exists).toBe(true)
+
+            let! reloadedArc = loadArcAsync arcPath
+            Vitest.expect(reloadedArc.ContainsStudy("NewStudy")).toBe(true)
+        }))
+
+    Vitest.test("adds a run and creates the canonical run file", fun () ->
+        withTempArc ignore (fun arcPath -> promise {
+            let! arc = loadArcAsync arcPath
+            do! arc.AddAsync(arcPath, ArcFiles.Run(ArcRun("NewRun")))
+
+            let canonicalPath = join [| arcPath; "runs"; "NewRun"; "isa.run.xlsx" |]
+            let! exists = pathExistsAsync canonicalPath
+            Vitest.expect(exists).toBe(true)
+
+            let! reloadedArc = loadArcAsync arcPath
+            Vitest.expect(reloadedArc.ContainsRun("NewRun")).toBe(true)
+        }))
+
+    Vitest.test("adds a workflow and creates the canonical workflow file", fun () ->
+        withTempArc ignore (fun arcPath -> promise {
+            let! arc = loadArcAsync arcPath
+            do! arc.AddAsync(arcPath, ArcFiles.Workflow(ArcWorkflow("NewWorkflow")))
+
+            let canonicalPath = join [| arcPath; "workflows"; "NewWorkflow"; "isa.workflow.xlsx" |]
+            let! exists = pathExistsAsync canonicalPath
+            Vitest.expect(exists).toBe(true)
+
+            let! reloadedArc = loadArcAsync arcPath
+            Vitest.expect(reloadedArc.ContainsWorkflow("NewWorkflow")).toBe(true)
+        }))
+
+    Vitest.test("rejects duplicate entity identifiers", fun () ->
+        withTempArc (fun arc -> arc.AddAssay(ArcAssay("ExistingAssay"))) (fun arcPath -> promise {
+            let! arc = loadArcAsync arcPath
+            let! addResult = arc.TryAddAsync(arcPath, ArcFiles.Assay(ArcAssay("ExistingAssay")))
+
+            match addResult with
+            | Ok _ -> failwith "Expected duplicate assay add to fail."
+            | Error errors ->
+                Vitest.expect(errors.[0]).toContain("already contains assay")
+        }))
+
+    Vitest.test("rejects unsupported ARC file kinds", fun () ->
+        withTempArc ignore (fun arcPath -> promise {
+            let! arc = loadArcAsync arcPath
+
+            let unsupportedArcFiles = [|
+                ArcFiles.Investigation(ArcInvestigation("Investigation")), "investigation"
+                ArcFiles.DataMap(None, DataMap.init()), "datamap"
+                ArcFiles.Template(Template.init "Template"), "template"
+            |]
+
+            for arcFile, expectedMessage in unsupportedArcFiles do
+                let! addResult = arc.TryAddAsync(arcPath, arcFile)
+
+                match addResult with
+                | Ok _ -> failwith $"Expected {expectedMessage} add to fail."
+                | Error errors -> Vitest.expect(errors.[0]).toContain(expectedMessage)
+        }))
+
+    Vitest.test("keeps existing entities when adding a new one", fun () ->
+        withTempArc (fun arc -> arc.AddStudy(ArcStudy("ExistingStudy"))) (fun arcPath -> promise {
+            let! arc = loadArcAsync arcPath
+            do! arc.AddAsync(arcPath, ArcFiles.Assay(ArcAssay("NewAssay")))
+
+            let! reloadedArc = loadArcAsync arcPath
+            Vitest.expect(reloadedArc.ContainsStudy("ExistingStudy")).toBe(true)
+            Vitest.expect(reloadedArc.ContainsAssay("NewAssay")).toBe(true)
+        }))
+
+    Vitest.test("ApplyArcFileAndSave adds new entities and updates existing entities through the same IPC-facing path", fun () ->
+        withTempArc (fun arc -> arc.AddAssay(ArcAssay("ExistingAssay", title = "Old title"))) (fun arcPath -> promise {
+            let! loadedArc = loadArcAsync arcPath
+            let dirtyAssay = loadedArc.GetAssay("ExistingAssay")
+            dirtyAssay.Title <- Some "Unsaved local title"
+
+            let vault = ArcVault(testWindow ())
+            vault.path <- Some arcPath
+            vault.arc <- Some loadedArc
+            vault.hasUnsavedArcChanges <- true
+
+            let newAssayRequest =
+                FileContentDTO.fromArcFile(ArcFiles.Assay(ArcAssay("NewAssay")))
+                |> expectSome <| "Expected new assay DTO."
+
+            match! vault.ApplyArcFileAndSave newAssayRequest with
+            | Error error -> failwith error.Message
+            | Ok() -> ()
+
+            let! reloadedAfterAdd = loadArcAsync arcPath
+            Vitest.expect(reloadedAfterAdd.ContainsAssay("NewAssay")).toBe(true)
+            Vitest.expect(reloadedAfterAdd.GetAssay("ExistingAssay").Title).toEqual(Some "Old title")
+            Vitest.expect(vault.hasUnsavedArcChanges).toBe(true)
+
+            let updatedExistingAssay = ArcAssay("ExistingAssay", title = "Updated title")
+
+            let existingAssayRequest =
+                FileContentDTO.fromArcFile(ArcFiles.Assay updatedExistingAssay)
+                |> expectSome <| "Expected existing assay DTO."
+
+            match! vault.ApplyArcFileAndSave existingAssayRequest with
+            | Error error -> failwith error.Message
+            | Ok() -> ()
+
+            let! reloadedArc = loadArcAsync arcPath
+            Vitest.expect(reloadedArc.ContainsAssay("NewAssay")).toBe(true)
+            Vitest.expect(reloadedArc.GetAssay("ExistingAssay").Title).toEqual(Some "Updated title")
+            Vitest.expect(vault.hasUnsavedArcChanges).toBe(false)
+        }))
+)

--- a/tests/Electron.Core/Electron.Core.Tests.fsproj
+++ b/tests/Electron.Core/Electron.Core.Tests.fsproj
@@ -6,6 +6,7 @@
     <Compile Include="FileTreeCompaction.test.fs" />
     <Compile Include="FileTreeCreator.test.fs" />
     <Compile Include="ArcFileMutationHelper.test.fs" />
+    <Compile Include="ArcAddExtensions.test.fs" />
     <Compile Include="ArcObjectWidget.test.fs" />
     <Compile Include="ArcObjectGraphExplorer.test.fs" />
     <Compile Include="JsonDTOUnwrapper.test.fs" />

--- a/tests/Electron.Core/Electron.Core.Tests.fsproj
+++ b/tests/Electron.Core/Electron.Core.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="NoteSearchReader.test.fs" />
     <Compile Include="GitService.test.fs" />
     <Compile Include="IpcArchitectureReview.test.fs" />
+    <Compile Include="RenamePathRules.test.fs" />
     <Compile Include="GitValidation.test.fs" />
     <Compile Include="SecureAuthStore.test.fs" />
   </ItemGroup>

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -84,7 +84,19 @@ let private assertEntityFolderRenameSync
 
         let! _ = fsPromisesDynamic?rename (sourceAbsolutePath, targetAbsolutePath) |> unbox<JS.Promise<obj>>
 
-        match! ArcRenameHelper.syncRenamedEntityIdentifierOnDisk arcPath sourceRelativePath targetRelativePath with
+        let renamePlan =
+            match
+                ArcRenameHelper.tryBuildRenamePlan {
+                    relativePath = sourceRelativePath
+                    newName = newIdentifier
+                }
+            with
+            | Error planError -> failwith planError.Message
+            | Ok renamePlan ->
+                Vitest.expect(renamePlan.TargetPath).toBe(targetRelativePath)
+                renamePlan
+
+        match! ArcRenameHelper.syncRenamedEntityIdentifierOnDisk arcPath renamePlan with
         | Error syncError -> return failwith syncError.Message
         | Ok() ->
             match! ARC.tryLoadAsync arcPath with
@@ -369,47 +381,17 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
                 Vitest.expect(study.RegisteredAssayIdentifiers |> Seq.contains "NewAssay").toBe(true))
     )
 
-    Vitest.test("tryBuildIdentifierRenameSyncPlan rejects non-entity rename paths", fun () ->
+    Vitest.test("tryBuildRenamePlan rejects non-entity rename paths", fun () ->
         let result =
-            ArcRenameHelper.tryBuildIdentifierRenameSyncPlan
-                "assays/StudyA/notes/info.md"
-                "assays/StudyA/notes/renamed.md"
+            ArcRenameHelper.tryBuildRenamePlan {
+                relativePath = "assays/StudyA/notes/info.md"
+                newName = "renamed.md"
+            }
 
         match result with
         | Ok _ -> failwith "Expected non-entity rename path classification to be rejected."
         | Error error ->
-            Vitest.expect(error.Message.Contains "requires ARC entity folder paths").toBe(true)
-    )
-
-    Vitest.test("rename event synthesis emits old canonical unlink and new canonical add events", fun () ->
-        let events =
-            ArcRenameHelper.buildRenameEvents "assays/OldAssay" "assays/NewAssay"
-
-        let unlinkPaths =
-            events
-            |> List.choose (fun event ->
-                match event.EventName with
-                | EventName.Unlink -> Some event.Path
-                | _ -> None
-            )
-
-        let addPaths =
-            events
-            |> List.choose (fun event ->
-                match event.EventName with
-                | EventName.Add -> Some event.Path
-                | _ -> None
-            )
-
-        Vitest.expect(unlinkPaths).toEqual([ "assays/OldAssay/isa.assay.xlsx"; "assays/OldAssay/isa.datamap.xlsx" ])
-        Vitest.expect(addPaths).toEqual([ "assays/NewAssay/isa.assay.xlsx"; "assays/NewAssay/isa.datamap.xlsx" ])
-    )
-
-    Vitest.test("rename event synthesis stays empty for generic path renames", fun () ->
-        let events =
-            ArcRenameHelper.buildRenameEvents "assays/StudyA/notes/info.md" "assays/StudyA/notes/renamed.md"
-
-        Vitest.expect(events).toEqual([])
+            Vitest.expect(error.Message.Contains "generic files or folders").toBe(true)
     )
 
     Vitest.test("tryBuildRenamePlan accepts entity-folder rename paths", fun () ->
@@ -424,6 +406,9 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
         | Ok plan ->
             Vitest.expect(plan.SourcePath).toBe("assays/OldAssay")
             Vitest.expect(plan.TargetPath).toBe("assays/NewAssay")
+            Vitest.expect(plan.SyncPlan.Zone).toEqual(ArcDeletePathRules.AddZone.Assays)
+            Vitest.expect(plan.SyncPlan.OldIdentifier).toBe("OldAssay")
+            Vitest.expect(plan.SyncPlan.NewIdentifier).toBe("NewAssay")
     )
 
     Vitest.test("tryBuildRenamePlan rejects canonical ARC file rename paths", fun () ->
@@ -437,5 +422,44 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
         | Ok _ -> failwith "Expected canonical ARC file rename path to be rejected."
         | Error error ->
             Vitest.expect(error.Message.Contains "Rename the containing ARC entity folder instead").toBe(true)
+    )
+
+    Vitest.test("mergeReloadedArcAfterRename preserves dirty local assay state under the new identifier", fun () ->
+        let localArc = ARC("MergeArc")
+        localArc.InitStudy("StudyA") |> ignore
+        localArc.InitAssay("OldAssay") |> ignore
+        localArc.RegisterAssay("StudyA", "OldAssay")
+        localArc.Assays.[0].Title <- Some "Unsaved assay title"
+        localArc.Assays.[0].DataMap <- Some(DataMap.init ())
+
+        let reloadedArc = ARC("MergeArc")
+        reloadedArc.InitStudy("StudyA") |> ignore
+        reloadedArc.InitAssay("NewAssay") |> ignore
+        reloadedArc.Assays.[0].Title <- Some "Disk assay title"
+        reloadedArc.RegisterAssay("StudyA", "NewAssay")
+
+        let renamePlan =
+            match
+                ArcRenameHelper.tryBuildRenamePlan {
+                    relativePath = "assays/OldAssay"
+                    newName = "NewAssay"
+                }
+            with
+            | Error error -> failwith error.Message
+            | Ok renamePlan -> renamePlan
+
+        match ArcRenameHelper.mergeReloadedArcAfterRename renamePlan localArc reloadedArc with
+        | Error error -> failwith error.Message
+        | Ok mergeResult ->
+            Vitest.expect(mergeResult.Arc.ContainsAssay("OldAssay")).toBe(false)
+            Vitest.expect(mergeResult.Arc.ContainsAssay("NewAssay")).toBe(true)
+
+            let renamedAssay = mergeResult.Arc.GetAssay("NewAssay")
+            Vitest.expect(renamedAssay.Title).toEqual(Some "Unsaved assay title")
+            Vitest.expect(renamedAssay.DataMap.IsSome).toBe(true)
+
+            let study = mergeResult.Arc.GetStudy("StudyA")
+            Vitest.expect(study.RegisteredAssayIdentifiers |> Seq.contains "OldAssay").toBe(false)
+            Vitest.expect(study.RegisteredAssayIdentifiers |> Seq.contains "NewAssay").toBe(true)
     )
 )

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -12,6 +12,7 @@ open ARCtrl
 open Vitest
 
 let private fsPromisesDynamic: obj = importAll "fs/promises"
+let private osDynamic: obj = importAll "os"
 
 let private readUtf8FileAsync (path: string) : JS.Promise<string> =
     fsPromisesDynamic?readFile (path, "utf8") |> unbox<JS.Promise<string>>
@@ -35,6 +36,63 @@ let private expectSourceContainsInOrder (sourceText: string) (snippets: string[]
         let snippetIndex = sourceText.IndexOf(snippet, searchStartIndex)
         Vitest.expect(snippetIndex >= 0, $"Expected source to contain (in order): {snippet}").toBe(true)
         searchStartIndex <- snippetIndex + snippet.Length
+
+let private createTempDirectoryAsync () : JS.Promise<string> =
+    let prefix =
+        join [|
+            osDynamic?tmpdir () |> unbox<string>
+            "swate-ipc-rename-sync-"
+        |]
+
+    fsPromisesDynamic?mkdtemp (prefix) |> unbox<JS.Promise<string>>
+
+let private removeDirectoryAsync (path: string) : JS.Promise<unit> = promise {
+    let! _ =
+        fsPromisesDynamic?rm (path, createObj [ "recursive" ==> true; "force" ==> true ])
+        |> unbox<JS.Promise<obj>>
+
+    return ()
+}
+
+let private withTempArc (seedArc: ARC -> unit) (testBody: string -> JS.Promise<unit>) : JS.Promise<unit> = promise {
+    let! rootPath = createTempDirectoryAsync ()
+    let arcPath = join [| rootPath; "arc" |]
+
+    try
+        let arc = ARC("RenameSyncArc")
+        seedArc arc
+        do! arc.WriteAsync arcPath
+        do! testBody arcPath
+        do! removeDirectoryAsync rootPath
+    with error ->
+        do! removeDirectoryAsync rootPath
+        return raise error
+}
+
+let private assertEntityFolderRenameSync
+    (zoneFolder: string)
+    (oldIdentifier: string)
+    (newIdentifier: string)
+    (seedArc: ARC -> unit)
+    (assertReloadedArc: ARC -> unit)
+    : JS.Promise<unit> =
+    withTempArc seedArc (fun arcPath -> promise {
+        let sourceRelativePath = $"{zoneFolder}/{oldIdentifier}"
+        let targetRelativePath = $"{zoneFolder}/{newIdentifier}"
+        let sourceAbsolutePath = join [| arcPath; zoneFolder; oldIdentifier |]
+        let targetAbsolutePath = join [| arcPath; zoneFolder; newIdentifier |]
+
+        let! _ = fsPromisesDynamic?rename (sourceAbsolutePath, targetAbsolutePath) |> unbox<JS.Promise<obj>>
+
+        match! ArcRenameHelper.syncRenamedEntityIdentifierOnDisk arcPath sourceRelativePath targetRelativePath with
+        | Error syncError -> return failwith syncError.Message
+        | Ok() ->
+            match! ARC.tryLoadAsync arcPath with
+            | Error loadError -> return failwith $"Expected ARC reload to succeed after rename sync: {loadError}"
+            | Ok reloadedArc ->
+                assertReloadedArc reloadedArc
+                return ()
+    })
 
 Vitest.describe("IPC architecture review fixes", fun () ->
     Vitest.test("Arc vault dialogs consistently use a centralized IPC dialog parent helper", fun () ->
@@ -248,6 +306,79 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
             |> List.map _.Path
 
         Vitest.expect(helperFallbackPaths).toEqual(sharedFallbackPaths)
+    )
+
+    Vitest.test("syncRenamedEntityIdentifierOnDisk updates assay identifier after assay folder rename", fun () ->
+        assertEntityFolderRenameSync
+            "assays"
+            "OldAssay"
+            "NewAssay"
+            (fun arc -> arc.InitAssay("OldAssay") |> ignore)
+            (fun reloadedArc ->
+                Vitest.expect(reloadedArc.ContainsAssay("OldAssay")).toBe(false)
+                Vitest.expect(reloadedArc.ContainsAssay("NewAssay")).toBe(true))
+    )
+
+    Vitest.test("syncRenamedEntityIdentifierOnDisk updates study identifier after study folder rename", fun () ->
+        assertEntityFolderRenameSync
+            "studies"
+            "OldStudy"
+            "NewStudy"
+            (fun arc -> arc.InitStudy("OldStudy") |> ignore)
+            (fun reloadedArc ->
+                Vitest.expect(reloadedArc.ContainsStudy("OldStudy")).toBe(false)
+                Vitest.expect(reloadedArc.ContainsStudy("NewStudy")).toBe(true))
+    )
+
+    Vitest.test("syncRenamedEntityIdentifierOnDisk updates run identifier after run folder rename", fun () ->
+        assertEntityFolderRenameSync
+            "runs"
+            "OldRun"
+            "NewRun"
+            (fun arc -> arc.InitRun("OldRun") |> ignore)
+            (fun reloadedArc ->
+                Vitest.expect(reloadedArc.ContainsRun("OldRun")).toBe(false)
+                Vitest.expect(reloadedArc.ContainsRun("NewRun")).toBe(true))
+    )
+
+    Vitest.test("syncRenamedEntityIdentifierOnDisk updates workflow identifier after workflow folder rename", fun () ->
+        assertEntityFolderRenameSync
+            "workflows"
+            "OldWorkflow"
+            "NewWorkflow"
+            (fun arc -> arc.InitWorkflow("OldWorkflow") |> ignore)
+            (fun reloadedArc ->
+                Vitest.expect(reloadedArc.ContainsWorkflow("OldWorkflow")).toBe(false)
+                Vitest.expect(reloadedArc.ContainsWorkflow("NewWorkflow")).toBe(true))
+    )
+
+    Vitest.test("syncRenamedEntityIdentifierOnDisk updates study assay registrations when an assay is renamed", fun () ->
+        assertEntityFolderRenameSync
+            "assays"
+            "OldAssay"
+            "NewAssay"
+            (fun arc ->
+                arc.InitStudy("StudyA") |> ignore
+                arc.InitAssay("OldAssay") |> ignore
+                arc.RegisterAssay("StudyA", "OldAssay"))
+            (fun reloadedArc ->
+                let study = reloadedArc.GetStudy("StudyA")
+                Vitest.expect(reloadedArc.ContainsAssay("OldAssay")).toBe(false)
+                Vitest.expect(reloadedArc.ContainsAssay("NewAssay")).toBe(true)
+                Vitest.expect(study.RegisteredAssayIdentifiers |> Seq.contains "OldAssay").toBe(false)
+                Vitest.expect(study.RegisteredAssayIdentifiers |> Seq.contains "NewAssay").toBe(true))
+    )
+
+    Vitest.test("tryBuildIdentifierRenameSyncPlan rejects non-entity rename paths", fun () ->
+        let result =
+            ArcRenameHelper.tryBuildIdentifierRenameSyncPlan
+                "assays/StudyA/notes/info.md"
+                "assays/StudyA/notes/renamed.md"
+
+        match result with
+        | Ok _ -> failwith "Expected non-entity rename path classification to be rejected."
+        | Error error ->
+            Vitest.expect(error.Message.Contains "requires ARC entity folder paths").toBe(true)
     )
 
     Vitest.test("rename event synthesis emits old canonical unlink and new canonical add events", fun () ->

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -96,6 +96,7 @@ Vitest.describe("IPC architecture review fixes", fun () ->
             expectSourceContains arcVaultApiSource "deletePath ="
             expectSourceContains arcVaultApiSource "ArcDeletePathRules.isDeletePathAllowed"
             expectSourceContains arcVaultApiSource "do! vault.RefreshFileTree()"
+            expectSourceContains arcVaultApiSource "runArcDiskMutation"
             expectSourceContains arcVaultApiSource "ArcDeleteHelper.mergeReloadedArcAfterDelete"
             expectSourceContains arcVaultApiSource "ARC.merge"
             expectSourceContains arcVaultApiSource "ArcDeletePathRules.buildFallbackUnlinkPaths"
@@ -103,8 +104,15 @@ Vitest.describe("IPC architecture review fixes", fun () ->
                 arcVaultApiSource
                 [|
                     "fsPromisesDynamic?rm"
-                    "do! vault.RefreshFileTree()"
+                    "runArcDiskMutation"
                     "ArcDeleteHelper.mergeReloadedArcAfterDelete"
+                |]
+            expectSourceContainsInOrder
+                arcVaultApiSource
+                [|
+                    "let private runArcDiskMutation"
+                    "do! vault.RefreshFileTree()"
+                    "match mergeReloadedArc reloadedArc"
                 |]
         })
 

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -175,7 +175,8 @@ Vitest.describe("IPC architecture review fixes", fun () ->
                 [|
                     "let private runArcDiskMutation"
                     "do! vault.RefreshFileTree()"
-                    "match mergeReloadedArc reloadedArc"
+                    "match! postReloadArcMutation reloadedArc"
+                    "match mergeReloadedArc postMutationArc"
                 |]
         })
 

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -307,49 +307,4 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
         | Error error ->
             Vitest.expect(error.Message.Contains "Rename the containing ARC entity folder instead").toBe(true)
     )
-
-
-    Vitest.test("mapRenameDiskError maps ENOENT to source-missing message", fun () ->
-        let mappedError =
-            ArcRenameHelper.mapRenameDiskError
-                "assays/OldAssay"
-                "assays/NewAssay"
-                (createNodeLikeError "ENOENT" "rename failed")
-
-        Vitest.expect(mappedError.Message.Contains "source path no longer exists on disk").toBe(true)
-    )
-
-    Vitest.test("mapRenameDiskError maps EEXIST and ENOTEMPTY to destination-exists message", fun () ->
-        let eexistMappedError =
-            ArcRenameHelper.mapRenameDiskError
-                "assays/OldAssay"
-                "assays/NewAssay"
-                (createNodeLikeError "EEXIST" "rename failed")
-
-        let enotemptyMappedError =
-            ArcRenameHelper.mapRenameDiskError
-                "assays/OldAssay"
-                "assays/NewAssay"
-                (createNodeLikeError "ENOTEMPTY" "rename failed")
-
-        Vitest.expect(eexistMappedError.Message.Contains "destination already exists").toBe(true)
-        Vitest.expect(enotemptyMappedError.Message.Contains "destination already exists").toBe(true)
-    )
-
-    Vitest.test("mapRenameDiskError maps EPERM and EACCES to lock/permission guidance", fun () ->
-        let epermMappedError =
-            ArcRenameHelper.mapRenameDiskError
-                "assays/OldAssay"
-                "assays/NewAssay"
-                (createNodeLikeError "EPERM" "rename failed")
-
-        let eaccesMappedError =
-            ArcRenameHelper.mapRenameDiskError
-                "assays/OldAssay"
-                "assays/NewAssay"
-                (createNodeLikeError "EACCES" "rename failed")
-
-        Vitest.expect(epermMappedError.Message.Contains "permission or file-lock conflict").toBe(true)
-        Vitest.expect(eaccesMappedError.Message.Contains "permission or file-lock conflict").toBe(true)
-    )
 )

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -120,45 +120,11 @@ Vitest.describe("IPC architecture review fixes", fun () ->
         promise {
             let! ipcTypesSource = sourcePath [| "Swate.Electron.Shared"; "IPCTypes.fs" |] |> readUtf8FileAsync
             let! fileIoTypesSource = sourcePath [| "Swate.Electron.Shared"; "FileIOTypes.fs" |] |> readUtf8FileAsync
-            let! arcVaultApiSource = sourcePath [| "Main"; "IPC"; "IArcVaultsApi.fs" |] |> readUtf8FileAsync
 
             expectSourceContains fileIoTypesSource "type RenamePathRequest = {"
             expectSourceContains fileIoTypesSource "relativePath: string"
             expectSourceContains fileIoTypesSource "newName: string"
             expectSourceContains ipcTypesSource "renamePath: RenamePathRequest -> JS.Promise<Result<unit, exn>>"
-            expectSourceContains arcVaultApiSource "renamePath ="
-            expectSourceContains arcVaultApiSource "runArcDiskMutation"
-            expectSourceContains arcVaultApiSource "ArcRenameHelper.mergeReloadedArcAfterRename"
-            expectSourceContains arcVaultApiSource "renameWithRetriesAsync sourceAbsolutePath targetAbsolutePath"
-            expectSourceContains arcVaultApiSource "let private renameRetryStrategy"
-            expectSourceContains arcVaultApiSource "| Some \"EPERM\""
-            expectSourceContains arcVaultApiSource "| Some \"EACCES\""
-            expectSourceContains arcVaultApiSource "| Some \"EBUSY\""
-            expectSourceContains arcVaultApiSource "| Some \"ENOTEMPTY\""
-            expectSourceContains arcVaultApiSource "attemptIndex < renameRetryStrategy.DelaysMs.Length - 1"
-            expectSourceContainsInOrder
-                arcVaultApiSource
-                [|
-                    "renamePath ="
-                    "runArcDiskMutation"
-                    "ArcRenameHelper.mergeReloadedArcAfterRename"
-                |]
-            expectSourceNotContains arcVaultApiSource "pathExistsAsync sourceAbsolutePath"
-            expectSourceNotContains arcVaultApiSource "pathExistsAsync targetAbsolutePath"
-            expectSourceNotContains arcVaultApiSource "do! vault.StopFileWatcher()"
-            expectSourceNotContains arcVaultApiSource "vault.StartFileWatcher()"
-        })
-
-    Vitest.test("file watcher uses windows polling options in createFileWatcher", fun () ->
-        promise {
-            let! arcVaultHelperSource = sourcePath [| "Main"; "ArcVault"; "ArcVaultHelper.fs" |] |> readUtf8FileAsync
-
-            expectSourceContains arcVaultHelperSource "let private windowsWatcherProfile"
-            expectSourceContains arcVaultHelperSource "if isWindowsPlatform () then windowsWatcherProfile"
-            expectSourceContains arcVaultHelperSource "UsePolling = Some true"
-            expectSourceContains arcVaultHelperSource "Interval = Some 200"
-            expectSourceContains arcVaultHelperSource "BinaryInterval = Some 400"
-            expectSourceContains arcVaultHelperSource "awaitWriteFinish = watcherProfile.AwaitWriteFinish"
         })
 )
 
@@ -378,10 +344,10 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
         Vitest.expect(events).toEqual([])
     )
 
-    Vitest.test("tryBuildRenamePlan resolves canonical ARC file rename to entity folder path", fun () ->
+    Vitest.test("tryBuildRenamePlan accepts entity-folder rename paths", fun () ->
         let result =
             ArcRenameHelper.tryBuildRenamePlan {
-                relativePath = "assays/OldAssay/isa.assay.xlsx"
+                relativePath = "assays/OldAssay"
                 newName = "NewAssay"
             }
 
@@ -391,6 +357,20 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
             Vitest.expect(plan.SourcePath).toBe("assays/OldAssay")
             Vitest.expect(plan.TargetPath).toBe("assays/NewAssay")
     )
+
+    Vitest.test("tryBuildRenamePlan rejects canonical ARC file rename paths", fun () ->
+        let result =
+            ArcRenameHelper.tryBuildRenamePlan {
+                relativePath = "assays/OldAssay/isa.assay.xlsx"
+                newName = "NewAssay"
+            }
+
+        match result with
+        | Ok _ -> failwith "Expected canonical ARC file rename path to be rejected."
+        | Error error ->
+            Vitest.expect(error.Message.Contains "Rename the containing ARC entity folder instead").toBe(true)
+    )
+
 
     Vitest.test("mapRenameDiskError maps ENOENT to source-missing message", fun () ->
         let mappedError =

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -107,6 +107,51 @@ Vitest.describe("IPC architecture review fixes", fun () ->
                     "ArcDeleteHelper.mergeReloadedArcAfterDelete"
                 |]
         })
+
+    Vitest.test("Arc vault IPC contract and implementation expose renamePath", fun () ->
+        promise {
+            let! ipcTypesSource = sourcePath [| "Swate.Electron.Shared"; "IPCTypes.fs" |] |> readUtf8FileAsync
+            let! fileIoTypesSource = sourcePath [| "Swate.Electron.Shared"; "FileIOTypes.fs" |] |> readUtf8FileAsync
+            let! arcVaultApiSource = sourcePath [| "Main"; "IPC"; "IArcVaultsApi.fs" |] |> readUtf8FileAsync
+
+            expectSourceContains fileIoTypesSource "type RenamePathRequest = {"
+            expectSourceContains fileIoTypesSource "relativePath: string"
+            expectSourceContains fileIoTypesSource "newName: string"
+            expectSourceContains ipcTypesSource "renamePath: RenamePathRequest -> JS.Promise<Result<unit, exn>>"
+            expectSourceContains arcVaultApiSource "renamePath ="
+            expectSourceContains arcVaultApiSource "runArcDiskMutation"
+            expectSourceContains arcVaultApiSource "ArcRenameHelper.mergeReloadedArcAfterRename"
+            expectSourceContains arcVaultApiSource "renameWithRetriesAsync sourceAbsolutePath targetAbsolutePath"
+            expectSourceContains arcVaultApiSource "let private renameRetryStrategy"
+            expectSourceContains arcVaultApiSource "| Some \"EPERM\""
+            expectSourceContains arcVaultApiSource "| Some \"EACCES\""
+            expectSourceContains arcVaultApiSource "| Some \"EBUSY\""
+            expectSourceContains arcVaultApiSource "| Some \"ENOTEMPTY\""
+            expectSourceContains arcVaultApiSource "attemptIndex < renameRetryStrategy.DelaysMs.Length - 1"
+            expectSourceContainsInOrder
+                arcVaultApiSource
+                [|
+                    "renamePath ="
+                    "runArcDiskMutation"
+                    "ArcRenameHelper.mergeReloadedArcAfterRename"
+                |]
+            expectSourceNotContains arcVaultApiSource "pathExistsAsync sourceAbsolutePath"
+            expectSourceNotContains arcVaultApiSource "pathExistsAsync targetAbsolutePath"
+            expectSourceNotContains arcVaultApiSource "do! vault.StopFileWatcher()"
+            expectSourceNotContains arcVaultApiSource "vault.StartFileWatcher()"
+        })
+
+    Vitest.test("file watcher uses windows polling options in createFileWatcher", fun () ->
+        promise {
+            let! arcVaultHelperSource = sourcePath [| "Main"; "ArcVault"; "ArcVaultHelper.fs" |] |> readUtf8FileAsync
+
+            expectSourceContains arcVaultHelperSource "let private windowsWatcherProfile"
+            expectSourceContains arcVaultHelperSource "if isWindowsPlatform () then windowsWatcherProfile"
+            expectSourceContains arcVaultHelperSource "UsePolling = Some true"
+            expectSourceContains arcVaultHelperSource "Interval = Some 200"
+            expectSourceContains arcVaultHelperSource "BinaryInterval = Some 400"
+            expectSourceContains arcVaultHelperSource "awaitWriteFinish = watcherProfile.AwaitWriteFinish"
+        })
 )
 
 Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
@@ -292,5 +337,94 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
             |> List.map _.Path
 
         Vitest.expect(helperFallbackPaths).toEqual(sharedFallbackPaths)
+    )
+
+    Vitest.test("rename event synthesis emits old canonical unlink and new canonical add events", fun () ->
+        let events =
+            ArcRenameHelper.buildRenameEvents "assays/OldAssay" "assays/NewAssay"
+
+        let unlinkPaths =
+            events
+            |> List.choose (fun event ->
+                match event.EventName with
+                | EventName.Unlink -> Some event.Path
+                | _ -> None
+            )
+
+        let addPaths =
+            events
+            |> List.choose (fun event ->
+                match event.EventName with
+                | EventName.Add -> Some event.Path
+                | _ -> None
+            )
+
+        Vitest.expect(unlinkPaths).toEqual([ "assays/OldAssay/isa.assay.xlsx"; "assays/OldAssay/isa.datamap.xlsx" ])
+        Vitest.expect(addPaths).toEqual([ "assays/NewAssay/isa.assay.xlsx"; "assays/NewAssay/isa.datamap.xlsx" ])
+    )
+
+    Vitest.test("rename event synthesis stays empty for generic path renames", fun () ->
+        let events =
+            ArcRenameHelper.buildRenameEvents "assays/StudyA/notes/info.md" "assays/StudyA/notes/renamed.md"
+
+        Vitest.expect(events).toEqual([])
+    )
+
+    Vitest.test("tryBuildRenamePlan resolves canonical ARC file rename to entity folder path", fun () ->
+        let result =
+            ArcRenameHelper.tryBuildRenamePlan {
+                relativePath = "assays/OldAssay/isa.assay.xlsx"
+                newName = "NewAssay"
+            }
+
+        match result with
+        | Error error -> failwith error.Message
+        | Ok plan ->
+            Vitest.expect(plan.SourcePath).toBe("assays/OldAssay")
+            Vitest.expect(plan.TargetPath).toBe("assays/NewAssay")
+    )
+
+    Vitest.test("mapRenameDiskError maps ENOENT to source-missing message", fun () ->
+        let mappedError =
+            ArcRenameHelper.mapRenameDiskError
+                "assays/OldAssay"
+                "assays/NewAssay"
+                (createNodeLikeError "ENOENT" "rename failed")
+
+        Vitest.expect(mappedError.Message.Contains "source path no longer exists on disk").toBe(true)
+    )
+
+    Vitest.test("mapRenameDiskError maps EEXIST and ENOTEMPTY to destination-exists message", fun () ->
+        let eexistMappedError =
+            ArcRenameHelper.mapRenameDiskError
+                "assays/OldAssay"
+                "assays/NewAssay"
+                (createNodeLikeError "EEXIST" "rename failed")
+
+        let enotemptyMappedError =
+            ArcRenameHelper.mapRenameDiskError
+                "assays/OldAssay"
+                "assays/NewAssay"
+                (createNodeLikeError "ENOTEMPTY" "rename failed")
+
+        Vitest.expect(eexistMappedError.Message.Contains "destination already exists").toBe(true)
+        Vitest.expect(enotemptyMappedError.Message.Contains "destination already exists").toBe(true)
+    )
+
+    Vitest.test("mapRenameDiskError maps EPERM and EACCES to lock/permission guidance", fun () ->
+        let epermMappedError =
+            ArcRenameHelper.mapRenameDiskError
+                "assays/OldAssay"
+                "assays/NewAssay"
+                (createNodeLikeError "EPERM" "rename failed")
+
+        let eaccesMappedError =
+            ArcRenameHelper.mapRenameDiskError
+                "assays/OldAssay"
+                "assays/NewAssay"
+                (createNodeLikeError "EACCES" "rename failed")
+
+        Vitest.expect(epermMappedError.Message.Contains "permission or file-lock conflict").toBe(true)
+        Vitest.expect(eaccesMappedError.Message.Contains "permission or file-lock conflict").toBe(true)
     )
 )

--- a/tests/Electron.Core/RenamePathRules.test.fs
+++ b/tests/Electron.Core/RenamePathRules.test.fs
@@ -25,6 +25,12 @@ Vitest.describe("RenamePathRules", fun () ->
         let result = tryBuildRenameTargetPath "assays/OldAssay" "OldAssay"
         Vitest.expect(result).toEqual(Error "Rename target is identical to the current path.")
     )
+
+    Vitest.test("ArcDeletePathRules.isRenamePathAllowed only allows entity folders", fun () ->
+        Vitest.expect(ArcDeletePathRules.isRenamePathAllowed "assays/OldAssay").toBe(true)
+        Vitest.expect(ArcDeletePathRules.isRenamePathAllowed "assays/OldAssay/isa.assay.xlsx").toBe(false)
+        Vitest.expect(ArcDeletePathRules.isRenamePathAllowed "assays/OldAssay/notes/custom.txt").toBe(false)
+    )
 )
 
 Vitest.describe("PathHelpers path relation helpers", fun () ->

--- a/tests/Electron.Core/RenamePathRules.test.fs
+++ b/tests/Electron.Core/RenamePathRules.test.fs
@@ -1,0 +1,44 @@
+module ElectronCore.RenamePathRulesTests
+
+open Swate.Electron.Shared.RenamePathRules
+open Swate.Components.Shared
+open Vitest
+
+Vitest.describe("RenamePathRules", fun () ->
+    Vitest.test("validateRenameName accepts valid names", fun () ->
+        match validateRenameName "  New Assay  " with
+        | Ok normalizedName -> Vitest.expect(normalizedName).toBe("New Assay")
+        | Error errorMessage -> failwith errorMessage
+    )
+
+    Vitest.test("validateRenameName rejects path separators", fun () ->
+        let result = validateRenameName "bad/name"
+        Vitest.expect(result).toEqual(Error "The new name must not contain path separators or null characters.")
+    )
+
+    Vitest.test("buildRenamedSiblingPath keeps parent path and replaces leaf", fun () ->
+        let targetPath = buildRenamedSiblingPath "assays/OldAssay" "NewAssay"
+        Vitest.expect(targetPath).toBe("assays/NewAssay")
+    )
+
+    Vitest.test("tryBuildRenameTargetPath rejects no-op rename", fun () ->
+        let result = tryBuildRenameTargetPath "assays/OldAssay" "OldAssay"
+        Vitest.expect(result).toEqual(Error "Rename target is identical to the current path.")
+    )
+)
+
+Vitest.describe("PathHelpers path relation helpers", fun () ->
+    Vitest.test("containsPathTraversalSegments detects traversal markers", fun () ->
+        Vitest.expect(PathHelpers.containsPathTraversalSegments "../assays/MyAssay").toBe(true)
+        Vitest.expect(PathHelpers.containsPathTraversalSegments "assays/./MyAssay").toBe(true)
+        Vitest.expect(PathHelpers.containsPathTraversalSegments "assays/MyAssay").toBe(false)
+    )
+
+    Vitest.test("isSameOrDescendantPathForFsComparison is case-insensitive and normalized", fun () ->
+        Vitest.expect(PathHelpers.isSameOrDescendantPathForFsComparison "C:/Repo/ARC/Assays/A" "c:\\repo\\arc")
+            .toBe(true)
+
+        Vitest.expect(PathHelpers.isSameOrDescendantPathForFsComparison "C:/Repo/Other/A" "c:/repo/arc")
+            .toBe(false)
+    )
+)

--- a/tests/Electron.Renderer/Electron.Renderer.Tests.fsproj
+++ b/tests/Electron.Renderer/Electron.Renderer.Tests.fsproj
@@ -6,6 +6,7 @@
     <Compile Include="IpcReceiverDisposable.test.fs" />
     <Compile Include="MainSyncedState.test.fs" />
     <Compile Include="FileStateContextReload.test.fs" />
+    <Compile Include="FileTreeRenameWorkflow.test.fs" />
     <Compile Include="GitWorkflow.test.fs" />
     <Compile Include="NoteSearchInterop.test.fs" />
   </ItemGroup>

--- a/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
+++ b/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
@@ -3,6 +3,7 @@ module ElectronRenderer.FileTreeRenameWorkflowTests
 open Browser.Dom
 open Browser.Types
 open Feliz
+open ARCtrl
 open Renderer.Components.LeftSidebar.FileExplorer.FileTreeRenameHelper
 open Renderer.Components.LeftSidebar.FileExplorer.Types
 open Swate.Components.FileExplorer.Types
@@ -53,14 +54,12 @@ let private createFolderItem (name: string) (path: string) =
 Vitest.afterEach (fun () -> document.body.innerHTML <- "")
 
 Vitest.describe("FileTreeRenameHelper", fun () ->
-    Vitest.test("tryBuildRenameDraft resolves canonical ARC files to entity folder rename source", fun () ->
+    Vitest.test("tryBuildRenameDraft rejects canonical ARC files", fun () ->
         let item = createFileItem "isa.assay.xlsx" "assays/OldAssay/isa.assay.xlsx"
 
         match tryBuildRenameDraft item with
-        | Error error -> failwith error
-        | Ok draft ->
-            Vitest.expect(draft.SourcePath).toBe("assays/OldAssay")
-            Vitest.expect(draft.InitialName).toBe("OldAssay")
+        | Ok _ -> failwith "Expected canonical ARC files to be non-renameable."
+        | Error _ -> ()
     )
 
     Vitest.test("tryRemapSelectionPath remaps descendants under renamed source prefixes", fun () ->
@@ -97,7 +96,7 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
         )
     )
 
-    Vitest.test("rename context menu item is shown for canonical entity and datamap ARC files", fun () ->
+    Vitest.test("rename context menu item is hidden for canonical entity and datamap ARC files", fun () ->
         let canonicalFilePaths =
             [
                 "assays/AssayA/isa.assay.xlsx"
@@ -114,8 +113,7 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
         |> List.iter (fun path ->
             let item = createFileItem (PathHelpers.getNameFromPath path) path
             let menuItems = getRenameMenuItems item
-            Vitest.expect(menuItems.Length).toBe(1)
-            Vitest.expect(menuItems.[0].Icon).toBe("swt:fluent--edit-24-regular")
+            Vitest.expect(menuItems.Length).toBe(0)
         )
     )
 
@@ -143,7 +141,7 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
     )
 
     Vitest.test("rename context menu action requests a rename draft for renameable items", fun () ->
-        let item = createFileItem "isa.assay.xlsx" "assays/OldAssay/isa.assay.xlsx"
+        let item = createFolderItem "OldAssay" "assays/OldAssay"
         let mutable pendingRenameDraft: ArcRenameDraft option = None
 
         let requestRenameItem =
@@ -221,7 +219,7 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
     Vitest.test("confirmRenameItem dispatches renamePath, remaps active selection, and refreshes git status", fun () ->
         promise {
             let renameDraftResult =
-                createFileItem "isa.assay.xlsx" "assays/OldAssay/isa.assay.xlsx"
+                createFolderItem "OldAssay" "assays/OldAssay"
                 |> tryBuildRenameDraft
 
             let renameDraft =
@@ -233,14 +231,22 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
             let mutable renamedSelection: ArcSelection option = None
             let mutable closed = false
             let mutable gitStatusRefreshCount = 0
+            let mutable reloadedPreviewPath: string option = None
 
             let config: RenameWorkflow.ConfirmRenameConfig = {
                 pendingRenameDraft = Some renameDraft
                 selectedTreePath = Some "assays/OldAssay/notes/protocol.md"
+                pageState = Some(Renderer.Types.PageState.ArcFilePage(ArcFiles.Assay(ArcAssay.init "OldAssay")))
                 closeRenameModal = fun () -> closed <- true
                 setIsRenaming = ignore
                 setSelection = fun selection -> renamedSelection <- Some selection
                 refreshGitStatus = fun () -> gitStatusRefreshCount <- gitStatusRefreshCount + 1
+                reloadPreviewByPath =
+                    fun path ->
+                        promise {
+                            reloadedPreviewPath <- Some path
+                            return Ok()
+                        }
                 renamePath =
                     fun request ->
                         promise {
@@ -262,6 +268,7 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
 
             Vitest.expect(renamedSelection.IsSome).toBe(true)
             Vitest.expect(renamedSelection.Value.TreePath).toEqual(Some "assays/NewAssay/notes/protocol.md")
+            Vitest.expect(reloadedPreviewPath).toEqual(Some "assays/NewAssay/isa.assay.xlsx")
             Vitest.expect(gitStatusRefreshCount).toBe(1)
         }
     )

--- a/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
+++ b/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
@@ -193,24 +193,27 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
             let! container, cleanup =
                 renderToBody (
                     Swate.Components.FileExplorer.FileExplorer.FileExplorer(
-                        initialItems = items
+                        initialItems = items,
+                        getItemActions = RenameWorkflow.renameContextMenuItems onRenameItem
                     )
                 )
 
-            entityFolderPaths
-            |> List.iter (fun path ->
-                let itemName = PathHelpers.getNameFromPath path
-                let buttonSelector = $"button[aria-label='Rename {itemName}']"
-                let renameButton = container.querySelector buttonSelector
+            try
+                entityFolderPaths
+                |> List.iter (fun path ->
+                    let itemName = PathHelpers.getNameFromPath path
+                    let buttonSelector = $"button[aria-label='Rename {itemName}']"
+                    let renameButton = container.querySelector buttonSelector
 
-                Vitest.expect(renameButton).not.toBeNull ()
-                (renameButton :?> HTMLElement).click ()
-            )
+                    Vitest.expect(renameButton).not.toBeNull ()
+                    (renameButton :?> HTMLElement).click ()
+                )
 
-            do! Promise.sleep 0
+                do! Promise.sleep 0
 
-            Vitest.expect(renamedPaths |> List.rev).toEqual(entityFolderPaths)
-            cleanup ()
+                Vitest.expect(renamedPaths |> List.rev).toEqual(entityFolderPaths)
+            finally
+                cleanup ()
         }
     )
 

--- a/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
+++ b/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
@@ -193,9 +193,7 @@ Vitest.describe("FileTreeRenameWorkflow", fun () ->
             let! container, cleanup =
                 renderToBody (
                     Swate.Components.FileExplorer.FileExplorer.FileExplorer(
-                        initialItems = items,
-                        canRenameItem = canRenameItem,
-                        onRenameItem = onRenameItem
+                        initialItems = items
                     )
                 )
 

--- a/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
+++ b/tests/Electron.Renderer/FileTreeRenameWorkflow.test.fs
@@ -1,0 +1,268 @@
+module ElectronRenderer.FileTreeRenameWorkflowTests
+
+open Browser.Dom
+open Browser.Types
+open Feliz
+open Renderer.Components.LeftSidebar.FileExplorer.FileTreeRenameHelper
+open Renderer.Components.LeftSidebar.FileExplorer.Types
+open Swate.Components.FileExplorer.Types
+open Swate.Components.Shared
+open Swate.Electron.Shared.FileIOTypes
+open Vitest
+
+module RenameWorkflow = Renderer.Components.LeftSidebar.FileExplorer.FileTreeRenameWorkflow
+
+let rec private waitUntil (predicate: unit -> bool, attempts: int) =
+    promise {
+        if predicate () then
+            return ()
+        elif attempts <= 0 then
+            failwith "Timed out waiting for rename workflow."
+        else
+            do! Promise.sleep 1
+            return! waitUntil (predicate, attempts - 1)
+    }
+
+let private renderToBody (element: ReactElement) = promise {
+    let container = document.createElement ("div") :?> HTMLDivElement
+    document.body.appendChild container |> ignore
+    let root = ReactDOM.createRoot container
+    root.render element
+    do! Promise.sleep 0
+
+    return
+        container,
+        (fun () ->
+            root.unmount ()
+            container.remove ()
+        )
+}
+
+let private createFileItem (name: string) (path: string) =
+    {
+        FileTree.createFile name (Some path) FileItemIcon.Document with
+            Id = path
+    }
+
+let private createFolderItem (name: string) (path: string) =
+    {
+        FileTree.createFolder name (Some path) FileItemIcon.Folder with
+            Id = path
+    }
+
+Vitest.afterEach (fun () -> document.body.innerHTML <- "")
+
+Vitest.describe("FileTreeRenameHelper", fun () ->
+    Vitest.test("tryBuildRenameDraft resolves canonical ARC files to entity folder rename source", fun () ->
+        let item = createFileItem "isa.assay.xlsx" "assays/OldAssay/isa.assay.xlsx"
+
+        match tryBuildRenameDraft item with
+        | Error error -> failwith error
+        | Ok draft ->
+            Vitest.expect(draft.SourcePath).toBe("assays/OldAssay")
+            Vitest.expect(draft.InitialName).toBe("OldAssay")
+    )
+
+    Vitest.test("tryRemapSelectionPath remaps descendants under renamed source prefixes", fun () ->
+        let remapped =
+            tryRemapSelectionPath
+                "assays/OldAssay"
+                "assays/NewAssay"
+                (Some "assays/OldAssay/notes/protocol.md")
+
+        Vitest.expect(remapped).toEqual(Some "assays/NewAssay/notes/protocol.md")
+    )
+)
+
+Vitest.describe("FileTreeRenameWorkflow", fun () ->
+    let getRenameMenuItems (item: FileItem) =
+        RenameWorkflow.renameContextMenuItems (fun _ -> ()) item
+
+    Vitest.test("rename context menu item is shown for assay, study, workflow, and run entity folders", fun () ->
+        let entityFolderPaths =
+            [
+                "assays/AssayA"
+                "studies/StudyA"
+                "workflows/WorkflowA"
+                "runs/RunA"
+            ]
+
+        entityFolderPaths
+        |> List.iter (fun path ->
+            let item = createFolderItem (PathHelpers.getNameFromPath path) path
+            let menuItems = getRenameMenuItems item
+            Vitest.expect(menuItems.Length).toBe(1)
+            Vitest.expect(menuItems.[0].Label).toBe("Rename")
+            Vitest.expect(menuItems.[0].Icon).toBe("swt:fluent--edit-24-regular")
+        )
+    )
+
+    Vitest.test("rename context menu item is shown for canonical entity and datamap ARC files", fun () ->
+        let canonicalFilePaths =
+            [
+                "assays/AssayA/isa.assay.xlsx"
+                "assays/AssayA/isa.datamap.xlsx"
+                "studies/StudyA/isa.study.xlsx"
+                "studies/StudyA/isa.datamap.xlsx"
+                "workflows/WorkflowA/isa.workflow.xlsx"
+                "workflows/WorkflowA/isa.datamap.xlsx"
+                "runs/RunA/isa.run.xlsx"
+                "runs/RunA/isa.datamap.xlsx"
+            ]
+
+        canonicalFilePaths
+        |> List.iter (fun path ->
+            let item = createFileItem (PathHelpers.getNameFromPath path) path
+            let menuItems = getRenameMenuItems item
+            Vitest.expect(menuItems.Length).toBe(1)
+            Vitest.expect(menuItems.[0].Icon).toBe("swt:fluent--edit-24-regular")
+        )
+    )
+
+    Vitest.test("rename context menu item is hidden for add-zone root folders", fun () ->
+        let addZoneRootPaths =
+            [
+                "assays"
+                "studies"
+                "workflows"
+                "runs"
+            ]
+
+        addZoneRootPaths
+        |> List.iter (fun path ->
+            let item = createFolderItem path path
+            let menuItems = getRenameMenuItems item
+            Vitest.expect(menuItems.Length).toBe(0)
+        )
+    )
+
+    Vitest.test("rename context menu item is hidden for generic descendants", fun () ->
+        let item = createFileItem "custom.txt" "studies/MyStudy/notes/custom.txt"
+        let menuItems = getRenameMenuItems item
+        Vitest.expect(menuItems.Length).toBe(0)
+    )
+
+    Vitest.test("rename context menu action requests a rename draft for renameable items", fun () ->
+        let item = createFileItem "isa.assay.xlsx" "assays/OldAssay/isa.assay.xlsx"
+        let mutable pendingRenameDraft: ArcRenameDraft option = None
+
+        let requestRenameItem =
+            RenameWorkflow.requestRenameItem (fun draft -> pendingRenameDraft <- draft) ignore None
+
+        let menuItems =
+            RenameWorkflow.renameContextMenuItems requestRenameItem item
+
+        Vitest.expect(menuItems.Length).toBe(1)
+        menuItems.[0].OnClick()
+        Vitest.expect(pendingRenameDraft.IsSome).toBe(true)
+    )
+
+    Vitest.test("rename request surfaces validation errors instead of silently swallowing", fun () ->
+        let item = createFolderItem "assays" "assays"
+        let mutable pendingRenameDraft: ArcRenameDraft option = None
+        let mutable errorCount = 0
+
+        RenameWorkflow.requestRenameItem
+            (fun draft -> pendingRenameDraft <- draft)
+            (fun _ -> errorCount <- errorCount + 1)
+            None
+            item
+
+        Vitest.expect(pendingRenameDraft).toEqual(None)
+        Vitest.expect(errorCount).toBe(1)
+    )
+
+    Vitest.test("inline rename button dispatches for assay, study, workflow, and run entity folders", fun () ->
+        promise {
+            let entityFolderPaths =
+                [
+                    "assays/AssayA"
+                    "studies/StudyA"
+                    "workflows/WorkflowA"
+                    "runs/RunA"
+                ]
+
+            let items =
+                entityFolderPaths
+                |> List.map (fun path -> createFolderItem (PathHelpers.getNameFromPath path) path)
+
+            let mutable renamedPaths: string list = []
+
+            let onRenameItem (item: FileItem) =
+                let path = item.Path |> Option.defaultValue ""
+                renamedPaths <- path :: renamedPaths
+
+            let! container, cleanup =
+                renderToBody (
+                    Swate.Components.FileExplorer.FileExplorer.FileExplorer(
+                        initialItems = items,
+                        canRenameItem = canRenameItem,
+                        onRenameItem = onRenameItem
+                    )
+                )
+
+            entityFolderPaths
+            |> List.iter (fun path ->
+                let itemName = PathHelpers.getNameFromPath path
+                let buttonSelector = $"button[aria-label='Rename {itemName}']"
+                let renameButton = container.querySelector buttonSelector
+
+                Vitest.expect(renameButton).not.toBeNull ()
+                (renameButton :?> HTMLElement).click ()
+            )
+
+            do! Promise.sleep 0
+
+            Vitest.expect(renamedPaths |> List.rev).toEqual(entityFolderPaths)
+            cleanup ()
+        }
+    )
+
+    Vitest.test("confirmRenameItem dispatches renamePath, remaps active selection, and refreshes git status", fun () ->
+        promise {
+            let renameDraftResult =
+                createFileItem "isa.assay.xlsx" "assays/OldAssay/isa.assay.xlsx"
+                |> tryBuildRenameDraft
+
+            let renameDraft =
+                match renameDraftResult with
+                | Ok draft -> draft
+                | Error error -> failwith error
+
+            let mutable renameRequest: RenamePathRequest option = None
+            let mutable renamedSelection: ArcSelection option = None
+            let mutable closed = false
+            let mutable gitStatusRefreshCount = 0
+
+            let config: RenameWorkflow.ConfirmRenameConfig = {
+                pendingRenameDraft = Some renameDraft
+                selectedTreePath = Some "assays/OldAssay/notes/protocol.md"
+                closeRenameModal = fun () -> closed <- true
+                setIsRenaming = ignore
+                setSelection = fun selection -> renamedSelection <- Some selection
+                refreshGitStatus = fun () -> gitStatusRefreshCount <- gitStatusRefreshCount + 1
+                renamePath =
+                    fun request ->
+                        promise {
+                            renameRequest <- Some request
+                            return Ok()
+                        }
+                enqueueError = fun _ -> failwith "Did not expect rename error."
+                arcScopeId = None
+            }
+
+            RenameWorkflow.confirmRenameItem config "NewAssay"
+            do! waitUntil ((fun () -> renameRequest.IsSome && closed), 50)
+
+            match renameRequest with
+            | None -> failwith "Expected renamePath to be dispatched."
+            | Some request ->
+                Vitest.expect(request.relativePath).toBe("assays/OldAssay")
+                Vitest.expect(request.newName).toBe("NewAssay")
+
+            Vitest.expect(renamedSelection.IsSome).toBe(true)
+            Vitest.expect(renamedSelection.Value.TreePath).toEqual(Some "assays/NewAssay/notes/protocol.md")
+            Vitest.expect(gitStatusRefreshCount).toBe(1)
+        }
+    )
+)

--- a/tests/Shared/PathHelpers.Tests.fs
+++ b/tests/Shared/PathHelpers.Tests.fs
@@ -171,7 +171,7 @@ let tests =
                 "runs/MyRun"
                 "Renaming a canonical ARC file should rename the parent entity folder."
 
-        testCase "isRenamePathAllowed blocks root and add-zone roots but allows generic descendants" <| fun _ ->
+        testCase "isRenamePathAllowed only allows entity folders" <| fun _ ->
             Expect.isFalse
                 (ArcDeletePathRules.isRenamePathAllowed "")
                 "ARC root must not be renameable."
@@ -180,9 +180,17 @@ let tests =
                 (ArcDeletePathRules.isRenamePathAllowed "studies")
                 "Add-zone roots must stay protected."
 
+            Expect.isFalse
+                (ArcDeletePathRules.isRenamePathAllowed "studies/MyStudy/isa.study.xlsx")
+                "Canonical ARC files should not be renameable."
+
             Expect.isTrue
+                (ArcDeletePathRules.isRenamePathAllowed "studies/MyStudy")
+                "Entity folders should be renameable."
+
+            Expect.isFalse
                 (ArcDeletePathRules.isRenamePathAllowed "studies/MyStudy/notes/custom.txt")
-                "Generic descendants under add zones should stay renameable."
+                "Generic descendants should not be renameable."
 
         testCase "buildCanonicalEntityPaths returns entity and datamap canonical files" <| fun _ ->
             let paths =

--- a/tests/Shared/PathHelpers.Tests.fs
+++ b/tests/Shared/PathHelpers.Tests.fs
@@ -152,4 +152,47 @@ let tests =
                 fallbackPaths
                 [ "workflows/MyFlow/isa.datamap.xlsx" ]
                 "Canonical file fallback should return the normalized target path."
+
+        testCase "classifyRenameTarget maps canonical ARC file paths to dedicated rename variants" <| fun _ ->
+            let classification =
+                ArcDeletePathRules.classifyRenameTarget "assays/MyAssay/isa.assay.xlsx"
+
+            match classification with
+            | ArcDeletePathRules.RenamePathClassification.CanonicalEntityFileTarget(
+                ArcDeletePathRules.AddZone.Assays,
+                "MyAssay",
+                _
+              ) -> ()
+            | _ -> failwith "Expected canonical assay file rename classification."
+
+        testCase "resolveRenameSourcePath redirects canonical ARC files to their entity folder" <| fun _ ->
+            Expect.equal
+                (ArcDeletePathRules.resolveRenameSourcePath "runs/MyRun/isa.run.xlsx")
+                "runs/MyRun"
+                "Renaming a canonical ARC file should rename the parent entity folder."
+
+        testCase "isRenamePathAllowed blocks root and add-zone roots but allows generic descendants" <| fun _ ->
+            Expect.isFalse
+                (ArcDeletePathRules.isRenamePathAllowed "")
+                "ARC root must not be renameable."
+
+            Expect.isFalse
+                (ArcDeletePathRules.isRenamePathAllowed "studies")
+                "Add-zone roots must stay protected."
+
+            Expect.isTrue
+                (ArcDeletePathRules.isRenamePathAllowed "studies/MyStudy/notes/custom.txt")
+                "Generic descendants under add zones should stay renameable."
+
+        testCase "buildCanonicalEntityPaths returns entity and datamap canonical files" <| fun _ ->
+            let paths =
+                ArcDeletePathRules.buildCanonicalEntityPaths ArcDeletePathRules.AddZone.Workflows "MyWorkflow"
+
+            Expect.equal
+                paths
+                [
+                    "workflows/MyWorkflow/isa.workflow.xlsx"
+                    "workflows/MyWorkflow/isa.datamap.xlsx"
+                ]
+                "Canonical rename merge paths should include entity and datamap files."
     ]


### PR DESCRIPTION
# Sync in-memory ARC and file system

## syntax

- **"generic" file or folder** - refers to any file with no collection state in the app
- **arc** file or folder - refers to any file 
- **local arc** - refers to the arc stored on the disc
- **in-memory arc** - refers to the arc stored in ArcVault
- **arc merge** - refers to a function call to merge changes between a local and a in-memory arc.

## use cases

### add/delete/rename generic file or folder

1. file watcher updates filetree with change

### add/delete/rename local arc file or folder

Pre 1: Investigate how renaming an assay/study/run/workflow folder affects arc integrity, as the identifier field SHOULD(?)/MUST(?) be equal to the folder name?

1. Use arc merge
2. file watcher updates filetree with change

### add arc file via filetree

Pre 2: Requires a new `ARC.Add<ArcFile>Async` function, similiar to `ARC.Rename<ArcFile>Async` and `ARC.Delete<ArcFile>Async`.

- Call `ARC.Add<ArcFile>Async` to add the new ArcFile to local AND in memory arc.
- file watcher triggers arc merge
    > [!WARNING]
    > this is some doubled logic, as the filewatcher will detect changes in an ARC file and trigger an arc merge, merging the new local file in the already existing in-memory file
- file watcher updates filetree

### rename arc file via filetree

=> Depends on `Pre 1`. 

If ARCtrl handles difference in folder and identifier name gracefully then

info: If we can use `fs` module we should use it, as it allows us to use the same logic for generic files too.

- Rename ArcFile folder using `fs` module
- file watcher triggers arc merge
- file watcher updates filetree

else

- Call `ARC.Rename<ArcFile>Async` to rename local and in memory ArcFile (this will update in-memory identifier and local ArcFile folder name)
- file watcher triggers arc merge
    > [!WARNING]
    > this is some doubled logic, as the filewatcher will detect changes in an ARC file and trigger an arc merge, merging the new local file in the already existing in-memory file
- file watcher updates filetree 

### delete arc fle via filetree

info: If we can use `fs` module we should use it, as it allows us to use the same logic for generic files too.

- Delete ArcFile folder using `fs` module
- file watcher triggers arc merge
- file watcher updates filetree

