### PR TITLE
Fix git environment for mac/linux and set lfs download to false by default

### DIFF
--- a/src/Electron/src/Main/Git/GitAuthAdapter.fs
+++ b/src/Electron/src/Main/Git/GitAuthAdapter.fs
@@ -43,43 +43,46 @@ let toConfigEntries (args: string[]) =
 /// All Git entry points should use this so Electron never blocks waiting for credentials.
 let createNonInteractiveEnv () : obj =
     // Keep existing env variables but drop unsafe git/editor overrides that simple-git rejects by default.
-    emitJsExpr
-        ()
-        """
-        (() => {
-            const blocked = new Set([
-                'editor',
-                'git_askpass',
-                'git_config_global',
-                'git_config_system',
-                'git_config_count',
-                'git_config',
-                'git_editor',
-                'git_exec_path',
-                'git_external_diff',
-                'git_pager',
-                'git_proxy_command',
-                'git_template_dir',
-                'git_sequence_editor',
-                'git_ssh',
-                'git_ssh_command',
-                'pager',
-                'prefix',
-                'ssh_askpass'
-            ]);
-            const source = process.env ?? {};
-            const safeEnv = {};
+    let safeEnv: obj =
+        emitJsExpr
+            ()
+            """
+            (() => {
+                const blocked = new Set([
+                    'editor',
+                    'git_askpass',
+                    'git_config_global',
+                    'git_config_system',
+                    'git_config_count',
+                    'git_config',
+                    'git_editor',
+                    'git_exec_path',
+                    'git_external_diff',
+                    'git_pager',
+                    'git_proxy_command',
+                    'git_template_dir',
+                    'git_sequence_editor',
+                    'git_ssh',
+                    'git_ssh_command',
+                    'pager',
+                    'prefix',
+                    'ssh_askpass'
+                ]);
+                const source = process.env ?? {};
+                const safeEnv = {};
 
-            for (const [key, value] of Object.entries(source)) {
-                if (!blocked.has(String(key).toLowerCase())) {
-                    safeEnv[key] = value;
+                for (const [key, value] of Object.entries(source)) {
+                    if (!blocked.has(String(key).toLowerCase())) {
+                        safeEnv[key] = value;
+                    }
                 }
-            }
 
-            safeEnv.GIT_TERMINAL_PROMPT = '0';
-            return safeEnv;
-        })()
-        """
+                safeEnv.GIT_TERMINAL_PROMPT = '0';
+                return safeEnv;
+            })()
+            """
+
+    GitCommandResolver.ensureGitToolPath safeEnv
 
 /// Applies the non-interactive environment to a simple-git instance.
 let applyNonInteractiveEnv (git: ISimpleGit) = git.env (createNonInteractiveEnv ())

--- a/src/Electron/src/Main/Git/GitCommandResolver.fs
+++ b/src/Electron/src/Main/Git/GitCommandResolver.fs
@@ -43,10 +43,7 @@ let private distinctPathEntries (separator: char) (fallbackEntries: string[]) (c
 
     let addEntry (entry: string) =
         let normalizedEntry =
-            entry
-            |> Option.ofObj
-            |> Option.defaultValue String.Empty
-            |> _.Trim()
+            entry |> Option.ofObj |> Option.defaultValue String.Empty |> _.Trim()
 
         if not (String.IsNullOrWhiteSpace normalizedEntry) && seen.Add normalizedEntry then
             entries.Add normalizedEntry
@@ -69,8 +66,7 @@ let resolveGitToolPath (canResolveGitLfs: string -> bool) (platform: string) (cu
         |> _.Trim()
         |> _.ToLowerInvariant()
 
-    let existingPath =
-        currentPath |> Option.ofObj |> Option.defaultValue String.Empty
+    let existingPath = currentPath |> Option.ofObj |> Option.defaultValue String.Empty
 
     if supportsFallback normalizedPlatform && not (canResolveGitLfs existingPath) then
         distinctPathEntries (pathSeparator normalizedPlatform) (fallbackDirectories normalizedPlatform) existingPath

--- a/src/Electron/src/Main/Git/GitCommandResolver.fs
+++ b/src/Electron/src/Main/Git/GitCommandResolver.fs
@@ -1,0 +1,129 @@
+module Main.Git.GitCommandResolver
+
+open System
+open System.Collections.Generic
+open Fable.Core
+open Fable.Core.JsInterop
+open Main.Bindings.Node
+
+let private macGitToolDirectories = [|
+    "/opt/homebrew/bin"
+    "/usr/local/bin"
+    "/opt/local/bin"
+    "/usr/bin"
+    "/bin"
+|]
+
+let private linuxGitToolDirectories = [|
+    "/home/linuxbrew/.linuxbrew/bin"
+    "/usr/local/bin"
+    "/usr/bin"
+    "/bin"
+    "/snap/bin"
+|]
+
+let private supportsFallback (platform: string) =
+    platform = "darwin" || platform = "linux"
+
+let private fallbackDirectories (platform: string) =
+    match platform with
+    | "darwin" -> macGitToolDirectories
+    | "linux" -> linuxGitToolDirectories
+    | _ -> [||]
+
+let private pathSeparator (platform: string) =
+    if platform.StartsWith("win", StringComparison.OrdinalIgnoreCase) then
+        ';'
+    else
+        ':'
+
+let private distinctPathEntries (separator: char) (fallbackEntries: string[]) (currentPath: string) =
+    let entries = ResizeArray<string>()
+    let seen = HashSet<string>()
+
+    let addEntry (entry: string) =
+        let normalizedEntry =
+            entry
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+            |> _.Trim()
+
+        if not (String.IsNullOrWhiteSpace normalizedEntry) && seen.Add normalizedEntry then
+            entries.Add normalizedEntry
+
+    fallbackEntries |> Array.iter addEntry
+
+    currentPath.Split([| separator |], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.iter addEntry
+
+    entries.ToArray() |> String.concat (string separator)
+
+/// Returns the inherited PATH when the current environment can run `git lfs --version`.
+/// On macOS/Linux desktop launches, Electron may miss shell startup PATH entries; in that case
+/// prepend common package-manager Git locations while preserving the original PATH tail.
+let resolveGitToolPath (canResolveGitLfs: string -> bool) (platform: string) (currentPath: string) =
+    let normalizedPlatform =
+        platform
+        |> Option.ofObj
+        |> Option.defaultValue String.Empty
+        |> _.Trim()
+        |> _.ToLowerInvariant()
+
+    let existingPath =
+        currentPath |> Option.ofObj |> Option.defaultValue String.Empty
+
+    if supportsFallback normalizedPlatform && not (canResolveGitLfs existingPath) then
+        distinctPathEntries (pathSeparator normalizedPlatform) (fallbackDirectories normalizedPlatform) existingPath
+    else
+        existingPath
+
+[<Emit("process.platform")>]
+let private getProcessPlatform () : string = jsNative
+
+[<Emit("$0?.PATH || $0?.Path || $0?.path || ''")>]
+let private getEnvironmentPath (_environment: obj) : string = jsNative
+
+[<Emit("{ ...$0, PATH: $1 }")>]
+let private withEnvironmentPath (_environment: obj) (_pathValue: string) : obj = jsNative
+
+let private canRunGitLfsVersionWithPath (baseEnvironment: obj) (pathValue: string) =
+    try
+        let environment = withEnvironmentPath baseEnvironment pathValue
+
+        childProcessDynamic?execFileSync (
+            "git",
+            [| "lfs"; "--version" |],
+            createObj [
+                "encoding" ==> "utf8"
+                "stdio" ==> "pipe"
+                "shell" ==> false
+                "env" ==> environment
+            ]
+        )
+        |> ignore
+
+        true
+    with _ ->
+        false
+
+let mutable private cachedGitToolPath: string option = None
+
+/// Applies a resolved PATH to an environment object only when the inherited environment cannot
+/// run `git lfs --version` on macOS/Linux.
+let ensureGitToolPath (environment: obj) =
+    let currentPath = getEnvironmentPath environment
+
+    let resolvedPath =
+        match cachedGitToolPath with
+        | Some path -> path
+        | None ->
+            let path =
+                resolveGitToolPath (canRunGitLfsVersionWithPath environment) (getProcessPlatform ()) currentPath
+
+            cachedGitToolPath <- Some path
+            path
+
+    if String.Equals(currentPath, resolvedPath, StringComparison.Ordinal) then
+        environment
+    else
+        withEnvironmentPath environment resolvedPath

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -49,7 +49,7 @@ let private gitLfsThresholdConfigKey = "swate.lfs.autotrackthresholdmb"
 let private gitLfsDownloadLargeFilesConfigKey = "swate.lfs.downloadlargefiles"
 let private gitLfsDefaultThresholdMb = 1
 let private gitLfsMaximumThresholdMb = 100
-let private gitLfsDefaultDownloadLargeFiles = true
+let private gitLfsDefaultDownloadLargeFiles = false
 
 let private normalizeOptionalGitRef (value: string option) =
     value

--- a/src/Electron/src/Main/Git/GitlfsAdapter.fs
+++ b/src/Electron/src/Main/Git/GitlfsAdapter.fs
@@ -5,6 +5,7 @@ open Fable.Core.JsInterop
 open Fable.Core.JS
 open Swate.Electron.Shared.GitTypes
 open Main.Bindings.Node
+open Main.Git.GitAuthAdapter
 
 [<Literal>]
 let private repoValidationTimeoutMs = 5000
@@ -27,6 +28,11 @@ type GitSpawnResult = {
     TimedOut: bool
 }
 
+let private resolveGitEnvironment (environment: obj option) =
+    environment
+    |> Option.defaultWith createNonInteractiveEnv
+    |> GitCommandResolver.ensureGitToolPath
+
 let private runGitProcess (captureStdout: bool) (request: GitSpawnRequest) : Promise<GitSpawnResult> = promise {
     let! result =
         Fable.Core.JS.Constructors.Promise.Create(fun resolve _ ->
@@ -34,13 +40,10 @@ let private runGitProcess (captureStdout: bool) (request: GitSpawnRequest) : Pro
                 createObj [
                     "shell" ==> false
                     "windowsHide" ==> true
+                    "env" ==> resolveGitEnvironment request.Environment
 
                     match request.WorkingDirectory with
                     | Some value -> "cwd" ==> value
-                    | None -> ()
-
-                    match request.Environment with
-                    | Some value -> "env" ==> value
                     | None -> ()
                 ]
 
@@ -144,6 +147,7 @@ let tryExecGitText (workingDirectory: string option) (timeoutMs: int) (args: str
                     "stdio" ==> "pipe"
                     "shell" ==> false
                     "timeout" ==> timeoutMs
+                    "env" ==> createNonInteractiveEnv ()
 
                     match workingDirectory with
                     | Some value -> "cwd" ==> value
@@ -220,6 +224,7 @@ type NodeGitLfsAdapter() =
                         "encoding" ==> "utf8"
                         "stdio" ==> "pipe"
                         "shell" ==> false
+                        "env" ==> createNonInteractiveEnv ()
                     ]
                 )
                 |> unbox<string>
@@ -253,6 +258,7 @@ type NodeGitLfsAdapter() =
                             let spawnOptions =
                                 createObj [
                                     "shell" ==> false
+                                    "env" ==> createNonInteractiveEnv ()
 
                                     match workingDirectory with
                                     | Some value -> "cwd" ==> value
@@ -407,6 +413,7 @@ type NodeGitLfsAdapter() =
                             "encoding" ==> "utf8"
                             "stdio" ==> "pipe"
                             "shell" ==> false
+                            "env" ==> createNonInteractiveEnv ()
                         ]
                     )
                     |> unbox<string>

--- a/src/Electron/src/Main/Main.fsproj
+++ b/src/Electron/src/Main/Main.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="SettingsStore.fs" />
     <Compile Include="RecentArcStore.fs" />
     <Compile Include="Git\JsonDecoder.fs" />
+    <Compile Include="Git\GitCommandResolver.fs" />
     <Compile Include="Git\GitAuthAdapter.fs" />
     <Compile Include="Git\GitlfsAdapter.fs" />
     <Compile Include="Git\GitLfsService.fs" />

--- a/tests/Electron.Core/GitValidation.test.fs
+++ b/tests/Electron.Core/GitValidation.test.fs
@@ -19,6 +19,7 @@ open Vitest
 module GitService = Main.Git.GitService
 module GitProvisioningService = Main.Git.GitProvisioningService
 module GitAuthAdapter = Main.Git.GitAuthAdapter
+module GitCommandResolver = Main.Git.GitCommandResolver
 module GitTokenProvider = Main.Git.GitTokenProvider
 module AuthService = Main.Auth.AuthService
 
@@ -322,6 +323,50 @@ Vitest.describe (
             fun () ->
                 let redacted = GitAuthAdapter.redactToken "Authorization: Bearer abc123"
                 Vitest.expect(redacted).toBe ("Authorization: [REDACTED]")
+        )
+)
+
+Vitest.describe (
+    "GitCommandResolver.resolveGitToolPath",
+    fun () ->
+        Vitest.test (
+            "keeps the inherited PATH when Git LFS resolves normally",
+            fun () ->
+                let path =
+                    GitCommandResolver.resolveGitToolPath (fun _ -> true) "darwin" "/usr/bin:/bin"
+
+                Vitest.expect(path).toBe ("/usr/bin:/bin")
+        )
+
+        Vitest.test (
+            "prepends common macOS Git tool directories when automatic resolution fails",
+            fun () ->
+                let path =
+                    GitCommandResolver.resolveGitToolPath (fun _ -> false) "darwin" "/usr/bin:/bin:/custom/bin"
+
+                Vitest
+                    .expect(path)
+                    .toBe ("/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:/usr/bin:/bin:/custom/bin")
+        )
+
+        Vitest.test (
+            "prepends common Linux Git tool directories when automatic resolution fails",
+            fun () ->
+                let path =
+                    GitCommandResolver.resolveGitToolPath (fun _ -> false) "linux" "/usr/bin:/bin:/custom/bin"
+
+                Vitest
+                    .expect(path)
+                    .toBe ("/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin:/custom/bin")
+        )
+
+        Vitest.test (
+            "does not alter unsupported platforms",
+            fun () ->
+                let path =
+                    GitCommandResolver.resolveGitToolPath (fun _ -> false) "win32" "C:\\Git\\cmd;C:\\Windows"
+
+                Vitest.expect(path).toBe ("C:\\Git\\cmd;C:\\Windows")
         )
 )
 

--- a/tests/Electron.Core/GitValidation.test.fs
+++ b/tests/Electron.Core/GitValidation.test.fs
@@ -344,9 +344,7 @@ Vitest.describe (
                 let path =
                     GitCommandResolver.resolveGitToolPath (fun _ -> false) "darwin" "/usr/bin:/bin:/custom/bin"
 
-                Vitest
-                    .expect(path)
-                    .toBe ("/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:/usr/bin:/bin:/custom/bin")
+                Vitest.expect(path).toBe ("/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:/usr/bin:/bin:/custom/bin")
         )
 
         Vitest.test (


### PR DESCRIPTION
This PR adds path context to the simple git save environment for mac/linux compatibility and sets default lfs download to false again.