### PR TITLE
Prevent reinitialization of deleted files when saving

### DIFF
--- a/src/Electron/src/Main/IPC/Delete.fs
+++ b/src/Electron/src/Main/IPC/Delete.fs
@@ -83,6 +83,25 @@ module ArcDeleteHelper =
             return Ok mergedArc
     }
 
+    let removeKnownPath relativePath (arc: ARC) =
+        arc.FileSystem.Tree.ToFilePaths()
+        |> Array.filter (fun path -> PathHelpers.isSameOrDescendantPath path relativePath |> not)
+        |> arc.SetFilePaths
+
+        match ArcEntityRef.fromPath relativePath with
+        | ArcEntityRef.AssayDataMap identifier ->
+            arc.TryGetAssay(identifier)
+            |> Option.iter (fun entity -> entity.DataMap <- None)
+        | ArcEntityRef.StudyDataMap identifier ->
+            arc.TryGetStudy(identifier)
+            |> Option.iter (fun entity -> entity.DataMap <- None)
+        | ArcEntityRef.WorkflowDataMap identifier ->
+            arc.TryGetWorkflow(identifier)
+            |> Option.iter (fun entity -> entity.DataMap <- None)
+        | ArcEntityRef.RunDataMap identifier ->
+            arc.TryGetRun(identifier) |> Option.iter (fun entity -> entity.DataMap <- None)
+        | _ -> ()
+
     let private tryGetEntityDeleteTarget relativePath =
         match ArcEntityPathRules.classifyDeleteTarget relativePath with
         | ArcEntityPathRules.DeletePathClassification.EntityFolderTarget(zone, identifier, normalizedRelativePath) ->

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -471,10 +471,16 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                                                 "Deletion is only allowed for safe non-ARC filesystem items inside the ARC."
                                         )
                                 else
-                                    return!
+                                    match!
                                         ArcFileSystemHelper.deleteGenericFileSystemItemOnDisk
                                             arcPath
                                             normalizedGenericPath
+                                    with
+                                    | Error deleteError -> return Error deleteError
+                                    | Ok() ->
+                                        ArcDeleteHelper.removeKnownPath normalizedGenericPath vault.arc.Value
+                                        do! vault.RefreshFileTree()
+                                        return Ok()
                             | ArcEntityPathRules.DeletePathClassification.CanonicalFileTarget(ArcEntityPathRules.CanonicalArcFileTarget.InvestigationFile,
                                                                                               _) ->
                                 return Error(exn "Deleting the investigation file is not supported.")

--- a/tests/Electron.Core/ArcDeleteHelper.test.fs
+++ b/tests/Electron.Core/ArcDeleteHelper.test.fs
@@ -6,6 +6,7 @@ open Main.ArcVault
 open Main.ArcVaultHelper
 open Main.Bindings.Path
 open Main.IPC.Delete
+open Main.IPC.FileSystemIO
 open Swate.Components.Shared
 open ARCtrl
 open Vitest
@@ -205,6 +206,29 @@ Vitest.describe (
                             Vitest.expect(inMemoryArc.ContainsAssay("DeleteAssay")).toBe (false)
                             Vitest.expect(inMemoryArc.GetAssay("KeepAssay").Title).toEqual (Some "Unsaved local title")
                             Vitest.expect(vault.hasUnsavedArcChanges).toBe (true)
+                    })
+        )
+
+        Vitest.test (
+            "deleted generic file stays deleted after saving the ARC",
+            fun () ->
+                withTempArc
+                    (fun arc -> arc.AddAssay(ArcAssay("AssayA")))
+                    (fun arcPath -> promise {
+                        let relativePath = "assays/AssayA/protocol.md"
+                        let absolutePath = join [| arcPath; "assays"; "AssayA"; "protocol.md" |]
+                        do! ARCtrl.FileSystemHelper.writeFileTextAsync absolutePath "protocol"
+
+                        let! arc = loadArcAsync arcPath
+
+                        match! ArcFileSystemHelper.deleteGenericFileSystemItemOnDisk arcPath relativePath with
+                        | Error error -> failwith error.Message
+                        | Ok() -> ArcDeleteHelper.removeKnownPath relativePath arc
+
+                        do! arc.UpdateAsync arcPath
+
+                        let! exists = pathExistsAsync absolutePath
+                        Vitest.expect(exists).toBe (false)
                     })
         )
 )


### PR DESCRIPTION
Remove deleted paths from the in-memory ARC to prevent ARC save from restoring deleted files.