### PR TITLE
preview window full height

### DIFF
--- a/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
@@ -82,7 +82,8 @@ type TextInputWithMarkdown =
 
         let options = {
             MarkdownOptions.defaults with
-                Height = defaultArg height MarkdownOptions.defaults.Height
+                MinHeight = defaultArg height MarkdownOptions.defaults.MinHeight
+                MaxHeight = defaultArg height MarkdownOptions.defaults.MaxHeight
                 Mode = defaultArg mode MarkdownOptions.defaults.Mode
                 PreviewClassName =
                     match previewClassName with
@@ -423,8 +424,8 @@ type TextInputWithMarkdown =
 
         let previewClassName =
             match options.PreviewClassName with
-            | Some className -> $"swt:p-4 {className}"
-            | None -> "swt:p-4"
+            | Some className -> $"swt:p-4 swt:h-[360px]{className}"
+            | None -> "swt:p-4 swt:h-[360px]"
 
         let editorWrapperClasses = [
             "wmde-markdown-var swt:w-full swt:max-w-none swt:p-0 swt:overflow-hidden swt:min-h-0 swt:rounded-field swt:border swt:border-base-300 swt:bg-base-100"
@@ -525,7 +526,7 @@ type TextInputWithMarkdown =
                                                     if activeMode = PreviewMode.Live then
                                                         "swt:border-b swt:border-base-300 swt:lg:border-b-0 swt:lg:border-r"
                                                 ]
-                                                prop.style [ style.height options.Height ]
+                                                prop.style [ style.maxHeight options.MaxHeight; style.minHeight options.MinHeight ]
                                                 prop.children [
                                                     Html.textarea [
                                                         prop.ref textareaRef
@@ -545,7 +546,7 @@ type TextInputWithMarkdown =
                                         if activeMode <> PreviewMode.Edit then
                                             Html.div [
                                                 prop.className "swt:min-w-0 swt:overflow-auto swt:bg-base-100"
-                                                prop.style [ style.height options.Height ]
+                                                prop.style [ style.maxHeight options.MaxHeight; style.minHeight options.MinHeight ]
                                                 prop.children [
                                                     ReactMDEditor.MarkdownPreview(
                                                         tempValue,

--- a/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
@@ -64,6 +64,7 @@ type TextInputWithMarkdown =
         (
             value: string,
             setValue: string -> unit,
+            ?parent: MarkdownParent,
             ?label: string,
             ?placeholder: string,
             ?disabled: bool,
@@ -82,8 +83,8 @@ type TextInputWithMarkdown =
 
         let options = {
             MarkdownOptions.defaults with
-                MinHeight = defaultArg height MarkdownOptions.defaults.MinHeight
-                MaxHeight = defaultArg height MarkdownOptions.defaults.MaxHeight
+                CreatedHeight = defaultArg height MarkdownOptions.defaults.CreatedHeight
+                EditorHeight = defaultArg height MarkdownOptions.defaults.EditorHeight
                 Mode = defaultArg mode MarkdownOptions.defaults.Mode
                 PreviewClassName =
                     match previewClassName with
@@ -422,10 +423,17 @@ type TextInputWithMarkdown =
                 prop.onClick (fun _ -> setActiveMode targetMode)
             ]
 
+        let specificHeight =
+            match parent with
+            | Some MarkdownParent.Editor -> options.EditorHeight
+            | Some MarkdownParent.Created -> options.CreatedHeight
+            | None -> options.CreatedHeight
+
         let previewClassName =
             match options.PreviewClassName with
-            | Some className -> $"swt:p-4 swt:h-[360px]{className}"
-            | None -> "swt:p-4 swt:h-[360px]"
+            | Some className -> $"swt:p-4 swt:h-[{specificHeight}px {className}]"
+            | None -> $"swt:p-4 swt:h-[{specificHeight}px]"
+
 
         let editorWrapperClasses = [
             "wmde-markdown-var swt:w-full swt:max-w-none swt:p-0 swt:overflow-hidden swt:min-h-0 swt:rounded-field swt:border swt:border-base-300 swt:bg-base-100"
@@ -526,7 +534,7 @@ type TextInputWithMarkdown =
                                                     if activeMode = PreviewMode.Live then
                                                         "swt:border-b swt:border-base-300 swt:lg:border-b-0 swt:lg:border-r"
                                                 ]
-                                                prop.style [ style.height options.Height ]
+                                                prop.style [ style.height specificHeight ]
                                                 prop.children [
                                                     Html.textarea [
                                                         prop.ref textareaRef
@@ -546,10 +554,7 @@ type TextInputWithMarkdown =
                                         if activeMode <> PreviewMode.Edit then
                                             Html.div [
                                                 prop.className "swt:min-w-0 swt:overflow-auto swt:bg-base-100"
-                                                prop.style [
-                                                    style.height options.MaxHeight
-                                                    style.minHeight options.MinHeight
-                                                ]
+                                                prop.style [ style.height specificHeight ]
                                                 prop.children [
                                                     ReactMDEditor.MarkdownPreview(
                                                         tempValue,
@@ -622,4 +627,4 @@ flowchart TD
 
         let value, setValue = React.useState entryInitialValue
 
-        TextInputWithMarkdown.TextInputWithMarkdown(value, setValue, placeholder = "Write markdown...", height = 440)
+        TextInputWithMarkdown.TextInputWithMarkdown(value, setValue, placeholder = "Write markdown...")

--- a/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
@@ -525,8 +525,10 @@ type TextInputWithMarkdown =
                                                             if height = 560 then
                                                                 "swt:h-full"
                                                         ]
-                                                        if height = 360 then
-                                                            prop.style [ style.height height ]
+                                                        // if (defaultMode = PreviewMode.Edit) then
+                                                        //     prop.style [ style.height height ]
+                                                    
+                                                        prop.style [ style.height height ]
                                                         prop.disabled disabled
                                                         prop.readOnly disabled
                                                         prop.value tempValue

--- a/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
@@ -513,13 +513,20 @@ type TextInputWithMarkdown =
                                                     "swt:min-w-0"
                                                     if activeMode = PreviewMode.Live then
                                                         "swt:border-b swt:border-base-300 swt:lg:border-b-0 swt:lg:border-r"
+                                                    if height = 560 then
+                                                        "swt:h-full"
+
                                                 ]
                                                 prop.children [
                                                     Html.textarea [
                                                         prop.ref textareaRef
-                                                        prop.className
+                                                        prop.className [
                                                             "swt:w-full swt:border-0 swt:swt:bg-transparent swt:resize-none swt:px-3 swt:py-2 swt:focus:outline-hidden"
-                                                        prop.style [ style.height height ]
+                                                            if height = 560 then
+                                                                "swt:h-full"
+                                                        ]
+                                                        if height = 360 then
+                                                            prop.style [ style.height height ]
                                                         prop.disabled disabled
                                                         prop.readOnly disabled
                                                         prop.value tempValue

--- a/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
@@ -64,7 +64,7 @@ type TextInputWithMarkdown =
         (
             value: string,
             setValue: string -> unit,
-            ?parent: MarkdownParent,
+            height: int,
             ?label: string,
             ?placeholder: string,
             ?disabled: bool,
@@ -72,7 +72,6 @@ type TextInputWithMarkdown =
             ?isJoin: bool,
             ?rmv: MouseEvent -> unit,
             ?validator: string -> Result<unit, string>,
-            ?height: int,
             ?mode: PreviewMode,
             ?previewClassName: string,
             ?plugins: MarkdownToolbarPlugin list,
@@ -80,21 +79,12 @@ type TextInputWithMarkdown =
         ) =
         let disabled = defaultArg disabled false
         let isJoin = defaultArg isJoin false
-
-        let options = {
-            MarkdownOptions.defaults with
-                CreatedHeight = defaultArg height MarkdownOptions.defaults.CreatedHeight
-                EditorHeight = defaultArg height MarkdownOptions.defaults.EditorHeight
-                Mode = defaultArg mode MarkdownOptions.defaults.Mode
-                PreviewClassName =
-                    match previewClassName with
-                    | Some value -> Some value
-                    | None -> MarkdownOptions.defaults.PreviewClassName
-        }
+        let previewClassName = defaultArg previewClassName "swt:p-4 swt:h-full"
+        let defaultMode = defaultArg mode MarkdownOptions.defaults.Mode
 
         let startedChange = React.useRef false
         let tempValue, setTempValue = React.useState value
-        let activeMode, setActiveMode = React.useState options.Mode
+        let activeMode, setActiveMode = React.useState defaultMode
         let debouncedValue = React.useDebounce (tempValue, 300)
         let validationError, setValidationError = React.useState (None: string option)
 
@@ -423,16 +413,6 @@ type TextInputWithMarkdown =
                 prop.onClick (fun _ -> setActiveMode targetMode)
             ]
 
-        let specificHeight =
-            match parent with
-            | Some MarkdownParent.Editor -> options.EditorHeight
-            | Some MarkdownParent.Created -> options.CreatedHeight
-            | None -> options.CreatedHeight
-
-        let previewClassName =
-            match options.PreviewClassName with
-            | Some className -> $"swt:p-4 swt:h-[{specificHeight}px {className}]"
-            | None -> $"swt:p-4 swt:h-[{specificHeight}px]"
 
 
         let editorWrapperClasses = [
@@ -534,12 +514,12 @@ type TextInputWithMarkdown =
                                                     if activeMode = PreviewMode.Live then
                                                         "swt:border-b swt:border-base-300 swt:lg:border-b-0 swt:lg:border-r"
                                                 ]
-                                                prop.style [ style.height specificHeight ]
                                                 prop.children [
                                                     Html.textarea [
                                                         prop.ref textareaRef
                                                         prop.className
-                                                            "swt:w-full swt:h-full swt:border-0 swt:bg-transparent swt:resize-none swt:px-3 swt:py-2 swt:focus:outline-hidden"
+                                                            "swt:w-full swt:border-0 swt:swt:bg-transparent swt:resize-none swt:px-3 swt:py-2 swt:focus:outline-hidden"
+                                                        prop.style [ style.height height ]
                                                         prop.disabled disabled
                                                         prop.readOnly disabled
                                                         prop.value tempValue
@@ -553,8 +533,8 @@ type TextInputWithMarkdown =
 
                                         if activeMode <> PreviewMode.Edit then
                                             Html.div [
-                                                prop.className "swt:min-w-0 swt:overflow-auto swt:bg-base-100"
-                                                prop.style [ style.height specificHeight ]
+                                                prop.className
+                                                    "swt:min-w-0 swt:h-full swt:overflow-auto swt:bg-base-100"
                                                 prop.children [
                                                     ReactMDEditor.MarkdownPreview(
                                                         tempValue,
@@ -627,4 +607,4 @@ flowchart TD
 
         let value, setValue = React.useState entryInitialValue
 
-        TextInputWithMarkdown.TextInputWithMarkdown(value, setValue, placeholder = "Write markdown...")
+        TextInputWithMarkdown.TextInputWithMarkdown(value, setValue, placeholder = "Write markdown...", height = 360)

--- a/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
@@ -526,7 +526,10 @@ type TextInputWithMarkdown =
                                                     if activeMode = PreviewMode.Live then
                                                         "swt:border-b swt:border-base-300 swt:lg:border-b-0 swt:lg:border-r"
                                                 ]
-                                                prop.style [ style.maxHeight options.MaxHeight; style.minHeight options.MinHeight ]
+                                                prop.style [
+                                                    style.maxHeight options.MaxHeight
+                                                    style.minHeight options.MinHeight
+                                                ]
                                                 prop.children [
                                                     Html.textarea [
                                                         prop.ref textareaRef
@@ -546,7 +549,10 @@ type TextInputWithMarkdown =
                                         if activeMode <> PreviewMode.Edit then
                                             Html.div [
                                                 prop.className "swt:min-w-0 swt:overflow-auto swt:bg-base-100"
-                                                prop.style [ style.maxHeight options.MaxHeight; style.minHeight options.MinHeight ]
+                                                prop.style [
+                                                    style.maxHeight options.MaxHeight
+                                                    style.minHeight options.MinHeight
+                                                ]
                                                 prop.children [
                                                     ReactMDEditor.MarkdownPreview(
                                                         tempValue,

--- a/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
+++ b/src/Components/src/Composite/MarkdownText/TextInputWithMarkdown.fs
@@ -526,10 +526,7 @@ type TextInputWithMarkdown =
                                                     if activeMode = PreviewMode.Live then
                                                         "swt:border-b swt:border-base-300 swt:lg:border-b-0 swt:lg:border-r"
                                                 ]
-                                                prop.style [
-                                                    style.maxHeight options.MaxHeight
-                                                    style.minHeight options.MinHeight
-                                                ]
+                                                prop.style [ style.height options.Height ]
                                                 prop.children [
                                                     Html.textarea [
                                                         prop.ref textareaRef
@@ -550,7 +547,7 @@ type TextInputWithMarkdown =
                                             Html.div [
                                                 prop.className "swt:min-w-0 swt:overflow-auto swt:bg-base-100"
                                                 prop.style [
-                                                    style.maxHeight options.MaxHeight
+                                                    style.height options.MaxHeight
                                                     style.minHeight options.MinHeight
                                                 ]
                                                 prop.children [

--- a/src/Components/src/Composite/MarkdownText/Types.fs
+++ b/src/Components/src/Composite/MarkdownText/Types.fs
@@ -7,7 +7,8 @@ type PreviewMode =
     | Preview
 
 type MarkdownOptions = {
-    Height: int
+    MinHeight: int
+    MaxHeight: int
     Mode: PreviewMode
     PreviewClassName: string option
 }
@@ -16,7 +17,8 @@ type MarkdownOptions = {
 module MarkdownOptions =
 
     let defaults = {
-        Height = 360
+        MinHeight = 240
+        MaxHeight = 360
         Mode = PreviewMode.Live
         PreviewClassName = None
     }

--- a/src/Components/src/Composite/MarkdownText/Types.fs
+++ b/src/Components/src/Composite/MarkdownText/Types.fs
@@ -7,22 +7,13 @@ type PreviewMode =
     | Preview
 
 type MarkdownOptions = {
-    CreatedHeight: int
-    EditorHeight: int
     Mode: PreviewMode
     PreviewClassName: string option
 }
 
 [<RequireQualifiedAccess>]
-type MarkdownParent =
-    | Editor
-    | Created
-
-[<RequireQualifiedAccess>]
 module MarkdownOptions =
     let defaults = {
-        CreatedHeight = 560
-        EditorHeight = 360
         Mode = PreviewMode.Live
         PreviewClassName = None
     }

--- a/src/Components/src/Composite/MarkdownText/Types.fs
+++ b/src/Components/src/Composite/MarkdownText/Types.fs
@@ -7,6 +7,7 @@ type PreviewMode =
     | Preview
 
 type MarkdownOptions = {
+    Height: int
     MinHeight: int
     MaxHeight: int
     Mode: PreviewMode
@@ -17,6 +18,7 @@ type MarkdownOptions = {
 module MarkdownOptions =
 
     let defaults = {
+        Height = 360
         MinHeight = 240
         MaxHeight = 360
         Mode = PreviewMode.Live

--- a/src/Components/src/Composite/MarkdownText/Types.fs
+++ b/src/Components/src/Composite/MarkdownText/Types.fs
@@ -7,20 +7,22 @@ type PreviewMode =
     | Preview
 
 type MarkdownOptions = {
-    Height: int
-    MinHeight: int
-    MaxHeight: int
+    CreatedHeight: int
+    EditorHeight: int
     Mode: PreviewMode
     PreviewClassName: string option
 }
 
 [<RequireQualifiedAccess>]
-module MarkdownOptions =
+type MarkdownParent =
+    | Editor
+    | Created
 
+[<RequireQualifiedAccess>]
+module MarkdownOptions =
     let defaults = {
-        Height = 360
-        MinHeight = 240
-        MaxHeight = 360
+        CreatedHeight = 560
+        EditorHeight = 360
         Mode = PreviewMode.Live
         PreviewClassName = None
     }

--- a/src/Components/src/Composite/Notes/Editor/NoteFormFields.fs
+++ b/src/Components/src/Composite/Notes/Editor/NoteFormFields.fs
@@ -186,7 +186,7 @@ module NoteFormFields =
                     TextInputWithMarkdown.TextInputWithMarkdown(
                         draft.MainText,
                         (fun value -> setDraft { draft with MainText = value }),
-                        parent = MarkdownParent.Editor,
+                        height = 360,
                         label = "Main Text",
                         placeholder = "Write note markdown..."
                     )

--- a/src/Components/src/Composite/Notes/Editor/NoteFormFields.fs
+++ b/src/Components/src/Composite/Notes/Editor/NoteFormFields.fs
@@ -10,6 +10,7 @@ open Swate.Components.Composite.MarkdownText
 open Swate.Components.Composite.TermSearch
 open Swate.Components.Composite.TermSearch.Types
 open Swate.Components.Primitive.LayoutComponents
+open Swate.Components.Composite.MarkdownText.Types
 
 [<RequireQualifiedAccess>]
 module NoteFormFields =
@@ -185,9 +186,9 @@ module NoteFormFields =
                     TextInputWithMarkdown.TextInputWithMarkdown(
                         draft.MainText,
                         (fun value -> setDraft { draft with MainText = value }),
+                        parent = MarkdownParent.Editor,
                         label = "Main Text",
-                        placeholder = "Write note markdown...",
-                        height = 360
+                        placeholder = "Write note markdown..."
                     )
                 ]
             ]

--- a/src/Electron/src/Renderer/Components/MainContent/MarkdownEditorTarget.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/MarkdownEditorTarget.fs
@@ -87,7 +87,6 @@ let MarkdownEditorTarget (content: string) =
                     TextInputWithMarkdown.TextInputWithMarkdown(
                         markdown,
                         (fun value -> setMarkdown value),
-                        parent = MarkdownParent.Created,
                         placeholder = "Write markdown...",
                         mode = PreviewMode.Live,
                         height = 560

--- a/src/Electron/src/Renderer/Components/MainContent/MarkdownEditorTarget.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/MarkdownEditorTarget.fs
@@ -82,11 +82,12 @@ let MarkdownEditorTarget (content: string) =
                 ]
             ]
             Html.div [
-                prop.className "swt:min-h-0 swt:flex-1"
+                prop.className "swt:flex-1"
                 prop.children [
                     TextInputWithMarkdown.TextInputWithMarkdown(
                         markdown,
                         (fun value -> setMarkdown value),
+                        parent = MarkdownParent.Created,
                         placeholder = "Write markdown...",
                         mode = PreviewMode.Live,
                         height = 560


### PR DESCRIPTION
Preview window is now full height and should grow/shrink if the window size changes.

Edit:
<img width="1007" height="782" alt="grafik" src="https://github.com/user-attachments/assets/457eab40-c9b5-4e37-9249-edf5579f8adb" />
Preview:
<img width="1002" height="718" alt="grafik" src="https://github.com/user-attachments/assets/7d1dd2f6-0c19-4233-84fb-6ab9c3c33a51" />
