### PR TITLE
Feature/git visual feedback

### DIFF
--- a/src/Components/src/Page/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.fs
@@ -303,7 +303,7 @@ type GitSidebar =
                                                         prop.style [
                                                             style.width (length.percent value)
                                                             style.custom (
-                                                                "background-color",
+                                                                "backgroundColor",
                                                                 "var(--color-base-content)"
                                                             )
                                                         ]

--- a/src/Components/src/Page/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.fs
@@ -293,12 +293,22 @@ type GitSidebar =
 
                                         match progressValue with
                                         | Some value ->
-                                            Html.progress [
+                                            Html.div [
                                                 prop.testId "GitSidebarProgressBar"
-                                                prop.className "swt:progress swt:progress-info swt:h-1.5 swt:w-full"
-                                                prop.value value
-                                                prop.max 100
-                                                prop.ariaLabel "Git operation progress"
+                                                prop.className "swt:h-1.5 swt:w-full swt:rounded-full swt:bg-base-300"
+                                                prop.children [
+                                                    Html.div [
+                                                        prop.className
+                                                            "swt:h-full swt:rounded-full swt:transition-all swt:duration-300"
+                                                        prop.style [
+                                                            style.width (length.percent value)
+                                                            style.custom (
+                                                                "background-color",
+                                                                "var(--color-base-content)"
+                                                            )
+                                                        ]
+                                                    ]
+                                                ]
                                             ]
                                         | None -> Html.none
                                     ]

--- a/src/Components/src/Page/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.fs
@@ -111,6 +111,11 @@ module private GitSidebarInternal =
         |> List.choose id
         |> String.concat " | "
 
+    let progressOutput (progress: GitSidebarProgress) =
+        progress.Output
+        |> Option.bind Option.ofObj
+        |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
     let formatThresholdInput (thresholdMb: int) = string thresholdMb
 
     let tryRangeBetween (orderedPaths: string[]) (anchorPath: string) (clickedPath: string) =
@@ -265,6 +270,7 @@ type GitSidebar =
             match runStatus with
             | GitSidebarRunStatus.Progress progress ->
                 let progressValue = GitSidebarInternal.progressPercentValue progress
+                let progressOutput = GitSidebarInternal.progressOutput progress
 
                 Html.div [
                     prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
@@ -307,6 +313,26 @@ type GitSidebar =
                                                                 "var(--color-base-content)"
                                                             )
                                                         ]
+                                                    ]
+                                                ]
+                                            ]
+                                        | None -> Html.none
+
+                                        match progressOutput with
+                                        | Some output ->
+                                            Html.details [
+                                                prop.testId "GitSidebarProgressOutput"
+                                                prop.className "swt:min-w-0"
+                                                prop.children [
+                                                    Html.summary [
+                                                        prop.className
+                                                            "swt:cursor-pointer swt:select-none swt:text-xs swt:font-medium"
+                                                        prop.text "Git output"
+                                                    ]
+                                                    Html.pre [
+                                                        prop.className
+                                                            "swt:mt-2 swt:max-h-36 swt:overflow-auto swt:whitespace-pre-wrap swt:break-words swt:rounded swt:border swt:border-base-300 swt:bg-base-100 swt:p-2 swt:font-mono swt:text-xs"
+                                                        prop.text output
                                                     ]
                                                 ]
                                             ]

--- a/src/Components/src/Page/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.fs
@@ -96,11 +96,17 @@ module private GitSidebarInternal =
         | GitSidebarBranchKind.Local -> "Local"
         | GitSidebarBranchKind.Remote -> "Remote"
 
+    let progressPercentValue (progress: GitSidebarProgress) =
+        progress.ProgressPercent
+        |> Option.map (fun value -> value |> max 0.0 |> min 100.0)
+
     let progressText (progress: GitSidebarProgress) =
         [
             progress.Method
             progress.Stage
-            progress.ProgressPercent |> Option.map (fun value -> $"{Math.Round(value)}%%")
+            progress
+            |> progressPercentValue
+            |> Option.map (fun value -> $"{Math.Round(value)}%%")
         ]
         |> List.choose id
         |> String.concat " | "
@@ -258,6 +264,8 @@ type GitSidebar =
         React.Fragment [
             match runStatus with
             | GitSidebarRunStatus.Progress progress ->
+                let progressValue = GitSidebarInternal.progressPercentValue progress
+
                 Html.div [
                     prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                     prop.children [
@@ -268,17 +276,32 @@ type GitSidebar =
                                 "swt:alert swt:alert-info swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className
-                                        "swt:iconify swt:fluent--arrow-sync-24-regular swt:size-4 swt:shrink-0"
+                                    prop.className "swt:loading swt:loading-spinner swt:loading-xs swt:shrink-0"
                                 ]
-                                Html.span [
-                                    prop.className "swt:min-w-0 swt:wrap-anywhere"
-                                    prop.text (
-                                        GitSidebarInternal.progressText progress
-                                        |> function
-                                            | "" -> "Git operation in progress"
-                                            | text -> text
-                                    )
+                                Html.div [
+                                    prop.className "swt:flex swt:min-w-0 swt:flex-1 swt:flex-col swt:gap-2"
+                                    prop.children [
+                                        Html.span [
+                                            prop.className "swt:min-w-0 swt:wrap-anywhere"
+                                            prop.text (
+                                                GitSidebarInternal.progressText progress
+                                                |> function
+                                                    | "" -> "Git operation in progress"
+                                                    | text -> text
+                                            )
+                                        ]
+
+                                        match progressValue with
+                                        | Some value ->
+                                            Html.progress [
+                                                prop.testId "GitSidebarProgressBar"
+                                                prop.className "swt:progress swt:progress-info swt:h-1.5 swt:w-full"
+                                                prop.value value
+                                                prop.max 100
+                                                prop.ariaLabel "Git operation progress"
+                                            ]
+                                        | None -> Html.none
+                                    ]
                                 ]
                             ]
                         ]
@@ -295,7 +318,7 @@ type GitSidebar =
                                 "swt:alert swt:alert-info swt:min-w-0 swt:px-3 swt:py-2 swt:text-sm swt:@max-xs:px-2"
                             prop.children [
                                 Html.span [
-                                    prop.className "swt:iconify swt:fluent--clock-24-regular swt:size-4 swt:shrink-0"
+                                    prop.className "swt:loading swt:loading-spinner swt:loading-xs swt:shrink-0"
                                 ]
                                 Html.span [
                                     prop.className "swt:min-w-0 swt:wrap-anywhere"

--- a/src/Components/src/Page/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.fs
@@ -331,7 +331,7 @@ type GitSidebar =
                                                     ]
                                                     Html.pre [
                                                         prop.className
-                                                            "swt:mt-2 swt:max-h-36 swt:overflow-auto swt:whitespace-pre-wrap swt:break-words swt:rounded swt:border swt:border-base-300 swt:bg-base-100 swt:p-2 swt:font-mono swt:text-xs"
+                                                            "swt:mt-2 swt:max-h-36 swt:overflow-auto swt:whitespace-pre-wrap swt:break-words swt:rounded swt:border swt:border-base-content/30 swt:bg-base-content swt:p-2 swt:font-mono swt:text-xs swt:text-base-100"
                                                         prop.text output
                                                     ]
                                                 ]
@@ -609,6 +609,11 @@ type GitSidebar =
                     ]
                 ]
             ]
+        ]
+
+    [<ReactComponent>]
+    static member private BranchStatusDetails(props: BranchHeaderProps) =
+        React.Fragment [
             Html.div [
                 prop.className "swt:px-3 swt:pt-3 swt:@max-xs:px-2"
                 prop.children [
@@ -1949,24 +1954,34 @@ type GitSidebar =
                 )
             )
 
+        let branchHeaderProps = {
+            Status = status
+            HasConflicts = hasConflicts
+            IsBusy = isBusy
+            CanOpenRemoteRepository = canOpenRemoteRepository
+            OnOpenRemoteRepository = onOpenRemoteRepository
+            OnRefresh =
+                fun () ->
+                    setLocalError None
+                    onRefresh ()
+        }
+
         Html.div [
             prop.testId "GitSidebar"
             prop.className
                 "swt:@container/gitSidebar swt:flex swt:h-full swt:min-h-0 swt:min-w-0 swt:flex-col swt:overflow-x-hidden swt:bg-base-100"
             prop.children [
-                GitSidebar.BranchHeader(
-                    {
-                        Status = status
-                        HasConflicts = hasConflicts
-                        IsBusy = isBusy
-                        CanOpenRemoteRepository = canOpenRemoteRepository
-                        OnOpenRemoteRepository = onOpenRemoteRepository
-                        OnRefresh =
-                            fun () ->
-                                setLocalError None
-                                onRefresh ()
-                    }
+                GitSidebar.BranchHeader(branchHeaderProps)
+
+                GitSidebar.OperationStatusNotice(
+                    ?runStatus = Some runStatus,
+                    ?errorNotice = visibleError,
+                    ?warningNotice = warningNotice,
+                    busyTestId = "GitSidebarProgressNotice",
+                    errorTestId = "GitSidebarErrorNotice"
                 )
+
+                GitSidebar.BranchStatusDetails(branchHeaderProps)
 
                 GitSidebar.AdvancedActions(
                     {
@@ -2030,14 +2045,6 @@ type GitSidebar =
                         SubmitPrimarySave = submitPrimarySave
                         SubmitLocalCommit = submitLocalCommit
                     }
-                )
-
-                GitSidebar.OperationStatusNotice(
-                    ?runStatus = Some runStatus,
-                    ?errorNotice = visibleError,
-                    ?warningNotice = warningNotice,
-                    busyTestId = "GitSidebarProgressNotice",
-                    errorTestId = "GitSidebarErrorNotice"
                 )
 
                 if hasConflicts then

--- a/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
@@ -57,6 +57,7 @@ const buildProgressRunStatus = (progress: {
   Method?: string;
   Stage?: string;
   ProgressPercent?: number;
+  Output?: string;
 }) => ({
   // Fable DU: GitSidebarRunStatus.Progress
   tag: 2,
@@ -566,6 +567,7 @@ export const BusyProgressState: Story = {
       Method: "pull",
       Stage: "Receiving objects",
       ProgressPercent: 54,
+      Output: "remote: Enumerating objects: 18, done.\nremote: Counting objects: 100% (18/18), done.\n",
     }),
     callbacks: buildCallbacks(),
     downloadLargeFiles: true,
@@ -578,7 +580,13 @@ export const BusyProgressState: Story = {
     );
     await expect(canvas.getByTestId("GitSidebarProgressBar")).toBeInTheDocument();
     const fillBar = canvas.getByTestId("GitSidebarProgressBar").firstElementChild;
-    await expect(fillBar).toHaveStyle({ width: "54%" });
+    await expect(fillBar).toHaveAttribute("style", expect.stringContaining("width: 54%"));
+    const outputDetails = canvas.getByTestId("GitSidebarProgressOutput");
+    await expect(outputDetails).not.toHaveAttribute("open");
+    await expect(outputDetails).toHaveTextContent("Git output");
+    await expect(outputDetails).toHaveTextContent(
+      "remote: Enumerating objects: 18, done.",
+    );
   },
 };
 

--- a/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
@@ -54,9 +54,9 @@ const buildBusyRunStatus = (notice: string) => ({
 });
 
 const buildProgressRunStatus = (progress: {
-  Method: string;
-  Stage: string;
-  ProgressPercent: number;
+  Method?: string;
+  Stage?: string;
+  ProgressPercent?: number;
 }) => ({
   // Fable DU: GitSidebarRunStatus.Progress
   tag: 2,
@@ -576,6 +576,30 @@ export const BusyProgressState: Story = {
     await expect(canvas.getByTestId("GitSidebarProgressNotice")).toHaveTextContent(
       "pull | Receiving objects | 54%",
     );
+    await expect(canvas.getByTestId("GitSidebarProgressBar")).toHaveAttribute("value", "54");
+    await expect(canvas.getByTestId("GitSidebarProgressBar")).toHaveAttribute("max", "100");
+  },
+};
+
+export const ClonePhaseProgressState: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: changedFiles.slice(),
+    branchOptions: branchOptions.slice(),
+    runStatus: buildProgressRunStatus({
+      Method: "clone",
+      Stage: "Preparing clone",
+    }),
+    callbacks: buildCallbacks(),
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("GitSidebarProgressNotice")).toHaveTextContent(
+      "clone | Preparing clone",
+    );
+    await expect(canvas.queryByTestId("GitSidebarProgressBar")).not.toBeInTheDocument();
   },
 };
 

--- a/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
@@ -587,6 +587,20 @@ export const BusyProgressState: Story = {
     await expect(outputDetails).toHaveTextContent(
       "remote: Enumerating objects: 18, done.",
     );
+    const outputConsole = within(outputDetails).getByText(/remote: Enumerating objects/);
+    await expect(outputConsole).toHaveClass("swt:bg-base-content");
+    await expect(outputConsole).toHaveClass("swt:text-base-100");
+
+    const sourceControlTitle = canvas.getByText("Source Control");
+    const trackingInfo = canvas.getByText("Tracking origin/feature/git-sidebar");
+    expect(
+      sourceControlTitle.compareDocumentPosition(canvas.getByTestId("GitSidebarProgressNotice")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      canvas.getByTestId("GitSidebarProgressNotice").compareDocumentPosition(trackingInfo) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   },
 };
 

--- a/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
@@ -576,8 +576,9 @@ export const BusyProgressState: Story = {
     await expect(canvas.getByTestId("GitSidebarProgressNotice")).toHaveTextContent(
       "pull | Receiving objects | 54%",
     );
-    await expect(canvas.getByTestId("GitSidebarProgressBar")).toHaveAttribute("value", "54");
-    await expect(canvas.getByTestId("GitSidebarProgressBar")).toHaveAttribute("max", "100");
+    await expect(canvas.getByTestId("GitSidebarProgressBar")).toBeInTheDocument();
+    const fillBar = canvas.getByTestId("GitSidebarProgressBar").firstElementChild;
+    await expect(fillBar).toHaveStyle({ width: "54%" });
   },
 };
 

--- a/src/Components/src/Page/GitSidebar/Types.fs
+++ b/src/Components/src/Page/GitSidebar/Types.fs
@@ -37,6 +37,7 @@ type GitSidebarProgress = {
     Method: string option
     Stage: string option
     ProgressPercent: float option
+    Output: string option
 }
 
 [<RequireQualifiedAccess>]

--- a/src/Electron/src/Main/Git/GitInternals.fs
+++ b/src/Electron/src/Main/Git/GitInternals.fs
@@ -2,18 +2,20 @@ module Main.Git.GitInternals
 
 open System
 open Fable.Core
+open Fable.Core.JsInterop
 open Swate.Electron.Shared.GitTypes
 open Main.Bindings.SimpleGit
 open Main.Git.GitAuthAdapter
 
 type GitProgressCallback = GitProgressDto -> unit
 
-let internal createProgressDto methodName stage progress processed total : GitProgressDto = {
+let internal createProgressDto methodName stage progress processed total output : GitProgressDto = {
     Method = methodName
     Stage = stage
     Progress = progress
     Processed = processed
     Total = total
+    Output = output
 }
 
 let internal progressFromSimpleGit (progressEvent: SimpleGitProgressEvent) =
@@ -23,10 +25,44 @@ let internal progressFromSimpleGit (progressEvent: SimpleGitProgressEvent) =
         (Some progressEvent.progress)
         (Some progressEvent.processed)
         (Some progressEvent.total)
+        None
 
 let internal reportPhase (progressCallback: GitProgressCallback option) methodName stage =
     progressCallback
-    |> Option.iter (fun report -> createProgressDto (Some methodName) (Some stage) None None None |> report)
+    |> Option.iter (fun report -> createProgressDto (Some methodName) (Some stage) None None None None |> report)
+
+let internal reportOutputText (progressCallback: GitProgressCallback option) (text: string) =
+    progressCallback
+    |> Option.iter (fun report ->
+        let output = text |> Option.ofObj |> Option.defaultValue String.Empty |> redactToken
+
+        if not (String.IsNullOrEmpty output) then
+            createProgressDto None None None None None (Some output) |> report
+    )
+
+[<Emit("$0 != null && typeof $0.on === 'function'")>]
+let private hasStreamListener (_stream: obj) : bool = jsNative
+
+[<Emit("$0.outputHandler(function(command, stdout, stderr, args) { $1(command, stdout, stderr, args); })")>]
+let private attachOutputHandler (_git: ISimpleGit) (_handler: string -> obj -> obj -> string[] -> unit) : ISimpleGit =
+    jsNative
+
+let internal withGitOutputProgress (progressCallback: GitProgressCallback option) (git: ISimpleGit) =
+    match progressCallback with
+    | None -> git
+    | Some _ ->
+        attachOutputHandler
+            git
+            (fun (_command: string) (stdout: obj) (stderr: obj) (_args: string[]) ->
+                let handleChunk chunk =
+                    reportOutputText progressCallback (string chunk)
+
+                if hasStreamListener stdout then
+                    stdout?on ("data", handleChunk) |> ignore
+
+                if hasStreamListener stderr then
+                    stderr?on ("data", handleChunk) |> ignore
+            )
 
 // `internal` stays inside the Main assembly boundary (not accessible from shared/renderer projects).
 let internal unsafeOptions =

--- a/src/Electron/src/Main/Git/GitInternals.fs
+++ b/src/Electron/src/Main/Git/GitInternals.fs
@@ -1,11 +1,94 @@
 module Main.Git.GitInternals
 
 open System
+open System.Text.RegularExpressions
 open Fable.Core
+open Fable.Core.JsInterop
+open Swate.Electron.Shared.GitTypes
 open Main.Bindings.SimpleGit
 open Main.Git.GitAuthAdapter
 
-type GitProgressCallback = SimpleGitProgressEvent -> unit
+type GitProgressCallback = GitProgressDto -> unit
+
+let private gitLfsProgressPattern =
+    Regex(
+        @"^\s*(?<stage>[^:\r\n]+):\s*(?<percent>\d+(?:\.\d+)?)%\s+\((?<processed>\d+(?:\.\d+)?)/(?<total>\d+(?:\.\d+)?)\)",
+        RegexOptions.IgnoreCase
+    )
+
+let internal createProgressDto methodName stage progress processed total : GitProgressDto = {
+    Method = methodName
+    Stage = stage
+    Progress = progress
+    Processed = processed
+    Total = total
+}
+
+let private parseFloat (value: string) =
+    let parsed: float = emitJsExpr value "Number.parseFloat($0)"
+
+    if Double.IsNaN parsed then None else Some parsed
+
+let internal progressFromSimpleGit (progressEvent: SimpleGitProgressEvent) =
+    createProgressDto
+        (Some progressEvent.method)
+        (Some progressEvent.stage)
+        (Some progressEvent.progress)
+        (Some progressEvent.processed)
+        (Some progressEvent.total)
+
+let internal reportPhase (progressCallback: GitProgressCallback option) methodName stage =
+    progressCallback
+    |> Option.iter (fun report -> createProgressDto (Some methodName) (Some stage) None None None |> report)
+
+let internal tryParseGitLfsProgressMessage (message: string) =
+    let matchResult =
+        message
+        |> Option.ofObj
+        |> Option.defaultValue String.Empty
+        |> gitLfsProgressPattern.Match
+
+    if not matchResult.Success then
+        None
+    else
+        match
+            parseFloat matchResult.Groups["percent"].Value,
+            parseFloat matchResult.Groups["processed"].Value,
+            parseFloat matchResult.Groups["total"].Value
+        with
+        | Some progress, Some processed, Some total ->
+            Some(
+                createProgressDto
+                    (Some "lfs")
+                    (Some(matchResult.Groups["stage"].Value.Trim()))
+                    (Some progress)
+                    (Some processed)
+                    (Some total)
+            )
+        | _ -> None
+
+let internal reportGitLfsProgressText (progressCallback: GitProgressCallback option) (text: string) =
+    progressCallback
+    |> Option.iter (fun report ->
+        text
+        |> Option.ofObj
+        |> Option.defaultValue String.Empty
+        |> fun value -> value.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.choose tryParseGitLfsProgressMessage
+        |> Array.iter report
+    )
+
+let internal withGitLfsOutputProgress (progressCallback: GitProgressCallback option) (git: ISimpleGit) =
+    match progressCallback with
+    | None -> git
+    | Some _ ->
+        git.outputHandler (fun (_command: string) (stdout: obj) (stderr: obj) (_args: string[]) ->
+            let handleChunk chunk =
+                reportGitLfsProgressText progressCallback (string chunk)
+
+            stdout?on ("data", handleChunk) |> ignore
+            stderr?on ("data", handleChunk) |> ignore
+        )
 
 // `internal` stays inside the Main assembly boundary (not accessible from shared/renderer projects).
 let internal unsafeOptions =
@@ -19,7 +102,7 @@ let internal standardTimeout =
     SimpleGitTimeoutOptions(block = 30000, stdOut = true, stdErr = true)
 
 let internal syncTimeout =
-    SimpleGitTimeoutOptions(block = 120000, stdOut = false, stdErr = false)
+    SimpleGitTimeoutOptions(block = 120000, stdOut = true, stdErr = true)
 
 /// Creates the standard simple-git options used by Main Git services.
 /// maxConcurrentProcesses is intentionally one to serialize commands for a repository-scoped instance.
@@ -28,7 +111,21 @@ let internal createOptions
     (timeout: SimpleGitTimeoutOptions)
     (progressCallback: GitProgressCallback option)
     =
-    let options =
+    let progressHandler =
+        progressCallback
+        |> Option.map (fun progress -> progressFromSimpleGit >> progress)
+
+    match progressHandler with
+    | Some handler ->
+        SimpleGitOptions(
+            baseDir = baseDir,
+            binary = U3.Case1 "git",
+            maxConcurrentProcesses = 1,
+            timeout = timeout,
+            ``unsafe`` = unsafeOptions,
+            progress = handler
+        )
+    | None ->
         SimpleGitOptions(
             baseDir = baseDir,
             binary = U3.Case1 "git",
@@ -36,11 +133,6 @@ let internal createOptions
             timeout = timeout,
             ``unsafe`` = unsafeOptions
         )
-
-    progressCallback
-    |> Option.iter (fun progress -> options.progress <- Some progress)
-
-    options
 
 /// Creates a simple-git instance with non-interactive prompt suppression applied.
 let internal createGit (options: SimpleGitOptions) : ISimpleGit =

--- a/src/Electron/src/Main/Git/GitInternals.fs
+++ b/src/Electron/src/Main/Git/GitInternals.fs
@@ -1,20 +1,12 @@
 module Main.Git.GitInternals
 
 open System
-open System.Text.RegularExpressions
 open Fable.Core
-open Fable.Core.JsInterop
 open Swate.Electron.Shared.GitTypes
 open Main.Bindings.SimpleGit
 open Main.Git.GitAuthAdapter
 
 type GitProgressCallback = GitProgressDto -> unit
-
-let private gitLfsProgressPattern =
-    Regex(
-        @"^\s*(?<stage>[^:\r\n]+):\s*(?<percent>\d+(?:\.\d+)?)%\s+\((?<processed>\d+(?:\.\d+)?)/(?<total>\d+(?:\.\d+)?)\)",
-        RegexOptions.IgnoreCase
-    )
 
 let internal createProgressDto methodName stage progress processed total : GitProgressDto = {
     Method = methodName
@@ -23,11 +15,6 @@ let internal createProgressDto methodName stage progress processed total : GitPr
     Processed = processed
     Total = total
 }
-
-let private parseFloat (value: string) =
-    let parsed: float = emitJsExpr value "Number.parseFloat($0)"
-
-    if Double.IsNaN parsed then None else Some parsed
 
 let internal progressFromSimpleGit (progressEvent: SimpleGitProgressEvent) =
     createProgressDto
@@ -40,55 +27,6 @@ let internal progressFromSimpleGit (progressEvent: SimpleGitProgressEvent) =
 let internal reportPhase (progressCallback: GitProgressCallback option) methodName stage =
     progressCallback
     |> Option.iter (fun report -> createProgressDto (Some methodName) (Some stage) None None None |> report)
-
-let internal tryParseGitLfsProgressMessage (message: string) =
-    let matchResult =
-        message
-        |> Option.ofObj
-        |> Option.defaultValue String.Empty
-        |> gitLfsProgressPattern.Match
-
-    if not matchResult.Success then
-        None
-    else
-        match
-            parseFloat matchResult.Groups["percent"].Value,
-            parseFloat matchResult.Groups["processed"].Value,
-            parseFloat matchResult.Groups["total"].Value
-        with
-        | Some progress, Some processed, Some total ->
-            Some(
-                createProgressDto
-                    (Some "lfs")
-                    (Some(matchResult.Groups["stage"].Value.Trim()))
-                    (Some progress)
-                    (Some processed)
-                    (Some total)
-            )
-        | _ -> None
-
-let internal reportGitLfsProgressText (progressCallback: GitProgressCallback option) (text: string) =
-    progressCallback
-    |> Option.iter (fun report ->
-        text
-        |> Option.ofObj
-        |> Option.defaultValue String.Empty
-        |> fun value -> value.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
-        |> Array.choose tryParseGitLfsProgressMessage
-        |> Array.iter report
-    )
-
-let internal withGitLfsOutputProgress (progressCallback: GitProgressCallback option) (git: ISimpleGit) =
-    match progressCallback with
-    | None -> git
-    | Some _ ->
-        git.outputHandler (fun (_command: string) (stdout: obj) (stderr: obj) (_args: string[]) ->
-            let handleChunk chunk =
-                reportGitLfsProgressText progressCallback (string chunk)
-
-            stdout?on ("data", handleChunk) |> ignore
-            stderr?on ("data", handleChunk) |> ignore
-        )
 
 // `internal` stays inside the Main assembly boundary (not accessible from shared/renderer projects).
 let internal unsafeOptions =

--- a/src/Electron/src/Main/Git/GitProvisioningService.fs
+++ b/src/Electron/src/Main/Git/GitProvisioningService.fs
@@ -410,14 +410,21 @@ let cloneRepository
                                                                 | Some token ->
                                                                     Ok(
                                                                         applyAuth
-                                                                            createGit
+                                                                            (fun options ->
+                                                                                createGit options
+                                                                                |> withGitOutputProgress progress
+                                                                            )
                                                                             repoOptions
                                                                             host
                                                                             token
                                                                             (Some "origin")
                                                                             (Some safeRemoteUrl)
                                                                     )
-                                                                | None -> Ok(createGit repoOptions)
+                                                                | None ->
+                                                                    Ok(
+                                                                        createGit repoOptions
+                                                                        |> withGitOutputProgress progress
+                                                                    )
                                                             with authError ->
                                                                 Error authError
 
@@ -450,7 +457,10 @@ let cloneRepository
                                                         try
                                                             Ok(
                                                                 applyAuth
-                                                                    createGit
+                                                                    (fun options ->
+                                                                        createGit options
+                                                                        |> withGitOutputProgress progress
+                                                                    )
                                                                     cloneOptions
                                                                     host
                                                                     token
@@ -479,7 +489,9 @@ let cloneRepository
                                                                 hydrateIfRequested (Some token) authenticatedCloneResult
                                                 | None ->
                                                     let unauthenticatedGit =
-                                                        createGit cloneOptions |> applyCloneSkipSmudge
+                                                        createGit cloneOptions
+                                                        |> withGitOutputProgress progress
+                                                        |> applyCloneSkipSmudge
 
                                                     GitInternals.reportPhase progress "clone" "Cloning repository"
 

--- a/src/Electron/src/Main/Git/GitProvisioningService.fs
+++ b/src/Electron/src/Main/Git/GitProvisioningService.fs
@@ -137,8 +137,6 @@ let private runSimpleGit
     : JS.Promise<GitService.GitResult<'T>> =
     GitInternals.runSimpleGit toFailure operation git
 
-let tryParseGitLfsProgressMessage = GitInternals.tryParseGitLfsProgressMessage
-
 let private resolveAbsolutePath (pathValue: string) = resolve [| pathValue |]
 
 let private dirname (pathValue: string) = Main.Bindings.Path.dirname pathValue
@@ -431,10 +429,7 @@ let cloneRepository
                                                                 "lfs"
                                                                 "Downloading Git LFS files"
 
-                                                            let! hydrateResult =
-                                                                hydrateGit
-                                                                |> GitInternals.withGitLfsOutputProgress progress
-                                                                |> hydrateClonedLfsContent
+                                                            let! hydrateResult = hydrateClonedLfsContent hydrateGit
 
                                                             match hydrateResult with
                                                             | Ok() -> return cloneResult

--- a/src/Electron/src/Main/Git/GitProvisioningService.fs
+++ b/src/Electron/src/Main/Git/GitProvisioningService.fs
@@ -137,6 +137,8 @@ let private runSimpleGit
     : JS.Promise<GitService.GitResult<'T>> =
     GitInternals.runSimpleGit toFailure operation git
 
+let tryParseGitLfsProgressMessage = GitInternals.tryParseGitLfsProgressMessage
+
 let private resolveAbsolutePath (pathValue: string) = resolve [| pathValue |]
 
 let private dirname (pathValue: string) = Main.Bindings.Path.dirname pathValue
@@ -304,6 +306,8 @@ let cloneRepository
     (progress: GitService.GitProgressCallback option)
     : JS.Promise<GitService.GitResult<string>> =
     promise {
+        GitInternals.reportPhase progress "clone" "Preparing clone"
+
         let remoteUrlCandidate =
             remoteUrl |> Option.ofObj |> Option.defaultValue String.Empty
 
@@ -380,6 +384,11 @@ let cloneRepository
                                                 match cloneResult with
                                                 | Error _ -> return cloneResult
                                                 | Ok _ ->
+                                                    GitInternals.reportPhase
+                                                        progress
+                                                        "clone"
+                                                        "Saving Git LFS preference"
+
                                                     let! persistResult =
                                                         persistCloneDownloadPreference
                                                             normalizedTargetPath
@@ -417,7 +426,15 @@ let cloneRepository
                                                         match hydrateGitResult with
                                                         | Error authError -> return errorResult authError
                                                         | Ok hydrateGit ->
-                                                            let! hydrateResult = hydrateClonedLfsContent hydrateGit
+                                                            GitInternals.reportPhase
+                                                                progress
+                                                                "lfs"
+                                                                "Downloading Git LFS files"
+
+                                                            let! hydrateResult =
+                                                                hydrateGit
+                                                                |> GitInternals.withGitLfsOutputProgress progress
+                                                                |> hydrateClonedLfsContent
 
                                                             match hydrateResult with
                                                             | Ok() -> return cloneResult
@@ -452,6 +469,7 @@ let cloneRepository
                                                     | Error authError -> return errorResult authError
                                                     | Ok authenticatedGit ->
                                                         let configuredGit = applyCloneSkipSmudge authenticatedGit
+                                                        GitInternals.reportPhase progress "clone" "Cloning repository"
 
                                                         let! authenticatedCloneResult =
                                                             cloneWithGit
@@ -467,6 +485,8 @@ let cloneRepository
                                                 | None ->
                                                     let unauthenticatedGit =
                                                         createGit cloneOptions |> applyCloneSkipSmudge
+
+                                                    GitInternals.reportPhase progress "clone" "Cloning repository"
 
                                                     let! unauthenticatedCloneResult =
                                                         cloneWithGit

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -953,17 +953,23 @@ let private applyLfsDownloadPreference (downloadLargeFiles: bool) (git: ISimpleG
         git.env (GitLfsSkipSmudgeEnvKey, "1")
 
 // GitService keeps explicit post-pull hydration here because it must reuse the authenticated git instance created for the pull workflow.
-let private hydratePulledLfsContent (git: ISimpleGit) : JS.Promise<GitResult<unit>> = promise {
-    let! result =
-        runSimpleGit
-            (fun currentGit -> promise {
-                let! _ = currentGit.raw [| "lfs"; "pull" |]
-                return ()
-            })
-            git
+let private hydratePulledLfsContent
+    (progressCallback: GitProgressCallback option)
+    (git: ISimpleGit)
+    : JS.Promise<GitResult<unit>> =
+    promise {
+        reportPhase progressCallback "lfs" "Downloading Git LFS files"
 
-    return result
-}
+        let! result =
+            runSimpleGit
+                (fun currentGit -> promise {
+                    let! _ = currentGit.raw [| "lfs"; "pull" |]
+                    return ()
+                })
+                (withGitLfsOutputProgress progressCallback git)
+
+        return result
+    }
 
 let private createPullHydrationFailure (failure: GitFailure) = {
     failure with
@@ -1697,7 +1703,7 @@ let pull
                                 ()
 
                             if downloadLargeFiles then
-                                let! lfsPullResult = hydratePulledLfsContent effectiveGit
+                                let! lfsPullResult = hydratePulledLfsContent progressCallback effectiveGit
 
                                 match lfsPullResult with
                                 | Ok() -> return { Warning = None }
@@ -1782,6 +1788,8 @@ let push
                                 executePushWorkflow
                                     pushTarget
                                     (fun () ->
+                                        reportPhase progressCallback "lfs" "Checking Git LFS objects"
+
                                         planOutboundPush
                                             runSimpleGit
                                             runGitCaptured
@@ -1795,6 +1803,8 @@ let push
                                             git
                                     )
                                     (fun objectIds -> promise {
+                                        reportPhase progressCallback "lfs" "Uploading Git LFS objects"
+
                                         let! uploadResult =
                                             GitLfsService.uploadObjects
                                                 runGitCaptured

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -966,7 +966,7 @@ let private hydratePulledLfsContent
                     let! _ = currentGit.raw [| "lfs"; "pull" |]
                     return ()
                 })
-                (withGitLfsOutputProgress progressCallback git)
+                git
 
         return result
     }

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -726,6 +726,16 @@ let private reconcileTrackingBranchForCheckout
 let private runSimpleGit (operation: ISimpleGit -> JS.Promise<'T>) (git: ISimpleGit) : JS.Promise<GitResult<'T>> =
     GitInternals.runSimpleGit toFailure operation git
 
+let private reportGitSpawnOutput progressCallback (result: GitSpawnResult) =
+    GitInternals.reportOutputText progressCallback result.StdoutText
+    GitInternals.reportOutputText progressCallback result.StderrText
+    result
+
+let private runGitCapturedWithOutput progressCallback request = promise {
+    let! result = runGitCaptured request
+    return reportGitSpawnOutput progressCallback result
+}
+
 // GitService reads the threshold because stage/commit need the value while deciding whether to enforce LFS automatically.
 let private getConfiguredLfsThresholdMb (git: ISimpleGit) : JS.Promise<int> = promise {
     try
@@ -985,7 +995,7 @@ let private createLocalGitSession arcPath progressCallback =
     let options = createOptions arcPath syncTimeout progressCallback
 
     {
-        Git = createGit options
+        Git = createGit options |> withGitOutputProgress progressCallback
         CommandAuth = {
             ConfigArgs = [||]
             Environment = createNonInteractiveEnv ()
@@ -1027,7 +1037,7 @@ let private createAuthenticatedGitSession
 
                             let git =
                                 applyAuth
-                                    createGit
+                                    (fun options -> createGit options |> withGitOutputProgress progressCallback)
                                     operationOptions
                                     host
                                     token
@@ -1098,16 +1108,24 @@ let private ensureRepo (git: ISimpleGit) = promise {
         return Error(exn "The selected ARC path is not a git repository.")
 }
 
-let private withLocalGit (arcPath: string) (operation: ISimpleGit -> JS.Promise<'T>) : JS.Promise<GitResult<'T>> = promise {
-    let options = createOptions arcPath standardTimeout None
-    let git = createGit options
+let private withLocalGitAndProgress
+    (arcPath: string)
+    (progressCallback: GitProgressCallback option)
+    (operation: ISimpleGit -> JS.Promise<'T>)
+    : JS.Promise<GitResult<'T>> =
+    promise {
+        let options = createOptions arcPath standardTimeout None
+        let git = createGit options |> withGitOutputProgress progressCallback
 
-    let! repoCheckResult = ensureRepo git
+        let! repoCheckResult = ensureRepo git
 
-    match repoCheckResult with
-    | Error repoError -> return errorResult repoError
-    | Ok() -> return! runSimpleGit operation git
-}
+        match repoCheckResult with
+        | Error repoError -> return errorResult repoError
+        | Ok() -> return! runSimpleGit operation git
+    }
+
+let private withLocalGit (arcPath: string) (operation: ISimpleGit -> JS.Promise<'T>) : JS.Promise<GitResult<'T>> =
+    withLocalGitAndProgress arcPath None operation
 
 type private RemoteUrlState =
     | RemoteMissing
@@ -1622,7 +1640,7 @@ let previewPull
                                             ()
 
                                         let! mergeTreeResult =
-                                            runGitCaptured {
+                                            runGitCapturedWithOutput progressCallback {
                                                 WorkingDirectory = Some arcPath
                                                 Arguments = [|
                                                     "merge-tree"
@@ -1772,6 +1790,7 @@ let push
                     | Error failure -> return Error failure
                     | Ok session ->
                         let git = session.Git
+                        let runGitCapturedForProgress = runGitCapturedWithOutput progressCallback
                         let! pushStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
 
                         match pushStatusResult with
@@ -1792,7 +1811,7 @@ let push
 
                                         planOutboundPush
                                             runSimpleGit
-                                            runGitCaptured
+                                            runGitCapturedForProgress
                                             toFailure
                                             (fun currentGit ->
                                                 runSimpleGit (fun gitInstance -> gitInstance.status ()) currentGit
@@ -1807,7 +1826,7 @@ let push
 
                                         let! uploadResult =
                                             GitLfsService.uploadObjects
-                                                runGitCaptured
+                                                runGitCapturedForProgress
                                                 session.CommandAuth
                                                 arcPath
                                                 safeRemoteName
@@ -1880,34 +1899,45 @@ let setLfsSettings (arcPath: string) (settings: GitLfsSettingsDto) : JS.Promise<
                 })
 }
 
-let pruneLfsCache (arcPath: string) : JS.Promise<GitResult<string>> = promise {
-    let! localValidationResult =
-        withLocalGit
-            arcPath
-            (fun git -> promise {
-                match! requireCleanWorkingTreeForLfsStorageAction "Cleaning the Git LFS cache" git with
-                | Error validationError -> return abortGitPromiseWith validationError
-                | Ok() ->
-                    match! rejectCustomLfsStorageForPrune git with
+let pruneLfsCacheWithProgress
+    (arcPath: string)
+    (progressCallback: GitProgressCallback option)
+    : JS.Promise<GitResult<string>> =
+    promise {
+        let! localValidationResult =
+            withLocalGitAndProgress
+                arcPath
+                progressCallback
+                (fun git -> promise {
+                    match! requireCleanWorkingTreeForLfsStorageAction "Cleaning the Git LFS cache" git with
                     | Error validationError -> return abortGitPromiseWith validationError
-                    | Ok() -> return ()
-            })
+                    | Ok() ->
+                        match! rejectCustomLfsStorageForPrune git with
+                        | Error validationError -> return abortGitPromiseWith validationError
+                        | Ok() -> return ()
+                })
 
-    match localValidationResult with
-    | Error failure -> return Error failure
-    | Ok() ->
-        let! gitResult = createOriginLfsRemoteGit arcPath None
-
-        match gitResult with
+        match localValidationResult with
         | Error failure -> return Error failure
-        | Ok git ->
-            let! result = runSimpleGit (fun currentGit -> currentGit.raw GitLfsService.storagePruneArgs) git
-            return result
-}
+        | Ok() ->
+            let! gitResult = createOriginLfsRemoteGit arcPath progressCallback
 
-let dedupLfsStorage (arcPath: string) : JS.Promise<GitResult<string>> =
-    withLocalGit
+            match gitResult with
+            | Error failure -> return Error failure
+            | Ok git ->
+                let! result = runSimpleGit (fun currentGit -> currentGit.raw GitLfsService.storagePruneArgs) git
+                return result
+    }
+
+let pruneLfsCache (arcPath: string) : JS.Promise<GitResult<string>> = pruneLfsCacheWithProgress arcPath None
+
+let dedupLfsStorageWithProgress
+    (arcPath: string)
+    (progressCallback: GitProgressCallback option)
+    : JS.Promise<GitResult<string>> =
+    withLocalGitAndProgress
         arcPath
+        progressCallback
         (fun git -> promise {
             match! requireCleanWorkingTreeForLfsStorageAction "Reducing Git LFS duplicate storage" git with
             | Error validationError -> return abortGitPromiseWith validationError
@@ -1915,6 +1945,9 @@ let dedupLfsStorage (arcPath: string) : JS.Promise<GitResult<string>> =
                 let! output = git.raw GitLfsService.storageDedupArgs
                 return output
         })
+
+let dedupLfsStorage (arcPath: string) : JS.Promise<GitResult<string>> =
+    dedupLfsStorageWithProgress arcPath None
 
 /// Stages validated pathspecs and auto-tracks oversized selected files in Git LFS before restaging.
 let stagePaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<unit>> = promise {

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -87,20 +87,19 @@ let private toGitPageLoadResultDto
         | Some unsupported -> Ok(GitPageLoadResultDto.Unsupported unsupported)
         | None -> Error(exn $"{operationName} failed ({failure.Kind}): {failure.Message}")
 
-let private createGitProgressReporter (vault: ArcVault) : GitService.GitProgressCallback =
+let private createGitProgressReporterForWindow (window: BrowserWindow) : GitService.GitProgressCallback =
     let rendererApi =
         Remoting.createIpc ()
-        |> Remoting.withWindow vault.window
+        |> Remoting.withWindow window
         |> Remoting.buildProxySender<IGitProgressRendererApi>
 
-    fun progressEvent ->
-        rendererApi.gitProgressUpdate {
-            Method = Some progressEvent.method
-            Stage = Some progressEvent.stage
-            Progress = Some progressEvent.progress
-            Processed = Some progressEvent.processed
-            Total = Some progressEvent.total
-        }
+    fun progress -> rendererApi.gitProgressUpdate progress
+
+let private createGitProgressReporter (vault: ArcVault) : GitService.GitProgressCallback =
+    createGitProgressReporterForWindow vault.window
+
+let tryCreateGitProgressReporterFromIpcEvent (event: IpcMainInvokeEvent) : GitService.GitProgressCallback option =
+    windowFromIpcEvent event |> Option.map createGitProgressReporterForWindow
 
 let api (event: IpcMainInvokeEvent) : IGitApi = {
     checkGitVersions = fun () -> checkGitVersions ()
@@ -289,9 +288,7 @@ let api (event: IpcMainInvokeEvent) : IGitApi = {
         }
     gitCloneRepository =
         fun (request: GitCloneRepositoryRequest) -> promise {
-            let progressReporter =
-                ARC_VAULTS.TryGetVault(windowIdFromIpcEvent event)
-                |> Option.map createGitProgressReporter
+            let progressReporter = tryCreateGitProgressReporterFromIpcEvent event
 
             let! result =
                 GitProvisioningService.cloneRepository

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -389,11 +389,13 @@ let api (event: IpcMainInvokeEvent) : IGitApi = {
             match tryGetVaultAndArcPath event with
             | Error error -> return Error error
             | Ok(vault, arcPath) ->
+                let progressReporter = createGitProgressReporter vault
+
                 return!
                     withBusyWriting
                         vault
                         (fun () -> promise {
-                            let! result = GitService.pruneLfsCache arcPath
+                            let! result = GitService.pruneLfsCacheWithProgress arcPath (Some progressReporter)
 
                             return
                                 toGitOperationResult (fun _ -> Some "Hidden Git LFS cache cleaned.") None None result
@@ -426,11 +428,13 @@ let api (event: IpcMainInvokeEvent) : IGitApi = {
             match tryGetVaultAndArcPath event with
             | Error error -> return Error error
             | Ok(vault, arcPath) ->
+                let progressReporter = createGitProgressReporter vault
+
                 return!
                     withBusyWriting
                         vault
                         (fun () -> promise {
-                            let! result = GitService.dedupLfsStorage arcPath
+                            let! result = GitService.dedupLfsStorageWithProgress arcPath (Some progressReporter)
 
                             return
                                 toGitOperationResult

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -539,6 +539,7 @@ let private withBusyOperation busyOperation model = {
     model with
         BusyOperation = busyOperation
         BusyNotice = busyOperation |> Option.bind busyNoticeFromOperation
+        CurrentProgress = None
 }
 
 let private startRefreshRequest requestId model = {
@@ -999,12 +1000,13 @@ let update
     : GitState * Cmd<Msg> =
     match msg with
     | ResetWorkflow -> GitState.Empty, Cmd.none
-    | SetCurrentProgress currentProgress ->
+    | SetCurrentProgress(Some progress) when model.BusyOperation.IsSome ->
         {
             model with
-                CurrentProgress = currentProgress
+                CurrentProgress = Some progress
         },
         Cmd.none
+    | SetCurrentProgress _ -> { model with CurrentProgress = None }, Cmd.none
     | ArcPathChanged arcPath when arcPath = model.CurrentArcPath -> model, Cmd.none
     | ArcPathChanged arcPath ->
         let nextModel = {

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -345,7 +345,32 @@ let mapProgress (progress: GitProgressDto) : GitSidebarProgress = {
     Method = progress.Method
     Stage = progress.Stage
     ProgressPercent = progress.Progress
+    Output = progress.Output
 }
+
+let private appendProgressOutput current incoming =
+    match current, incoming with
+    | None, None -> None
+    | Some output, None -> Some output
+    | None, Some output -> Some output
+    | Some currentOutput, Some incomingOutput -> Some(currentOutput + incomingOutput)
+
+let private mergeProgressUpdate (model: GitState) (incoming: GitSidebarProgress) =
+    let current =
+        model.CurrentProgress
+        |> Option.defaultValue {
+            Method = None
+            Stage = model.BusyNotice
+            ProgressPercent = None
+            Output = None
+        }
+
+    {
+        Method = incoming.Method |> Option.orElse current.Method
+        Stage = incoming.Stage |> Option.orElse current.Stage
+        ProgressPercent = incoming.ProgressPercent |> Option.orElse current.ProgressPercent
+        Output = appendProgressOutput current.Output incoming.Output
+    }
 
 let private hasMatchingOriginBranch (branchName: string) (model: GitState) =
     model.BranchOptions
@@ -1003,7 +1028,7 @@ let update
     | SetCurrentProgress(Some progress) when model.BusyOperation.IsSome ->
         {
             model with
-                CurrentProgress = Some progress
+                CurrentProgress = Some(mergeProgressUpdate model progress)
         },
         Cmd.none
     | SetCurrentProgress _ -> { model with CurrentProgress = None }, Cmd.none

--- a/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/GitTypes.fs
@@ -112,6 +112,7 @@ type GitProgressDto = {
     Progress: float option
     Processed: float option
     Total: float option
+    Output: string option
 }
 
 type GitRemoteOperationRequest = {

--- a/tests/Electron.Core/Electron.Core.Tests.fsproj
+++ b/tests/Electron.Core/Electron.Core.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="NoteSearchReader.test.fs" />
     <Compile Include="EnsureNotesFolder.test.fs" />
     <Compile Include="GitService.test.fs" />
+    <Compile Include="GitIpcProgress.test.fs" />
     <Compile Include="IpcArchitectureReview.test.fs" />
     <Compile Include="ArcFileSystemHelper.test.fs" />
     <Compile Include="RenamePathRules.test.fs" />

--- a/tests/Electron.Core/GitIpcProgress.test.fs
+++ b/tests/Electron.Core/GitIpcProgress.test.fs
@@ -1,0 +1,39 @@
+module ElectronCore.GitIpcProgressTests
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Electron
+open Vitest
+
+let private electronMock: obj = import "__electronMock" "electron"
+
+let private resetElectronMock () = electronMock?reset () |> ignore
+
+let private setBrowserWindowFromWebContents (handler: obj -> obj) =
+    electronMock?setBrowserWindowFromWebContents (handler) |> ignore
+
+let private ipcEventWithSenderId senderId : IpcMainInvokeEvent =
+    createObj [ "sender" ==> createObj [ "id" ==> senderId ] ]
+    |> unbox<IpcMainInvokeEvent>
+
+Vitest.describe (
+    "Git IPC progress reporters",
+    fun () ->
+        Vitest.afterEach (fun () -> resetElectronMock ())
+
+        Vitest.test (
+            "clone progress can target the invoking renderer window without a loaded ARC vault",
+            fun () ->
+                let expectedWindow = TestHelpers.testWindow ()
+
+                setBrowserWindowFromWebContents (fun webContents ->
+                    Vitest.expect(webContents?id).toBe (37)
+                    expectedWindow :> obj
+                )
+
+                let reporter =
+                    Main.IPC.IGitApi.tryCreateGitProgressReporterFromIpcEvent (ipcEventWithSenderId 37)
+
+                Vitest.expect(reporter.IsSome).toBe (true)
+        )
+)

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -751,6 +751,70 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "fetch reports raw git output through the progress callback",
+            gitServiceIntegrationTestOptions,
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let remotePath = join [| context.RootPath; "origin.git" |]
+                        let clonePath = join [| context.RootPath; "incoming" |]
+                        let repoFilePath = join [| context.RepoPath; "fetch-output.txt" |]
+                        let progressEvents = ResizeArray<GitProgressDto>()
+
+                        do! writeUtf8FileAsync repoFilePath "base\n"
+                        let! stageBase = GitService.stagePaths context.RepoPath [| "fetch-output.txt" |]
+                        expectOk "stage fetch-output base" stageBase |> ignore
+
+                        let! commitBase = GitService.commit context.RepoPath "test: fetch output base"
+                        expectOk "commit fetch-output base" commitBase |> ignore
+
+                        let! baseStatus =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status after fetch-output base commit")
+
+                        let baseBranch =
+                            baseStatus.Current
+                            |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
+
+                        let! _ =
+                            context.Git.raw [|
+                                "init"
+                                "--bare"
+                                $"--initial-branch={baseBranch}"
+                                remotePath
+                            |]
+
+                        do! configureLocalRemoteRewrite context.Git remotePath
+                        let! _ = context.Git.raw [| "remote"; "add"; "origin"; testRemoteUrl |]
+                        let! _ = context.Git.raw [| "push"; "-u"; "origin"; baseBranch |]
+
+                        let! _ = context.Git.raw [| "clone"; remotePath; clonePath |]
+                        let cloneGit = createSimpleGit clonePath
+                        do! configureRepositoryAsync cloneGit
+
+                        let cloneFilePath = join [| clonePath; "fetch-output.txt" |]
+                        do! writeUtf8FileAsync cloneFilePath "remote update\n"
+                        let! _ = cloneGit.raw [| "add"; "fetch-output.txt" |]
+                        let! _ = cloneGit.raw [| "commit"; "-m"; "test: remote fetch output" |]
+                        let! _ = cloneGit.raw [| "push"; "origin"; baseBranch |]
+
+                        do!
+                            withTestTokenProvider (fun () -> promise {
+                                let! fetchResult =
+                                    GitService.fetch context.RepoPath None None (Some progressEvents.Add)
+
+                                expectOk "fetch with progress output" fetchResult |> ignore
+                            })
+
+                        let rawOutput = progressEvents |> Seq.choose _.Output |> String.concat ""
+
+                        Vitest.expect(String.IsNullOrWhiteSpace rawOutput).toBe (false)
+                    })
+            }
+        )
+
+        Vitest.test (
             "push publishes a local repository by creating origin from the active DataHub account",
             gitServiceIntegrationTestOptions,
             fun () -> promise {

--- a/tests/Electron.Core/GitValidation.test.fs
+++ b/tests/Electron.Core/GitValidation.test.fs
@@ -655,22 +655,6 @@ Vitest.describe (
                         Vitest.expect(progressEvents[0].Progress).toEqual (None)
                     }
                 )
-
-                Vitest.test (
-                    "parses Git LFS download progress into the shared Git progress shape",
-                    fun () ->
-                        match
-                            GitProvisioningService.tryParseGitLfsProgressMessage
-                                "Downloading LFS objects: 42% (5/12), 128 MB | 2.0 MB/s"
-                        with
-                        | None -> failwith "Expected Git LFS progress to be parsed."
-                        | Some progress ->
-                            Vitest.expect(progress.Method).toEqual (Some "lfs")
-                            Vitest.expect(progress.Stage).toEqual (Some "Downloading LFS objects")
-                            Vitest.expect(progress.Progress).toEqual (Some 42.0)
-                            Vitest.expect(progress.Processed).toEqual (Some 5.0)
-                            Vitest.expect(progress.Total).toEqual (Some 12.0)
-                )
         )
 )
 

--- a/tests/Electron.Core/GitValidation.test.fs
+++ b/tests/Electron.Core/GitValidation.test.fs
@@ -634,6 +634,44 @@ Vitest.describe (
                         Vitest.expect(options).toEqual ([| "--branch"; "feature/clone-flow" |])
                 )
         )
+
+        Vitest.describe (
+            "clone progress events",
+            fun () ->
+                Vitest.test (
+                    "reports an initial clone phase before Git emits percentage progress",
+                    fun () -> promise {
+                        let progressEvents = ResizeArray<GitProgressDto>()
+
+                        let! result = GitProvisioningService.cloneRepository "" "" None false (Some progressEvents.Add)
+
+                        match result with
+                        | Ok _ -> failwith "Expected clone to fail for an invalid request."
+                        | Error _ -> ()
+
+                        Vitest.expect(progressEvents.Count).toBe (1)
+                        Vitest.expect(progressEvents[0].Method).toEqual (Some "clone")
+                        Vitest.expect(progressEvents[0].Stage).toEqual (Some "Preparing clone")
+                        Vitest.expect(progressEvents[0].Progress).toEqual (None)
+                    }
+                )
+
+                Vitest.test (
+                    "parses Git LFS download progress into the shared Git progress shape",
+                    fun () ->
+                        match
+                            GitProvisioningService.tryParseGitLfsProgressMessage
+                                "Downloading LFS objects: 42% (5/12), 128 MB | 2.0 MB/s"
+                        with
+                        | None -> failwith "Expected Git LFS progress to be parsed."
+                        | Some progress ->
+                            Vitest.expect(progress.Method).toEqual (Some "lfs")
+                            Vitest.expect(progress.Stage).toEqual (Some "Downloading LFS objects")
+                            Vitest.expect(progress.Progress).toEqual (Some 42.0)
+                            Vitest.expect(progress.Processed).toEqual (Some 5.0)
+                            Vitest.expect(progress.Total).toEqual (Some 12.0)
+                )
+        )
 )
 
 Vitest.describe (

--- a/tests/Electron.Core/electron.mock.mts
+++ b/tests/Electron.Core/electron.mock.mts
@@ -1,4 +1,14 @@
 const noop = () => {};
+let fromWebContentsMock: ((webContents: unknown) => unknown) | undefined;
+
+export const __electronMock = {
+    reset: () => {
+        fromWebContentsMock = undefined;
+    },
+    setBrowserWindowFromWebContents: (handler: (webContents: unknown) => unknown) => {
+        fromWebContentsMock = handler;
+    },
+};
 
 export const app = {
     getPath: () => {
@@ -23,7 +33,7 @@ export const safeStorage = {
 
 export class BrowserWindow {
     static getAllWindows = () => [];
-    static fromWebContents = () => undefined;
+    static fromWebContents = (webContents: unknown) => fromWebContentsMock?.(webContents);
 }
 
 export const contextBridge = { exposeInMainWorld: noop };

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -103,6 +103,14 @@ let private sidebarProgress stage percent = {
     Method = Some "git"
     Stage = Some stage
     ProgressPercent = Some percent
+    Output = None
+}
+
+let private sidebarOutput output = {
+    Method = None
+    Stage = None
+    ProgressPercent = None
+    Output = Some output
 }
 
 let private changedFile path indexStatus workingTreeStatus isConflicted = {
@@ -979,6 +987,35 @@ Vitest.describe (
 
                 Vitest.expect(nextState.CurrentProgress).toEqual (None)
                 Vitest.expect(currentRunStatus nextState).toEqual (None)
+                Vitest.expect(cmd).toEqual (Cmd.none)
+        )
+
+        Vitest.test (
+            "SetCurrentProgress appends Git output to the active progress notice",
+            fun () ->
+                let initialProgress = sidebarProgress "Receiving objects" 72.0
+
+                let initialState = {
+                    GitState.Empty with
+                        BusyOperation = Some GitBusyOperation.PullingFromRemote
+                        BusyNotice = Some "Pulling from remote"
+                        CurrentProgress = Some initialProgress
+                }
+
+                let nextState, cmd =
+                    update
+                        defaultDependencies
+                        ignore
+                        (SetCurrentProgress(Some(sidebarOutput "remote: counting objects\n")))
+                        initialState
+
+                let expectedProgress = {
+                    initialProgress with
+                        Output = Some "remote: counting objects\n"
+                }
+
+                Vitest.expect(nextState.CurrentProgress).toEqual (Some expectedProgress)
+                Vitest.expect(currentRunStatus nextState).toEqual (Some(GitSidebarRunStatus.Progress expectedProgress))
                 Vitest.expect(cmd).toEqual (Cmd.none)
         )
 

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -968,6 +968,69 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "SetCurrentProgress ignores late Git progress after the busy operation has finished",
+            fun () ->
+                let nextState, cmd =
+                    update
+                        defaultDependencies
+                        ignore
+                        (SetCurrentProgress(Some(sidebarProgress "Receiving objects" 72.0)))
+                        GitState.Empty
+
+                Vitest.expect(nextState.CurrentProgress).toEqual (None)
+                Vitest.expect(currentRunStatus nextState).toEqual (None)
+                Vitest.expect(cmd).toEqual (Cmd.none)
+        )
+
+        Vitest.test (
+            "WriteRequested clears stale transfer progress before showing the new operation notice",
+            fun () ->
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        CurrentProgress = Some(sidebarProgress "Receiving objects" 72.0)
+                }
+
+                let nextState, _cmd =
+                    update defaultDependencies ignore (WriteRequested WriteRequest.Push) initialState
+
+                Vitest.expect(nextState.CurrentProgress).toEqual (None)
+                Vitest.expect(currentRunStatus nextState).toEqual (Some(GitSidebarRunStatus.Busy "Pushing to remote"))
+        )
+
+        Vitest.test (
+            "UpdateFromOnline safe preflight clears fetch progress before scheduling the pull phase",
+            fun () -> promise {
+                let initialState = {
+                    GitState.Empty with
+                        CurrentArcPath = Some "C:/arc"
+                        BusyOperation = Some GitBusyOperation.FetchingFromRemote
+                        BusyNotice = Some "Fetching from remote"
+                        CurrentProgress = Some(sidebarProgress "Receiving objects" 88.0)
+                }
+
+                let nextState, cmd =
+                    update
+                        defaultDependencies
+                        ignore
+                        (UpdatePreflightCompleted(
+                            initialState.ArcSessionId,
+                            Ok {
+                                Status = GitPullPreflightStatus.SafeToPull
+                                Message = None
+                            }
+                        ))
+                        initialState
+
+                let! messages = collectMessages cmd
+
+                Vitest.expect(nextState.CurrentProgress).toEqual (None)
+                Vitest.expect(currentRunStatus nextState).toEqual (None)
+                Vitest.expect(messages).toEqual ([| WriteRequested WriteRequest.Pull |])
+            }
+        )
+
+        Vitest.test (
             "SaveDownloadLargeFilesRequested updates local state immediately when no ARC is loaded",
             fun () -> promise {
                 let state = {
@@ -1065,6 +1128,31 @@ Vitest.describe (
                 Vitest.expect(stateAfterRequest.BusyOperation).toEqual (Some GitBusyOperation.CloningRepository)
                 Vitest.expect(replyResult).toEqual (Some(Ok "C:/clone-target"))
             }
+        )
+
+        Vitest.test (
+            "clone progress updates the current run status while the start-page clone is busy",
+            fun () ->
+                let reply _ = ()
+
+                let request = {
+                    RemoteUrl = "https://example.org/repo.git"
+                    TargetPath = "C:/clone-target"
+                    Branch = None
+                    DownloadLargeFiles = false
+                }
+
+                let stateAfterRequest, _ =
+                    update defaultDependencies ignore (WriteRequested(Clone(request, reply))) GitState.Empty
+
+                let progress = sidebarProgress "Receiving objects" 48.0
+
+                let nextState, cmd =
+                    update defaultDependencies ignore (SetCurrentProgress(Some progress)) stateAfterRequest
+
+                Vitest.expect(nextState.CurrentProgress).toEqual (Some progress)
+                Vitest.expect(currentRunStatus nextState).toEqual (Some(GitSidebarRunStatus.Progress progress))
+                Vitest.expect(cmd).toEqual (Cmd.none)
         )
 
         Vitest.test (


### PR DESCRIPTION
Adds Git operation progress feedback and inspectable raw command output to the Git sidebar.

## Changes

- Shows structured progress for supported Git operations.
- Adds optional raw command output to git progress DTOs and carries it through IPC, renderer state, and the Git sidebar.
- Captures stdout and stderr from simple-git and spawned git commands, including fetch, pull, push, clone, and LFS maintenance flows.
- Shows raw git output inside a collapsed "Git output" section on progress notices.
- Moves the progress notice under "Source Control" and above the tracking branch details.