### PR TITLE
Git initialization flow and ARC creation

### DIFF
--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -387,7 +387,7 @@ module ArcVaultExtensions =
                 sendMsg.pathChange (Some normalizedPath)
         }
 
-        member this.CreateARC(path: string, identifier: string, initGit: bool) = promise {
+        member this.CreateARC(path: string, identifier: string) = promise {
             match this.path, this.arc with
             | Some _, _ -> swatefailfn this.window.id "Unable to create ARC in vault bound to path."
             | _, Some _ -> swatefailfn this.window.id "Unable to create ARC in vault bound to ARC."
@@ -414,11 +414,6 @@ module ArcVaultExtensions =
                             (PathHelpers.formatContractErrors errors)
                 finally
                     this.isBusyWriting <- false
-
-                if initGit then
-                    match! Git.GitProvisioningService.initRepository normalizedPath with
-                    | Error failure -> swatelogfn this.window.id $"Git init failed for '{normalizedPath}': {failure}"
-                    | Ok _ -> ()
 
                 do! this.Startup()
                 sendMsg.pathChange (Some normalizedPath)
@@ -511,6 +506,14 @@ type ArcOpenDisposition =
     | FocusedExisting of path: string
     | CreatedInCurrent of path: string
     | CreatedInNewWindow of path: string
+
+    member this.CreatedArcPath =
+        match this with
+        | CreatedInCurrent path
+        | CreatedInNewWindow path -> Some path
+        | OpenedInCurrent _
+        | OpenedInNewWindow _
+        | FocusedExisting _ -> None
 
 module ArcOpenDisposition =
     let path =
@@ -651,24 +654,21 @@ type ArcVaults() =
         return id
     }
 
-    member this.RegisterVaultWithNewArc
-        (path: string, newIdentifier: string, initGit: bool)
-        : Fable.Core.JS.Promise<int> =
-        promise {
-            let! window = createWindow ()
-            let id = window.id
-            let vault = ArcVault(window)
-            this.Vaults.Add(id, vault)
+    member this.RegisterVaultWithNewArc(path: string, newIdentifier: string) : Fable.Core.JS.Promise<int> = promise {
+        let! window = createWindow ()
+        let id = window.id
+        let vault = ArcVault(window)
+        this.Vaults.Add(id, vault)
 
-            do! vault.CreateARC(path, newIdentifier, initGit)
+        do! vault.CreateARC(path, newIdentifier)
 
-            this.OnCloseWindow(window, vault, id)
+        this.OnCloseWindow(window, vault, id)
 
-            window.focus ()
-            swatelogfn id "Register window"
+        window.focus ()
+        swatelogfn id "Register window"
 
-            return id
-        }
+        return id
+    }
 
     member this.OpenARCInVault(windowId: int, path: string) = promise {
         match this.Vaults.TryGetValue windowId with
@@ -678,10 +678,10 @@ type ArcVaults() =
         return ()
     }
 
-    member this.CreateARCInVault(windowId: int, path: string, identifier: string, initGit: bool) = promise {
+    member this.CreateARCInVault(windowId: int, path: string, identifier: string) = promise {
         match this.Vaults.TryGetValue windowId with
         | false, _ -> failwith $"Vault with window-id '{windowId}' not found."
-        | true, vault -> do! vault.CreateARC(path, identifier, initGit)
+        | true, vault -> do! vault.CreateARC(path, identifier)
 
         return ()
     }
@@ -729,7 +729,7 @@ type ArcVaults() =
 
     /// Create a new ARC at the given path with the given identifier.
     /// Decision: path already open → focus, calling window empty → create there, else → new window.
-    member this.CreateOrFocusArc(callingWindowId: int, arcPath: string, identifier: string, initGit: bool) = promise {
+    member this.CreateOrFocusArc(callingWindowId: int, arcPath: string, identifier: string) = promise {
         let normalizedArcPath = PathHelpers.normalizePath arcPath
 
         match this.TryGetVaultByPath normalizedArcPath with
@@ -740,12 +740,12 @@ type ArcVaults() =
         | None ->
             match this.TryGetVault callingWindowId with
             | Some vault when vault.path.IsNone ->
-                do! vault.CreateARC(normalizedArcPath, identifier, initGit)
+                do! vault.CreateARC(normalizedArcPath, identifier)
                 do! vault.RefreshFileTree()
                 this.TrackRecentAndBroadcast(normalizedArcPath)
                 return ArcOpenDisposition.CreatedInCurrent normalizedArcPath
             | _ ->
-                let! newWindowId = this.RegisterVaultWithNewArc(normalizedArcPath, identifier, initGit)
+                let! newWindowId = this.RegisterVaultWithNewArc(normalizedArcPath, identifier)
 
                 match this.TryGetVault newWindowId with
                 | Some newVault -> do! newVault.RefreshFileTree()

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -387,7 +387,7 @@ module ArcVaultExtensions =
                 sendMsg.pathChange (Some normalizedPath)
         }
 
-        member this.CreateARC(path: string, identifier: string) = promise {
+        member this.CreateARC(path: string, identifier: string, initGit: bool) = promise {
             match this.path, this.arc with
             | Some _, _ -> swatefailfn this.window.id "Unable to create ARC in vault bound to path."
             | _, Some _ -> swatefailfn this.window.id "Unable to create ARC in vault bound to ARC."
@@ -414,6 +414,12 @@ module ArcVaultExtensions =
                             (PathHelpers.formatContractErrors errors)
                 finally
                     this.isBusyWriting <- false
+
+                if initGit then
+                    match! Git.GitProvisioningService.initRepository normalizedPath with
+                    | Error failure ->
+                        swatelogfn this.window.id $"Git init failed for '{normalizedPath}': {failure}"
+                    | Ok _ -> ()
 
                 do! this.Startup()
                 sendMsg.pathChange (Some normalizedPath)
@@ -646,13 +652,13 @@ type ArcVaults() =
         return id
     }
 
-    member this.RegisterVaultWithNewArc(path: string, newIdentifier: string) : Fable.Core.JS.Promise<int> = promise {
+    member this.RegisterVaultWithNewArc(path: string, newIdentifier: string, initGit: bool) : Fable.Core.JS.Promise<int> = promise {
         let! window = createWindow ()
         let id = window.id
         let vault = ArcVault(window)
         this.Vaults.Add(id, vault)
 
-        do! vault.CreateARC(path, newIdentifier)
+        do! vault.CreateARC(path, newIdentifier, initGit)
 
         this.OnCloseWindow(window, vault, id)
 
@@ -670,10 +676,10 @@ type ArcVaults() =
         return ()
     }
 
-    member this.CreateARCInVault(windowId: int, path: string, identifier: string) = promise {
+    member this.CreateARCInVault(windowId: int, path: string, identifier: string, initGit: bool) = promise {
         match this.Vaults.TryGetValue windowId with
         | false, _ -> failwith $"Vault with window-id '{windowId}' not found."
-        | true, vault -> do! vault.CreateARC(path, identifier)
+        | true, vault -> do! vault.CreateARC(path, identifier, initGit)
 
         return ()
     }
@@ -721,7 +727,7 @@ type ArcVaults() =
 
     /// Create a new ARC at the given path with the given identifier.
     /// Decision: path already open → focus, calling window empty → create there, else → new window.
-    member this.CreateOrFocusArc(callingWindowId: int, arcPath: string, identifier: string) = promise {
+    member this.CreateOrFocusArc(callingWindowId: int, arcPath: string, identifier: string, initGit: bool) = promise {
         let normalizedArcPath = PathHelpers.normalizePath arcPath
 
         match this.TryGetVaultByPath normalizedArcPath with
@@ -732,12 +738,12 @@ type ArcVaults() =
         | None ->
             match this.TryGetVault callingWindowId with
             | Some vault when vault.path.IsNone ->
-                do! vault.CreateARC(normalizedArcPath, identifier)
+                do! vault.CreateARC(normalizedArcPath, identifier, initGit)
                 do! vault.RefreshFileTree()
                 this.TrackRecentAndBroadcast(normalizedArcPath)
                 return ArcOpenDisposition.CreatedInCurrent normalizedArcPath
             | _ ->
-                let! newWindowId = this.RegisterVaultWithNewArc(normalizedArcPath, identifier)
+                let! newWindowId = this.RegisterVaultWithNewArc(normalizedArcPath, identifier, initGit)
 
                 match this.TryGetVault newWindowId with
                 | Some newVault -> do! newVault.RefreshFileTree()

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -417,8 +417,7 @@ module ArcVaultExtensions =
 
                 if initGit then
                     match! Git.GitProvisioningService.initRepository normalizedPath with
-                    | Error failure ->
-                        swatelogfn this.window.id $"Git init failed for '{normalizedPath}': {failure}"
+                    | Error failure -> swatelogfn this.window.id $"Git init failed for '{normalizedPath}': {failure}"
                     | Ok _ -> ()
 
                 do! this.Startup()
@@ -652,21 +651,24 @@ type ArcVaults() =
         return id
     }
 
-    member this.RegisterVaultWithNewArc(path: string, newIdentifier: string, initGit: bool) : Fable.Core.JS.Promise<int> = promise {
-        let! window = createWindow ()
-        let id = window.id
-        let vault = ArcVault(window)
-        this.Vaults.Add(id, vault)
+    member this.RegisterVaultWithNewArc
+        (path: string, newIdentifier: string, initGit: bool)
+        : Fable.Core.JS.Promise<int> =
+        promise {
+            let! window = createWindow ()
+            let id = window.id
+            let vault = ArcVault(window)
+            this.Vaults.Add(id, vault)
 
-        do! vault.CreateARC(path, newIdentifier, initGit)
+            do! vault.CreateARC(path, newIdentifier, initGit)
 
-        this.OnCloseWindow(window, vault, id)
+            this.OnCloseWindow(window, vault, id)
 
-        window.focus ()
-        swatelogfn id "Register window"
+            window.focus ()
+            swatelogfn id "Register window"
 
-        return id
-    }
+            return id
+        }
 
     member this.OpenARCInVault(windowId: int, path: string) = promise {
         match this.Vaults.TryGetValue windowId with

--- a/src/Electron/src/Main/Git/GitProvisioningService.fs
+++ b/src/Electron/src/Main/Git/GitProvisioningService.fs
@@ -283,7 +283,7 @@ let initRepository (targetPath: string) : JS.Promise<GitService.GitResult<string
                 let! initResult =
                     runSimpleGit
                         (fun git -> promise {
-                            let! _ = git.init ()
+                            let! _ = git.init (U2.Case1 [| "--initial-branch=main" |])
                             return normalizedTargetPath
                         })
                         initGit

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -126,7 +126,7 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                 return Error e
         }
     createARC =
-        fun (identifier: string) -> promise {
+        fun (request: CreateArcRequest) -> promise {
             let window = dialogParentFromIpcEvent event
 
             let! r =
@@ -145,11 +145,11 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                 let arcContainerPath = r.filePaths |> Array.exactlyOne
 
                 let arcPath =
-                    ARCtrl.ArcPathHelper.combine arcContainerPath identifier
+                    ARCtrl.ArcPathHelper.combine arcContainerPath request.identifier
                     |> PathHelpers.normalizePath
 
                 let windowId = windowIdFromIpcEvent event
-                let! disposition = ARC_VAULTS.CreateOrFocusArc(windowId, arcPath, identifier)
+                let! disposition = ARC_VAULTS.CreateOrFocusArc(windowId, arcPath, request.identifier, request.initGit)
                 return Ok(ArcOpenDisposition.path disposition)
         }
     ensureNotesFolder =

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -4,9 +4,11 @@ open System
 open Fable.Core
 open Fable.Electron
 open Fable.Electron.Main
+open Fable.Electron.Remoting.Main
 open Swate.Components.Shared
 open Swate.Electron.Shared
 open Swate.Electron.Shared.IPCTypes
+open Swate.Electron.Shared.IPCTypes.MainToRendererIpc
 open Swate.Electron.Shared.GitTypes
 open Swate.Electron.Shared.FileIOTypes
 open Swate.Electron.Shared.FileIOHelper
@@ -90,6 +92,28 @@ let private runLoadedArcPathAction
             return Error e
     }
 
+let private initGitRepositoryForCreatedArcDisposition
+    (initRepository: string -> JS.Promise<Main.Git.GitService.GitResult<string>>)
+    (initGit: bool)
+    (disposition: ArcOpenDisposition)
+    : JS.Promise<Main.Git.GitService.GitResult<string option>> =
+    promise {
+        match initGit, disposition.CreatedArcPath with
+        | true, Some createdArcPath ->
+            let! initResult = initRepository createdArcPath
+            return initResult |> Result.map (fun _ -> Some createdArcPath)
+        | _ -> return Ok None
+    }
+
+let private notifyGitRepositoryInitialized (arcPath: string) =
+    ARC_VAULTS.TryGetVaultByPath arcPath
+    |> Option.iter (fun vault ->
+        Remoting.createIpc ()
+        |> Remoting.withWindow vault.window
+        |> Remoting.buildProxySender<IGitRepositoryRendererApi>
+        |> fun rendererApi -> rendererApi.gitRepositoryInitialized arcPath
+    )
+
 /// This depends on the types in this file, but the types on this file must call this to bind IPC calls :/
 let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
     openARC =
@@ -149,7 +173,21 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                     |> PathHelpers.normalizePath
 
                 let windowId = windowIdFromIpcEvent event
-                let! disposition = ARC_VAULTS.CreateOrFocusArc(windowId, arcPath, request.identifier, request.initGit)
+                let! disposition = ARC_VAULTS.CreateOrFocusArc(windowId, arcPath, request.identifier)
+
+                match!
+                    initGitRepositoryForCreatedArcDisposition
+                        Main.Git.GitProvisioningService.initRepository
+                        request.initGit
+                        disposition
+                with
+                | Error failure ->
+                    Swate.Components.console.log (
+                        $"Git init failed for '{ArcOpenDisposition.path disposition}': {failure.Message}"
+                    )
+                | Ok(Some initializedArcPath) -> notifyGitRepositoryInitialized initializedArcPath
+                | Ok None -> ()
+
                 return Ok(ArcOpenDisposition.path disposition)
         }
     ensureNotesFolder =

--- a/src/Electron/src/Preload/preload.fs
+++ b/src/Electron/src/Preload/preload.fs
@@ -14,6 +14,7 @@ Remoting.createIpc () |> Remoting.buildBridge<IRecentArcsRendererApi>
 Remoting.createIpc () |> Remoting.buildBridge<IAuthAccountsRendererApi>
 Remoting.createIpc () |> Remoting.buildBridge<IFileTreeRendererApi>
 Remoting.createIpc () |> Remoting.buildBridge<IGitProgressRendererApi>
+Remoting.createIpc () |> Remoting.buildBridge<IGitRepositoryRendererApi>
 Remoting.createIpc () |> Remoting.buildBridge<IGitLfsProgressRendererApi>
 Remoting.createIpc () |> Remoting.buildBridge<IHasUnsavedArcChangesRendererApi>
 

--- a/src/Electron/src/Renderer/Components/Helper/ArcVaultHelper.fs
+++ b/src/Electron/src/Renderer/Components/Helper/ArcVaultHelper.fs
@@ -64,7 +64,11 @@ let openArcByPath (onError: string -> unit) (arcPath: string) : JS.Promise<bool>
 }
 
 let createArc (onError: string -> unit) (identifier: string) (initGit: bool) : JS.Promise<string option> = promise {
-    let request = { identifier = identifier; initGit = initGit }
+    let request = {
+        identifier = identifier
+        initGit = initGit
+    }
+
     match! Api.ipcArcVaultApi.createARC request with
     | Error exn ->
         onError exn.Message

--- a/src/Electron/src/Renderer/Components/Helper/ArcVaultHelper.fs
+++ b/src/Electron/src/Renderer/Components/Helper/ArcVaultHelper.fs
@@ -5,6 +5,7 @@ open Browser.Dom
 open Fable.Core
 open Swate.Components.PageComponents.SettingsPage
 open Swate.Components.Primitive.ErrorModal.Types
+open Swate.Electron.Shared.IPCTypes
 
 let private tryParseLocalStorageBool (raw: string option) : bool option =
     raw
@@ -62,12 +63,13 @@ let openArcByPath (onError: string -> unit) (arcPath: string) : JS.Promise<bool>
         return true
 }
 
-let createArc (onError: string -> unit) (identifier: string) : JS.Promise<bool> = promise {
-    match! Api.ipcArcVaultApi.createARC identifier with
+let createArc (onError: string -> unit) (identifier: string) (initGit: bool) : JS.Promise<string option> = promise {
+    let request = { identifier = identifier; initGit = initGit }
+    match! Api.ipcArcVaultApi.createARC request with
     | Error exn ->
         onError exn.Message
-        return false
-    | Ok _ ->
+        return None
+    | Ok path ->
         do! ensureNotesFolderIfEnabled onError
-        return true
+        return Some path
 }

--- a/src/Electron/src/Renderer/Components/InitState.fs
+++ b/src/Electron/src/Renderer/Components/InitState.fs
@@ -71,14 +71,15 @@ let CreateNewArcModalContent (close: unit -> unit) =
                 ]
             ]
         ]
-        Html.div [
-            prop.className "swt:form-control swt:mt-4"
+        Html.fieldSet [
+            prop.className "swt:fieldset swt:mt-4"
             prop.children [
                 Html.label [
                     prop.className "swt:label swt:cursor-pointer swt:justify-start swt:gap-2"
                     prop.children [
                         Html.input [
                             prop.type'.checkbox
+                            prop.className "swt:checkbox"
                             prop.isChecked initGit
                             prop.onCheckedChange setInitGit
                             prop.disabled isBusy

--- a/src/Electron/src/Renderer/Components/InitState.fs
+++ b/src/Electron/src/Renderer/Components/InitState.fs
@@ -30,9 +30,7 @@ let CreateNewArcModalContent (close: unit -> unit) =
                     let! _ = createArc onCreateArcError temp initGit
                     ()
                 }
-                |> Promise.catch (fun ex ->
-                    console.warn ($"Error during ARC creation: {ex.Message}")
-                )
+                |> Promise.catch (fun ex -> console.warn ($"Error during ARC creation: {ex.Message}"))
                 |> Promise.start
 
             close ()

--- a/src/Electron/src/Renderer/Components/InitState.fs
+++ b/src/Electron/src/Renderer/Components/InitState.fs
@@ -1,5 +1,6 @@
 module Renderer.Components.InitState
 
+open Browser.Dom
 open Feliz
 open Renderer.Components.Helper.ArcVaultHelper
 open Swate.Components
@@ -12,6 +13,8 @@ let CreateNewArcModalContent (close: unit -> unit) =
 
     let isValid, setIsValid = React.useState (true)
     let temp, setTemp = React.useState ("")
+    let initGit, setInitGit = React.useState (true)
+    let isBusy, setIsBusy = React.useState (false)
     let errorModal = useErrorModalCtx ()
     let appStateCtx = Renderer.Context.AppStateContext.useAppStateCtx ()
 
@@ -20,8 +23,17 @@ let CreateNewArcModalContent (close: unit -> unit) =
 
     let handleSubmit =
         fun () ->
-            if isValid then
-                createArc onCreateArcError temp |> Promise.start
+            if isValid && not isBusy then
+                setIsBusy true
+
+                promise {
+                    let! _ = createArc onCreateArcError temp initGit
+                    ()
+                }
+                |> Promise.catch (fun ex ->
+                    console.warn ($"Error during ARC creation: {ex.Message}")
+                )
+                |> Promise.start
 
             close ()
 
@@ -39,6 +51,7 @@ let CreateNewArcModalContent (close: unit -> unit) =
                         Html.input [
                             prop.type'.text
                             prop.required true
+                            prop.disabled isBusy
                             prop.onKeyDown (key.enter, fun _ -> handleSubmit ())
                             prop.onChange (fun (v: string) ->
                                 if System.String.IsNullOrEmpty v then
@@ -60,11 +73,32 @@ let CreateNewArcModalContent (close: unit -> unit) =
                 ]
             ]
         ]
+        Html.div [
+            prop.className "swt:form-control swt:mt-4"
+            prop.children [
+                Html.label [
+                    prop.className "swt:label swt:cursor-pointer swt:justify-start swt:gap-2"
+                    prop.children [
+                        Html.input [
+                            prop.type'.checkbox
+                            prop.isChecked initGit
+                            prop.onCheckedChange setInitGit
+                            prop.disabled isBusy
+                            prop.testId "CreateNewArcInitGitCheckbox"
+                        ]
+                        Html.span [
+                            prop.className "swt:label-text"
+                            prop.text "Initialize Git Repository"
+                        ]
+                    ]
+                ]
+            ]
+        ]
         Html.button [
             prop.className "swt:btn swt:mt-4"
-            prop.disabled (not isValid)
+            prop.disabled (not isValid || isBusy)
             prop.onClick (fun _ -> handleSubmit ())
-            prop.text "Create new ARC"
+            prop.text (if isBusy then "Creating..." else "Create new ARC")
         ]
     ]
 

--- a/src/Electron/src/Renderer/Components/LeftSidebar/Git/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/Git/GitSidebarPanel.fs
@@ -14,7 +14,6 @@ let Main () =
     let authState = Renderer.Context.AuthStateContext.useAuthStateCtx ()
     let pageStateCtx = Renderer.Context.PageStateContext.usePageStateCtx ()
     let runStatus = Renderer.Context.GitWorkflow.currentRunStatus gitStateCtx.state
-    let remoteProjectName, setRemoteProjectName = React.useState ""
     let errorCtx = useErrorModalCtx ()
     let appStateCtx = Renderer.Context.AppStateContext.useAppStateCtx ()
 
@@ -41,12 +40,6 @@ let Main () =
             None
         else
             Some "Sign in to a DataHub account to use fetch, pull, push, update, and remote bootstrap."
-
-    let normalizedRemoteProjectName =
-        remoteProjectName.Trim()
-        |> function
-            | "" -> None
-            | value -> Some value
 
     let openArc =
         fun _ ->
@@ -90,45 +83,8 @@ let Main () =
                         "Initialize Repository"
                 IconClassName = "swt:fluent--branch-fork-24-regular"
                 Disabled = gitStateCtx.state.BusyOperation.IsSome
-                OnClick =
-                    (fun () ->
-                        gitStateCtx.initRepository (
-                            if remoteActionsEnabled then
-                                normalizedRemoteProjectName
-                            else
-                                None
-                        )
-                    )
-            },
-            extraContent =
-                Html.div [
-                    prop.className "swt:flex swt:flex-col swt:gap-2"
-                    prop.children [
-                        Html.label [
-                            prop.className "swt:flex swt:flex-col swt:gap-1"
-                            prop.children [
-                                Html.span [
-                                    prop.className "swt:text-xs swt:font-medium swt:text-base-content/70"
-                                    prop.text "DataHub repository name"
-                                ]
-                                Html.input [
-                                    prop.testId "GitSidebarRemoteProjectNameInput"
-                                    prop.className "swt:input swt:input-bordered swt:w-full"
-                                    prop.disabled (gitStateCtx.state.BusyOperation.IsSome || not remoteActionsEnabled)
-                                    prop.value remoteProjectName
-                                    prop.placeholder "my-arc"
-                                    prop.onChange setRemoteProjectName
-                                ]
-                            ]
-                        ]
-                        Html.p [
-                            prop.className "swt:text-xs swt:text-base-content/60"
-                            prop.text
-                                "If you provide a name, Swate creates a project on the active DataHub and adds it as origin right after git init."
-                        ]
-                    ]
-                ],
-            ?infoText = remoteActionsWarning
+                OnClick = fun () -> gitStateCtx.initRepository ()
+            }
         )
     | Some _ ->
         Swate.Components.Page.GitSidebar.Main(

--- a/src/Electron/src/Renderer/Context/GitStateContext.fs
+++ b/src/Electron/src/Renderer/Context/GitStateContext.fs
@@ -15,7 +15,7 @@ open Renderer.Context.GitWorkflow
 type GitStateController = {
     state: GitState
     refresh: unit -> unit
-    initRepository: string option -> unit
+    initRepository: unit -> unit
     fetch: unit -> unit
     pull: unit -> unit
     push: unit -> unit
@@ -75,17 +75,11 @@ module private Helper =
                 let! result = Api.ipcArcVaultApi.renameOpenArcRoot newName
                 return result |> Result.mapError _.Message
             }
-        createDataHubProject =
-            fun projectName -> promise {
-                let! result = Api.ipcGitLabApi.createProject projectName
-                return result |> Result.mapError _.GitLabErrorToString
-            }
         installGitLfs = Renderer.GitApiClient.installGitLfs
         previewGitPull = Renderer.GitApiClient.previewGitPull
         gitFetch = Renderer.GitApiClient.gitFetch
         gitPull = Renderer.GitApiClient.gitPull
         gitPush = Renderer.GitApiClient.gitPush
-        gitAddRemote = Renderer.GitApiClient.gitAddRemote
         gitCloneRepository = Renderer.GitApiClient.gitCloneRepository
         createBranch = Renderer.GitApiClient.createBranch
         checkoutBranch = Renderer.GitApiClient.checkoutBranch
@@ -106,7 +100,7 @@ let GitStateCtx =
         {
             state = GitState.Empty
             refresh = fun () -> ()
-            initRepository = fun _ -> ()
+            initRepository = fun () -> ()
             fetch = fun () -> ()
             pull = fun () -> ()
             push = fun () -> ()
@@ -146,8 +140,7 @@ let GitStateCtxProvider (children: ReactElement) =
 
     let refresh () = dispatch RefreshRequested
 
-    let initRepository remoteProjectName =
-        dispatch (InitRepositoryRequested remoteProjectName)
+    let initRepository () = dispatch InitRepositoryRequested
 
     let fetch () = dispatch FetchRequested
 

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -189,6 +189,7 @@ type Msg =
     | ResetWorkflow
     | SetCurrentProgress of GitSidebarProgress option
     | ArcPathChanged of ArcRootPath
+    | GitRepositoryInitialized of arcPath: string
     | RefreshRequested
     | RefreshCompleted of requestId: int * result: Result<GitRefreshResult, string>
     | InitRepositoryRequested
@@ -996,6 +997,11 @@ let update
             | None -> applyPageChangeCmd setPageState GitPageChange.Clear
 
         nextModel, cmd
+    | GitRepositoryInitialized arcPath ->
+        match model.CurrentArcPath with
+        | Some currentArcPath when Swate.Components.Shared.PathHelpers.pathsEqual currentArcPath arcPath ->
+            model, Cmd.ofMsg RefreshRequested
+        | _ -> model, Cmd.none
     | RefreshRequested when model.CurrentArcPath.IsNone ->
         {
             GitState.Empty with
@@ -1686,6 +1692,16 @@ let subscribe (_model: GitState) : Sub<Msg> = [
         let dispose =
             Renderer.IpcReceiver.subscribeProxyReceiver<IGitProgressRendererApi> {
                 gitProgressUpdate = fun progress -> dispatch (SetCurrentProgress(Some(mapProgress progress)))
+            }
+
+        { new System.IDisposable with
+            member _.Dispose() = dispose ()
+        }
+    [ "gitRepositoryInitialized" ],
+    fun dispatch ->
+        let dispose =
+            Renderer.IpcReceiver.subscribeProxyReceiver<IGitRepositoryRendererApi> {
+                gitRepositoryInitialized = fun arcPath -> dispatch (GitRepositoryInitialized arcPath)
             }
 
         { new System.IDisposable with

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -5,7 +5,6 @@ open Elmish
 open Fable.Core
 
 open Renderer.Types
-open Swate.Components.Api.GitLabApi
 open Swate.Components.Page.GitSidebarTypes
 open Swate.Electron.Shared
 open Swate.Electron.Shared.GitTypes
@@ -192,7 +191,7 @@ type Msg =
     | ArcPathChanged of ArcRootPath
     | RefreshRequested
     | RefreshCompleted of requestId: int * result: Result<GitRefreshResult, string>
-    | InitRepositoryRequested of remoteProjectName: string option
+    | InitRepositoryRequested
     | InitRepositoryCompleted of sessionId: int * result: Result<InitRepositoryOutcome, string>
     | SelectChangeRequested of GitSidebarChange * Reply<unit>
     | SelectChangeCompleted of
@@ -238,13 +237,11 @@ type GitDependencies = {
     loadMergeConflictPage: string -> JS.Promise<Result<PageState, string>>
     initGitRepository: string -> JS.Promise<Result<string, string>>
     renameOpenArcRoot: string -> JS.Promise<Result<string, string>>
-    createDataHubProject: string -> JS.Promise<Result<ExploreProjectDto, string>>
     installGitLfs: unit -> JS.Promise<Result<GitOperationResult, string>>
     previewGitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitPullPreflightResult, string>>
     gitFetch: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPush: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
-    gitAddRemote: GitRemoteConfigRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitCloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, string>>
     createBranch: GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
     checkoutBranch: GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
@@ -537,39 +534,12 @@ let private refreshAllAsync (deps: GitDependencies) = promise {
     }
 }
 
-let private runInitRepositoryAsync (deps: GitDependencies) (arcPath: string) (remoteProjectName: string option) = promise {
+let private runInitRepositoryAsync (deps: GitDependencies) (arcPath: string) = promise {
     let! initResult = deps.initGitRepository arcPath
 
     match initResult with
     | Error message -> return Error message
-    | Ok _ ->
-        match
-            remoteProjectName
-            |> Option.map _.Trim()
-            |> Option.filter (String.IsNullOrWhiteSpace >> not)
-        with
-        | None -> return Ok { WarningMessage = None }
-        | Some projectName ->
-            let! projectResult = deps.createDataHubProject projectName
-
-            match projectResult with
-            | Error message -> return Ok { WarningMessage = Some message }
-            | Ok project ->
-                let! addRemoteResult =
-                    deps.gitAddRemote {
-                        RemoteName = "origin"
-                        RemoteUrl = project.http_url_to_repo
-                    }
-
-                match addRemoteResult with
-                | Error message -> return Ok { WarningMessage = Some message }
-                | Ok operationResult when operationResult.Success -> return Ok { WarningMessage = None }
-                | Ok operationResult ->
-                    return
-                        Ok {
-                            WarningMessage =
-                                Some(operationResult.Message |> Option.defaultValue "Adding origin remote failed.")
-                        }
+    | Ok _ -> return Ok { WarningMessage = None }
 }
 
 let private loadPageAsync (deps: GitDependencies) (path: string) (isConflicted: bool) = promise {
@@ -1097,8 +1067,8 @@ let update
                 Cmd.none
 
         nextModel, cmd
-    | InitRepositoryRequested _ when model.CurrentArcPath.IsNone -> model, Cmd.none
-    | InitRepositoryRequested remoteProjectName ->
+    | InitRepositoryRequested when model.CurrentArcPath.IsNone -> model, Cmd.none
+    | InitRepositoryRequested ->
         let nextModel =
             model
             |> withBusyOperation (Some GitBusyOperation.InitializingRepository)
@@ -1110,8 +1080,8 @@ let update
 
         let cmd =
             Cmd.OfPromise.either
-                (fun (deps, arcPath, remoteProjectName) -> runInitRepositoryAsync deps arcPath remoteProjectName)
-                (deps, Option.get model.CurrentArcPath, remoteProjectName)
+                (fun (deps, arcPath) -> runInitRepositoryAsync deps arcPath)
+                (deps, Option.get model.CurrentArcPath)
                 (fun result -> InitRepositoryCompleted(model.ArcSessionId, result))
                 (fun err -> InitRepositoryCompleted(model.ArcSessionId, Error(string err)))
 

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -145,6 +145,10 @@ module MainToRendererIpc =
         gitProgressUpdate: GitProgressDto -> unit
     }
 
+    type IGitRepositoryRendererApi = {
+        gitRepositoryInitialized: string -> unit
+    }
+
     type IGitLfsProgressRendererApi = {
         gitLfsProgressUpdate: GitLfsProgressDto -> unit
     }

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -21,6 +21,11 @@ module IPCTypesHelper =
 
 open IPCTypesHelper
 
+type CreateArcRequest = {
+    identifier: string
+    initGit: bool
+}
+
 /// Two Way Bridge: Renderer <-> Main
 type IArcVaultsApi = {
     /// Open ARC via folder dialog. Main decides: current window / new window / focus existing.
@@ -28,7 +33,7 @@ type IArcVaultsApi = {
     /// Open ARC at a known path (e.g. recent-ARC click). Main decides disposition.
     openARCByPath: string -> JS.Promise<Result<string, exn>>
     /// Create ARC via folder dialog. Main decides disposition.
-    createARC: string -> JS.Promise<Result<string, exn>>
+    createARC: CreateArcRequest -> JS.Promise<Result<string, exn>>
     /// Ensure ARC notes scaffolding exists for the ARCVault root path.
     ensureNotesFolder: unit -> JS.Promise<Result<unit, exn>>
     closeARC: unit -> JS.Promise<Result<unit, exn>>

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -21,10 +21,7 @@ module IPCTypesHelper =
 
 open IPCTypesHelper
 
-type CreateArcRequest = {
-    identifier: string
-    initGit: bool
-}
+type CreateArcRequest = { identifier: string; initGit: bool }
 
 /// Two Way Bridge: Renderer <-> Main
 type IArcVaultsApi = {

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -883,7 +883,14 @@ Vitest.describe (
                             baseStatus.Current
                             |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
 
-                        let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
+                        let! _ =
+                            context.Git.raw [|
+                                "init"
+                                "--bare"
+                                $"--initial-branch={baseBranch}"
+                                remotePath
+                            |]
+
                         do! configureLocalRemoteRewrite context.Git remotePath
                         let! _ = context.Git.raw [| "remote"; "add"; "origin"; testRemoteUrl |]
                         let! _ = context.Git.raw [| "push"; "-u"; "origin"; baseBranch |]
@@ -934,7 +941,14 @@ Vitest.describe (
                             baseStatus.Current
                             |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
 
-                        let! _ = context.Git.raw [| "init"; "--bare"; remotePath |]
+                        let! _ =
+                            context.Git.raw [|
+                                "init"
+                                "--bare"
+                                $"--initial-branch={baseBranch}"
+                                remotePath
+                            |]
+
                         do! configureLocalRemoteRewrite context.Git remotePath
                         let! _ = context.Git.raw [| "remote"; "add"; "origin"; testRemoteUrl |]
                         let! _ = context.Git.raw [| "push"; "-u"; "origin"; baseBranch |]

--- a/tests/Electron.Core/IpcArchitectureReview.test.fs
+++ b/tests/Electron.Core/IpcArchitectureReview.test.fs
@@ -214,6 +214,26 @@ Vitest.describe (
                     })
         )
 
+        Vitest.test (
+            "ArcOpenDisposition exposes the returned created ARC path",
+            fun () ->
+                Vitest
+                    .expect((ArcOpenDisposition.CreatedInCurrent "C:/picked/ReturnedArc").CreatedArcPath)
+                    .toEqual (Some "C:/picked/ReturnedArc")
+
+                Vitest
+                    .expect((ArcOpenDisposition.CreatedInNewWindow "C:/picked/ReturnedArc").CreatedArcPath)
+                    .toEqual (Some "C:/picked/ReturnedArc")
+        )
+
+        Vitest.test (
+            "ArcOpenDisposition omits created ARC path for non-create outcomes",
+            fun () ->
+                Vitest.expect((ArcOpenDisposition.FocusedExisting "C:/existing/Arc").CreatedArcPath).toEqual (None)
+                Vitest.expect((ArcOpenDisposition.OpenedInCurrent "C:/opened/Arc").CreatedArcPath).toEqual (None)
+                Vitest.expect((ArcOpenDisposition.OpenedInNewWindow "C:/opened/Arc").CreatedArcPath).toEqual (None)
+        )
+
 )
 
 Vitest.describe (

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -268,13 +268,11 @@ let private defaultDependencies: GitDependencies = {
     loadMergeConflictPage = fun path -> unexpectedPromise $"loadMergeConflictPage:{path}"
     initGitRepository = fun path -> unexpectedPromise $"initGitRepository:{path}"
     renameOpenArcRoot = fun name -> unexpectedPromise $"renameOpenArcRoot:{name}"
-    createDataHubProject = fun name -> unexpectedPromise $"createDataHubProject:{name}"
     installGitLfs = fun () -> unexpectedPromise "installGitLfs"
     previewGitPull = fun _ -> unexpectedPromise "previewGitPull"
     gitFetch = fun _ -> unexpectedPromise "gitFetch"
     gitPull = fun _ -> unexpectedPromise "gitPull"
     gitPush = fun _ -> unexpectedPromise "gitPush"
-    gitAddRemote = fun _ -> unexpectedPromise "gitAddRemote"
     gitCloneRepository = fun _ -> unexpectedPromise "gitCloneRepository"
     createBranch = fun _ -> unexpectedPromise "createBranch"
     checkoutBranch = fun _ -> unexpectedPromise "checkoutBranch"
@@ -915,7 +913,7 @@ Vitest.describe (
                 }
 
                 let requestedState, requestCmd =
-                    update deps ignore (InitRepositoryRequested None) state
+                    update deps ignore InitRepositoryRequested state
 
                 let! requestMessages = collectMessages requestCmd
 
@@ -933,143 +931,6 @@ Vitest.describe (
                 match finishMessages with
                 | [| RefreshRequested |] -> ()
                 | _ -> failwith "Expected init-repository success to trigger RefreshRequested."
-            }
-        )
-
-        Vitest.test (
-            "InitRepositoryRequested can create a DataHub project and add origin before refreshing",
-            fun () -> promise {
-                let mutable addedRemote = None
-
-                let deps = {
-                    defaultDependencies with
-                        initGitRepository = fun path -> promise { return Ok path }
-                        createDataHubProject =
-                            fun projectName -> promise {
-                                return
-                                    Ok {
-                                        id = 42
-                                        name = projectName
-                                        path_with_namespace = $"caroott/{projectName}"
-                                        name_with_namespace = $"caroott / {projectName}"
-                                        description = None
-                                        web_url = $"https://git.nfdi4plants.org/caroott/{projectName}"
-                                        http_url_to_repo = $"https://git.nfdi4plants.org/caroott/{projectName}.git"
-                                        ssh_url_to_repo = None
-                                        avatar_url = None
-                                        visibility = Some "private"
-                                        star_count = 0
-                                        created_at = None
-                                        last_activity_at = None
-                                        tag_list = [||]
-                                        ``namespace`` = {
-                                            id = 1
-                                            name = "caroott"
-                                            kind = "user"
-                                            full_path = "caroott"
-                                        }
-                                    }
-                            }
-                        gitAddRemote =
-                            fun request -> promise {
-                                addedRemote <- Some request
-                                return Ok okOperationResult
-                            }
-                }
-
-                let state = {
-                    GitState.Empty with
-                        CurrentArcPath = Some "C:/arc-a"
-                        RepositoryAvailability = GitRepositoryAvailability.MissingRepository
-                }
-
-                let requestedState, requestCmd =
-                    update deps ignore (InitRepositoryRequested(Some "arc-a")) state
-
-                let! requestMessages = collectMessages requestCmd
-
-                let nextState, finishCmd =
-                    match requestMessages with
-                    | [| InitRepositoryCompleted(sessionId, Ok _) |] when sessionId = state.ArcSessionId ->
-                        update deps ignore requestMessages[0] requestedState
-                    | _ -> failwith "Expected a successful init-and-remote bootstrap completion."
-
-                let! finishMessages = collectMessages finishCmd
-
-                Vitest
-                    .expect(addedRemote)
-                    .toEqual (
-                        Some {
-                            RemoteName = "origin"
-                            RemoteUrl = "https://git.nfdi4plants.org/caroott/arc-a.git"
-                        }
-                    )
-
-                Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
-
-                match finishMessages with
-                | [| RefreshRequested |] -> ()
-                | _ -> failwith "Expected remote bootstrap success to trigger RefreshRequested."
-            }
-        )
-
-        Vitest.test (
-            "InitRepositoryRequested recovers to a ready local repository when DataHub bootstrap fails after git init",
-            fun () -> promise {
-                let warningMessage = "DataHub project creation failed."
-
-                let deps = {
-                    defaultDependencies with
-                        initGitRepository = fun path -> promise { return Ok path }
-                        createDataHubProject = fun _ -> promise { return Error warningMessage }
-                        getGitStatus = fun () -> promise { return Ok cleanStatus }
-                        getGitBranches = fun () -> promise { return Ok [| localBranch "main" true true |] }
-                        getGitLfsSettings = fun () -> promise { return Ok(lfsSettings 1 false) }
-                }
-
-                let state = {
-                    GitState.Empty with
-                        CurrentArcPath = Some "C:/arc-a"
-                        RepositoryAvailability = GitRepositoryAvailability.MissingRepository
-                }
-
-                let requestedState, requestCmd =
-                    update deps ignore (InitRepositoryRequested(Some "arc-a")) state
-
-                let! requestMessages = collectMessages requestCmd
-
-                let nextState, finishCmd =
-                    match requestMessages with
-                    | [| (InitRepositoryCompleted _ as message) |] -> update deps ignore message requestedState
-                    | _ -> failwith "Expected init-repository completion."
-
-                let! finishMessages = collectMessages finishCmd
-
-                Vitest.expect(nextState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
-                Vitest.expect(nextState.BusyOperation).toEqual (None)
-
-                let afterRefreshRequestedState, refreshRequestCmd =
-                    match finishMessages with
-                    | [| RefreshRequested |] -> update deps ignore RefreshRequested nextState
-                    | _ -> failwith "Expected partial init success to trigger RefreshRequested."
-
-                let! refreshMessages = collectMessages refreshRequestCmd
-
-                let finalState, finalCmd =
-                    match refreshMessages with
-                    | [| RefreshCompleted(_, Ok refreshResult) |] ->
-                        update deps ignore refreshMessages[0] afterRefreshRequestedState
-                    | _ -> failwith "Expected queued refresh completion."
-
-                let! finalMessages = collectMessages finalCmd
-
-                Vitest.expect(finalState.RepositoryAvailability).toEqual (GitRepositoryAvailability.Ready)
-                Vitest.expect(finalState.WarningNotice).toEqual (Some warningMessage)
-                Vitest.expect(finalMessages).toEqual ([||])
-
-                match finishMessages with
-                | [| RefreshRequested |] -> ()
-                | _ -> failwith "Expected partial init success to trigger RefreshRequested."
             }
         )
 

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -912,8 +912,7 @@ Vitest.describe (
                         RepositoryAvailability = GitRepositoryAvailability.MissingRepository
                 }
 
-                let requestedState, requestCmd =
-                    update deps ignore InitRepositoryRequested state
+                let requestedState, requestCmd = update deps ignore InitRepositoryRequested state
 
                 let! requestMessages = collectMessages requestCmd
 


### PR DESCRIPTION
Three interconnected changes to the Git sidebar initialization flow and ARC creation:

1. **Remove the direct-publish-through-namefield option from the Git sidebar init screen**
2. **Add a default-checked "Initialize Git Repository" checkbox to ARC creation**
3. **Set the default branch name to `main` instead of `master` on `git init`**

---

## Details

### 1. Remove old repo initialization path (`bb818be6`)

**Files:** `GitSidebarPanel.fs`, `GitWorkflow.fs`, `GitStateContext.fs`, `GitWorkflow.test.fs`

Removed the "DataHub repository name" text field from the missing-repository state in the Git sidebar. Previously, entering a name would create a DataHub project and set it as `origin` remote during init. This was a separate feature from the publish-on-push flow (which remains untouched).

- Removed `remoteProjectName` state hook, `normalizedRemoteProjectName` computation, and the `extraContent` UI block (text input + help text + `?infoText`)
- Changed `InitRepositoryRequested of remoteProjectName: string option` to parameterless `InitRepositoryRequested`
- Removed `createDataHubProject` and `gitAddRemote` from `GitDependencies`
- Simplified `runInitRepositoryAsync` to only do local `git init` — no DataHub project creation or remote setup
- Removed unused `open Swate.Components.Api.GitLabApi` (the publish-on-push flow calls `GitLabApi.CreateProject` directly in the main process, not through this dependency chain)
- Updated `GitStateController.initRepository` from `string option -> unit` to `unit -> unit`
- Removed two obsolete tests and updated the remaining init test

### 2. Add init git by default to ARC creation (`83162f41`)

**Files:** `InitState.fs`, `ArcVaultHelper.fs`, `IPCTypes.fs`, `IArcVaultsApi.fs`, `ArcVault.fs`

Added a checkbox "Initialize Git Repository" (checked by default) to the ARC creation modal. When checked, the new ARC gets a git repository initialized automatically — using the same `git init` flow as the sidebar. The modal is shared between the init-state page and the navbar selector, so both entry points benefit.

**IPC contract change:** `createARC` now accepts a `CreateArcRequest` record with `identifier: string` and `initGit: bool` instead of a plain string. This threads the flag through the main process call chain (`CreateOrFocusArc` → `RegisterVaultWithNewArc` / `CreateARC`).

### 3. Rename master to main on git init (`023503ba`)

**File:** `GitProvisioningService.fs`

Changed `git.init()` to `git.init (U2.Case1 [| "--initial-branch=main" |])`. Compatible with git >= 2.28.