### PR TITLE
Update git metadata handling and save button disabling

### DIFF
--- a/src/Client/Update/SpreadsheetUpdate.fs
+++ b/src/Client/Update/SpreadsheetUpdate.fs
@@ -3,15 +3,11 @@ namespace Update
 open Messages
 open Elmish
 open Spreadsheet
-open LocalHistory
 open Model
-open Swate.Components
 open Swate.Components.Shared
-open Fable.Remoting.Client
 open FsSpreadsheet.Js
 open ARCtrl
 open ARCtrl.Spreadsheet
-open ARCtrl.Json
 
 module Spreadsheet =
 

--- a/src/Electron/src/Main/ARCtrlExtensions/InMemoryChanges.fs
+++ b/src/Electron/src/Main/ARCtrlExtensions/InMemoryChanges.fs
@@ -1,9 +1,9 @@
-namespace Main.ArcMerge
+namespace Main.ARCtrlExtensions
 
 open ARCtrl
 
 [<AutoOpen>]
-module ArcMergeExtensions =
+module InMemoryChangesExtensions =
 
     // Used to handle initiated but empty datamaps that have a StaticHash of 0, which would otherwise be indistinguishable from unchanged datamaps.
     let private cleanEmptyDataMapStaticHash = System.Int32.MinValue
@@ -12,6 +12,32 @@ module ArcMergeExtensions =
         let hash = dataMap.GetHashCode()
 
         if hash = 0 then cleanEmptyDataMapStaticHash else hash
+
+    let private baselineDataMapStaticHash (dataMap: DataMap option) =
+        dataMap |> Option.iter (fun dm -> dm.StaticHash <- cleanDataMapStaticHash dm)
+
+    /// Sets the current loaded ARC state as the clean in-memory baseline.
+    let baselineArcStaticHashes (arc: ARC) : unit =
+        arc.License
+        |> Option.iter (fun license -> license.StaticHash <- license.GetHashCode())
+
+        for study in arc.Studies do
+            study.StaticHash <- study.GetLightHashCode()
+            baselineDataMapStaticHash study.DataMap
+
+        for assay in arc.Assays do
+            assay.StaticHash <- assay.GetLightHashCode()
+            baselineDataMapStaticHash assay.DataMap
+
+        for workflow in arc.Workflows do
+            workflow.StaticHash <- workflow.GetLightHashCode()
+            baselineDataMapStaticHash workflow.DataMap
+
+        for run in arc.Runs do
+            run.StaticHash <- run.GetLightHashCode()
+            baselineDataMapStaticHash run.DataMap
+
+        arc.StaticHash <- arc.GetLightHashCode()
 
     type DataMap with
         member this.hasInMemoryChanges() : bool =

--- a/src/Electron/src/Main/ARCtrlExtensions/LoadAsync.fs
+++ b/src/Electron/src/Main/ARCtrlExtensions/LoadAsync.fs
@@ -1,0 +1,171 @@
+namespace Main.ARCtrlExtensions
+
+open System
+open ARCtrl
+open ARCtrl.Contract
+open Main.Bindings.Filesystem
+open Main.Bindings.Path
+open Swate.Electron.Shared.FileIOHelper
+
+[<AutoOpen>]
+module ArcLoadExtensions =
+
+    /// Returns true when a path addresses Git's private repository metadata.
+    /// `.gitignore`, `.gitattributes`, and similarly named files remain ordinary ARC payload.
+    let isGitMetadataPath (pathValue: string) =
+        pathValue
+        |> getNonEmptyPathParts
+        |> Array.exists (fun segment -> String.Equals(segment, ".git", StringComparison.OrdinalIgnoreCase))
+
+    let private getAllArcFilePathsAsync (arcPath: string) =
+        let rec collectFiles (absoluteDirectoryPath: string) (relativeDirectoryPath: string) = promise {
+            let! entries = readdirWithTypesAsync absoluteDirectoryPath (ReaddirOptions(withFileTypes = true))
+            let files = ResizeArray<string>()
+
+            for entry in entries do
+                let relativePath =
+                    if relativeDirectoryPath = "" then
+                        entry.name
+                    else
+                        $"{relativeDirectoryPath}/{entry.name}"
+
+                if not (isGitMetadataPath relativePath) then
+                    if entry.isDirectory () then
+                        let absolutePath = join [| absoluteDirectoryPath; entry.name |]
+                        let! nestedFiles = collectFiles absolutePath relativePath
+                        files.AddRange nestedFiles
+                    elif entry.isFile () then
+                        files.Add relativePath
+
+            return files.ToArray()
+        }
+
+        collectFiles arcPath ""
+
+    type private CanonicalArcFileRepairSpec = {
+        CollectionFolder: string
+        FileName: string
+        CreateContracts: string -> Contract[]
+    }
+
+    let private canonicalArcFileRepairSpecs = [|
+        {
+            CollectionFolder = "assays"
+            FileName = "isa.assay.xlsx"
+            CreateContracts = fun identifier -> (ArcAssay.init identifier).ToCreateContract(false)
+        }
+        {
+            CollectionFolder = "studies"
+            FileName = "isa.study.xlsx"
+            CreateContracts = fun identifier -> (ArcStudy.init identifier).ToCreateContract(false)
+        }
+        {
+            CollectionFolder = "workflows"
+            FileName = "isa.workflow.xlsx"
+            CreateContracts = fun identifier -> (ArcWorkflow.init identifier).ToCreateContract(false)
+        }
+        {
+            CollectionFolder = "runs"
+            FileName = "isa.run.xlsx"
+            CreateContracts = fun identifier -> (ArcRun.init identifier).ToCreateContract(false)
+        }
+    |]
+
+    let private isZeroByteZipReadError (errors: string[]) =
+        errors
+        |> Array.exists (fun error ->
+            let normalizedError = error.ToLowerInvariant()
+
+            normalizedError.Contains("error reading contract")
+            && normalizedError.Contains("data length = 0")
+        )
+
+    let private tryReadDirectoryAsync (directoryPath: string) = promise {
+        try
+            return! readdirAsync directoryPath
+        with _ ->
+            return [||]
+    }
+
+    let private tryGetFileSizeAsync (filePath: string) = promise {
+        try
+            let! stats = statAsync filePath
+            return Some stats.size
+        with _ ->
+            return None
+    }
+
+    let private repairZeroByteCanonicalArcFile
+        (arcPath: string)
+        (spec: CanonicalArcFileRepairSpec)
+        (identifier: string)
+        =
+        promise {
+            let absolutePath =
+                join [|
+                    arcPath
+                    spec.CollectionFolder
+                    identifier
+                    spec.FileName
+                |]
+
+            let! fileSize = tryGetFileSizeAsync absolutePath
+
+            match fileSize with
+            | Some size when size = 0.0 ->
+                match! fullFillContractBatchAsync arcPath (spec.CreateContracts identifier) with
+                | Ok _ -> return true
+                | Error _ -> return false
+            | _ -> return false
+        }
+
+    let private repairZeroByteCanonicalArcFiles (arcPath: string) = promise {
+        let mutable repairedAny = false
+
+        for spec in canonicalArcFileRepairSpecs do
+            let collectionPath = join [| arcPath; spec.CollectionFolder |]
+            let! identifiers = tryReadDirectoryAsync collectionPath
+
+            for identifier in identifiers do
+                let! repaired = repairZeroByteCanonicalArcFile arcPath spec identifier
+                repairedAny <- repairedAny || repaired
+
+        return repairedAny
+    }
+
+    type ARC with
+
+        /// Hotfix for #619, not fixed in the consumed ARCtrl 3.0.0-beta.12.
+        /// Mirrors ARC.tryLoadAsync, changing only filesystem traversal so `.git` directories are never enumerated.
+        static member LoadAsyncSwate(arcPath: string) = promise {
+            let! paths = getAllArcFilePathsAsync arcPath
+            let arc = ARC.fromFilePaths paths
+            let contracts = arc.GetReadContracts()
+
+            match! fullFillContractBatchAsync arcPath contracts with
+            | Ok fulfilledContracts ->
+                arc.SetISAFromContracts fulfilledContracts
+                return Ok arc
+            | Error errors -> return Error errors
+        }
+
+        /// Hotfix for #620, not fixed in the consumed ARCtrl 3.0.0-beta.12.
+        /// Repairs only zero-byte canonical workbooks left by interrupted creates, then retries LoadAsyncSwate.
+        static member LoadAsyncSwateZeroByteRepair(arcPath: string) = promise {
+            match! ARC.LoadAsyncSwate arcPath with
+            | Ok arc ->
+                baselineArcStaticHashes arc
+                return Ok arc
+            | Error errors when isZeroByteZipReadError errors ->
+                let! repairedAny = repairZeroByteCanonicalArcFiles arcPath
+
+                if repairedAny then
+                    match! ARC.LoadAsyncSwate arcPath with
+                    | Ok arc ->
+                        baselineArcStaticHashes arc
+                        return Ok arc
+                    | Error errors -> return Error errors
+                else
+                    return Error errors
+            | Error errors -> return Error errors
+        }

--- a/src/Electron/src/Main/ARCtrlExtensions/WriteAsync.fs
+++ b/src/Electron/src/Main/ARCtrlExtensions/WriteAsync.fs
@@ -1,4 +1,4 @@
-namespace Main.ArcMerge
+namespace Main.ARCtrlExtensions
 
 open ARCtrl
 open ARCtrl.Contract
@@ -23,8 +23,9 @@ module ArcWriteExtensions =
 
     type ARC with
 
-        /// This function is a hotfix for ARCtrl bug #XXXX
-        /// copy paste from ARCtrl, except for filesystem iteration
+        /// Hotfix for #618, not fixed in the consumed ARCtrl 3.0.0-beta.12.
+        /// Mirrors ARCtrl.GetWriteContracts except that it emits only managed ARC payload contracts instead of
+        /// iterating the complete filesystem model, where stale or Git metadata paths could be recreated.
         member this.GetWriteContractsSwate(?skipUpdateFS: bool) =
             if not (defaultArg skipUpdateFS false) then
                 this.UpdateFileSystem()
@@ -138,6 +139,6 @@ module ArcWriteExtensions =
                     yield Contract.createCreate (entry.Key, dtoType, dto)
             |]
 
-        /// Hotfix for ARCtrl issue #618. Writes only contracts selected by GetWriteContractsSwate.
+        /// Hotfix for #618. Writes only contracts selected by GetWriteContractsSwate.
         member this.TryWriteAsyncSwate(arcPath: string) =
             this.GetWriteContractsSwate() |> fullFillContractBatchAsync arcPath

--- a/src/Electron/src/Main/ArcMerge/ArcAddExtensions.fs
+++ b/src/Electron/src/Main/ArcMerge/ArcAddExtensions.fs
@@ -3,6 +3,7 @@ namespace Main.ArcMerge
 open ARCtrl
 open ARCtrl.Contract
 open CrossAsync
+open Main.ARCtrlExtensions
 open Swate.Components.Shared
 
 [<AutoOpen>]

--- a/src/Electron/src/Main/ArcMerge/ArcMergeLibraryExtensions.fs
+++ b/src/Electron/src/Main/ArcMerge/ArcMergeLibraryExtensions.fs
@@ -1,7 +1,7 @@
 namespace Main.ArcMerge
 
 open ARCtrl
-open Main.ArcMerge.ArcMergeExtensions
+open Main.ARCtrlExtensions
 
 module ArcMergeHelper =
 

--- a/src/Electron/src/Main/ArcMerge/ArcWriteExtensions.fs
+++ b/src/Electron/src/Main/ArcMerge/ArcWriteExtensions.fs
@@ -23,69 +23,88 @@ module ArcWriteExtensions =
 
     type ARC with
 
-        /// This function is a hotfix for ARCtrl bug #XXXX 
+        /// This function is a hotfix for ARCtrl bug #XXXX
         /// copy paste from ARCtrl, except for filesystem iteration
-        member this.GetWriteContractsSwate(?skipUpdateFS : bool) =
+        member this.GetWriteContractsSwate(?skipUpdateFS: bool) =
             if not (defaultArg skipUpdateFS false) then
                 this.UpdateFileSystem()
             //let datamapFile = defaultArg datamapFile false
             /// Map containing the fileName and the types for DTOTypes and objects.
-            let filemap = System.Collections.Generic.Dictionary<string, DTOType*DTO>()
-        
+            let filemap = System.Collections.Generic.Dictionary<string, DTOType * DTO>()
+
             let investigationConverter = ArcInvestigation.toFsWorkbook
-            filemap.Add (ARCtrl.ArcPathHelper.InvestigationFileName, (DTOType.ISA_Investigation, investigationConverter this |> box |> DTO.Spreadsheet))
+
+            filemap.Add(
+                ARCtrl.ArcPathHelper.InvestigationFileName,
+                (DTOType.ISA_Investigation, investigationConverter this |> box |> DTO.Spreadsheet)
+            )
+
             this.StaticHash <- this.GetLightHashCode()
+
             this.Studies
             |> Seq.iter (fun s ->
                 s.StaticHash <- s.GetLightHashCode()
-                filemap.Add (
+
+                filemap.Add(
                     Identifier.Study.fileNameFromIdentifier s.Identifier,
                     (DTOType.ISA_Study, ArcStudy.toFsWorkbook s |> box |> DTO.Spreadsheet)
                 )
-                if s.DataMap.IsSome (*&& datamapFile*) then 
+
+                if s.DataMap.IsSome (*&& datamapFile*) then
                     let dm = s.DataMap.Value
                     dm.StaticHash <- dm.GetHashCode()
-                    filemap.Add (
+
+                    filemap.Add(
                         Identifier.Study.datamapFileNameFromIdentifier s.Identifier,
                         (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
                     )
-                
+
             )
+
             this.Assays
             |> Seq.iter (fun a ->
                 a.StaticHash <- a.GetLightHashCode()
-                filemap.Add (
+
+                filemap.Add(
                     Identifier.Assay.fileNameFromIdentifier a.Identifier,
-                    (DTOType.ISA_Assay, ArcAssay.toFsWorkbook a |> box |> DTO.Spreadsheet))     
-                if a.DataMap.IsSome (*&& datamapFile*) then 
+                    (DTOType.ISA_Assay, ArcAssay.toFsWorkbook a |> box |> DTO.Spreadsheet)
+                )
+
+                if a.DataMap.IsSome (*&& datamapFile*) then
                     let dm = a.DataMap.Value
                     dm.StaticHash <- dm.GetHashCode()
-                    filemap.Add (
+
+                    filemap.Add(
                         Identifier.Assay.datamapFileNameFromIdentifier a.Identifier,
                         (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
                     )
             )
+
             this.Workflows
             |> Seq.iter (fun w ->
                 w.StaticHash <- w.GetLightHashCode()
-                filemap.Add (
+
+                filemap.Add(
                     Identifier.Workflow.fileNameFromIdentifier w.Identifier,
                     (DTOType.ISA_Workflow, ArcWorkflow.toFsWorkbook w |> box |> DTO.Spreadsheet)
                 )
                 //if w.CWLDescription.IsSome then
                 //    failwith "Not implemented yet: CWL description in ARC.GetWriteContracts"
-                if w.DataMap.IsSome (*&& datamapFile*) then 
+                if w.DataMap.IsSome (*&& datamapFile*) then
                     let dm = w.DataMap.Value
                     dm.StaticHash <- dm.GetHashCode()
-                    filemap.Add (
+
+                    filemap.Add(
                         Identifier.Workflow.datamapFileNameFromIdentifier w.Identifier,
                         (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
                     )
             )
+
             this.Runs
             |> Seq.iter (fun r ->
                 r.StaticHash <- r.GetLightHashCode()
-                filemap.Add (
+
+                filemap.Add(
                     Identifier.Run.fileNameFromIdentifier r.Identifier,
                     (DTOType.ISA_Run, ArcRun.toFsWorkbook r |> box |> DTO.Spreadsheet)
                 )
@@ -93,10 +112,11 @@ module ArcWriteExtensions =
                 //    failwith "Not implemented yet: CWL description in ARC.GetWriteContracts"
                 //if r.CWLInput.Count > 0 then
                 //    failwith "Not implemented yet: CWL YAML input in ARC.GetWriteContracts"
-                if r.DataMap.IsSome (*&& datamapFile*) then 
+                if r.DataMap.IsSome (*&& datamapFile*) then
                     let dm = r.DataMap.Value
                     dm.StaticHash <- dm.GetHashCode()
-                    filemap.Add (
+
+                    filemap.Add(
                         Identifier.Run.datamapFileNameFromIdentifier r.Identifier,
                         (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
                     )
@@ -107,9 +127,8 @@ module ArcWriteExtensions =
                 match l.Type with
                 | LicenseContentType.Fulltext ->
                     l.StaticHash <- l.GetHashCode()
-                    filemap.Add (l.Path, (DTOType.PlainText, DTO.Text l.Content))
-            | None ->
-                ()
+                    filemap.Add(l.Path, (DTOType.PlainText, DTO.Text l.Content))
+            | None -> ()
 
             [|
                 yield! collectionGitKeepContracts

--- a/src/Electron/src/Main/ArcMerge/ArcWriteExtensions.fs
+++ b/src/Electron/src/Main/ArcMerge/ArcWriteExtensions.fs
@@ -1,0 +1,124 @@
+namespace Main.ArcMerge
+
+open ARCtrl
+open ARCtrl.Contract
+open ARCtrl.Helper
+open ARCtrl.Spreadsheet
+
+[<AutoOpen>]
+module ArcWriteExtensions =
+
+    let private collectionGitKeepContracts =
+        [|
+            ArcPathHelper.AssaysFolderName
+            ArcPathHelper.StudiesFolderName
+            ArcPathHelper.WorkflowsFolderName
+            ArcPathHelper.RunsFolderName
+        |]
+        |> Array.map (fun collectionFolder ->
+            let path = ArcPathHelper.combine collectionFolder ArcPathHelper.GitKeepFileName
+
+            Contract.createCreate (path, DTOType.PlainText)
+        )
+
+    type ARC with
+
+        /// This function is a hotfix for ARCtrl bug #XXXX 
+        /// copy paste from ARCtrl, except for filesystem iteration
+        member this.GetWriteContractsSwate(?skipUpdateFS : bool) =
+            if not (defaultArg skipUpdateFS false) then
+                this.UpdateFileSystem()
+            //let datamapFile = defaultArg datamapFile false
+            /// Map containing the fileName and the types for DTOTypes and objects.
+            let filemap = System.Collections.Generic.Dictionary<string, DTOType*DTO>()
+        
+            let investigationConverter = ArcInvestigation.toFsWorkbook
+            filemap.Add (ARCtrl.ArcPathHelper.InvestigationFileName, (DTOType.ISA_Investigation, investigationConverter this |> box |> DTO.Spreadsheet))
+            this.StaticHash <- this.GetLightHashCode()
+            this.Studies
+            |> Seq.iter (fun s ->
+                s.StaticHash <- s.GetLightHashCode()
+                filemap.Add (
+                    Identifier.Study.fileNameFromIdentifier s.Identifier,
+                    (DTOType.ISA_Study, ArcStudy.toFsWorkbook s |> box |> DTO.Spreadsheet)
+                )
+                if s.DataMap.IsSome (*&& datamapFile*) then 
+                    let dm = s.DataMap.Value
+                    dm.StaticHash <- dm.GetHashCode()
+                    filemap.Add (
+                        Identifier.Study.datamapFileNameFromIdentifier s.Identifier,
+                        (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
+                    )
+                
+            )
+            this.Assays
+            |> Seq.iter (fun a ->
+                a.StaticHash <- a.GetLightHashCode()
+                filemap.Add (
+                    Identifier.Assay.fileNameFromIdentifier a.Identifier,
+                    (DTOType.ISA_Assay, ArcAssay.toFsWorkbook a |> box |> DTO.Spreadsheet))     
+                if a.DataMap.IsSome (*&& datamapFile*) then 
+                    let dm = a.DataMap.Value
+                    dm.StaticHash <- dm.GetHashCode()
+                    filemap.Add (
+                        Identifier.Assay.datamapFileNameFromIdentifier a.Identifier,
+                        (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
+                    )
+            )
+            this.Workflows
+            |> Seq.iter (fun w ->
+                w.StaticHash <- w.GetLightHashCode()
+                filemap.Add (
+                    Identifier.Workflow.fileNameFromIdentifier w.Identifier,
+                    (DTOType.ISA_Workflow, ArcWorkflow.toFsWorkbook w |> box |> DTO.Spreadsheet)
+                )
+                //if w.CWLDescription.IsSome then
+                //    failwith "Not implemented yet: CWL description in ARC.GetWriteContracts"
+                if w.DataMap.IsSome (*&& datamapFile*) then 
+                    let dm = w.DataMap.Value
+                    dm.StaticHash <- dm.GetHashCode()
+                    filemap.Add (
+                        Identifier.Workflow.datamapFileNameFromIdentifier w.Identifier,
+                        (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
+                    )
+            )
+            this.Runs
+            |> Seq.iter (fun r ->
+                r.StaticHash <- r.GetLightHashCode()
+                filemap.Add (
+                    Identifier.Run.fileNameFromIdentifier r.Identifier,
+                    (DTOType.ISA_Run, ArcRun.toFsWorkbook r |> box |> DTO.Spreadsheet)
+                )
+                //if r.CWLDescription.IsSome then
+                //    failwith "Not implemented yet: CWL description in ARC.GetWriteContracts"
+                //if r.CWLInput.Count > 0 then
+                //    failwith "Not implemented yet: CWL YAML input in ARC.GetWriteContracts"
+                if r.DataMap.IsSome (*&& datamapFile*) then 
+                    let dm = r.DataMap.Value
+                    dm.StaticHash <- dm.GetHashCode()
+                    filemap.Add (
+                        Identifier.Run.datamapFileNameFromIdentifier r.Identifier,
+                        (DTOType.ISA_Datamap, Spreadsheet.DataMap.toFsWorkbook dm |> box |> DTO.Spreadsheet)
+                    )
+            )
+
+            match this.License with
+            | Some l ->
+                match l.Type with
+                | LicenseContentType.Fulltext ->
+                    l.StaticHash <- l.GetHashCode()
+                    filemap.Add (l.Path, (DTOType.PlainText, DTO.Text l.Content))
+            | None ->
+                ()
+
+            [|
+                yield! collectionGitKeepContracts
+
+                for entry in filemap do
+                    let dtoType, dto = entry.Value
+                    yield Contract.createCreate (entry.Key, dtoType, dto)
+            |]
+
+        /// Hotfix for ARCtrl issue #618. Writes only contracts selected by GetWriteContractsSwate.
+        member this.TryWriteAsyncSwate(arcPath: string) =
+            this.GetWriteContractsSwate() |> fullFillContractBatchAsync arcPath

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -97,7 +97,7 @@ module ArcVaultExtensions =
         member private this.ApplyWatcherArcMerge(events: FileEvent list) = promise {
             match this.path, this.arc with
             | Some arcPath, Some arcLocal ->
-                match! ARC.tryLoadAsync arcPath with
+                match! tryLoadArcIgnoringGitMetadataAsync arcPath with
                 | Error loadError ->
                     swatelogfn
                         this.window.id
@@ -239,7 +239,7 @@ module ArcVaultExtensions =
 
                 try
                     try
-                        do! arc.UpdateAsync(arcPath)
+                        do! updateArcPreservingExistingPayloadFiles arcPath arc
                         this.RefreshHasUnsavedArcChangesFlag()
                         return Ok()
                     with e ->
@@ -267,7 +267,7 @@ module ArcVaultExtensions =
                         match! arcLocal.TryAddArcFileAsync(arcPath, arcFile, false) with
                         | Error errors -> return Error(exn (PathHelpers.formatContractErrors errors))
                         | Ok _ ->
-                            match! ARC.tryLoadAsync arcPath with
+                            match! tryLoadArcIgnoringGitMetadataAsync arcPath with
                             | Ok persistedArc ->
                                 baselineArcStaticHashes persistedArc
                                 syncAddedArcFileFromPersisted persistedArc arcLocal arcFile

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -5,6 +5,7 @@ open System.Collections.Generic
 open Fable.Electron
 open Fable.Electron.Remoting.Main
 open Main
+open Main.ARCtrlExtensions
 open Main.Bindings
 open Main.ArcMerge
 open Main.ArcVaultHelper
@@ -97,7 +98,7 @@ module ArcVaultExtensions =
         member private this.ApplyWatcherArcMerge(events: FileEvent list) = promise {
             match this.path, this.arc with
             | Some arcPath, Some arcLocal ->
-                match! tryLoadArcIgnoringGitMetadataAsync arcPath with
+                match! ARC.LoadAsyncSwate arcPath with
                 | Error loadError ->
                     swatelogfn
                         this.window.id
@@ -239,7 +240,7 @@ module ArcVaultExtensions =
 
                 try
                     try
-                        do! updateArcPreservingExistingPayloadFiles arcPath arc
+                        do! arc.UpdateAsync(arcPath)
                         this.RefreshHasUnsavedArcChangesFlag()
                         return Ok()
                     with e ->
@@ -267,7 +268,7 @@ module ArcVaultExtensions =
                         match! arcLocal.TryAddArcFileAsync(arcPath, arcFile, false) with
                         | Error errors -> return Error(exn (PathHelpers.formatContractErrors errors))
                         | Ok _ ->
-                            match! tryLoadArcIgnoringGitMetadataAsync arcPath with
+                            match! ARC.LoadAsyncSwate arcPath with
                             | Ok persistedArc ->
                                 baselineArcStaticHashes persistedArc
                                 syncAddedArcFileFromPersisted persistedArc arcLocal arcFile
@@ -317,7 +318,7 @@ module ArcVaultExtensions =
 
         member this.LoadArc() = promise {
             if this.path.IsSome then
-                match! tryLoadArcWithZeroByteRepair this.window.id this.path.Value with
+                match! ARC.LoadAsyncSwateZeroByteRepair this.path.Value with
                 | Error e -> swatefailfn this.window.id "Unable to load ARC: %s" (PathHelpers.formatContractErrors e)
                 | Ok arc ->
                     this.SetArc(arc)

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -398,7 +398,12 @@ module ArcVaultExtensions =
                 this.isBusyWriting <- true
 
                 try
-                    do! arc.WriteAsync(normalizedPath)
+                    match! arc.TryWriteAsyncSwate(normalizedPath) with
+                    | Ok _ -> ()
+                    | Error errors ->
+                        failwithf
+                            "Could not write ARC, failed with the following errors %s"
+                            (PathHelpers.formatContractErrors errors)
                 finally
                     this.isBusyWriting <- false
 

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -6,6 +6,7 @@ open Swate.Electron.Shared.FileIOHelper
 open Swate.Electron.Shared.FileIOTypes
 open ARCtrl
 open Fable.Electron
+open Fable.Core
 open Fable.Core.JsInterop
 open Main
 open Main.ARCtrlExtensions

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -72,21 +72,18 @@ let tryLoadArcIgnoringGitMetadataAsync (arcPath: string) = promise {
 }
 
 /// Replaces ARC.UpdateAsync for full ARC saves because its generated contracts may include Git metadata
-/// and empty scaffold contracts that would overwrite existing payload files.
+/// and DTO-less write contracts that would overwrite or restore payload files.
 let updateArcPreservingExistingPayloadFiles (arcPath: string) (arc: ARC) = promise {
-    let contractsToWrite = ResizeArray<Contract>()
+    let contractsToWrite =
+        arc.GetUpdateContracts()
+        |> Array.filter (fun contract ->
+            not (isGitMetadataContract contract)
+            && match contract.Operation, contract.DTO with
+               | (Operation.CREATE | Operation.UPDATE), None -> false
+               | _ -> true
+        )
 
-    for contract in arc.GetUpdateContracts() |> Array.filter (isGitMetadataContract >> not) do
-        match contract.Operation, contract.DTO with
-        | Operation.CREATE, None ->
-            let absolutePath = path.join (arcPath, contract.Path)
-            let! fileExists = ARCtrl.FileSystemHelper.fileExistsAsync absolutePath
-
-            if not fileExists then
-                contractsToWrite.Add contract
-        | _ -> contractsToWrite.Add contract
-
-    match! fullFillContractBatchAsync arcPath (contractsToWrite.ToArray()) with
+    match! fullFillContractBatchAsync arcPath contractsToWrite with
     | Ok _ -> ()
     | Error errors -> return failwith (PathHelpers.formatContractErrors errors)
 }

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -55,10 +55,9 @@ let private getAllArcFilePathsIgnoringGitMetadataAsync (arcPath: string) =
 
 let private isGitMetadataContract (contract: Contract) =
     isGitMetadataPath contract.Path
-    ||
-    match contract.Operation, contract.DTO with
-    | Operation.RENAME, Some(DTO.Text targetPath) -> isGitMetadataPath targetPath
-    | _ -> false
+    || match contract.Operation, contract.DTO with
+       | Operation.RENAME, Some(DTO.Text targetPath) -> isGitMetadataPath targetPath
+       | _ -> false
 
 /// Loads an ARC while enforcing that Git metadata never enters its filesystem model.
 let tryLoadArcIgnoringGitMetadataAsync (arcPath: string) = promise {

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -1,92 +1,16 @@
 module Main.ArcVaultHelper
 
 
-open System
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOHelper
 open Swate.Electron.Shared.FileIOTypes
 open ARCtrl
-open ARCtrl.Contract
 open Fable.Electron
-open Fable.Core
 open Fable.Core.JsInterop
 open Main
-open Main.ArcMerge
+open Main.ARCtrlExtensions
 open Main.Bindings
-open Main.Bindings.Filesystem
 open Node.Api
-
-let private fsPromisesDynamic: obj = importAll "fs/promises"
-
-/// Returns true when a path addresses Git's private repository metadata.
-/// `.gitignore`, `.gitattributes`, and similarly named files remain ordinary ARC payload.
-let isGitMetadataPath (pathValue: string) =
-    pathValue
-    |> getNonEmptyPathParts
-    |> Array.exists (fun segment -> String.Equals(segment, ".git", StringComparison.OrdinalIgnoreCase))
-
-let private getAllArcFilePathsIgnoringGitMetadataAsync (arcPath: string) =
-    let rec collectFiles (absoluteDirectoryPath: string) (relativeDirectoryPath: string) = promise {
-        let! entries = readdirWithTypesAsync absoluteDirectoryPath (ReaddirOptions(withFileTypes = true))
-
-        let files = ResizeArray<string>()
-
-        for entry in entries do
-            let name = entry.name
-
-            let relativePath =
-                if relativeDirectoryPath = "" then
-                    name
-                else
-                    $"{relativeDirectoryPath}/{name}"
-
-            if not (isGitMetadataPath relativePath) then
-                if entry.isDirectory () then
-                    let absolutePath = path.join (absoluteDirectoryPath, name)
-                    let! nestedFiles = collectFiles absolutePath relativePath
-                    files.AddRange nestedFiles
-                elif entry.isFile () then
-                    files.Add relativePath
-
-        return files.ToArray()
-    }
-
-    collectFiles arcPath ""
-
-let private isGitMetadataContract (contract: Contract) =
-    isGitMetadataPath contract.Path
-    || match contract.Operation, contract.DTO with
-       | Operation.RENAME, Some(DTO.Text targetPath) -> isGitMetadataPath targetPath
-       | _ -> false
-
-/// Loads an ARC while enforcing that Git metadata never enters its filesystem model.
-let tryLoadArcIgnoringGitMetadataAsync (arcPath: string) = promise {
-    let! paths = getAllArcFilePathsIgnoringGitMetadataAsync arcPath
-    let arc = ARC.fromFilePaths paths
-
-    match! fullFillContractBatchAsync arcPath (arc.GetReadContracts()) with
-    | Error errors -> return Error errors
-    | Ok contracts ->
-        arc.SetISAFromContracts contracts
-        return Ok arc
-}
-
-/// Replaces ARC.UpdateAsync for full ARC saves because its generated contracts may include Git metadata
-/// and DTO-less write contracts that would overwrite or restore payload files.
-let updateArcPreservingExistingPayloadFiles (arcPath: string) (arc: ARC) = promise {
-    let contractsToWrite =
-        arc.GetUpdateContracts()
-        |> Array.filter (fun contract ->
-            not (isGitMetadataContract contract)
-            && match contract.Operation, contract.DTO with
-               | (Operation.CREATE | Operation.UPDATE), None -> false
-               | _ -> true
-        )
-
-    match! fullFillContractBatchAsync arcPath contractsToWrite with
-    | Ok _ -> ()
-    | Error errors -> return failwith (PathHelpers.formatContractErrors errors)
-}
 
 /// This function mutably sets the datamap on the correct parent based on the datamap parent info included in the file content DTO.
 /// It also ensures that the static hash is preserved to avoid unnecessary changes to the ARC when saving a datamap.
@@ -135,32 +59,6 @@ let private setDataMapByParentInfo (arc: ARC) (dmpi: DatamapParentInfo) (dm: Dat
             Ok()
     with e ->
         Error(exn $"Failed to set datamap on ARC: {e.Message}")
-
-let private baselineDataMapStaticHash (dataMap: DataMap option) =
-    dataMap |> Option.iter (fun dm -> dm.StaticHash <- cleanDataMapStaticHash dm)
-
-/// Sets the current loaded ARC state as the clean in-memory baseline.
-let baselineArcStaticHashes (arc: ARC) : unit =
-    arc.License
-    |> Option.iter (fun license -> license.StaticHash <- license.GetHashCode())
-
-    for study in arc.Studies do
-        study.StaticHash <- study.GetLightHashCode()
-        baselineDataMapStaticHash study.DataMap
-
-    for assay in arc.Assays do
-        assay.StaticHash <- assay.GetLightHashCode()
-        baselineDataMapStaticHash assay.DataMap
-
-    for workflow in arc.Workflows do
-        workflow.StaticHash <- workflow.GetLightHashCode()
-        baselineDataMapStaticHash workflow.DataMap
-
-    for run in arc.Runs do
-        run.StaticHash <- run.GetLightHashCode()
-        baselineDataMapStaticHash run.DataMap
-
-    arc.StaticHash <- arc.GetLightHashCode()
 
 /// Replaces the just-added ARC entity with the disk round-tripped version.
 /// This keeps lossy serialization details from becoming immediate unsaved changes.
@@ -259,131 +157,6 @@ let swatelogfn id fmt =
 
 let swatefailfn id fmt =
     Printf.kprintf (fun s -> failwith ("[Swate-" + string id + "] " + s)) fmt
-
-type private CanonicalArcFileRepairSpec = {
-    CollectionFolder: string
-    FileName: string
-    CreateContracts: string -> Contract[]
-}
-
-let private canonicalArcFileRepairSpecs = [|
-    {
-        CollectionFolder = "assays"
-        FileName = "isa.assay.xlsx"
-        CreateContracts = fun identifier -> (ArcAssay.init identifier).ToCreateContract(false)
-    }
-    {
-        CollectionFolder = "studies"
-        FileName = "isa.study.xlsx"
-        CreateContracts = fun identifier -> (ArcStudy.init identifier).ToCreateContract(false)
-    }
-    {
-        CollectionFolder = "workflows"
-        FileName = "isa.workflow.xlsx"
-        CreateContracts = fun identifier -> (ArcWorkflow.init identifier).ToCreateContract(false)
-    }
-    {
-        CollectionFolder = "runs"
-        FileName = "isa.run.xlsx"
-        CreateContracts = fun identifier -> (ArcRun.init identifier).ToCreateContract(false)
-    }
-|]
-
-let private isZeroByteZipReadError (errors: string[]) =
-    errors
-    |> Array.exists (fun error ->
-        let normalizedError = error.ToLowerInvariant()
-
-        normalizedError.Contains("error reading contract")
-        && normalizedError.Contains("data length = 0")
-    )
-
-let private tryReadDirectoryAsync (directoryPath: string) = promise {
-    try
-        let! entries = fsPromisesDynamic?readdir (directoryPath) |> unbox<JS.Promise<string[]>>
-        return entries
-    with _ ->
-        return [||]
-}
-
-let private tryGetFileSizeAsync (filePath: string) = promise {
-    try
-        let! stats = fsPromisesDynamic?stat (filePath) |> unbox<JS.Promise<obj>>
-        return Some(stats?size |> unbox<float>)
-    with _ ->
-        return None
-}
-
-let private repairZeroByteCanonicalArcFile
-    (windowId: int)
-    (arcPath: string)
-    (spec: CanonicalArcFileRepairSpec)
-    (identifier: string)
-    =
-    promise {
-        let relativePath =
-            ARCtrl.ArcPathHelper.combineMany [| spec.CollectionFolder; identifier; spec.FileName |]
-
-        let absolutePath =
-            path.join (arcPath, spec.CollectionFolder, identifier, spec.FileName)
-
-        let! fileSize = tryGetFileSizeAsync absolutePath
-
-        match fileSize with
-        | Some size when size = 0.0 ->
-            swatelogfn windowId "Repairing zero-byte ARC workbook: %s" relativePath
-            let! repairResult = fullFillContractBatchAsync arcPath (spec.CreateContracts identifier)
-
-            match repairResult with
-            | Ok _ -> return true
-            | Error errors ->
-                swatelogfn
-                    windowId
-                    "Unable to repair zero-byte ARC workbook '%s': %s"
-                    relativePath
-                    (PathHelpers.formatContractErrors errors)
-
-                return false
-        | _ -> return false
-    }
-
-let private repairZeroByteCanonicalArcFiles (windowId: int) (arcPath: string) = promise {
-    let mutable repairedAny = false
-
-    for spec in canonicalArcFileRepairSpecs do
-        let collectionPath = path.join (arcPath, spec.CollectionFolder)
-        let! identifiers = tryReadDirectoryAsync collectionPath
-
-        for identifier in identifiers do
-            let! repaired = repairZeroByteCanonicalArcFile windowId arcPath spec identifier
-            repairedAny <- repairedAny || repaired
-
-    return repairedAny
-}
-
-/// Loads an ARC, repairing empty canonical workbooks that can be left behind by interrupted creates.
-let tryLoadArcWithZeroByteRepair (windowId: int) (arcPath: string) = promise {
-    let! loadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
-
-    match loadResult with
-    | Ok arc ->
-        baselineArcStaticHashes arc
-        return Ok arc
-    | Error errors when isZeroByteZipReadError errors ->
-        let! repairedAny = repairZeroByteCanonicalArcFiles windowId arcPath
-
-        if repairedAny then
-            let! retryLoadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
-
-            match retryLoadResult with
-            | Ok arc ->
-                baselineArcStaticHashes arc
-                return Ok arc
-            | Error errors -> return Error errors
-        else
-            return Error errors
-    | Error errors -> return Error errors
-}
 
 let createWindow () = promise {
     printfn "[Swate] Creating new window"

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -71,7 +71,8 @@ let tryLoadArcIgnoringGitMetadataAsync (arcPath: string) = promise {
         return Ok arc
 }
 
-/// Writes ARC updates without touching Git metadata or replacing existing payload with empty scaffold contracts.
+/// Replaces ARC.UpdateAsync for full ARC saves because its generated contracts may include Git metadata
+/// and empty scaffold contracts that would overwrite existing payload files.
 let updateArcPreservingExistingPayloadFiles (arcPath: string) (arc: ARC) = promise {
     let contractsToWrite = ResizeArray<Contract>()
 

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -13,9 +13,83 @@ open Fable.Core.JsInterop
 open Main
 open Main.ArcMerge
 open Main.Bindings
+open Main.Bindings.Filesystem
 open Node.Api
 
 let private fsPromisesDynamic: obj = importAll "fs/promises"
+
+/// Returns true when a path addresses Git's private repository metadata.
+/// `.gitignore`, `.gitattributes`, and similarly named files remain ordinary ARC payload.
+let isGitMetadataPath (pathValue: string) =
+    pathValue
+    |> getNonEmptyPathParts
+    |> Array.exists (fun segment -> String.Equals(segment, ".git", StringComparison.OrdinalIgnoreCase))
+
+let private getAllArcFilePathsIgnoringGitMetadataAsync (arcPath: string) =
+    let rec collectFiles (absoluteDirectoryPath: string) (relativeDirectoryPath: string) = promise {
+        let! entries = readdirWithTypesAsync absoluteDirectoryPath (ReaddirOptions(withFileTypes = true))
+
+        let files = ResizeArray<string>()
+
+        for entry in entries do
+            let name = entry.name
+
+            let relativePath =
+                if relativeDirectoryPath = "" then
+                    name
+                else
+                    $"{relativeDirectoryPath}/{name}"
+
+            if not (isGitMetadataPath relativePath) then
+                if entry.isDirectory () then
+                    let absolutePath = path.join (absoluteDirectoryPath, name)
+                    let! nestedFiles = collectFiles absolutePath relativePath
+                    files.AddRange nestedFiles
+                elif entry.isFile () then
+                    files.Add relativePath
+
+        return files.ToArray()
+    }
+
+    collectFiles arcPath ""
+
+let private isGitMetadataContract (contract: Contract) =
+    isGitMetadataPath contract.Path
+    ||
+    match contract.Operation, contract.DTO with
+    | Operation.RENAME, Some(DTO.Text targetPath) -> isGitMetadataPath targetPath
+    | _ -> false
+
+/// Loads an ARC while enforcing that Git metadata never enters its filesystem model.
+let tryLoadArcIgnoringGitMetadataAsync (arcPath: string) = promise {
+    let! paths = getAllArcFilePathsIgnoringGitMetadataAsync arcPath
+    let arc = ARC.fromFilePaths paths
+
+    match! fullFillContractBatchAsync arcPath (arc.GetReadContracts()) with
+    | Error errors -> return Error errors
+    | Ok contracts ->
+        arc.SetISAFromContracts contracts
+        return Ok arc
+}
+
+/// Writes ARC updates without touching Git metadata or replacing existing payload with empty scaffold contracts.
+let updateArcPreservingExistingPayloadFiles (arcPath: string) (arc: ARC) = promise {
+    let contractsToWrite = ResizeArray<Contract>()
+
+    for contract in arc.GetUpdateContracts() |> Array.filter (isGitMetadataContract >> not) do
+        match contract.Operation, contract.DTO with
+        | Operation.CREATE, None ->
+            let absolutePath = path.join (arcPath, contract.Path)
+            let! fileExists = ARCtrl.FileSystemHelper.fileExistsAsync absolutePath
+
+            if not fileExists then
+                contractsToWrite.Add contract
+        | _ -> contractsToWrite.Add contract
+
+    match! fullFillContractBatchAsync arcPath (contractsToWrite.ToArray()) with
+    | Ok _ -> ()
+    | Error errors -> return failwith (PathHelpers.formatContractErrors errors)
+}
 
 /// This function mutably sets the datamap on the correct parent based on the datamap parent info included in the file content DTO.
 /// It also ensures that the static hash is preserved to avoid unnecessary changes to the ARC when saving a datamap.
@@ -292,7 +366,7 @@ let private repairZeroByteCanonicalArcFiles (windowId: int) (arcPath: string) = 
 
 /// Loads an ARC, repairing empty canonical workbooks that can be left behind by interrupted creates.
 let tryLoadArcWithZeroByteRepair (windowId: int) (arcPath: string) = promise {
-    let! loadResult = ARC.tryLoadAsync arcPath
+    let! loadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
 
     match loadResult with
     | Ok arc ->
@@ -302,7 +376,7 @@ let tryLoadArcWithZeroByteRepair (windowId: int) (arcPath: string) = promise {
         let! repairedAny = repairZeroByteCanonicalArcFiles windowId arcPath
 
         if repairedAny then
-            let! retryLoadResult = ARC.tryLoadAsync arcPath
+            let! retryLoadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
 
             match retryLoadResult with
             | Ok arc ->
@@ -363,21 +437,11 @@ let createFileWatcher (path: string) (usePolling: bool option) =
 
     let ignoreFn =
         fun (path: string) ->
-            let normalizedPath = path.Replace("\\", "/")
-
-            let segments =
-                normalizedPath.Trim('/').Split('/', System.StringSplitOptions.RemoveEmptyEntries)
-
+            let normalizedPath = PathHelpers.normalizeSeparators path
             let tempXlsxPattern = """\.~\$.*\.xlsx$"""
 
-            // skip temporary Excel files (created when editing an xlsx file)
-            if System.Text.RegularExpressions.Regex.IsMatch(normalizedPath, tempXlsxPattern) then
-                true
-            // skip git folder itself (and its contents) to avoid expensive scans
-            elif segments |> Array.exists (fun segment -> segment = ".git") then
-                true
-            else
-                false
+            System.Text.RegularExpressions.Regex.IsMatch(normalizedPath, tempXlsxPattern)
+            || isGitMetadataPath normalizedPath
 
     // Native Windows file events can keep handles that block app-initiated folder renames.
     let usePolling =

--- a/src/Electron/src/Main/IPC/Delete.fs
+++ b/src/Electron/src/Main/IPC/Delete.fs
@@ -61,7 +61,7 @@ module ArcDeleteHelper =
         ArcEntityPathRules.buildCanonicalEntityPaths zone identifier |> List.head
 
     let private mergeDeletedEntityFromDisk arcPath canonicalFilePath (arcLocal: ARC) = promise {
-        match! ARC.tryLoadAsync arcPath with
+        match! tryLoadArcIgnoringGitMetadataAsync arcPath with
         | Error errors ->
             return
                 Error(
@@ -110,7 +110,7 @@ module ArcDeleteHelper =
         | Error validationError -> return Error validationError
         | Ok(fileType, identifier, normalizedRelativePath, canonicalFilePath) ->
             try
-                match! ARC.tryLoadAsync arcPath with
+                match! tryLoadArcIgnoringGitMetadataAsync arcPath with
                 | Error errors ->
                     return
                         Error(

--- a/src/Electron/src/Main/IPC/Delete.fs
+++ b/src/Electron/src/Main/IPC/Delete.fs
@@ -3,8 +3,8 @@ module Main.IPC.Delete
 open Fable.Core
 open ARCtrl
 open ARCtrl.Contract
+open Main.ARCtrlExtensions
 open Main.ArcMerge
-open Main.ArcVaultHelper
 open Swate.Components.Shared
 open ARC
 
@@ -61,7 +61,7 @@ module ArcDeleteHelper =
         ArcEntityPathRules.buildCanonicalEntityPaths zone identifier |> List.head
 
     let private mergeDeletedEntityFromDisk arcPath canonicalFilePath (arcLocal: ARC) = promise {
-        match! tryLoadArcIgnoringGitMetadataAsync arcPath with
+        match! ARC.LoadAsyncSwate arcPath with
         | Error errors ->
             return
                 Error(
@@ -110,7 +110,7 @@ module ArcDeleteHelper =
         | Error validationError -> return Error validationError
         | Ok(fileType, identifier, normalizedRelativePath, canonicalFilePath) ->
             try
-                match! tryLoadArcIgnoringGitMetadataAsync arcPath with
+                match! ARC.LoadAsyncSwate arcPath with
                 | Error errors ->
                     return
                         Error(

--- a/src/Electron/src/Main/IPC/Rename.fs
+++ b/src/Electron/src/Main/IPC/Rename.fs
@@ -3,6 +3,7 @@ module Main.IPC.Rename
 open System
 open Fable.Core
 open ARCtrl
+open Main.ARCtrlExtensions
 open Main.ArcMerge
 open Main.ArcVaultHelper
 open Main.IPC.Delete
@@ -61,7 +62,7 @@ module ArcRenameHelper =
         (arcLocal: ARC)
         =
         promise {
-            match! tryLoadArcIgnoringGitMetadataAsync arcPath with
+            match! ARC.LoadAsyncSwate arcPath with
             | Error errors ->
                 return
                     Error(
@@ -101,7 +102,7 @@ module ArcRenameHelper =
                                     $"Cannot rename '{sourcePath}' to '{targetPath}' because the destination already exists."
                             )
                     else
-                        match! tryLoadArcIgnoringGitMetadataAsync arcPath with
+                        match! ARC.LoadAsyncSwate arcPath with
                         | Error errors ->
                             return
                                 Error(

--- a/src/Electron/src/Main/IPC/Rename.fs
+++ b/src/Electron/src/Main/IPC/Rename.fs
@@ -61,7 +61,7 @@ module ArcRenameHelper =
         (arcLocal: ARC)
         =
         promise {
-            match! ARC.tryLoadAsync arcPath with
+            match! tryLoadArcIgnoringGitMetadataAsync arcPath with
             | Error errors ->
                 return
                     Error(
@@ -101,7 +101,7 @@ module ArcRenameHelper =
                                     $"Cannot rename '{sourcePath}' to '{targetPath}' because the destination already exists."
                             )
                     else
-                        match! ARC.tryLoadAsync arcPath with
+                        match! tryLoadArcIgnoringGitMetadataAsync arcPath with
                         | Error errors ->
                             return
                                 Error(

--- a/src/Electron/src/Main/Main.fsproj
+++ b/src/Electron/src/Main/Main.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="FileTreeCreator.fs" />
     <Compile Include="ArcMerge\Types.fs" />
     <Compile Include="ArcMerge\Extensions.fs" />
+    <Compile Include="ArcMerge\ArcWriteExtensions.fs" />
     <Compile Include="ArcMerge\ArcEntityRefHelper.fs" />
     <Compile Include="ArcMerge\ArcMergeLibraryExtensions.fs" />
     <Compile Include="ArcMerge\ArcAddExtensions.fs" />

--- a/src/Electron/src/Main/Main.fsproj
+++ b/src/Electron/src/Main/Main.fsproj
@@ -23,8 +23,9 @@
     <Compile Include="Git\GitLfsService.fs" />
     <Compile Include="FileTreeCreator.fs" />
     <Compile Include="ArcMerge\Types.fs" />
-    <Compile Include="ArcMerge\Extensions.fs" />
-    <Compile Include="ArcMerge\ArcWriteExtensions.fs" />
+    <Compile Include="ARCtrlExtensions\InMemoryChanges.fs" />
+    <Compile Include="ARCtrlExtensions\WriteAsync.fs" />
+    <Compile Include="ARCtrlExtensions\LoadAsync.fs" />
     <Compile Include="ArcMerge\ArcEntityRefHelper.fs" />
     <Compile Include="ArcMerge\ArcMergeLibraryExtensions.fs" />
     <Compile Include="ArcMerge\ArcAddExtensions.fs" />

--- a/src/Electron/src/Renderer/Components/Navbar.fs
+++ b/src/Electron/src/Renderer/Components/Navbar.fs
@@ -237,6 +237,7 @@ type Navbar =
     static member private SaveArcButton() =
 
         let errorCtx = useErrorModalCtx ()
+        let isSaving, setIsSaving = React.useState false
 
         let hasUnsavedChanges =
             Renderer.MainSyncedState.useMainSyncedState {
@@ -260,21 +261,27 @@ type Navbar =
                 dependencies = [||]
             }
 
-        let onSaveArc =
-            fun _ ->
-                promise {
-                    if not hasUnsavedChanges.state then
-                        return ()
+        let onSaveArc (event: Browser.Types.MouseEvent) =
+            if hasUnsavedChanges.state && not isSaving then
+                (event.currentTarget :?> Browser.Types.HTMLButtonElement).disabled <- true
+                setIsSaving true
 
+                promise {
                     match! Api.ipcArcVaultApi.saveArcFile () with
                     | Ok _ -> ()
                     | Error ex -> errorCtx.enqueue (ErrorModalRequest.create (ex.Message, title = "Error saving ARC"))
+
+                    setIsSaving false
                 }
+                |> Promise.catch (fun ex ->
+                    setIsSaving false
+                    errorCtx.enqueue (ErrorModalRequest.create (ex.Message, title = "Error saving ARC"))
+                )
                 |> Promise.start
 
         Html.button [
             prop.type'.button
-            prop.disabled (not hasUnsavedChanges.state)
+            prop.disabled (isSaving || not hasUnsavedChanges.state)
             prop.className "swt:btn swt:btn-square swt:btn-info swt:btn-sm"
             prop.onClick onSaveArc
             prop.title "Save ARC"

--- a/src/Electron/src/Renderer/Components/Navbar.fs
+++ b/src/Electron/src/Renderer/Components/Navbar.fs
@@ -261,20 +261,20 @@ type Navbar =
                 dependencies = [||]
             }
 
-        let onSaveArc (event: Browser.Types.MouseEvent) =
+        let onSaveArc _ =
             if hasUnsavedChanges.state && not isSaving then
-                (event.currentTarget :?> Browser.Types.HTMLButtonElement).disabled <- true
                 setIsSaving true
 
                 promise {
-                    match! Api.ipcArcVaultApi.saveArcFile () with
-                    | Ok _ -> ()
-                    | Error ex -> errorCtx.enqueue (ErrorModalRequest.create (ex.Message, title = "Error saving ARC"))
-
-                    setIsSaving false
+                    try
+                        match! Api.ipcArcVaultApi.saveArcFile () with
+                        | Ok _ -> ()
+                        | Error ex ->
+                            errorCtx.enqueue (ErrorModalRequest.create (ex.Message, title = "Error saving ARC"))
+                    finally
+                        setIsSaving false
                 }
                 |> Promise.catch (fun ex ->
-                    setIsSaving false
                     errorCtx.enqueue (ErrorModalRequest.create (ex.Message, title = "Error saving ARC"))
                 )
                 |> Promise.start

--- a/tests/Electron.Core/ArcAddExtensions.test.fs
+++ b/tests/Electron.Core/ArcAddExtensions.test.fs
@@ -1,14 +1,12 @@
 module ElectronCore.ArcAddExtensionsTests
 
-open Fable.Core
+open Main.ARCtrlExtensions
 open Main.ArcMerge
 open Main.ArcVault
 open Main.Bindings.Path
-open Main.IPC.FileSystemIO
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOHelper
 open ARCtrl
-open ARCtrl.Contract
 open Vitest
 
 let private expectSome (value: 'T option) (message: string) : 'T =

--- a/tests/Electron.Core/ArcDeleteHelper.test.fs
+++ b/tests/Electron.Core/ArcDeleteHelper.test.fs
@@ -1,12 +1,9 @@
 module ElectronCore.ArcDeleteHelperTests
 
-open Fable.Core
-open Main.ArcMerge
+open Main.ARCtrlExtensions
 open Main.ArcVault
-open Main.ArcVaultHelper
 open Main.Bindings.Path
 open Main.IPC.Delete
-open Swate.Components.Shared
 open ARCtrl
 open Vitest
 

--- a/tests/Electron.Core/ArcFileMutationHelper.test.fs
+++ b/tests/Electron.Core/ArcFileMutationHelper.test.fs
@@ -1,7 +1,7 @@
 module ElectronCore.ArcFileMutationHelperTests
 
 open ARCtrl
-open Main.ArcMerge
+open Main.ARCtrlExtensions
 open Main.ArcVaultHelper
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOHelper

--- a/tests/Electron.Core/ArcMerge/HasInMemoryChanges.test.fs
+++ b/tests/Electron.Core/ArcMerge/HasInMemoryChanges.test.fs
@@ -1,7 +1,7 @@
 module ElectronCore.ArcMerge.HasInMemoryChangesTests
 
 open ARCtrl
-open Main.ArcMerge
+open Main.ARCtrlExtensions
 open Vitest
 
 Vitest.describe (

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -1,31 +1,20 @@
 module ElectronCore.ArcVaultHelperTests
 
 open ARCtrl
-open Fable.Core
-open Fable.Core.JsInterop
 open Main.ArcMerge
 open Main.ArcVault
 open Main.ArcVaultHelper
+open Main.Bindings.Filesystem
 open Main.Bindings.Path
 open Vitest
 
-let private fsPromisesDynamic: obj = importAll "fs/promises"
-
 let private mkdirRecursiveAsync (directoryPath: string) = promise {
-    let! _ =
-        fsPromisesDynamic?mkdir (directoryPath, createObj [ "recursive" ==> true ])
-        |> unbox<JS.Promise<obj>>
-
+    let! _ = mkdirAsync directoryPath (MkdirOptions(recursive = true))
     return ()
 }
 
-let private writeFileAsync (filePath: string) (content: string) = promise {
-    let! _ = fsPromisesDynamic?writeFile (filePath, content) |> unbox<JS.Promise<obj>>
-    return ()
-}
-
-let private readFileAsync (filePath: string) =
-    fsPromisesDynamic?readFile (filePath, "utf8") |> unbox<JS.Promise<string>>
+let private writeTextFileAsync (filePath: string) (content: string) =
+    writeFileAsync filePath content TextEncoding.Utf8
 
 let private addDataMapToAllEntityTypes (arc: ARC) =
     let study = ArcStudy("Study With DataMap")
@@ -81,9 +70,9 @@ Vitest.describe (
                         let gitObjectPath = join [| gitObjectFolder; "object" |]
                         do! mkdirRecursiveAsync gitObjectFolder
                         do! mkdirRecursiveAsync nestedGitFolder
-                        do! writeFileAsync gitObjectPath "git-object"
-                        do! writeFileAsync (join [| nestedGitFolder; "config" |]) "nested-git-config"
-                        do! writeFileAsync payloadPath "payload"
+                        do! writeTextFileAsync gitObjectPath "git-object"
+                        do! writeTextFileAsync (join [| nestedGitFolder; "config" |]) "nested-git-config"
+                        do! writeTextFileAsync payloadPath "payload"
 
                         let! loadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
                         let loadedArc = TestHelpers.expectLoadedArc loadResult
@@ -95,8 +84,8 @@ Vitest.describe (
                         loadedArc.StaticHash <- 0
                         do! updateArcPreservingExistingPayloadFiles arcPath loadedArc
 
-                        let! payload = readFileAsync payloadPath
-                        let! gitObject = readFileAsync gitObjectPath
+                        let! payload = readFileAsync payloadPath TextEncoding.Utf8
+                        let! gitObject = readFileAsync gitObjectPath TextEncoding.Utf8
                         Vitest.expect(payload).toBe ("payload")
                         Vitest.expect(gitObject).toBe ("git-object")
                     })
@@ -144,7 +133,7 @@ Vitest.describe (
                         let assayFile = join [| assayFolder; "isa.assay.xlsx" |]
 
                         do! mkdirRecursiveAsync assayFolder
-                        do! writeFileAsync assayFile ""
+                        do! writeTextFileAsync assayFile ""
 
                         let vault = ArcVault(TestHelpers.testWindow ())
                         vault.path <- Some arcPath

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -57,6 +57,104 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "Swate write contracts contain only targeted ARC files",
+            fun () ->
+                let arc = ARC("TargetedWriteArc")
+                addDataMapToAllEntityTypes arc
+                arc.SetLicenseFulltext("license text")
+
+                arc.SetFilePaths(
+                    [|
+                        ".git/config"
+                        "payload.txt"
+                        "missing-payload.txt"
+                        "assays/Assay With DataMap/README.md"
+                    |]
+                )
+
+                let actualPaths = arc.GetWriteContractsSwate() |> Array.map _.Path |> Array.sort
+
+                let expectedPaths =
+                    [|
+                        "LICENSE"
+                        "assays/.gitkeep"
+                        "assays/Assay With DataMap/isa.assay.xlsx"
+                        "assays/Assay With DataMap/isa.datamap.xlsx"
+                        "isa.investigation.xlsx"
+                        "runs/.gitkeep"
+                        "runs/Run With DataMap/isa.datamap.xlsx"
+                        "runs/Run With DataMap/isa.run.xlsx"
+                        "studies/.gitkeep"
+                        "studies/Study With DataMap/isa.datamap.xlsx"
+                        "studies/Study With DataMap/isa.study.xlsx"
+                        "workflows/.gitkeep"
+                        "workflows/Workflow With DataMap/isa.datamap.xlsx"
+                        "workflows/Workflow With DataMap/isa.workflow.xlsx"
+                    |]
+                    |> Array.sort
+
+                Vitest.expect(actualPaths).toEqual (expectedPaths)
+        )
+
+        Vitest.test (
+            "TryWriteAsyncSwate preserves payload and does not create unmanaged file-tree entries",
+            fun () -> promise {
+                let! rootPath = TestHelpers.createTempDirectoryAsync "swate-targeted-write-"
+                let arcPath = join [| rootPath; "arc" |]
+                let gitFolder = join [| arcPath; ".git" |]
+                let assayFolder = join [| arcPath; "assays"; "Assay 1" |]
+                let payloadPath = join [| arcPath; "payload.txt" |]
+                let gitConfigPath = join [| gitFolder; "config" |]
+                let readmePath = join [| assayFolder; "README.md" |]
+                let missingPayloadPath = join [| arcPath; "missing-payload.txt" |]
+
+                try
+                    do! mkdirRecursiveAsync gitFolder
+                    do! mkdirRecursiveAsync assayFolder
+                    do! writeTextFileAsync payloadPath "payload"
+                    do! writeTextFileAsync gitConfigPath "git-config"
+                    do! writeTextFileAsync readmePath "readme"
+
+                    let arc = ARC("TargetedWriteArc")
+                    arc.AddAssay(ArcAssay("Assay 1"))
+
+                    arc.SetFilePaths(
+                        [|
+                            ".git/config"
+                            "payload.txt"
+                            "missing-payload.txt"
+                            "assays/Assay 1/README.md"
+                        |]
+                    )
+
+                    match! arc.TryWriteAsyncSwate(arcPath) with
+                    | Error errors -> failwith (String.concat "\n" errors)
+                    | Ok _ -> ()
+
+                    let! payload = readFileAsync payloadPath TextEncoding.Utf8
+                    let! gitConfig = readFileAsync gitConfigPath TextEncoding.Utf8
+                    let! readme = readFileAsync readmePath TextEncoding.Utf8
+                    let! missingPayloadExists = TestHelpers.pathExistsAsync missingPayloadPath
+
+                    let! assayFileExists = TestHelpers.pathExistsAsync (join [| assayFolder; "isa.assay.xlsx" |])
+
+                    let! collectionGitKeepExists =
+                        TestHelpers.pathExistsAsync (join [| arcPath; "assays"; ".gitkeep" |])
+
+                    Vitest.expect(payload).toBe ("payload")
+                    Vitest.expect(gitConfig).toBe ("git-config")
+                    Vitest.expect(readme).toBe ("readme")
+                    Vitest.expect(missingPayloadExists).toBe (false)
+                    Vitest.expect(assayFileExists).toBe (true)
+                    Vitest.expect(collectionGitKeepExists).toBe (true)
+                    do! TestHelpers.removeDirectoryAsync rootPath
+                with error ->
+                    do! TestHelpers.removeDirectoryAsync rootPath
+                    return raise error
+            }
+        )
+
+        Vitest.test (
             "ARC loading and writing ignore Git metadata and preserve payload",
             fun () ->
                 TestHelpers.withTempArcWith
@@ -88,6 +186,42 @@ Vitest.describe (
                         let! gitObject = readFileAsync gitObjectPath TextEncoding.Utf8
                         Vitest.expect(payload).toBe ("payload")
                         Vitest.expect(gitObject).toBe ("git-object")
+                    })
+        )
+
+        Vitest.test (
+            "normal ARC save does not restore deleted DTO-less files from a stale file tree",
+            fun () ->
+                TestHelpers.withTempArcWith
+                    "swate-save-deleted-file-"
+                    "DeletedFileArc"
+                    ignore
+                    (fun arcPath -> promise {
+                        let payloadPath = join [| arcPath; "payload.txt" |]
+                        let collectionGitKeepPath = join [| arcPath; "assays"; ".gitkeep" |]
+                        do! writeTextFileAsync payloadPath "payload"
+
+                        let! loadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
+                        let loadedArc = TestHelpers.expectLoadedArc loadResult
+                        let stalePaths = loadedArc.FileSystem.Tree.ToFilePaths()
+
+                        Vitest.expect(stalePaths |> Array.contains "payload.txt").toBe (true)
+                        Vitest.expect(stalePaths |> Array.contains "assays/.gitkeep").toBe (true)
+
+                        do! rmAsync payloadPath (RmOptions())
+                        do! rmAsync collectionGitKeepPath (RmOptions())
+
+                        loadedArc.Title <- Some "Saved title"
+                        loadedArc.StaticHash <- 0
+                        do! updateArcPreservingExistingPayloadFiles arcPath loadedArc
+
+                        let! payloadExists = TestHelpers.pathExistsAsync payloadPath
+                        let! collectionGitKeepExists = TestHelpers.pathExistsAsync collectionGitKeepPath
+                        Vitest.expect(payloadExists).toBe (false)
+                        Vitest.expect(collectionGitKeepExists).toBe (false)
+
+                        let! reloadedArc = TestHelpers.loadArcAsync arcPath
+                        Vitest.expect(reloadedArc.Title).toEqual (Some "Saved title")
                     })
         )
 

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -24,6 +24,9 @@ let private writeFileAsync (filePath: string) (content: string) = promise {
     return ()
 }
 
+let private readFileAsync (filePath: string) =
+    fsPromisesDynamic?readFile (filePath, "utf8") |> unbox<JS.Promise<string>>
+
 let private addDataMapToAllEntityTypes (arc: ARC) =
     let study = ArcStudy("Study With DataMap")
     study.DataMap <- Some(DataMap.init ())
@@ -51,6 +54,52 @@ Vitest.describe (
                 Vitest.expect(shouldUsePollingByDefault "WIN32").toBe (true)
                 Vitest.expect(shouldUsePollingByDefault "linux").toBe (false)
                 Vitest.expect(shouldUsePollingByDefault "darwin").toBe (false)
+        )
+
+        Vitest.test (
+            "Git metadata path detection excludes only exact .git path segments",
+            fun () ->
+                Vitest.expect(isGitMetadataPath ".git").toBe (true)
+                Vitest.expect(isGitMetadataPath ".git/objects/ab/object").toBe (true)
+                Vitest.expect(isGitMetadataPath "notes\\.GIT\\config").toBe (true)
+                Vitest.expect(isGitMetadataPath ".gitignore").toBe (false)
+                Vitest.expect(isGitMetadataPath ".gitattributes").toBe (false)
+                Vitest.expect(isGitMetadataPath "notes/my.git/file.txt").toBe (false)
+        )
+
+        Vitest.test (
+            "ARC loading and writing ignore Git metadata and preserve payload",
+            fun () ->
+                TestHelpers.withTempArcWith
+                    "swate-load-arc-ignore-git-"
+                    "IgnoreGitArc"
+                    ignore
+                    (fun arcPath -> promise {
+                        let gitObjectFolder = join [| arcPath; ".git"; "objects"; "ab" |]
+                        let nestedGitFolder = join [| arcPath; "notes"; ".git" |]
+                        let payloadPath = join [| arcPath; "payload.txt" |]
+                        let gitObjectPath = join [| gitObjectFolder; "object" |]
+                        do! mkdirRecursiveAsync gitObjectFolder
+                        do! mkdirRecursiveAsync nestedGitFolder
+                        do! writeFileAsync gitObjectPath "git-object"
+                        do! writeFileAsync (join [| nestedGitFolder; "config" |]) "nested-git-config"
+                        do! writeFileAsync payloadPath "payload"
+
+                        let! loadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
+                        let loadedArc = TestHelpers.expectLoadedArc loadResult
+                        let paths = loadedArc.FileSystem.Tree.ToFilePaths()
+
+                        Vitest.expect(paths |> Array.exists isGitMetadataPath).toBe (false)
+
+                        loadedArc.SetFilePaths(Array.append paths [| ".git/objects/ab/object" |])
+                        loadedArc.StaticHash <- 0
+                        do! updateArcPreservingExistingPayloadFiles arcPath loadedArc
+
+                        let! payload = readFileAsync payloadPath
+                        let! gitObject = readFileAsync gitObjectPath
+                        Vitest.expect(payload).toBe ("payload")
+                        Vitest.expect(gitObject).toBe ("git-object")
+                    })
         )
 
         Vitest.test (

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -1,7 +1,7 @@
 module ElectronCore.ArcVaultHelperTests
 
 open ARCtrl
-open Main.ArcMerge
+open Main.ARCtrlExtensions
 open Main.ArcVault
 open Main.ArcVaultHelper
 open Main.Bindings.Filesystem
@@ -172,15 +172,15 @@ Vitest.describe (
                         do! writeTextFileAsync (join [| nestedGitFolder; "config" |]) "nested-git-config"
                         do! writeTextFileAsync payloadPath "payload"
 
-                        let! loadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
+                        let! loadResult = ARC.LoadAsyncSwate arcPath
                         let loadedArc = TestHelpers.expectLoadedArc loadResult
                         let paths = loadedArc.FileSystem.Tree.ToFilePaths()
 
                         Vitest.expect(paths |> Array.exists isGitMetadataPath).toBe (false)
 
                         loadedArc.SetFilePaths(Array.append paths [| ".git/objects/ab/object" |])
-                        loadedArc.StaticHash <- 0
-                        do! updateArcPreservingExistingPayloadFiles arcPath loadedArc
+                        loadedArc.Title <- Some "Saved title"
+                        do! loadedArc.UpdateAsync arcPath
 
                         let! payload = readFileAsync payloadPath TextEncoding.Utf8
                         let! gitObject = readFileAsync gitObjectPath TextEncoding.Utf8
@@ -201,7 +201,7 @@ Vitest.describe (
                         let collectionGitKeepPath = join [| arcPath; "assays"; ".gitkeep" |]
                         do! writeTextFileAsync payloadPath "payload"
 
-                        let! loadResult = tryLoadArcIgnoringGitMetadataAsync arcPath
+                        let! loadResult = ARC.LoadAsyncSwate arcPath
                         let loadedArc = TestHelpers.expectLoadedArc loadResult
                         let stalePaths = loadedArc.FileSystem.Tree.ToFilePaths()
 
@@ -212,8 +212,7 @@ Vitest.describe (
                         do! rmAsync collectionGitKeepPath (RmOptions())
 
                         loadedArc.Title <- Some "Saved title"
-                        loadedArc.StaticHash <- 0
-                        do! updateArcPreservingExistingPayloadFiles arcPath loadedArc
+                        do! loadedArc.UpdateAsync arcPath
 
                         let! payloadExists = TestHelpers.pathExistsAsync payloadPath
                         let! collectionGitKeepExists = TestHelpers.pathExistsAsync collectionGitKeepPath

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -6,7 +6,7 @@ open Main.ArcVault
 open Main.ArcVaultTypes
 open Main.IPC.FileSystemIO
 open Main.IPC.Rename
-open Main.ArcMerge
+open Main.ARCtrlExtensions
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOTypes
 open ARCtrl


### PR DESCRIPTION
* Remove git metadata paths from write, delete, rename and watcher
* Prevent replacing contracts with empy data
* Save button becomes inactive after first click to prevent multiple clicks