### PR TITLE
Add and Delete affected files are stored on the disk

### DIFF
--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -78,7 +78,14 @@ module ArcVaultExtensions =
                             (fun () ->
                                 promise {
                                     swatelogfn this.window.id "Scheduled ARC reload triggered by file watcher."
-                                    do! this.LoadArc()
+
+                                    if this.hasUnsavedArcChanges then
+                                        swatelogfn
+                                            this.window.id
+                                            "Skipping ARC reload due to unsaved in-memory ARC changes."
+                                    else
+                                        do! this.LoadArc()
+
                                     sendMsgApi.IsLoadingChanges false
 
                                     match this.path with
@@ -161,27 +168,47 @@ module ArcVaultExtensions =
         /// The in-memory ARC is only replaced after successful persistence.
         member this.ApplyArcFileAndSave(request: FileContentDTO) : Fable.Core.JS.Promise<Result<unit, exn>> = promise {
             match this.path, this.arc with
-            | Some arcPath, Some arc ->
+            | Some arcPath, Some arcLocal ->
                 let normalizedRequest =
                     Swate.Electron.Shared.FileIOHelper.FileContentDTO.normalizeArcFileRequestPath request
 
-                let workingArc = arc.Copy()
+                this.isBusyWriting <- true
 
-                match updateARCByFileContentDTO workingArc normalizedRequest with
-                | Error updateError -> return Error updateError
-                | Ok updatedArc ->
-                    this.isBusyWriting <- true
+                try
+                    match! ARC.tryLoadAsync arcPath with
+                    | Error loadError ->
+                        return Error(exn $"Unable to reload ARC before scoped save: {loadError}")
+                    | Ok arcFromDisk ->
+                        let arcForDiskPersistence = copyArcPreservingStaticHashes arcFromDisk
+                        let arcForInMemoryState = copyArcPreservingStaticHashes arcLocal
 
-                    try
-                        try
-                            do! updatedArc.UpdateAsync(arcPath)
-                            this.SetArc(updatedArc)
-                            this.SetHasUnsavedArcChanges false
-                            return Ok()
-                        with e ->
-                            return Error(exn $"Failed to persist ARC to disk: {e.Message}")
-                    finally
-                        this.isBusyWriting <- false
+                        match
+                            updateARCByFileContentDTO arcForDiskPersistence normalizedRequest,
+                            updateARCByFileContentDTO arcForInMemoryState normalizedRequest
+                        with
+                        | Error updateError, _
+                        | _, Error updateError -> return Error updateError
+                        | Ok updatedArcForDiskPersistence, Ok updatedArcForInMemoryState ->
+                            try
+                                do! updatedArcForDiskPersistence.UpdateAsync(arcPath)
+                                // Carry over the fresh persisted hash baseline so follow-up writes stay scoped.
+                                syncArcStaticHashes updatedArcForDiskPersistence updatedArcForInMemoryState
+
+                                let hasRemainingUnsavedArcChanges =
+                                    updatedArcForInMemoryState.GetUpdateContracts().Length > 0
+
+                                // Preserve a pre-existing dirty marker so scoped add/save does not
+                                // accidentally clear unrelated unsaved in-memory changes.
+                                let nextHasUnsavedArcChanges =
+                                    this.hasUnsavedArcChanges || hasRemainingUnsavedArcChanges
+
+                                this.SetArc(updatedArcForInMemoryState)
+                                this.SetHasUnsavedArcChanges nextHasUnsavedArcChanges
+                                return Ok()
+                            with e ->
+                                return Error(exn $"Failed to persist ARC to disk: {e.Message}")
+                finally
+                    this.isBusyWriting <- false
             | _ -> return Error(exn "ARC is not loaded.")
         }
 

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -60,6 +60,54 @@ let private setDataMapByParentInfo (arc: ARC) (dmpi: DatamapParentInfo) (dm: Dat
     with e ->
         Error(exn $"Failed to set datamap on ARC: {e.Message}")
 
+let private syncDataMapStaticHash (sourceDataMap: DataMap option) (targetDataMap: DataMap option) =
+    match sourceDataMap, targetDataMap with
+    | Some sourceDataMap, Some targetDataMap -> targetDataMap.StaticHash <- sourceDataMap.StaticHash
+    | _ -> ()
+
+/// Syncs static hashes from source ARC to target ARC for matching entities.
+/// This keeps ARCtrl update contract generation scoped to actual changes.
+let syncArcStaticHashes (source: ARC) (target: ARC) : unit =
+    target.StaticHash <- source.StaticHash
+
+    match source.License, target.License with
+    | Some sourceLicense, Some targetLicense -> targetLicense.StaticHash <- sourceLicense.StaticHash
+    | _ -> ()
+
+    for targetStudy in target.Studies do
+        match source.TryGetStudy targetStudy.Identifier with
+        | Some sourceStudy ->
+            targetStudy.StaticHash <- sourceStudy.StaticHash
+            syncDataMapStaticHash sourceStudy.DataMap targetStudy.DataMap
+        | None -> ()
+
+    for targetAssay in target.Assays do
+        match source.TryGetAssay targetAssay.Identifier with
+        | Some sourceAssay ->
+            targetAssay.StaticHash <- sourceAssay.StaticHash
+            syncDataMapStaticHash sourceAssay.DataMap targetAssay.DataMap
+        | None -> ()
+
+    for targetWorkflow in target.Workflows do
+        match source.TryGetWorkflow targetWorkflow.Identifier with
+        | Some sourceWorkflow ->
+            targetWorkflow.StaticHash <- sourceWorkflow.StaticHash
+            syncDataMapStaticHash sourceWorkflow.DataMap targetWorkflow.DataMap
+        | None -> ()
+
+    for targetRun in target.Runs do
+        match source.TryGetRun targetRun.Identifier with
+        | Some sourceRun ->
+            targetRun.StaticHash <- sourceRun.StaticHash
+            syncDataMapStaticHash sourceRun.DataMap targetRun.DataMap
+        | None -> ()
+
+/// Copies ARC and preserves static hashes so unchanged entities are not treated as newly created.
+let copyArcPreservingStaticHashes (arc: ARC) : ARC =
+    let copiedArc = arc.Copy()
+    syncArcStaticHashes arc copiedArc
+    copiedArc
+
 /// This function should only be used for partial updates to an ARC based on a file content DTO.
 let updateARCByFileContentDTO (oldArc: ARC) (dto: FileContentDTO) : Result<ARC, exn> =
     let arcfile = FileContentDTO.toArcFile dto

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -13,6 +13,7 @@ open Fable.Electron.Main
 open Fable.Core.JsInterop
 open Main
 open Main.ArcMerge
+open Main.ArcVaultHelper
 open Node.Api
 open ARCtrl
 open Swate.Electron.Shared.DTOs.NoteSearchDto
@@ -193,9 +194,10 @@ module ArcDeleteHelper =
         (arcLocal: ARC)
         (reloadedArc: ARC)
         : Result<MergeResult, exn> =
-        let arcLocalForMerge = arcLocal.Copy()
+        let arcLocalForMerge = copyArcPreservingStaticHashes arcLocal
         let unlinkEvents = buildDeleteUnlinkEvents deletedPath preDeleteFileRelativePaths
         let mergedArc = ARC.merge arcLocalForMerge reloadedArc unlinkEvents
+        syncArcStaticHashes arcLocal mergedArc
 
         Ok { Arc = mergedArc }
 

--- a/tests/Electron.Core/ArcFileMutationHelper.test.fs
+++ b/tests/Electron.Core/ArcFileMutationHelper.test.fs
@@ -82,4 +82,77 @@ Vitest.describe("ArcFileMutationHelper", fun () ->
         let updatedArc = updateARCByFileContentDTO oldArc request |> expectOk
         let updatedAssay = updatedArc.GetAssay("assay_1")
         Vitest.expect(updatedAssay.Title).toEqual(Some "stable"))
+
+    Vitest.test("copyArcPreservingStaticHashes keeps static hashes for unchanged entities", fun () ->
+        let sourceArc = ARC("test-arc")
+        sourceArc.AddAssay(ArcAssay("assay_1", title = "stable"))
+
+        sourceArc.GetWriteContracts() |> ignore
+
+        let copiedArc = copyArcPreservingStaticHashes sourceArc
+
+        Vitest.expect(copiedArc.StaticHash).toBe(sourceArc.StaticHash)
+        Vitest.expect(copiedArc.GetAssay("assay_1").StaticHash).toBe(sourceArc.GetAssay("assay_1").StaticHash)
+
+        let updateContracts = copiedArc.GetUpdateContracts()
+        let contractPaths = updateContracts |> Array.map _.Path
+        Vitest.expect(contractPaths |> Array.exists (fun path -> path.StartsWith("assays/assay_1/"))).toBe(false))
+
+    Vitest.test("preserved-hash working copy only generates contracts for newly added entity subtree", fun () ->
+        let oldArc = ARC("test-arc")
+        oldArc.AddAssay(ArcAssay("assay_1", title = "stable"))
+        oldArc.GetWriteContracts() |> ignore
+
+        let workingArc = copyArcPreservingStaticHashes oldArc
+        let newAssay = ArcAssay("assay_2", title = "new-title")
+
+        let request =
+            FileContentDTO.fromArcFile(ArcFiles.Assay newAssay)
+            |> expectSome <| "Expected new assay request DTO."
+
+        let updatedArc = updateARCByFileContentDTO workingArc request |> expectOk
+        let updateContracts = updatedArc.GetUpdateContracts()
+        let contractPaths = updateContracts |> Array.map _.Path
+
+        Vitest.expect(updateContracts.Length).toBe(4)
+        Vitest.expect(contractPaths |> Array.exists (fun path -> path = "assays/assay_2/isa.assay.xlsx")).toBe(true)
+        Vitest.expect(contractPaths |> Array.exists (fun path -> path.StartsWith("assays/assay_2/"))).toBe(true)
+        Vitest.expect(contractPaths |> Array.exists (fun path -> path.StartsWith("assays/assay_1/"))).toBe(false)
+        Vitest.expect(contractPaths |> Array.exists (fun path -> path = "isa.investigation.xlsx")).toBe(false))
+
+    Vitest.test("scoped add persistence does not flush unrelated in-memory entity edits", fun () ->
+        let persistedArc = ARC("test-arc")
+        persistedArc.AddAssay(ArcAssay("assay_1", title = "stable"))
+        persistedArc.GetWriteContracts() |> ignore
+
+        let localDirtyArc = copyArcPreservingStaticHashes persistedArc
+        let dirtyAssay = ArcAssay("assay_1", title = "local-unsaved-change")
+
+        let dirtyRequest =
+            FileContentDTO.fromArcFile(ArcFiles.Assay dirtyAssay)
+            |> expectSome <| "Expected local dirty assay request DTO."
+
+        let localDirtyArc = updateARCByFileContentDTO localDirtyArc dirtyRequest |> expectOk
+
+        let addRequest =
+            FileContentDTO.fromArcFile(ArcFiles.Assay(ArcAssay("assay_2", title = "new-assay")))
+            |> expectSome <| "Expected add-assay request DTO."
+
+        // Simulate scoped disk persistence: base the write on a clean reloaded ARC.
+        let diskWorkingArc = copyArcPreservingStaticHashes persistedArc
+        let updatedArcForDiskPersistence = updateARCByFileContentDTO diskWorkingArc addRequest |> expectOk
+        let diskContracts = updatedArcForDiskPersistence.GetUpdateContracts() |> Array.map _.Path
+
+        Vitest.expect(diskContracts |> Array.exists (fun path -> path.StartsWith("assays/assay_2/"))).toBe(true)
+        Vitest.expect(diskContracts |> Array.exists (fun path -> path.StartsWith("assays/assay_1/"))).toBe(false)
+
+        // Simulate post-save in-memory state: keep local edits, add the new entity, sync hash baseline from disk write.
+        let localWorkingArc = copyArcPreservingStaticHashes localDirtyArc
+        let updatedArcForInMemoryState = updateARCByFileContentDTO localWorkingArc addRequest |> expectOk
+        syncArcStaticHashes updatedArcForDiskPersistence updatedArcForInMemoryState
+
+        let remainingUnsavedContracts = updatedArcForInMemoryState.GetUpdateContracts() |> Array.map _.Path
+
+        Vitest.expect(remainingUnsavedContracts |> Array.exists (fun path -> path.StartsWith("assays/assay_1/"))).toBe(true)
+        Vitest.expect(remainingUnsavedContracts |> Array.exists (fun path -> path.StartsWith("assays/assay_2/"))).toBe(false))
 )

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -209,6 +209,32 @@ Vitest.describe("ArcDeleteHelper merge and validation", fun () ->
             Vitest.expect(mergeResult.Arc.ContainsAssay("My Assay")).toBe(false)
     )
 
+    Vitest.test("mergeReloadedArcAfterDelete preserves hash baseline so unaffected entities do not get rewritten", fun () ->
+        let localArc = ARC("MergeArc")
+        localArc.InitAssay("AssayKeep") |> ignore
+        localArc.InitAssay("AssayDelete") |> ignore
+        localArc.GetWriteContracts() |> ignore
+
+        let reloadedArc = localArc.Copy()
+        reloadedArc.RemoveAssay("AssayDelete")
+
+        let result =
+            ArcDeleteHelper.mergeReloadedArcAfterDelete
+                "assays/AssayDelete/isa.assay.xlsx"
+                [ "assays/AssayDelete/isa.assay.xlsx" ]
+                localArc
+                reloadedArc
+
+        match result with
+        | Error error -> failwith error.Message
+        | Ok mergeResult ->
+            Vitest.expect(mergeResult.Arc.ContainsAssay("AssayDelete")).toBe(false)
+            Vitest.expect(mergeResult.Arc.ContainsAssay("AssayKeep")).toBe(true)
+
+            let followUpContracts = mergeResult.Arc.GetUpdateContracts()
+            Vitest.expect(followUpContracts.Length).toBe(0)
+    )
+
     Vitest.test("unlink event path dedupe is idempotent", fun () ->
         let events =
             ArcDeleteHelper.buildDeleteUnlinkEvents


### PR DESCRIPTION
- Currently, the whole dirty ARC is stored on the disk, when Add or Delete of the filetree is called
- Only the affected entity of the Add or Delete logic of the filetree is stored on the disk
- Rest of the dirty ARC stays in-memory