### PR TITLE
Feature/fix git no remote

### DIFF
--- a/src/Components/src/Api/GitLabApi.fs
+++ b/src/Components/src/Api/GitLabApi.fs
@@ -270,6 +270,25 @@ module private Internals =
         | 404 -> GitLabError.NotFound
         | code -> GitLabError.HttpError code
 
+    let private compactResponseText (text: string) =
+        text
+        |> Option.ofObj
+        |> Option.map (fun value -> value.Replace("\r", " ").Replace("\n", " ").Trim())
+        |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
+    let mapHttpErrorWithBody status bodyText =
+        match mapHttpError status, compactResponseText bodyText with
+        | GitLabError.HttpError code, Some details -> GitLabError.InvalidRequest $"GitLab request failed with HTTP {code}: {details}"
+        | mappedError, _ -> mappedError
+
+    let readResponseText (response: Fetch.Types.Response) : JS.Promise<string> = promise {
+        try
+            let! text = response.text ()
+            return text
+        with _ ->
+            return ""
+    }
+
     let makeGetRequestOptions (pat: string option) (acceptJson: bool) =
         let headers = [
             match pat with
@@ -497,7 +516,8 @@ module private Internals =
                     let! response = fetchUnsafe url requestOptions
 
                     if not response.Ok then
-                        return Error(mapHttpError response.Status)
+                        let! errorText = readResponseText response
+                        return Error(mapHttpErrorWithBody response.Status errorText)
                     else
                         try
                             let! payload = response.json<'TResponse> ()

--- a/src/Components/src/Page/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.fs
@@ -224,6 +224,16 @@ type private ModalsProps = {
 }
 
 [<NoEquality; NoComparison>]
+type private PublishRenameDialogProps = {
+    Prompt: GitSidebarPublishRenamePrompt option
+    InputValue: string
+    SetInputValue: string -> unit
+    IsBusy: bool
+    Submit: unit -> unit
+    Cancel: unit -> unit
+}
+
+[<NoEquality; NoComparison>]
 type private PendingRemoteActionDialogProps = {
     PendingConfirmation: GitSidebarConfirmationDialog option
     ConfirmPendingRemoteAction: unit -> unit
@@ -1455,6 +1465,66 @@ type GitSidebar =
         )
 
     [<ReactComponent>]
+    static member private PublishRenameDialog(props: PublishRenameDialogProps) =
+        let prompt = props.Prompt
+        let normalizedInput = props.InputValue.Trim()
+
+        BaseModal.Modal(
+            isOpen = prompt.IsSome,
+            setIsOpen =
+                (fun isOpen ->
+                    if not isOpen then
+                        props.Cancel()
+                ),
+            header = Html.text "Rename Repository",
+            description =
+                Html.text (
+                    prompt
+                    |> Option.map _.Message
+                    |> Option.defaultValue "Choose a different repository name."
+                ),
+            children =
+                Html.div [
+                    prop.className "swt:flex swt:flex-col swt:gap-2"
+                    prop.children [
+                        Html.label [
+                            prop.className "swt:flex swt:flex-col swt:gap-2"
+                            prop.children [
+                                Html.span [
+                                    prop.className "swt:text-sm swt:font-medium"
+                                    prop.text "Repository name"
+                                ]
+                                Html.input [
+                                    prop.testId "GitSidebarPublishRenameInput"
+                                    prop.className "swt:input swt:input-bordered swt:w-full"
+                                    prop.disabled props.IsBusy
+                                    prop.value props.InputValue
+                                    prop.onChange props.SetInputValue
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+            footer =
+                React.Fragment [
+                    Html.button [
+                        prop.className "swt:btn swt:btn-ghost"
+                        prop.disabled props.IsBusy
+                        prop.text "Cancel"
+                        prop.onClick (fun _ -> props.Cancel())
+                    ]
+                    Html.button [
+                        prop.testId "GitSidebarPublishRenameSubmit"
+                        prop.className "swt:btn swt:btn-primary swt:ml-auto"
+                        prop.disabled (props.IsBusy || String.IsNullOrWhiteSpace normalizedInput)
+                        prop.text "Rename and Upload"
+                        prop.onClick (fun _ -> props.Submit())
+                    ]
+                ],
+            debug = "GitSidebarPublishRename"
+        )
+
+    [<ReactComponent>]
     static member Main
         (
             status: GitSidebarStatus,
@@ -1468,20 +1538,26 @@ type GitSidebar =
             ?errorNotice: string,
             ?warningNotice: string,
             ?pendingConfirmation: GitSidebarConfirmationDialog,
+            ?publishRenamePrompt: GitSidebarPublishRenamePrompt,
             ?remoteActionsEnabled: bool,
             ?remoteActionsWarning: string,
             ?canOpenRemoteRepository: bool,
-            ?onOpenRemoteRepository: unit -> unit
+            ?onOpenRemoteRepository: unit -> unit,
+            ?onSubmitPublishRename: string -> unit,
+            ?onCancelPublishRename: unit -> unit
         ) =
 
         let runStatus = defaultArg runStatus GitSidebarRunStatus.Idle
         let errorNotice = errorNotice
         let warningNotice = warningNotice
         let pendingConfirmation = pendingConfirmation
+        let publishRenamePrompt = publishRenamePrompt
         let remoteActionsEnabled = defaultArg remoteActionsEnabled true
         let remoteActionsWarning = remoteActionsWarning
         let canOpenRemoteRepository = defaultArg canOpenRemoteRepository false
         let onOpenRemoteRepository = defaultArg onOpenRemoteRepository (fun () -> ())
+        let onSubmitPublishRename = defaultArg onSubmitPublishRename (fun _ -> ())
+        let onCancelPublishRename = defaultArg onCancelPublishRename (fun () -> ())
         let _selectedFileForCompatibility = selectedFile
         let onRefresh = callbacks.OnRefresh
         let onFetch = callbacks.OnFetch
@@ -1506,6 +1582,8 @@ type GitSidebar =
         let branchName, setBranchName = React.useState ""
         let commitMessage, setCommitMessage = React.useState ""
         let isMissingMessageModalOpen, setMissingMessageModalOpen = React.useState false
+        let publishRenameInput, setPublishRenameInput =
+            React.useState (publishRenamePrompt |> Option.map _.CurrentName |> Option.defaultValue "")
 
         let downloadLargeFilesInput, setDownloadLargeFilesInput =
             React.useState downloadLargeFiles
@@ -1575,6 +1653,13 @@ type GitSidebar =
         React.useEffect (
             (fun () -> setLfsThresholdInput (GitSidebarInternal.formatThresholdInput lfsAutoTrackThresholdMb)),
             [| box lfsAutoTrackThresholdMb |]
+        )
+
+        React.useEffect (
+            (fun () ->
+                setPublishRenameInput (publishRenamePrompt |> Option.map _.CurrentName |> Option.defaultValue "")
+            ),
+            [| box publishRenamePrompt |]
         )
 
         let branchOptionsWithHead =
@@ -1768,6 +1853,15 @@ type GitSidebar =
                 onSwitchBranch branchName
                 setActiveDialog ActiveDialog.None
 
+        let submitPublishRename () =
+            let normalizedName = publishRenameInput.Trim()
+
+            if String.IsNullOrWhiteSpace normalizedName then
+                setLocalError (Some "Repository name must not be empty.")
+            else
+                setLocalError None
+                onSubmitPublishRename normalizedName
+
         let submitPruneLfsCache () =
             setLocalError None
             callbacks.OnPruneLfsCache()
@@ -1946,6 +2040,17 @@ type GitSidebar =
                         PendingConfirmation = pendingConfirmation
                         ConfirmPendingRemoteAction = onConfirmPendingRemoteAction
                         CancelPendingRemoteAction = onCancelPendingRemoteAction
+                    }
+                )
+
+                GitSidebar.PublishRenameDialog(
+                    {
+                        Prompt = publishRenamePrompt
+                        InputValue = publishRenameInput
+                        SetInputValue = setPublishRenameInput
+                        IsBusy = isBusy
+                        Submit = submitPublishRename
+                        Cancel = onCancelPublishRename
                     }
                 )
             ]

--- a/src/Components/src/Page/GitSidebar/Types.fs
+++ b/src/Components/src/Page/GitSidebar/Types.fs
@@ -59,6 +59,11 @@ type GitSidebarConfirmationDialog = {
     CancelLabel: string
 }
 
+type GitSidebarPublishRenamePrompt = {
+    CurrentName: string
+    Message: string
+}
+
 type GitSidebarCallbacks = {
     OnRefresh: unit -> unit
     OnFetch: unit -> unit

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -344,16 +344,23 @@ module ArcVaultExtensions =
             else
                 swatefailfn this.window.id "No path set for StartFileWatcher."
 
+        member this.ClearPendingFileWatcherState() =
+            this.fileWatcherReloadArcTimeout |> Option.iter Fable.Core.JS.clearTimeout
+            this.fileWatcherReloadArcTimeout <- None
+            this.fileWatcherPendingEvents.Clear()
+            this.fileWatcherPendingArcMergeEvents.Clear()
+
         member this.StopFileWatcher() = promise {
             match this.watcher with
-            | None -> return ()
+            | None -> ()
             | Some watcher ->
                 try
                     do! watcher.close ()
                 with _ ->
                     ()
 
-                this.watcher <- None
+            this.watcher <- None
+            this.ClearPendingFileWatcherState()
         }
 
         /// This functions should be called once, when an vault is first started with a path
@@ -430,6 +437,8 @@ module ArcVaultExtensions =
 
                 if hadWatcher then
                     do! this.StopFileWatcher()
+                else
+                    this.ClearPendingFileWatcherState()
 
                 let! renameResult = renameOpenArcRootDirectoryOnDisk currentPath newName
 
@@ -442,27 +451,46 @@ module ArcVaultExtensions =
                 | Ok renamedPath ->
                     this.path <- Some renamedPath
 
-                    try
-                        if this.arc.IsNone then
+                    if this.arc.IsNone then
+                        try
                             do! this.LoadArc()
+                        with loadError ->
+                            swatelogfn this.window.id "ARC folder was renamed to '%s', but reload failed: %s" renamedPath loadError.Message
 
-                        if hadWatcher then
+                    if hadWatcher then
+                        try
                             this.StartFileWatcher()
+                        with watcherError ->
+                            swatelogfn
+                                this.window.id
+                                "ARC folder was renamed to '%s', but file watcher restart failed: %s"
+                                renamedPath
+                                watcherError.Message
 
+                    try
                         do! this.RefreshFileTree()
+                    with refreshError ->
+                        swatelogfn
+                            this.window.id
+                            "ARC folder was renamed to '%s', but file tree refresh failed: %s"
+                            renamedPath
+                            refreshError.Message
 
+                    try
                         let sendMsg =
                             Remoting.createIpc ()
                             |> Remoting.withWindow this.window
                             |> Remoting.buildProxySender<IPathChangeRendererApi>
 
                         sendMsg.pathChange (Some renamedPath)
-                        return Ok renamedPath
-                    with reloadError ->
-                        if hadWatcher then
-                            this.StartFileWatcher()
+                    with notifyError ->
+                        swatelogfn
+                            this.window.id
+                            "ARC folder was renamed to '%s', but renderer path notification failed: %s"
+                            renamedPath
+                            notifyError.Message
 
-                        return Error(exn $"ARC folder was renamed to '{renamedPath}', but reload failed: {reloadError.Message}")
+                    return Ok renamedPath
         }
 
 

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -422,6 +422,49 @@ module ArcVaultExtensions =
             | None -> ()
         }
 
+        member this.RenameOpenArcRoot(newName: string) : Fable.Core.JS.Promise<Result<string, exn>> = promise {
+            match this.path with
+            | None -> return Error(exn "ARC is not loaded.")
+            | Some currentPath ->
+                let hadWatcher = this.watcher.IsSome
+
+                if hadWatcher then
+                    do! this.StopFileWatcher()
+
+                let! renameResult = renameOpenArcRootDirectoryOnDisk currentPath newName
+
+                match renameResult with
+                | Error renameError ->
+                    if hadWatcher then
+                        this.StartFileWatcher()
+
+                    return Error renameError
+                | Ok renamedPath ->
+                    this.path <- Some renamedPath
+
+                    try
+                        if this.arc.IsNone then
+                            do! this.LoadArc()
+
+                        if hadWatcher then
+                            this.StartFileWatcher()
+
+                        do! this.RefreshFileTree()
+
+                        let sendMsg =
+                            Remoting.createIpc ()
+                            |> Remoting.withWindow this.window
+                            |> Remoting.buildProxySender<IPathChangeRendererApi>
+
+                        sendMsg.pathChange (Some renamedPath)
+                        return Ok renamedPath
+                    with reloadError ->
+                        if hadWatcher then
+                            this.StartFileWatcher()
+
+                        return Error(exn $"ARC folder was renamed to '{renamedPath}', but reload failed: {reloadError.Message}")
+        }
+
 
 /// Describes the outcome of an ARC lifecycle action performed by the controller.
 [<RequireQualifiedAccess>]

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -13,6 +13,7 @@ open Main
 open Main.ARCtrlExtensions
 open Main.Bindings
 open Node.Api
+open Swate.Electron.Shared.RenamePathRules
 
 let private fsPromisesDynamic: obj = importAll "fs/promises"
 let private pathDynamic: obj = importAll "path"
@@ -169,15 +170,6 @@ type OpenArcRootRenamePlan = {
     NewName: string
 }
 
-let private normalizeArcRootFolderName (newName: string) =
-    newName
-    |> Option.ofObj
-    |> Option.map _.Trim()
-    |> Option.defaultValue String.Empty
-
-let private containsPathSeparator (value: string) =
-    value.IndexOf("/", StringComparison.Ordinal) >= 0 || value.IndexOf("\\", StringComparison.Ordinal) >= 0
-
 let private resolveAbsolutePath (pathValue: string) =
     pathDynamic?resolve (pathValue) |> unbox<string> |> PathHelpers.normalizePath
 
@@ -245,41 +237,39 @@ let private mapArcRootRenameDiskError (sourcePath: string) (targetPath: string) 
     | _ -> renameError
 
 let tryBuildOpenArcRootRenamePlan arcPath newName : Result<OpenArcRootRenamePlan, exn> =
-    let normalizedName = normalizeArcRootFolderName newName
+    let candidateName = newName |> Option.ofObj |> Option.defaultValue String.Empty
 
-    if String.IsNullOrWhiteSpace normalizedName then
-        Error(exn "ARC folder name must not be empty.")
-    elif
-        normalizedName = "."
-        || normalizedName = ".."
-        || containsPathSeparator normalizedName
-        || (pathDynamic?isAbsolute (normalizedName) |> unbox<bool>)
-        || PathHelpers.containsPathTraversalSegments normalizedName
-    then
-        Error(exn "ARC folder name must be a single folder name without path separators or traversal segments.")
-    else
-        let sourcePath = resolveAbsolutePath arcPath
-        let parentPath = pathDynamic?dirname (sourcePath) |> unbox<string>
-
-        let targetPath =
-            pathDynamic?resolve (parentPath, normalizedName)
-            |> unbox<string>
-            |> PathHelpers.normalizePath
-
+    match validateRenameName candidateName with
+    | Error validationError -> Error(exn validationError)
+    | Ok normalizedName ->
         if
-            String.Equals(
-                normalizePathForComparison sourcePath,
-                normalizePathForComparison targetPath,
-                StringComparison.Ordinal
-            )
+            (pathDynamic?isAbsolute (normalizedName) |> unbox<bool>)
+            || PathHelpers.containsPathTraversalSegments normalizedName
         then
-            Error(exn "New ARC folder name must be different from the current folder name.")
+            Error(exn "ARC folder name must be a single folder name without path separators or traversal segments.")
         else
-            Ok {
-                SourcePath = sourcePath
-                TargetPath = targetPath
-                NewName = normalizedName
-            }
+            let sourcePath = resolveAbsolutePath arcPath
+            let parentPath = pathDynamic?dirname (sourcePath) |> unbox<string>
+
+            let targetPath =
+                pathDynamic?resolve (parentPath, normalizedName)
+                |> unbox<string>
+                |> PathHelpers.normalizePath
+
+            if
+                String.Equals(
+                    normalizePathForComparison sourcePath,
+                    normalizePathForComparison targetPath,
+                    StringComparison.Ordinal
+                )
+            then
+                Error(exn "New ARC folder name must be different from the current folder name.")
+            else
+                Ok {
+                    SourcePath = sourcePath
+                    TargetPath = targetPath
+                    NewName = normalizedName
+                }
 
 let renameOpenArcRootDirectoryOnDisk arcPath newName : JS.Promise<Result<string, exn>> = promise {
     match tryBuildOpenArcRootRenamePlan arcPath newName with

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -173,9 +173,6 @@ type OpenArcRootRenamePlan = {
 let private resolveAbsolutePath (pathValue: string) =
     pathDynamic?resolve (pathValue) |> unbox<string> |> PathHelpers.normalizePath
 
-let private normalizePathForComparison (pathValue: string) =
-    PathHelpers.normalizePathForFsComparison pathValue
-
 let private tryGetNodeErrorCode (error: exn) : string option =
     try
         error?code |> unbox<string> |> Option.ofObj
@@ -258,8 +255,8 @@ let tryBuildOpenArcRootRenamePlan arcPath newName : Result<OpenArcRootRenamePlan
 
             if
                 String.Equals(
-                    normalizePathForComparison sourcePath,
-                    normalizePathForComparison targetPath,
+                    PathHelpers.normalizePathForFsComparison sourcePath,
+                    PathHelpers.normalizePathForFsComparison targetPath,
                     StringComparison.Ordinal
                 )
             then
@@ -293,7 +290,8 @@ let renameOpenArcRootDirectoryOnDisk arcPath newName : JS.Promise<Result<string,
 
                 match renameResult with
                 | Ok() -> return Ok plan.TargetPath
-                | Error renameError -> return Error(mapArcRootRenameDiskError plan.SourcePath plan.TargetPath renameError)
+                | Error renameError ->
+                    return Error(mapArcRootRenameDiskError plan.SourcePath plan.TargetPath renameError)
 }
 
 let createWindow () = promise {

--- a/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVaultHelper.fs
@@ -1,6 +1,7 @@
 module Main.ArcVaultHelper
 
 
+open System
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOHelper
 open Swate.Electron.Shared.FileIOTypes
@@ -12,6 +13,9 @@ open Main
 open Main.ARCtrlExtensions
 open Main.Bindings
 open Node.Api
+
+let private fsPromisesDynamic: obj = importAll "fs/promises"
+let private pathDynamic: obj = importAll "path"
 
 /// This function mutably sets the datamap on the correct parent based on the datamap parent info included in the file content DTO.
 /// It also ensures that the static hash is preserved to avoid unnecessary changes to the ARC when saving a datamap.
@@ -158,6 +162,149 @@ let swatelogfn id fmt =
 
 let swatefailfn id fmt =
     Printf.kprintf (fun s -> failwith ("[Swate-" + string id + "] " + s)) fmt
+
+type OpenArcRootRenamePlan = {
+    SourcePath: string
+    TargetPath: string
+    NewName: string
+}
+
+let private normalizeArcRootFolderName (newName: string) =
+    newName
+    |> Option.ofObj
+    |> Option.map _.Trim()
+    |> Option.defaultValue String.Empty
+
+let private containsPathSeparator (value: string) =
+    value.IndexOf("/", StringComparison.Ordinal) >= 0 || value.IndexOf("\\", StringComparison.Ordinal) >= 0
+
+let private resolveAbsolutePath (pathValue: string) =
+    pathDynamic?resolve (pathValue) |> unbox<string> |> PathHelpers.normalizePath
+
+let private normalizePathForComparison (pathValue: string) =
+    PathHelpers.normalizePathForFsComparison pathValue
+
+let private tryGetNodeErrorCode (error: exn) : string option =
+    try
+        error?code |> unbox<string> |> Option.ofObj
+    with _ ->
+        None
+
+let private pathExistsAsync (absolutePath: string) : JS.Promise<bool> = promise {
+    let! fileExists = ARCtrl.FileSystemHelper.fileExistsAsync absolutePath
+
+    if fileExists then
+        return true
+    else
+        return! ARCtrl.FileSystemHelper.directoryExistsAsync absolutePath
+}
+
+let private renameWithRetriesAsync
+    (sourceAbsolutePath: string)
+    (targetAbsolutePath: string)
+    : JS.Promise<Result<unit, exn>> =
+    let retryDelaysMs = [| 0; 75; 200; 500 |]
+
+    let isTransientRenameError =
+        function
+        | Some "EPERM"
+        | Some "EACCES"
+        | Some "EBUSY" -> true
+        | _ -> false
+
+    let rec attempt (attemptIndex: int) = promise {
+        if attemptIndex > 0 then
+            do! Promise.sleep retryDelaysMs.[attemptIndex]
+
+        try
+            let! _ =
+                fsPromisesDynamic?rename (sourceAbsolutePath, targetAbsolutePath)
+                |> unbox<JS.Promise<obj>>
+
+            return Ok()
+        with renameError ->
+            let errorCode = tryGetNodeErrorCode renameError
+
+            if attemptIndex < retryDelaysMs.Length - 1 && isTransientRenameError errorCode then
+                return! attempt (attemptIndex + 1)
+            else
+                return Error renameError
+    }
+
+    attempt 0
+
+let private mapArcRootRenameDiskError (sourcePath: string) (targetPath: string) (renameError: exn) =
+    match tryGetNodeErrorCode renameError with
+    | Some "EPERM"
+    | Some "EACCES" ->
+        exn
+            $"Cannot rename '{sourcePath}' to '{targetPath}'. Windows reported a permission or file-lock conflict. If the destination already exists, choose a different name and close apps that may be using these paths."
+    | Some "ENOTEMPTY"
+    | Some "EEXIST" -> exn $"Cannot rename '{sourcePath}' to '{targetPath}' because the destination already exists."
+    | Some "ENOENT" -> exn $"Cannot rename '{sourcePath}' because the source path no longer exists on disk."
+    | _ -> renameError
+
+let tryBuildOpenArcRootRenamePlan arcPath newName : Result<OpenArcRootRenamePlan, exn> =
+    let normalizedName = normalizeArcRootFolderName newName
+
+    if String.IsNullOrWhiteSpace normalizedName then
+        Error(exn "ARC folder name must not be empty.")
+    elif
+        normalizedName = "."
+        || normalizedName = ".."
+        || containsPathSeparator normalizedName
+        || (pathDynamic?isAbsolute (normalizedName) |> unbox<bool>)
+        || PathHelpers.containsPathTraversalSegments normalizedName
+    then
+        Error(exn "ARC folder name must be a single folder name without path separators or traversal segments.")
+    else
+        let sourcePath = resolveAbsolutePath arcPath
+        let parentPath = pathDynamic?dirname (sourcePath) |> unbox<string>
+
+        let targetPath =
+            pathDynamic?resolve (parentPath, normalizedName)
+            |> unbox<string>
+            |> PathHelpers.normalizePath
+
+        if
+            String.Equals(
+                normalizePathForComparison sourcePath,
+                normalizePathForComparison targetPath,
+                StringComparison.Ordinal
+            )
+        then
+            Error(exn "New ARC folder name must be different from the current folder name.")
+        else
+            Ok {
+                SourcePath = sourcePath
+                TargetPath = targetPath
+                NewName = normalizedName
+            }
+
+let renameOpenArcRootDirectoryOnDisk arcPath newName : JS.Promise<Result<string, exn>> = promise {
+    match tryBuildOpenArcRootRenamePlan arcPath newName with
+    | Error validationError -> return Error validationError
+    | Ok plan ->
+        let! sourceExists = ARCtrl.FileSystemHelper.directoryExistsAsync plan.SourcePath
+
+        if not sourceExists then
+            return Error(exn $"Cannot rename '{plan.SourcePath}' because the source path no longer exists on disk.")
+        else
+            let! targetExists = pathExistsAsync plan.TargetPath
+
+            if targetExists then
+                return
+                    Error(
+                        exn
+                            $"Cannot rename '{plan.SourcePath}' to '{plan.TargetPath}' because the destination already exists."
+                    )
+            else
+                let! renameResult = renameWithRetriesAsync plan.SourcePath plan.TargetPath
+
+                match renameResult with
+                | Ok() -> return Ok plan.TargetPath
+                | Error renameError -> return Error(mapArcRootRenameDiskError plan.SourcePath plan.TargetPath renameError)
+}
 
 let createWindow () = promise {
     printfn "[Swate] Creating new window"

--- a/src/Electron/src/Main/Auth/AuthService.fs
+++ b/src/Electron/src/Main/Auth/AuthService.fs
@@ -207,6 +207,26 @@ let private refreshTokenProvider () =
         TryGetAccessToken = fun host -> promise { return tryGetTokenForHost host }
     }
 
+    Main.Git.GitTokenProvider.RemoteProvisioning.setProvider {
+        CreateProject =
+            fun projectName -> promise {
+                match
+                    getActiveAccountState ()
+                    |> Option.filter canUseToken
+                    |> Option.map (fun accountState -> accountState.Summary.User, accountState.Token)
+                with
+                | None ->
+                    return Error "No usable DataHub account is signed in. Sign in before publishing this local repository."
+                | Some(user, token) when String.IsNullOrWhiteSpace user.TargetDataHub ->
+                    return Error "The active DataHub account has no DataHub endpoint configured."
+                | Some(user, token) ->
+                    let! projectResult =
+                        Swate.Components.Api.GitLabApi.GitLabApi.CreateProject(user.TargetDataHub, token, projectName)
+
+                    return projectResult |> Result.map _.http_url_to_repo |> Result.mapError _.GitLabErrorToString
+            }
+    }
+
 /// Get the current in-memory auth state for the active account.
 let getState () : AuthStateDto =
     reconcileActiveAccountInvariant ()

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -80,6 +80,15 @@ let classifyFailureKind (message: string) =
 
     if containsAny lfsInstallRequiredTokens then
         GitFailureKind.LfsInstallRequired
+    elif
+        containsAny [|
+            "has already been taken"
+            "name already exists"
+            "project already exists"
+            "repository already exists"
+        |]
+    then
+        GitFailureKind.RemoteProjectAlreadyExists
     elif containsAny [| "abort"; "cancelled"; "canceled"; "aborterror" |] then
         GitFailureKind.Canceled
     elif containsAny [| "timed out"; "timeout"; "time out" |] then

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -1067,6 +1067,136 @@ let private withLocalGit (arcPath: string) (operation: ISimpleGit -> JS.Promise<
     | Ok() -> return! runSimpleGit operation git
 }
 
+type private RemoteUrlState =
+    | RemoteMissing
+    | RemoteConfiguredWithoutUrl
+    | RemoteConfigured of string
+
+let private tryGetNonEmptyRemoteUrl (remote: RemoteWithRefs) =
+    [|
+        remote.refs.push
+        remote.refs.fetch
+    |]
+    |> Array.tryPick (fun url ->
+        url
+        |> Option.ofObj
+        |> Option.map _.Trim()
+        |> Option.filter (String.IsNullOrWhiteSpace >> not)
+    )
+
+let private getRemoteUrlState (remoteName: string) (git: ISimpleGit) : JS.Promise<RemoteUrlState> = promise {
+    let! remoteList = git.getRemotes true
+
+    let remoteUrl =
+        match remoteList with
+        | U2.Case1 remotes ->
+            remotes
+            |> Array.tryFind (fun remote -> String.Equals(remote.name, remoteName, StringComparison.Ordinal))
+            |> Option.map (fun _ -> RemoteConfiguredWithoutUrl)
+        | U2.Case2 remotes ->
+            remotes
+            |> Array.tryFind (fun remote -> String.Equals(remote.name, remoteName, StringComparison.Ordinal))
+            |> Option.map (fun remote ->
+                match tryGetNonEmptyRemoteUrl remote with
+                | Some url -> RemoteConfigured url
+                | None -> RemoteConfiguredWithoutUrl
+            )
+
+    return remoteUrl |> Option.defaultValue RemoteMissing
+}
+
+let private tryGetPublishRepositoryName (arcPath: string) =
+    let projectName =
+        arcPath
+        |> Option.ofObj
+        |> Option.map basename
+        |> Option.map _.Trim()
+        |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
+    match projectName with
+    | Some name -> Ok name
+    | None -> Error(exn "Cannot derive a DataHub repository name from the ARC path.")
+
+let private createPublishFailure (projectName: string) (message: string) =
+    let details =
+        message
+        |> Option.ofObj
+        |> Option.map _.Trim()
+        |> Option.filter (String.IsNullOrWhiteSpace >> not)
+        |> Option.defaultValue "DataHub project creation failed without details."
+
+    {
+        Kind = classifyFailureKind details
+        Message = $"Could not publish local repository '{projectName}' to the active DataHub account: {details}"
+    }
+
+let private configurePublishedOriginRemote
+    (arcPath: string)
+    (remoteState: RemoteUrlState)
+    (remoteUrl: string)
+    : JS.Promise<GitResult<unit>> =
+    withLocalGit
+        arcPath
+        (fun git -> promise {
+            match remoteState with
+            | RemoteMissing ->
+                let! _ = git.addRemote ("origin", remoteUrl)
+                return ()
+            | RemoteConfiguredWithoutUrl ->
+                let! _ = git.raw [| "remote"; "set-url"; "origin"; remoteUrl |]
+                return ()
+            | RemoteConfigured _ -> return ()
+        })
+
+let private publishOriginRemoteIfMissing
+    (arcPath: string)
+    (remoteName: string)
+    (remoteState: RemoteUrlState)
+    : JS.Promise<GitResult<unit>> =
+    promise {
+        if not (String.Equals(remoteName, "origin", StringComparison.Ordinal)) then
+            return
+                Error {
+                    Kind = GitFailureKind.Unknown
+                    Message = $"Remote '{remoteName}' is not configured. Configure the remote before pushing."
+                }
+        else
+            match tryGetPublishRepositoryName arcPath with
+            | Error nameError -> return errorResult nameError
+            | Ok projectName ->
+                let! projectResult = RemoteProvisioning.createProject projectName
+
+                match projectResult with
+                | Error message -> return Error(createPublishFailure projectName message)
+                | Ok remoteUrl ->
+                    match ensureAllowedRemoteUrl remoteUrl with
+                    | Error remoteUrlError ->
+                        return
+                            errorResult (
+                                exn
+                                    $"DataHub created repository '{projectName}', but returned an unusable Git remote URL: {remoteUrlError.Message}"
+                            )
+                    | Ok safeRemoteUrl ->
+                        return! configurePublishedOriginRemote arcPath remoteState safeRemoteUrl
+    }
+
+let private ensurePushRemoteConfigured (arcPath: string) (remoteName: string) : JS.Promise<GitResult<unit>> = promise {
+    let! remoteStateResult = withLocalGit arcPath (getRemoteUrlState remoteName)
+
+    match remoteStateResult with
+    | Error failure -> return Error failure
+    | Ok(RemoteConfigured remoteUrl) ->
+        match ensureAllowedRemoteUrl remoteUrl with
+        | Ok _ -> return Ok()
+        | Error validationError ->
+            return
+                errorResult (
+                    exn $"Remote '{remoteName}' is configured but cannot be used for authenticated push: {validationError.Message}"
+                )
+    | Ok((RemoteMissing | RemoteConfiguredWithoutUrl) as remoteState) ->
+        return! publishOriginRemoteIfMissing arcPath remoteName remoteState
+}
+
 let private withAuthenticatedGit
     (arcPath: string)
     (remoteName: string)
@@ -1592,79 +1722,84 @@ let push
             match validateOptionalBranchName branchName with
             | Error branchError -> return errorResult branchError
             | Ok safeBranchName ->
-                let! gitResult = createAuthenticatedGitSession arcPath safeRemoteName progressCallback
+                let! remoteConfigResult = ensurePushRemoteConfigured arcPath safeRemoteName
 
-                match gitResult with
+                match remoteConfigResult with
                 | Error failure -> return Error failure
-                | Ok session ->
-                    let git = session.Git
-                    let! pushStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
+                | Ok() ->
+                    let! gitResult = createAuthenticatedGitSession arcPath safeRemoteName progressCallback
 
-                    match pushStatusResult with
+                    match gitResult with
                     | Error failure -> return Error failure
-                    | Ok pushStatus ->
-                        let pushTarget =
-                            resolvePushTarget safeBranchName pushStatus.current pushStatus.tracking pushStatus.detached
+                    | Ok session ->
+                        let git = session.Git
+                        let! pushStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
 
-                        return!
-                            executePushWorkflow
-                                pushTarget
-                                (fun () ->
-                                    planOutboundPush
-                                        runSimpleGit
-                                        runGitCaptured
-                                        toFailure
-                                        (fun currentGit ->
-                                            runSimpleGit (fun gitInstance -> gitInstance.status ()) currentGit
-                                        )
-                                        arcPath
-                                        safeRemoteName
-                                        (Some pushTarget.RefSpec)
-                                        git
-                                )
-                                (fun objectIds -> promise {
-                                    let! uploadResult =
-                                        GitLfsService.uploadObjects
+                        match pushStatusResult with
+                        | Error failure -> return Error failure
+                        | Ok pushStatus ->
+                            let pushTarget =
+                                resolvePushTarget safeBranchName pushStatus.current pushStatus.tracking pushStatus.detached
+
+                            return!
+                                executePushWorkflow
+                                    pushTarget
+                                    (fun () ->
+                                        planOutboundPush
+                                            runSimpleGit
                                             runGitCaptured
-                                            session.CommandAuth
+                                            toFailure
+                                            (fun currentGit ->
+                                                runSimpleGit (fun gitInstance -> gitInstance.status ()) currentGit
+                                            )
                                             arcPath
                                             safeRemoteName
-                                            pushTarget.RefSpec
-                                            objectIds
+                                            (Some pushTarget.RefSpec)
+                                            git
+                                    )
+                                    (fun objectIds -> promise {
+                                        let! uploadResult =
+                                            GitLfsService.uploadObjects
+                                                runGitCaptured
+                                                session.CommandAuth
+                                                arcPath
+                                                safeRemoteName
+                                                pushTarget.RefSpec
+                                                objectIds
 
-                                    return uploadResult |> Result.mapError toFailure
-                                })
-                                (fun skipLfsHook currentPushTarget ->
-                                    runSimpleGit
-                                        (fun currentGit -> promise {
-                                            let pushGit =
-                                                if skipLfsHook then
-                                                    currentGit.env ("GIT_LFS_SKIP_PUSH", "1")
-                                                else
-                                                    currentGit
-
-                                            if currentPushTarget.SetUpstream then
-                                                let! _ =
-                                                    pushGit.push (
-                                                        safeRemoteName,
-                                                        currentPushTarget.PushBranch,
-                                                        !^[| "--set-upstream" |]
-                                                    )
-
-                                                return ()
-                                            else
-                                                let! _ = pushGit.push (safeRemoteName, currentPushTarget.PushBranch)
-                                                return ()
-                                        })
-                                        git
-                                )
-                                (fun _failure ->
-                                    collectPushDiagnostics
+                                        return uploadResult |> Result.mapError toFailure
+                                    })
+                                    (fun skipLfsHook currentPushTarget ->
                                         runSimpleGit
-                                        (fun currentFailure -> Some currentFailure.Message)
-                                        safeRemoteName
-                                        git
-                                )
+                                            (fun currentGit -> promise {
+                                                let pushGit =
+                                                    if skipLfsHook then
+                                                        currentGit.env ("GIT_LFS_SKIP_PUSH", "1")
+                                                    else
+                                                        currentGit
+
+                                                if currentPushTarget.SetUpstream then
+                                                    let! _ =
+                                                        pushGit.push (
+                                                            safeRemoteName,
+                                                            currentPushTarget.PushBranch,
+                                                            !^[| "--set-upstream" |]
+                                                        )
+
+                                                    return ()
+                                                else
+                                                    let! _ = pushGit.push (safeRemoteName, currentPushTarget.PushBranch)
+                                                    return ()
+                                            })
+                                            git
+                                    )
+                                    (fun _failure ->
+                                        collectPushDiagnostics
+                                            runSimpleGit
+                                            (fun currentFailure -> Some currentFailure.Message)
+                                            safeRemoteName
+                                            git
+                                    )
     }
 
 /// Persists Git workflow LFS settings in local repository config.

--- a/src/Electron/src/Main/Git/GitTokenProvider.fs
+++ b/src/Electron/src/Main/Git/GitTokenProvider.fs
@@ -23,6 +23,27 @@ let setTokenProvider (provider: GitTokenProvider) = activeTokenProvider <- provi
 let tryGetAccessToken (host: string) : JS.Promise<string option> =
     activeTokenProvider.TryGetAccessToken host
 
+module RemoteProvisioning =
+
+    type Provider = {
+        CreateProject: string -> JS.Promise<Result<string, string>>
+    }
+
+    let defaultProvider: Provider = {
+        CreateProject =
+            fun _ -> promise {
+                return Error "No usable DataHub account is signed in. Sign in before publishing this local repository."
+            }
+    }
+
+    let mutable private activeProvider = defaultProvider
+
+    let setProvider (provider: Provider) =
+        activeProvider <- provider
+
+    let createProject (projectName: string) =
+        activeProvider.CreateProject projectName
+
 let private tryExtractHostFromAbsoluteUri (remoteUrl: string) =
     let mutable uri = Unchecked.defaultof<Uri>
 

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -526,6 +526,27 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
             with e ->
                 return Error e
         }
+    renameOpenArcRoot =
+        fun (newName: string) -> promise {
+            try
+                return!
+                    withLoadedArcVault
+                        event
+                        (fun vault -> promise {
+                            let oldPath = vault.path
+                            let! renameResult = vault.RenameOpenArcRoot newName
+
+                            match renameResult with
+                            | Error renameError -> return Error renameError
+                            | Ok renamedPath ->
+                                oldPath |> Option.iter (fun path -> RECENT_ARCS.Remove(path) |> ignore)
+                                RECENT_ARCS.Add(renamedPath) |> ignore
+                                ARC_VAULTS.BroadcastRecentARCs()
+                                return Ok renamedPath
+                        })
+            with e ->
+                return Error e
+        }
     writeFile =
         fun (request: FileContentDTO) -> promise {
             try

--- a/src/Electron/src/Renderer/Components/LeftSidebar/Git/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/Git/GitSidebarPanel.fs
@@ -140,6 +140,12 @@ let Main () =
             ?errorNotice = gitStateCtx.state.ErrorNotice,
             ?warningNotice = gitStateCtx.state.WarningNotice,
             ?pendingConfirmation = gitStateCtx.state.PendingConfirmation,
+            ?publishRenamePrompt =
+                (gitStateCtx.state.PendingPublishRename
+                 |> Option.map (fun prompt -> {
+                     CurrentName = prompt.CurrentName
+                     Message = prompt.Message
+                 })),
             callbacks = {
                 OnRefresh = gitStateCtx.refresh
                 OnFetch = gitStateCtx.fetch
@@ -165,6 +171,8 @@ let Main () =
             lfsAutoTrackThresholdMb = gitStateCtx.state.LfsAutoTrackThresholdMb,
             remoteActionsEnabled = remoteActionsEnabled,
             canOpenRemoteRepository = gitStateCtx.state.OriginRemoteRepositoryWebUrl.IsSome,
+            onSubmitPublishRename = gitStateCtx.submitPublishRename,
+            onCancelPublishRename = gitStateCtx.cancelPublishRename,
             onOpenRemoteRepository =
                 (fun () ->
                     match gitStateCtx.state.OriginRemoteRepositoryWebUrl with

--- a/src/Electron/src/Renderer/Context/GitStateContext.fs
+++ b/src/Electron/src/Renderer/Context/GitStateContext.fs
@@ -28,6 +28,8 @@ type GitStateController = {
     discardSelection: string[] -> unit
     confirmPendingRemoteAction: unit -> unit
     cancelPendingRemoteAction: unit -> unit
+    submitPublishRename: string -> unit
+    cancelPublishRename: unit -> unit
     saveLfsAutoTrackThreshold: int -> unit
     saveDownloadLargeFiles: bool -> unit
     createBranch: GitSidebarCreateBranchRequest -> unit
@@ -66,8 +68,13 @@ module private Helper =
             fun requestedPath -> promise {
                 let! result = Renderer.GitApiClient.getGitMergeConflictViewData requestedPath
                 return mapMergeConflictPageResult requestedPath result
-            }
+        }
         initGitRepository = Renderer.GitApiClient.gitInitRepository
+        renameOpenArcRoot =
+            fun newName -> promise {
+                let! result = Api.ipcArcVaultApi.renameOpenArcRoot newName
+                return result |> Result.mapError _.Message
+            }
         createDataHubProject =
             fun projectName -> promise {
                 let! result = Api.ipcGitLabApi.createProject projectName
@@ -112,6 +119,8 @@ let GitStateCtx =
             discardSelection = fun _ -> ()
             confirmPendingRemoteAction = fun () -> ()
             cancelPendingRemoteAction = fun () -> ()
+            submitPublishRename = fun _ -> ()
+            cancelPublishRename = fun () -> ()
             saveLfsAutoTrackThreshold = fun _ -> ()
             saveDownloadLargeFiles = fun _ -> ()
             createBranch = fun _ -> ()
@@ -171,6 +180,12 @@ let GitStateCtxProvider (children: ReactElement) =
     let cancelPendingRemoteAction () =
         dispatch CancelPendingRemoteActionRequested
 
+    let submitPublishRename newName =
+        dispatch (SubmitPublishRenameRequested newName)
+
+    let cancelPublishRename () =
+        dispatch CancelPublishRenameRequested
+
     let saveLfsAutoTrackThreshold (thresholdMb: int) =
         dispatch (SaveLfsAutoTrackThresholdRequested thresholdMb)
 
@@ -213,6 +228,8 @@ let GitStateCtxProvider (children: ReactElement) =
                 discardSelection = discardSelection
                 confirmPendingRemoteAction = confirmPendingRemoteAction
                 cancelPendingRemoteAction = cancelPendingRemoteAction
+                submitPublishRename = submitPublishRename
+                cancelPublishRename = cancelPublishRename
                 saveLfsAutoTrackThreshold = saveLfsAutoTrackThreshold
                 saveDownloadLargeFiles = saveDownloadLargeFiles
                 createBranch = createBranchFrom

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -32,6 +32,7 @@ type GitBusyOperation =
     | CreatingBranch
     | SwitchingBranch
     | InstallingGitLfs
+    | RenamingRepository
     | PruningGitLfsCache
     | DeduplicatingGitLfsStorage
     | ConfirmingMergeResolution of path: string
@@ -59,6 +60,11 @@ type GitPendingRemoteAction =
     | UpdateFromOnline
     | CompletePrimarySavePush
 
+type GitPublishRenamePrompt = {
+    CurrentName: string
+    Message: string
+}
+
 type GitPullWorkflowResult = {
     Status: GitStatusDto option
     WarningMessage: string option
@@ -74,6 +80,7 @@ type GitState = {
     OriginRemoteRepositoryWebUrl: string option
     PendingConfirmation: GitSidebarConfirmationDialog option
     PendingRemoteAction: GitPendingRemoteAction
+    PendingPublishRename: GitPublishRenamePrompt option
     PendingPostMergePush: bool
     LfsAutoTrackThresholdMb: int
     DownloadLargeFiles: bool
@@ -108,6 +115,7 @@ type GitState = {
         OriginRemoteRepositoryWebUrl = None
         PendingConfirmation = None
         PendingRemoteAction = GitPendingRemoteAction.None
+        PendingPublishRename = None
         PendingPostMergePush = false
         LfsAutoTrackThresholdMb = 1
         DownloadLargeFiles = false
@@ -173,11 +181,13 @@ type WriteAttemptOutcome =
     | Completed of WriteSuccess
     | CompletedWithPendingRemoteConfirmation of WriteSuccess * GitSidebarConfirmationDialog * GitPendingRemoteAction
     | CompletedWithPendingRemoteFailure of WriteSuccess * string
+    | RequiresRemoteProjectRename of string
     | RequiresLfsInstall of string
 
 type private WriteOperationClassification =
     | WriteOperationReady of GitOperationResult
     | WriteOperationNeedsLfsInstall of string
+    | WriteOperationRemoteProjectAlreadyExists of string
 
 type Msg =
     | ResetWorkflow
@@ -210,6 +220,9 @@ type Msg =
     | DiscardSelectionRequested of string[]
     | ConfirmPendingRemoteActionRequested
     | CancelPendingRemoteActionRequested
+    | SubmitPublishRenameRequested of newName: string
+    | CancelPublishRenameRequested
+    | PublishRenameCompleted of sessionId: int * result: Result<string, string>
     | CreateBranchRequested of GitSidebarCreateBranchRequest
     | SwitchBranchRequested of string
     | PruneLfsCacheRequested
@@ -227,6 +240,7 @@ type GitDependencies = {
     loadDiffPage: string -> JS.Promise<Result<PageState, string>>
     loadMergeConflictPage: string -> JS.Promise<Result<PageState, string>>
     initGitRepository: string -> JS.Promise<Result<string, string>>
+    renameOpenArcRoot: string -> JS.Promise<Result<string, string>>
     createDataHubProject: string -> JS.Promise<Result<ExploreProjectDto, string>>
     installGitLfs: unit -> JS.Promise<Result<GitOperationResult, string>>
     previewGitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitPullPreflightResult, string>>
@@ -283,6 +297,7 @@ let busyNoticeFromOperation =
     | GitBusyOperation.CreatingBranch -> Some "Creating branch"
     | GitBusyOperation.SwitchingBranch -> Some "Switching branch"
     | GitBusyOperation.InstallingGitLfs -> Some "Installing Git LFS"
+    | GitBusyOperation.RenamingRepository -> Some "Renaming ARC"
     | GitBusyOperation.PruningGitLfsCache -> Some "Cleaning Git LFS cache"
     | GitBusyOperation.DeduplicatingGitLfsStorage -> Some "Reducing Git LFS duplicate storage"
     | GitBusyOperation.ConfirmingMergeResolution _ -> Some "Confirming merge resolution"
@@ -345,6 +360,28 @@ let shouldPublishCurrentBranchFirst (model: GitState) =
     match model.Status.CurrentBranch, model.Status.TrackingBranch with
     | Some currentBranch, None -> not (hasMatchingOriginBranch currentBranch model)
     | _ -> false
+
+let private tryGetPathLeaf (pathValue: string) =
+    pathValue
+    |> Option.ofObj
+    |> Option.map (fun value -> value.Trim().TrimEnd('/', '\\'))
+    |> Option.filter (String.IsNullOrWhiteSpace >> not)
+    |> Option.bind (fun trimmed ->
+        trimmed.Split([| '/'; '\\' |], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.tryLast
+    )
+    |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
+let private publishRenamePrompt message model =
+    let currentName =
+        model.CurrentArcPath
+        |> Option.bind tryGetPathLeaf
+        |> Option.defaultValue "ARC"
+
+    {
+        CurrentName = currentName
+        Message = message
+    }
 
 let private refreshErrorMessage (refreshResult: GitRefreshResult) =
     match refreshResult.Status, refreshResult.Branches, refreshResult.LfsSettings with
@@ -619,6 +656,7 @@ let private resolveStaleWriteCompletedCmd request result =
     | Ok(CompletedWithPendingRemoteConfirmation(success, _, _)) -> resolveCloneReplyCmd request (Ok success)
     | Ok(CompletedWithPendingRemoteFailure(success, _)) -> resolveCloneReplyCmd request (Ok success)
     | Ok(RequiresLfsInstall _) -> resolveCloneReplyCmd request (Error staleArcSessionMessage)
+    | Ok(RequiresRemoteProjectRename _) -> resolveCloneReplyCmd request (Error staleArcSessionMessage)
     | Error message -> resolveCloneReplyCmd request (Error message)
 
 let private writeErrorModel (message: string) (model: GitState) = {
@@ -638,6 +676,13 @@ let private classifyWriteResult (busyOperation: GitBusyOperation) (result: Resul
             WriteOperationNeedsLfsInstall(
                 operationResult.Message
                 |> Option.defaultValue "Git LFS is required for this operation. Install Git LFS now?"
+            )
+        )
+    | Ok operationResult when operationResult.FailureKind = Some GitFailureKind.RemoteProjectAlreadyExists ->
+        Ok(
+            WriteOperationRemoteProjectAlreadyExists(
+                operationResult.Message
+                |> Option.defaultValue "A DataHub repository with this name already exists."
             )
         )
     | Ok operationResult when not operationResult.Success ->
@@ -678,6 +723,8 @@ let private runSimpleWriteAttemptAsync
         match classifyWriteResult busyOperation result with
         | Error message -> return Error message
         | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+        | Ok(WriteOperationRemoteProjectAlreadyExists message) ->
+            return Ok(RequiresRemoteProjectRename message)
         | Ok(WriteOperationReady operationResult) ->
             return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.NoChange None
     }
@@ -689,6 +736,7 @@ let private runCloneAttemptAsync (deps: GitDependencies) (request: GitCloneRepos
         match classifyWriteResult GitBusyOperation.CloningRepository result with
         | Error message -> Error message
         | Ok(WriteOperationNeedsLfsInstall promptMessage) -> Ok(RequiresLfsInstall promptMessage)
+        | Ok(WriteOperationRemoteProjectAlreadyExists message) -> Error message
         | Ok(WriteOperationReady operationResult) ->
             Ok(Completed(CloneSuccess(operationResult.Path |> Option.defaultValue request.TargetPath)))
 }
@@ -699,6 +747,7 @@ let private runPullAttemptAsync (deps: GitDependencies) = promise {
     match classifyWriteResult GitBusyOperation.PullingFromRemote pullResult with
     | Error message -> return Error message
     | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+    | Ok(WriteOperationRemoteProjectAlreadyExists message) -> return Error message
     | Ok(WriteOperationReady operationResult) ->
         let! refreshResult = refreshAllAsync deps
 
@@ -743,18 +792,21 @@ let private runCommitAttemptAsync (deps: GitDependencies) (prepared: PreparedCom
         match classifyWriteResult prepared.BusyOperation unstageResult with
         | Error message -> return Error message
         | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+        | Ok(WriteOperationRemoteProjectAlreadyExists message) -> return Error message
         | Ok(WriteOperationReady _) ->
             let! stageResult = deps.gitStagePaths { Pathspecs = prepared.PathsToCommit }
 
             match classifyWriteResult prepared.BusyOperation stageResult with
             | Error message -> return Error message
             | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+            | Ok(WriteOperationRemoteProjectAlreadyExists message) -> return Error message
             | Ok(WriteOperationReady _) ->
                 let! commitResult = deps.gitCommit { Message = prepared.NormalizedMessage }
 
                 match classifyWriteResult prepared.BusyOperation commitResult with
                 | Error message -> return Error message
                 | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+                | Ok(WriteOperationRemoteProjectAlreadyExists message) -> return Error message
                 | Ok(WriteOperationReady operationResult) ->
                     return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.NoChange None
 }
@@ -770,6 +822,7 @@ let private runDiscardAttemptAsync (deps: GitDependencies) (paths: string[]) = p
         match classifyWriteResult GitBusyOperation.DiscardingSelectedChanges discardResult with
         | Error message -> return Error message
         | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+        | Ok(WriteOperationRemoteProjectAlreadyExists message) -> return Error message
         | Ok(WriteOperationReady operationResult) ->
             return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.Clear (Some None)
 }
@@ -798,6 +851,7 @@ let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState)
     match commitAttempt with
     | Error message -> return Error message
     | Ok(RequiresLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+    | Ok(RequiresRemoteProjectRename message) -> return Ok(RequiresRemoteProjectRename message)
     | Ok(Completed(UnitSuccess(refreshResult, pageChange, selectedChangePathOverride, _))) ->
         let localSuccessWithPendingWarning =
             UnitSuccess(refreshResult, pageChange, selectedChangePathOverride, Some pendingPrimarySaveWarning)
@@ -809,6 +863,7 @@ let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState)
             | Error message -> return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning message
             | Ok(WriteOperationNeedsLfsInstall promptMessage) ->
                 return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning promptMessage
+            | Ok(WriteOperationRemoteProjectAlreadyExists message) -> return Ok(RequiresRemoteProjectRename message)
             | Ok(WriteOperationReady operationResult) ->
                 return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.NoChange None
         }
@@ -829,6 +884,8 @@ let private runPrimarySaveAttemptAsync (deps: GitDependencies) (state: GitState)
                 | Error message -> return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning message
                 | Ok(WriteOperationNeedsLfsInstall promptMessage) ->
                     return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning promptMessage
+                | Ok(WriteOperationRemoteProjectAlreadyExists message) ->
+                    return pendingPrimarySaveRemoteFailure localSuccessWithPendingWarning message
                 | Ok(WriteOperationReady _) -> return! runPushAfterLocalCommit ()
             | Ok {
                      Status = GitPullPreflightStatus.WouldRequireMergeResolution
@@ -881,6 +938,7 @@ let private runSaveLfsSettingsAttemptAsync
         match classifyWriteResult busyOperation result with
         | Error message -> return Error message
         | Ok(WriteOperationNeedsLfsInstall promptMessage) -> return Ok(RequiresLfsInstall promptMessage)
+        | Ok(WriteOperationRemoteProjectAlreadyExists message) -> return Error message
         | Ok(WriteOperationReady operationResult) ->
             return! refreshAfterSuccess deps operationResult.WarningMessage GitPageChange.NoChange None
     }
@@ -925,6 +983,7 @@ let private missingRepositoryModel (model: GitState) = {
         OriginRemoteRepositoryWebUrl = None
         PendingConfirmation = None
         PendingRemoteAction = GitPendingRemoteAction.None
+        PendingPublishRename = None
         PendingPostMergePush = false
         LfsAutoTrackThresholdMb = GitState.Empty.LfsAutoTrackThresholdMb
         DownloadLargeFiles = GitState.Empty.DownloadLargeFiles
@@ -1342,6 +1401,68 @@ let update
                 PendingPostMergePush = false
         },
         Cmd.none
+    | CancelPublishRenameRequested ->
+        {
+            model with
+                PendingPublishRename = None
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = None
+        },
+        Cmd.none
+    | SubmitPublishRenameRequested _ when model.PendingPublishRename.IsNone -> model, Cmd.none
+    | SubmitPublishRenameRequested newName ->
+        let normalizedName =
+            newName
+            |> Option.ofObj
+            |> Option.map _.Trim()
+            |> Option.defaultValue String.Empty
+
+        if String.IsNullOrWhiteSpace normalizedName then
+            {
+                model with
+                    ErrorNotice = Some "ARC folder name must not be empty."
+            },
+            Cmd.none
+        else
+            let nextModel =
+                model
+                |> withBusyOperation (Some GitBusyOperation.RenamingRepository)
+                |> fun state -> {
+                    state with
+                        ErrorNotice = None
+                        CurrentProgress = None
+                }
+
+            let cmd =
+                Cmd.OfPromise.either
+                    deps.renameOpenArcRoot
+                    normalizedName
+                    (fun result -> PublishRenameCompleted(model.ArcSessionId, result))
+                    (fun err -> PublishRenameCompleted(model.ArcSessionId, Error(string err)))
+
+            nextModel, cmd
+    | PublishRenameCompleted(sessionId, _) when sessionId <> model.ArcSessionId -> model, Cmd.none
+    | PublishRenameCompleted(_, Error message) ->
+        {
+            model with
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = Some message
+        },
+        Cmd.none
+    | PublishRenameCompleted(_, Ok _) ->
+        {
+            model with
+                PendingPublishRename = None
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = None
+        },
+        Cmd.ofMsg (WriteRequested Push)
     | CreateBranchRequested request ->
         model,
         Cmd.ofMsg (
@@ -1424,6 +1545,17 @@ let update
     | WriteCompleted(_, request, Error message) ->
         let nextModel = writeErrorModel message model
         nextModel, resolveCloneReplyCmd request (Error message)
+    | WriteCompleted(_, _, Ok(RequiresRemoteProjectRename message)) ->
+        let nextModel = {
+            model with
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = None
+                PendingPublishRename = Some(publishRenamePrompt message model)
+        }
+
+        nextModel, Cmd.none
     | WriteCompleted(sessionId, request, Ok(RequiresLfsInstall promptMessage)) ->
         let nextModel = {
             model with
@@ -1563,6 +1695,7 @@ let update
                 CurrentProgress = None
                 ErrorNotice = None
                 WarningNotice = warningMessage
+                PendingPublishRename = None
         }
 
         nextModel,

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -1443,6 +1443,19 @@ let update
                     (fun err -> PublishRenameCompleted(model.ArcSessionId, Error(string err)))
 
             nextModel, cmd
+    | PublishRenameCompleted(sessionId, Ok renamedPath) when
+        sessionId <> model.ArcSessionId
+        && model.CurrentArcPath = Some renamedPath
+        ->
+        {
+            model with
+                PendingPublishRename = None
+                BusyOperation = None
+                BusyNotice = None
+                CurrentProgress = None
+                ErrorNotice = None
+        },
+        Cmd.ofMsg (WriteRequested Push)
     | PublishRenameCompleted(sessionId, _) when sessionId <> model.ArcSessionId -> model, Cmd.none
     | PublishRenameCompleted(_, Error message) ->
         {

--- a/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
@@ -38,6 +38,7 @@ type GitFailureKind =
     | Timeout
     | Canceled
     | LfsInstallRequired
+    | RemoteProjectAlreadyExists
     | Unknown
 
 [<StringEnum(CaseRules.None)>]

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -58,6 +58,7 @@ type IArcVaultsApi = {
     getHasUnsavedArcChanges: unit -> JS.Promise<Result<bool, exn>>
     deletePath: string -> JS.Promise<Result<unit, exn>>
     renamePath: RenamePathRequest -> JS.Promise<Result<unit, exn>>
+    renameOpenArcRoot: string -> JS.Promise<Result<string, exn>>
     writeFile: FileContentDTO -> JS.Promise<Result<unit, exn>>
     runGitLfs: GitLfsRequest -> JS.Promise<Result<GitLfsResult, exn>>
     cancelGitLfs: string -> JS.Promise<Result<string, exn>>

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -6,6 +6,7 @@ open Main.ArcVault
 open Main.ArcVaultHelper
 open Main.Bindings.Filesystem
 open Main.Bindings.Path
+open Swate.Components.Shared
 open Vitest
 
 let private mkdirRecursiveAsync (directoryPath: string) = promise {
@@ -252,6 +253,64 @@ Vitest.describe (
                     do! TestHelpers.removeDirectoryAsync rootPath
                     return raise error
             }
+        )
+
+        Vitest.test (
+            "RenameOpenArcRoot moves the active ARC folder and updates the vault path",
+            fun () ->
+                TestHelpers.withTempArcWith
+                    "swate-rename-arc-root-"
+                    "RenameRootArc"
+                    ignore
+                    (fun arcPath -> promise {
+                        let targetPath = join [| dirname arcPath; "renamed-arc" |] |> PathHelpers.normalizePath
+                        let vault = ArcVault(TestHelpers.testWindow ())
+                        vault.path <- Some arcPath
+
+                        do! vault.LoadArc()
+
+                        match! vault.RenameOpenArcRoot "renamed-arc" with
+                        | Error error -> failwith error.Message
+                        | Ok renamedPath ->
+                            Vitest.expect(renamedPath).toBe (targetPath)
+                            Vitest.expect(vault.path).toEqual (Some targetPath)
+
+                            let! oldPathExists = TestHelpers.pathExistsAsync arcPath
+                            let! newPathExists = TestHelpers.pathExistsAsync targetPath
+                            Vitest.expect(oldPathExists).toBe (false)
+                            Vitest.expect(newPathExists).toBe (true)
+
+                            let! reloadedArc = TestHelpers.loadArcAsync targetPath
+                            Vitest.expect(reloadedArc.Identifier).toBe ("RenameRootArc")
+                    })
+        )
+
+        Vitest.test (
+            "RenameOpenArcRoot rejects destination conflicts without moving the active ARC",
+            fun () ->
+                TestHelpers.withTempArcWith
+                    "swate-rename-arc-root-conflict-"
+                    "RenameRootConflictArc"
+                    ignore
+                    (fun arcPath -> promise {
+                        let targetPath = join [| dirname arcPath; "existing-arc" |] |> PathHelpers.normalizePath
+                        do! mkdirRecursiveAsync targetPath
+
+                        let vault = ArcVault(TestHelpers.testWindow ())
+                        vault.path <- Some arcPath
+                        do! vault.LoadArc()
+
+                        match! vault.RenameOpenArcRoot "existing-arc" with
+                        | Ok _ -> failwith "Expected active ARC root rename to reject an existing destination."
+                        | Error error ->
+                            Vitest.expect(error.Message).toContain ("destination already exists")
+                            Vitest.expect(vault.path).toEqual (Some arcPath)
+
+                            let! oldPathExists = TestHelpers.pathExistsAsync arcPath
+                            let! targetPathExists = TestHelpers.pathExistsAsync targetPath
+                            Vitest.expect(oldPathExists).toBe (true)
+                            Vitest.expect(targetPathExists).toBe (true)
+                    })
         )
 
         Vitest.test (

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -286,6 +286,46 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "RenameOpenArcRoot clears pending watcher state before moving the active ARC",
+            fun () ->
+                TestHelpers.withTempArcWith
+                    "swate-rename-arc-root-watcher-"
+                    "RenameRootWatcherArc"
+                    ignore
+                    (fun arcPath -> promise {
+                        let vault = ArcVault(TestHelpers.testWindow ())
+                        vault.path <- Some arcPath
+                        do! vault.LoadArc()
+
+                        let timeoutId = Fable.Core.JS.setTimeout (fun () -> ()) 60000
+
+                        vault.fileWatcherReloadArcTimeout <- Some timeoutId
+
+                        vault.fileWatcherPendingEvents.Add {
+                            EventName = "change"
+                            RelativePath = "isa.investigation.xlsx"
+                            AbsolutePath = join [| arcPath; "isa.investigation.xlsx" |]
+                        }
+
+                        vault.fileWatcherPendingArcMergeEvents.Add {
+                            EventName = "change"
+                            RelativePath = "isa.investigation.xlsx"
+                            AbsolutePath = join [| arcPath; "isa.investigation.xlsx" |]
+                        }
+
+                        try
+                            match! vault.RenameOpenArcRoot "renamed-arc-watcher" with
+                            | Error error -> failwith error.Message
+                            | Ok _ ->
+                                Vitest.expect(vault.fileWatcherReloadArcTimeout).toEqual (None)
+                                Vitest.expect(vault.fileWatcherPendingEvents.Count).toBe (0)
+                                Vitest.expect(vault.fileWatcherPendingArcMergeEvents.Count).toBe (0)
+                        finally
+                            vault.fileWatcherReloadArcTimeout |> Option.iter Fable.Core.JS.clearTimeout
+                    })
+        )
+
+        Vitest.test (
             "RenameOpenArcRoot rejects destination conflicts without moving the active ARC",
             fun () ->
                 TestHelpers.withTempArcWith
@@ -311,6 +351,14 @@ Vitest.describe (
                             Vitest.expect(oldPathExists).toBe (true)
                             Vitest.expect(targetPathExists).toBe (true)
                     })
+        )
+
+        Vitest.test (
+            "tryBuildOpenArcRootRenamePlan applies the shared rename-name validation rules",
+            fun () ->
+                match tryBuildOpenArcRootRenamePlan "C:/work/current-arc" "bad\u0000name" with
+                | Ok _ -> failwith "Expected ARC root rename to reject null characters."
+                | Error error -> Vitest.expect(error.Message).toContain ("null")
         )
 
         Vitest.test (

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -764,6 +764,7 @@ Vitest.describe (
                                         let! publishResult = GitService.push context.RepoPath None None None
                                         let failure = expectError publishResult
 
+                                        Vitest.expect(failure.Kind).toEqual (GitFailureKind.RemoteProjectAlreadyExists)
                                         Vitest.expect(failure.Message).toContain ("repo")
                                         Vitest.expect(failure.Message).toContain ("already been taken")
                                     }))

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -14,6 +14,7 @@ module GitProvisioningService = Main.Git.GitProvisioningService
 module GitAuthAdapter = Main.Git.GitAuthAdapter
 module GitLfsAdapter = Main.Git.GitLfsAdapter
 module GitLfsService = Main.Git.GitLfsService
+module GitRemoteProvisioningProvider = Main.Git.GitTokenProvider.RemoteProvisioning
 module GitTokenProvider = Main.Git.GitTokenProvider
 module JsonDecoder = Main.Git.JsonDecoder
 
@@ -236,6 +237,9 @@ let private expectErrorResult<'T> (result: Result<'T, exn>) =
 
 let private gitServiceIntegrationTimeoutMs = 120000
 
+let private gitServiceIntegrationTestOptions =
+    TestOptions(timeout = gitServiceIntegrationTimeoutMs)
+
 let private gitLfsIntegrationTestOptions =
     TestOptions(timeout = gitServiceIntegrationTimeoutMs)
 
@@ -338,6 +342,17 @@ let private withTestTokenProvider (body: unit -> JS.Promise<'T>) = promise {
         return! body ()
     finally
         GitTokenProvider.setTokenProvider GitTokenProvider.defaultTokenProvider
+}
+
+let private withTestRemoteProvisioningProvider createProject (body: unit -> JS.Promise<'T>) = promise {
+    GitRemoteProvisioningProvider.setProvider {
+        CreateProject = createProject
+    }
+
+    try
+        return! body ()
+    finally
+        GitRemoteProvisioningProvider.setProvider GitRemoteProvisioningProvider.defaultProvider
 }
 
 let private withTempRepository (testBody: TempRepositoryContext -> JS.Promise<unit>) : JS.Promise<unit> = promise {
@@ -658,6 +673,109 @@ Vitest.describe (
 
                         let! configuredRemoteUrl = context.Git.raw [| "remote"; "get-url"; "origin" |]
                         Vitest.expect(configuredRemoteUrl.Trim()).toBe (remoteUrl)
+                    })
+            }
+        )
+
+        Vitest.test (
+            "push publishes a local repository by creating origin from the active DataHub account",
+            gitServiceIntegrationTestOptions,
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let remotePath = join [| context.RootPath; "published.git" |]
+                        let filePath = join [| context.RepoPath; "published.txt" |]
+                        let mutable createdProjectName = None
+
+                        let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
+                        do! configureLocalRemoteRewrite context.Git remotePath
+
+                        do! writeUtf8FileAsync filePath "published\n"
+
+                        let! stageResult = GitService.stagePaths context.RepoPath [| "published.txt" |]
+                        expectOk "stage publish file" stageResult |> ignore
+
+                        let! commitResult = GitService.commit context.RepoPath "test: publish local repository"
+                        expectOk "commit publish file" commitResult |> ignore
+
+                        let! currentBranch =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status before publish")
+
+                        let branchName =
+                            currentBranch.Current
+                            |> Option.defaultWith (fun () -> failwith "Expected a current branch before publish.")
+
+                        do!
+                            withTestTokenProvider (fun () ->
+                                withTestRemoteProvisioningProvider
+                                    (fun projectName -> promise {
+                                        createdProjectName <- Some projectName
+                                        return Ok testRemoteUrl
+                                    })
+                                    (fun () -> promise {
+                                        let! publishResult = GitService.push context.RepoPath None None None
+                                        expectOk "publish local repository" publishResult |> ignore
+                                    }))
+
+                        Vitest.expect(createdProjectName).toEqual (Some "repo")
+
+                        let! configuredRemoteUrl = context.Git.raw [| "config"; "--get"; "remote.origin.url" |]
+                        Vitest.expect(configuredRemoteUrl.Trim()).toBe (testRemoteUrl)
+
+                        let! publishedStatus =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status after publish")
+
+                        Vitest.expect(publishedStatus.Tracking).toEqual (Some $"origin/{branchName}")
+
+                        let! remoteBranch =
+                            context.Git.raw [| "ls-remote"; remotePath; $"refs/heads/{branchName}" |]
+
+                        Vitest.expect(remoteBranch.Contains($"refs/heads/{branchName}")).toBe (true)
+                    })
+            }
+        )
+
+        Vitest.test (
+            "push reports the DataHub project creation error when the publish target already exists",
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let filePath = join [| context.RepoPath; "duplicate.txt" |]
+
+                        do! writeUtf8FileAsync filePath "duplicate\n"
+
+                        let! stageResult = GitService.stagePaths context.RepoPath [| "duplicate.txt" |]
+                        expectOk "stage duplicate file" stageResult |> ignore
+
+                        let! commitResult = GitService.commit context.RepoPath "test: duplicate publish target"
+                        expectOk "commit duplicate file" commitResult |> ignore
+
+                        do!
+                            withTestTokenProvider (fun () ->
+                                withTestRemoteProvisioningProvider
+                                    (fun _ -> promise {
+                                        return Error "GitLab rejected project creation (HTTP 400): name has already been taken."
+                                    })
+                                    (fun () -> promise {
+                                        let! publishResult = GitService.push context.RepoPath None None None
+                                        let failure = expectError publishResult
+
+                                        Vitest.expect(failure.Message).toContain ("repo")
+                                        Vitest.expect(failure.Message).toContain ("already been taken")
+                                    }))
+
+                        let! originLookup =
+                            runSimpleGitResult
+                                (fun git -> git.raw [| "remote"; "get-url"; "origin" |])
+                                context.Git
+
+                        match originLookup with
+                        | Ok _ -> failwith "Expected origin to remain unconfigured after project creation fails."
+                        | Error _ -> ()
                     })
             }
         )

--- a/tests/Electron.Core/GitValidation.test.fs
+++ b/tests/Electron.Core/GitValidation.test.fs
@@ -69,6 +69,9 @@ Vitest.describe (
             "maps network message", "could not resolve host github.com", GitFailureKind.Network
             "maps timeout message", "operation timed out", GitFailureKind.Timeout
             "maps canceled message", "AbortError: signal aborted", GitFailureKind.Canceled
+            "maps duplicate DataHub project message",
+            "GitLab request failed with HTTP 400: {\"message\":{\"name\":[\"has already been taken\"],\"path\":[\"has already been taken\"]}}",
+            GitFailureKind.RemoteProjectAlreadyExists
             "falls back to unknown message", "something unexpected", GitFailureKind.Unknown
             "keeps unauthorized priority over network indicators",
             "connection refused, could not read username",

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -155,6 +155,23 @@ globalThis.fetch = async (url, options) => {
 """)>]
 let private installGitLabCreateProjectFetchSpy () : unit = jsNative
 
+[<Emit("""
+globalThis.__swateOriginalFetch = globalThis.fetch;
+globalThis.__swateGitLabCreateProjectFetches = [];
+globalThis.fetch = async (url, options) => {
+  const body = options && options.body ? JSON.parse(options.body) : null;
+  globalThis.__swateGitLabCreateProjectFetches.push({ url, options, body });
+  return {
+    ok: false,
+    status: 400,
+    headers: { get: () => null },
+    text: async () => JSON.stringify({ message: { name: ["has already been taken"], path: ["has already been taken"] } }),
+    json: async () => ({ message: { name: ["has already been taken"], path: ["has already been taken"] } })
+  };
+};
+""")>]
+let private installGitLabCreateProjectFailureFetchSpy () : unit = jsNative
+
 [<Emit("globalThis.__swateGitLabCreateProjectFetches[globalThis.__swateGitLabCreateProjectFetches.length - 1].body")>]
 let private lastGitLabCreateProjectBody () : obj = jsNative
 
@@ -418,6 +435,26 @@ Vitest.describe (
                     Vitest.expect(getProperty<string> body "name").toBe ("My ARC Project")
                     Vitest.expect(getProperty<bool> body "initialize_with_readme").toBe (false)
                     Vitest.expect(hasOwnProperty body "path").toBe (false)
+                finally
+                    cleanupGitLabCreateProjectFetchSpy ()
+            }
+        )
+
+        Vitest.test (
+            "GitLabApi.CreateProject includes GitLab's duplicate-name response in the error",
+            fun () -> promise {
+                installGitLabCreateProjectFailureFetchSpy ()
+
+                try
+                    let! result = GitLabApi.CreateProject("https://gitlab.example/", "token-123", "Existing ARC")
+
+                    match result with
+                    | Ok _ -> failwith "Expected duplicate project creation to fail."
+                    | Error error ->
+                        let message = error.GitLabErrorToString
+
+                        Vitest.expect(message).toContain ("HTTP 400")
+                        Vitest.expect(message).toContain ("has already been taken")
                 finally
                     cleanupGitLabCreateProjectFetchSpy ()
             }

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -61,6 +61,15 @@ let private okOperationResult = {
     Path = None
 }
 
+let private duplicateRemoteProjectResult attemptedName = {
+    okOperationResult with
+        Success = false
+        Message =
+            Some
+                $"Could not publish local repository '{attemptedName}' to the active DataHub account: GitLab request failed with HTTP 400: name has already been taken."
+        FailureKind = Some GitFailureKind.RemoteProjectAlreadyExists
+}
+
 let private localBranch refName isCurrent isTracking = {
     RefName = refName
     DisplayLabel = refName
@@ -116,6 +125,13 @@ setter.call($0, $1);
 $0.dispatchEvent(new Event("input", { bubbles: true }));
 """)>]
 let private setTextAreaValue (element: HTMLTextAreaElement) (value: string) : unit = jsNative
+
+[<Emit("""
+const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value").set;
+setter.call($0, $1);
+$0.dispatchEvent(new Event("input", { bubbles: true }));
+""")>]
+let private setInputValue (element: HTMLInputElement) (value: string) : unit = jsNative
 
 [<Emit("""
 globalThis.__swateOriginalFetch = globalThis.fetch;
@@ -251,6 +267,7 @@ let private defaultDependencies: GitDependencies = {
     loadDiffPage = fun path -> unexpectedPromise $"loadDiffPage:{path}"
     loadMergeConflictPage = fun path -> unexpectedPromise $"loadMergeConflictPage:{path}"
     initGitRepository = fun path -> unexpectedPromise $"initGitRepository:{path}"
+    renameOpenArcRoot = fun name -> unexpectedPromise $"renameOpenArcRoot:{name}"
     createDataHubProject = fun name -> unexpectedPromise $"createDataHubProject:{name}"
     installGitLfs = fun () -> unexpectedPromise "installGitLfs"
     previewGitPull = fun _ -> unexpectedPromise "previewGitPull"
@@ -1141,6 +1158,102 @@ Vitest.describe (
                 Vitest.expect(nextState.BranchOptions |> Array.map _.RefName).toEqual ([| "feature/pushed" |])
                 Vitest.expect(nextState.LfsAutoTrackThresholdMb).toBe (9)
                 Vitest.expect(nextState.DownloadLargeFiles).toBe (true)
+            }
+        )
+
+        Vitest.test (
+            "WriteCompleted opens a publish rename prompt when first push finds an existing DataHub project",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        gitPush = fun _ -> promise { return Ok(duplicateRemoteProjectResult "Existing ARC") }
+                }
+
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/work/Existing ARC"
+                }
+
+                let stateAfterRequest, requestCmd =
+                    update deps ignore (WriteRequested Push) initialState
+
+                let! requestMessages = collectMessages requestCmd
+
+                let nextState, nextCmd =
+                    match requestMessages with
+                    | [| WriteCompleted(_, Push, Ok(RequiresRemoteProjectRename _)) |] ->
+                        update deps ignore requestMessages[0] stateAfterRequest
+                    | _ -> failwith "Expected duplicate project push to request ARC/project rename."
+
+                let! followUpMessages = collectMessages nextCmd
+
+                Vitest.expect(nextState.BusyOperation).toEqual (None)
+                Vitest.expect(nextState.ErrorNotice).toEqual (None)
+                Vitest.expect(nextState.PendingPublishRename |> Option.map _.CurrentName).toEqual (Some "Existing ARC")
+                Vitest.expect(followUpMessages).toEqual ([||])
+            }
+        )
+
+        Vitest.test (
+            "SubmitPublishRenameRequested renames the active ARC root before retrying push",
+            fun () -> promise {
+                let renamedNames = ResizeArray<string>()
+
+                let deps = {
+                    defaultDependencies with
+                        renameOpenArcRoot =
+                            fun newName -> promise {
+                                renamedNames.Add newName
+                                return Ok "C:/work/Renamed ARC"
+                            }
+                        gitPush = fun _ -> promise { return Ok okOperationResult }
+                        getGitStatus = fun () -> promise { return Ok(statusForBranch "main") }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                }
+
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/work/Existing ARC"
+                        PendingPublishRename =
+                            Some {
+                                CurrentName = "Existing ARC"
+                                Message = "A DataHub repository named 'Existing ARC' already exists."
+                            }
+                }
+
+                let stateAfterSubmit, renameCmd =
+                    update deps ignore (SubmitPublishRenameRequested " Renamed ARC ") initialState
+
+                let! renameMessages = collectMessages renameCmd
+
+                let stateAfterRename, retryCmd =
+                    match renameMessages with
+                    | [| PublishRenameCompleted(_, Ok "C:/work/Renamed ARC") |] ->
+                        update deps ignore renameMessages[0] stateAfterSubmit
+                    | _ -> failwith "Expected rename completion to be dispatched."
+
+                let! retryMessages = collectMessages retryCmd
+
+                let stateAfterRetryRequest, pushCmd =
+                    match retryMessages with
+                    | [| WriteRequested Push |] -> update deps ignore retryMessages[0] stateAfterRename
+                    | _ -> failwith "Expected push to be retried after renaming the ARC root."
+
+                let! pushMessages = collectMessages pushCmd
+
+                let finalState, finishCmd =
+                    match pushMessages with
+                    | [| WriteCompleted(_, Push, Ok(Completed(UnitSuccess(_, _, _, _)))) |] ->
+                        update deps ignore pushMessages[0] stateAfterRetryRequest
+                    | _ -> failwith "Expected retried push to complete successfully."
+
+                let! _ = collectMessages finishCmd
+
+                Vitest.expect(renamedNames |> Seq.toArray).toEqual ([| "Renamed ARC" |])
+                Vitest.expect(stateAfterSubmit.BusyOperation).toEqual (Some GitBusyOperation.RenamingRepository)
+                Vitest.expect(stateAfterRename.PendingPublishRename).toEqual (None)
+                Vitest.expect(finalState.ErrorNotice).toEqual (None)
             }
         )
 
@@ -3050,6 +3163,58 @@ Vitest.describe (
 
                 Vitest.expect(container.textContent.Contains("Save Selected Changes")).toBe (true)
                 Vitest.expect(container.querySelector ("[data-testid='GitSidebarErrorNotice']")).not.toBeNull ()
+
+                cleanup ()
+            }
+        )
+
+        Vitest.test (
+            "GitSidebar publish rename prompt submits the edited repository name",
+            fun () -> promise {
+                let mutable submittedName: string option = None
+                let mutable cancelCalls = 0
+
+                let! container, cleanup =
+                    renderToBody (
+                        Swate.Components.Page.GitSidebar.Main(
+                            status = {
+                                CurrentBranch = Some "main"
+                                TrackingBranch = None
+                                Ahead = 1
+                                Behind = 0
+                                IsClean = true
+                                IsMergeInProgress = false
+                            },
+                            changedFiles = [||],
+                            branchOptions = [| sidebarLocalBranch "main" true false |],
+                            callbacks = noopCallbacks,
+                            downloadLargeFiles = true,
+                            lfsAutoTrackThresholdMb = 5,
+                            publishRenamePrompt = {
+                                CurrentName = "Existing ARC"
+                                Message = "A DataHub repository named 'Existing ARC' already exists."
+                            },
+                            onSubmitPublishRename = (fun name -> submittedName <- Some name),
+                            onCancelPublishRename = (fun () -> cancelCalls <- cancelCalls + 1)
+                        )
+                    )
+
+                let input =
+                    document.body.querySelector ("[data-testid='GitSidebarPublishRenameInput']") :?> HTMLInputElement
+
+                Vitest.expect(input.value).toBe ("Existing ARC")
+
+                setInputValue input "Renamed ARC"
+                do! Promise.sleep 0
+
+                let submitButton =
+                    document.body.querySelector ("[data-testid='GitSidebarPublishRenameSubmit']") :?> HTMLButtonElement
+
+                submitButton.click ()
+                do! Promise.sleep 0
+
+                Vitest.expect(submittedName).toEqual (Some "Renamed ARC")
+                Vitest.expect(cancelCalls).toBe (0)
 
                 cleanup ()
             }

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -1258,6 +1258,51 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "PublishRenameCompleted still retries push when path-change update arrives first",
+            fun () -> promise {
+                let deps = {
+                    defaultDependencies with
+                        gitPush = fun _ -> promise { return Ok okOperationResult }
+                        getGitStatus = fun () -> promise { return Ok(statusForBranch "main") }
+                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
+                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 5 true) }
+                }
+
+                let renamingState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/work/Existing ARC"
+                        ArcSessionId = 7
+                        BusyOperation = Some GitBusyOperation.RenamingRepository
+                        BusyNotice = Some "Renaming ARC"
+                        PendingPublishRename =
+                            Some {
+                                CurrentName = "Existing ARC"
+                                Message = "A DataHub repository named 'Existing ARC' already exists."
+                            }
+                }
+
+                let stateAfterPathChange, pathChangeCmd =
+                    update deps ignore (ArcPathChanged(Some "C:/work/Renamed ARC")) renamingState
+
+                let! _ = collectMessages pathChangeCmd
+
+                let stateAfterRenameCompletion, retryCmd =
+                    update
+                        deps
+                        ignore
+                        (PublishRenameCompleted(7, Ok "C:/work/Renamed ARC"))
+                        stateAfterPathChange
+
+                let! retryMessages = collectMessages retryCmd
+
+                Vitest.expect(stateAfterPathChange.ArcSessionId).not.toBe (7)
+                Vitest.expect(stateAfterRenameCompletion.CurrentArcPath).toEqual (Some "C:/work/Renamed ARC")
+                Vitest.expect(stateAfterRenameCompletion.ErrorNotice).toEqual (None)
+                Vitest.expect(retryMessages).toEqual ([| WriteRequested Push |])
+            }
+        )
+
+        Vitest.test (
             "WriteRequested discards selected paths, refreshes status, and clears the open diff",
             fun () -> promise {
                 let discardedPathspecs = ResizeArray<string[]>()


### PR DESCRIPTION
Adds a safer DataHub publish flow for local ARCs that do not yet have a configured Git remote. When the default repository name already exists on the remote, the user can rename the open ARC/project and retry the push.

## Changes

- Supports pushing when `origin` is missing or has no usable URL by creating/configuring the DataHub remote before the push.
- Adds token-backed Git remote setup for publish/push operations.
- Detects remote repository name conflicts during first publish.
- Adds a publish-rename prompt in the Git sidebar.
- Renames the active ARC root on disk and updates the in-memory ARC path before retrying the push.
- Reuses the shared rename-name validation rules for ARC root rename planning.
- Clears pending file watcher state during ARC root rename so stale watcher events do not affect the renamed in-memory ARC.
- Handles renderer/main-process race conditions where `pathChange` may arrive before publish rename completion.
- Keeps post-rename side effects non-fatal after a successful disk move, avoiding split state between main process, renderer, and recent ARC tracking.