### PR TITLE
Feature/table editor

### DIFF
--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -88,7 +88,7 @@ module private FolderedDraggableListHelper =
         else
             "swt:btn-outline swt:bg-base-100 swt:cursor-grab swt:shadow-sm active:swt:cursor-grabbing"
         if isDragging then
-            "swt:absolute swt:pointer-events-none swt:opacity-0"
+            "swt:pointer-events-none swt:opacity-0"
     ]
 
 [<Erase; Mangle(false)>]
@@ -159,12 +159,15 @@ type FolderedDraggableList =
                 | _ -> ()
             ]
             prop.ariaLabel $"Drag {item.Label}"
+            if draggable.isDragging then
+                prop.custom ("aria-hidden", true)
+                prop.tabIndex -1
             match item.Tooltip with
             | Some tooltip when tooltip <> "" ->
                 prop.custom ("data-tip", tooltip)
                 prop.title tooltip
             | _ -> ()
-            if defaultArg debug false then
+            if defaultArg debug false && not draggable.isDragging then
                 prop.testId $"foldered-draggable-item-{item.Id}"
             prop.children [ renderItemContent renderProps ]
         ]
@@ -309,8 +312,11 @@ type FolderedDraggableList =
 
         DndKit.useDndMonitor (
             {|
+                onDragCancel = fun (_: DndKit.IDndKitEvent) -> setActiveDrag None
                 onDragEnd =
                     fun (event: DndKit.IDndKitEvent) ->
+                        setActiveDrag None
+
                         match expandedFolder, tryCreateItemFromExternalDrop, onFoldersChange with
                         | Some targetFolder, Some tryCreateItemFromExternalDrop, Some onFoldersChange when
                             FolderedDraggableListHelper.isShelfDrop shelfDropId event
@@ -400,6 +406,7 @@ type FolderedDraggableList =
                     ]
                 ]
                 DndKit.DragOverlay(
+                    dropAnimation = {| duration = 0; easing = "linear" |},
                     children =
                         match activeDrag with
                         | Some render ->

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -184,6 +184,13 @@ type FolderedDraggableList =
                 else
                     "swt:border-base-300 swt:bg-base-100 hover:swt:border-primary/60 hover:swt:bg-base-200"
             ]
+            match folder.Color with
+            | Some color when color <> "" ->
+                prop.custom ("data-foldered-folder-color", color)
+
+                if not isExpanded then
+                    prop.style [ style.borderColor color ]
+            | _ -> ()
             prop.custom ("aria-expanded", isExpanded)
             prop.ariaLabel (
                 if isExpanded then
@@ -206,6 +213,9 @@ type FolderedDraggableList =
                                 else
                                     "swt:fluent--folder-24-regular"
                             ]
+                            match folder.Color with
+                            | Some color when color <> "" -> prop.style [ style.color color ]
+                            | _ -> ()
                         ]
                         Html.span [
                             prop.className "swt:badge swt:badge-sm swt:shrink-0"

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -12,10 +12,15 @@ module private FolderedDraggableListHelper =
     let effectiveColor (folder: FolderedDraggableFolder<'payload>) (item: FolderedDraggableItem<'payload>) =
         item.Color |> Option.orElse folder.Color
 
-    let toggleExpanded allowMultipleOpen folderId (expanded: Set<string>) =
-        if expanded.Contains folderId then expanded.Remove folderId
-        elif allowMultipleOpen then expanded.Add folderId
-        else Set.singleton folderId
+    let expandedFolderId folders (expanded: Set<string>) =
+        folders
+        |> List.tryFind (fun folder -> expanded.Contains folder.Id)
+        |> Option.map (fun folder -> folder.Id)
+
+    let toggleExpanded folderId expandedFolderId =
+        match expandedFolderId with
+        | Some expandedFolderId when expandedFolderId = folderId -> Set.empty
+        | _ -> Set.singleton folderId
 
     let colorSwatch color =
         match color with
@@ -37,11 +42,21 @@ module private FolderedDraggableListHelper =
             match render.Item.Badge with
             | Some badge when badge <> "" ->
                 Html.span [
-                    prop.className "swt:badge swt:badge-xs swt:shrink-0"
+                    prop.className "swt:badge swt:badge-sm swt:shrink-0"
                     prop.text badge
                 ]
             | _ -> Html.none
         ]
+
+    let itemShellClass isDisabled isDragging = [
+        "swt:btn swt:btn-sm swt:h-auto swt:min-h-10 swt:w-fit swt:max-w-56 swt:shrink-0 swt:min-w-0 swt:justify-start swt:gap-2 swt:overflow-hidden swt:px-3 swt:py-2 swt:text-sm swt:normal-case"
+        if isDisabled then
+            "swt:btn-disabled swt:cursor-not-allowed"
+        else
+            "swt:btn-outline swt:bg-base-100 swt:cursor-grab swt:shadow-sm active:swt:cursor-grabbing"
+        if isDragging then
+            "swt:absolute swt:pointer-events-none swt:opacity-0"
+    ]
 
 [<Erase; Mangle(false)>]
 type FolderedDraggableList =
@@ -53,6 +68,7 @@ type FolderedDraggableList =
             item: FolderedDraggableItem<'payload>,
             dragId: FolderedDraggableFolder<'payload> -> FolderedDraggableItem<'payload> -> string,
             renderItemContent: FolderedDraggableItemRenderFn<'payload>,
+            onActiveDragChange: FolderedDraggableItemRender<'payload> option -> unit,
             ?debug: bool,
             ?key: string
         ) =
@@ -83,6 +99,16 @@ type FolderedDraggableList =
             IsDragging = draggable.isDragging
         }
 
+        React.useEffect (
+            (fun () ->
+                if draggable.isDragging then
+                    onActiveDragChange (Some renderProps)
+                else
+                    onActiveDragChange None
+            ),
+            [| box draggable.isDragging |]
+        )
+
         Html.button [
             match key with
             | Some key -> prop.key key
@@ -94,13 +120,7 @@ type FolderedDraggableList =
                 yield! prop.spread (!!draggable.attributes)
                 yield! prop.spread (!!draggable.listeners)
             prop.className [
-                "swt:btn swt:btn-sm swt:h-auto swt:min-h-8 swt:w-fit swt:max-w-full swt:shrink swt:min-w-0 swt:justify-start swt:gap-2 swt:overflow-hidden swt:px-3 swt:py-1.5 swt:text-xs swt:normal-case"
-                if item.Disabled then
-                    "swt:btn-disabled swt:cursor-not-allowed"
-                else
-                    "swt:btn-outline swt:bg-base-100 swt:cursor-grab active:swt:cursor-grabbing"
-                if draggable.isDragging then
-                    "swt:opacity-60 swt:ring-2 swt:ring-primary swt:ring-offset-2 swt:ring-offset-base-100"
+                yield! FolderedDraggableListHelper.itemShellClass item.Disabled draggable.isDragging
                 match item.Tooltip with
                 | Some tooltip when tooltip <> "" -> "swt:tooltip swt:tooltip-right"
                 | _ -> ()
@@ -118,49 +138,36 @@ type FolderedDraggableList =
 
     [<ReactComponent>]
     static member private Folder<'payload>
-        (
-            folder: FolderedDraggableFolder<'payload>,
-            isExpanded: bool,
-            onToggle: unit -> unit,
-            dragId: FolderedDraggableFolder<'payload> -> FolderedDraggableItem<'payload> -> string,
-            renderItemContent: FolderedDraggableItemRenderFn<'payload>,
-            ?debug: bool,
-            ?key: string
-        ) =
-        Html.div [
+        (folder: FolderedDraggableFolder<'payload>, isExpanded: bool, onToggle: unit -> unit, ?debug: bool, ?key: string) =
+        Html.button [
             match key with
             | Some key -> prop.key key
             | None -> ()
-            prop.className "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
+            prop.type'.button
+            prop.className [
+                "swt:btn swt:h-32 swt:w-36 swt:min-w-36 swt:flex-none swt:flex-col swt:items-stretch swt:justify-between swt:gap-2 swt:overflow-hidden swt:rounded-lg swt:border swt:p-3 swt:text-left swt:normal-case swt:shadow-sm swt:transition-all"
+                if isExpanded then
+                    "swt:border-primary swt:bg-primary/10 swt:text-primary swt:ring-2 swt:ring-primary/20"
+                else
+                    "swt:border-base-300 swt:bg-base-100 hover:swt:border-primary/60 hover:swt:bg-base-200"
+            ]
+            prop.custom ("aria-expanded", isExpanded)
+            prop.ariaLabel (
+                if isExpanded then
+                    $"Collapse {folder.Name}"
+                else
+                    $"Expand {folder.Name}"
+            )
+            prop.onClick (fun _ -> onToggle ())
             if defaultArg debug false then
                 prop.testId $"foldered-draggable-folder-{folder.Id}"
             prop.children [
-                Html.button [
-                    prop.type'.button
-                    prop.className
-                        "swt:btn swt:btn-sm swt:btn-ghost swt:min-h-8 swt:h-auto swt:w-full swt:justify-start swt:gap-2 swt:px-2 swt:py-1 swt:text-left"
-                    prop.custom ("aria-expanded", isExpanded)
-                    prop.ariaLabel (
-                        if isExpanded then
-                            $"Collapse {folder.Name}"
-                        else
-                            $"Expand {folder.Name}"
-                    )
-                    prop.onClick (fun _ -> onToggle ())
+                Html.div [
+                    prop.className "swt:flex swt:items-start swt:justify-between swt:gap-2"
                     prop.children [
                         Html.i [
                             prop.className [
-                                "swt:iconify swt:size-4 swt:shrink-0"
-                                if isExpanded then
-                                    "swt:fluent--chevron-down-20-regular"
-                                else
-                                    "swt:fluent--chevron-right-20-regular"
-                            ]
-                        ]
-                        FolderedDraggableListHelper.colorSwatch folder.Color
-                        Html.i [
-                            prop.className [
-                                "swt:iconify swt:size-4 swt:shrink-0"
+                                "swt:iconify swt:size-14 swt:shrink-0"
                                 if isExpanded then
                                     "swt:fluent--folder-open-24-regular"
                                 else
@@ -168,30 +175,35 @@ type FolderedDraggableList =
                             ]
                         ]
                         Html.span [
-                            prop.className "swt:min-w-0 swt:truncate swt:font-medium"
-                            prop.text folder.Name
-                        ]
-                        Html.span [
-                            prop.className "swt:badge swt:badge-xs swt:ml-auto swt:shrink-0"
+                            prop.className "swt:badge swt:badge-sm swt:shrink-0"
                             prop.text (string folder.Items.Length)
                         ]
                     ]
                 ]
-                if isExpanded then
-                    Html.div [
-                        prop.className "swt:flex swt:flex-wrap swt:gap-2 swt:pl-6"
-                        prop.children [
-                            for item in folder.Items do
-                                FolderedDraggableList.Item(
-                                    folder,
-                                    item,
-                                    dragId,
-                                    renderItemContent,
-                                    ?debug = debug,
-                                    key = $"{folder.Id}:{item.Id}"
-                                )
+                Html.div [
+                    prop.className "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
+                    prop.children [
+                        Html.span [
+                            prop.className "swt:w-full swt:truncate swt:text-sm swt:font-semibold"
+                            prop.text folder.Name
+                        ]
+                        Html.div [
+                            prop.className "swt:flex swt:items-center swt:gap-2"
+                            prop.children [
+                                FolderedDraggableListHelper.colorSwatch folder.Color
+                                Html.span [
+                                    prop.className "swt:text-xs swt:font-normal swt:text-base-content/70"
+                                    prop.text (
+                                        if folder.Items.Length = 1 then
+                                            "1 item"
+                                        else
+                                            $"{folder.Items.Length} items"
+                                    )
+                                ]
+                            ]
                         ]
                     ]
+                ]
             ]
         ]
 
@@ -203,18 +215,23 @@ type FolderedDraggableList =
             ?expandedFolderIds: Set<string>,
             ?defaultExpandedFolderIds: Set<string>,
             ?onExpandedFolderIdsChange: Set<string> -> unit,
-            ?allowMultipleOpen: bool,
             ?renderItemContent: FolderedDraggableItemRenderFn<'payload>,
             ?className: string,
             ?debug: bool
         ) =
-        let allowMultipleOpen = defaultArg allowMultipleOpen true
         let debug = defaultArg debug false
 
         let localExpanded, setLocalExpanded =
             React.useState (defaultArg defaultExpandedFolderIds Set.empty)
 
+        let activeDrag, setActiveDrag =
+            React.useState (None: FolderedDraggableItemRender<'payload> option)
+
         let expanded = expandedFolderIds |> Option.defaultValue localExpanded
+        let expandedFolderId = FolderedDraggableListHelper.expandedFolderId folders expanded
+
+        let expandedFolder =
+            folders |> List.tryFind (fun folder -> Some folder.Id = expandedFolderId)
 
         let setExpanded next =
             onExpandedFolderIdsChange |> Option.iter (fun fn -> fn next)
@@ -228,7 +245,7 @@ type FolderedDraggableList =
 
         Html.section [
             prop.className [
-                "swt:flex swt:min-w-0 swt:flex-col swt:gap-3"
+                "swt:flex swt:min-w-0 swt:flex-col swt:gap-4"
                 match className with
                 | Some className -> className
                 | None -> ()
@@ -236,21 +253,71 @@ type FolderedDraggableList =
             if debug then
                 prop.testId "foldered-draggable-list"
             prop.children [
-                for folder in folders do
-                    let isExpanded = expanded.Contains folder.Id
+                Html.div [
+                    prop.className
+                        "swt:flex swt:min-w-0 swt:flex-row swt:flex-nowrap swt:gap-3 swt:overflow-x-auto swt:overflow-y-hidden swt:pb-2"
+                    if debug then
+                        prop.testId "foldered-draggable-folder-row"
+                    prop.children [
+                        for folder in folders do
+                            let isExpanded = Some folder.Id = expandedFolderId
 
-                    FolderedDraggableList.Folder(
-                        folder,
-                        isExpanded,
-                        (fun () ->
-                            expanded
-                            |> FolderedDraggableListHelper.toggleExpanded allowMultipleOpen folder.Id
-                            |> setExpanded
-                        ),
-                        dragId,
-                        renderItemContent,
-                        debug = debug,
-                        key = folder.Id
-                    )
+                            FolderedDraggableList.Folder(
+                                folder,
+                                isExpanded,
+                                (fun () ->
+                                    expandedFolderId
+                                    |> FolderedDraggableListHelper.toggleExpanded folder.Id
+                                    |> setExpanded
+                                ),
+                                debug = debug,
+                                key = folder.Id
+                            )
+                    ]
+                ]
+                Html.div [
+                    prop.className
+                        "swt:min-h-24 swt:min-w-0 swt:rounded-lg swt:border swt:border-dashed swt:border-base-300 swt:bg-base-200/40 swt:p-3"
+                    if debug then
+                        prop.testId "foldered-draggable-item-shelf"
+                    prop.children [
+                        Html.div [
+                            prop.className
+                                "swt:relative swt:flex swt:min-h-12 swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-center swt:gap-2 swt:overflow-x-auto swt:overflow-y-hidden swt:pb-1"
+                            if debug then
+                                prop.testId "foldered-draggable-item-row"
+                            prop.children [
+                                match expandedFolder with
+                                | Some folder ->
+                                    for item in folder.Items do
+                                        FolderedDraggableList.Item(
+                                            folder,
+                                            item,
+                                            dragId,
+                                            renderItemContent,
+                                            setActiveDrag,
+                                            debug = debug,
+                                            key = $"{folder.Id}:{item.Id}"
+                                        )
+                                | None -> ()
+                            ]
+                        ]
+                    ]
+                ]
+                DndKit.DragOverlay(
+                    children =
+                        match activeDrag with
+                        | Some render ->
+                            Html.div [
+                                prop.className [
+                                    yield! FolderedDraggableListHelper.itemShellClass render.Item.Disabled false
+                                    "swt:pointer-events-none swt:shadow-xl swt:ring-2 swt:ring-primary swt:ring-offset-2 swt:ring-offset-base-100"
+                                ]
+                                if debug then
+                                    prop.testId "foldered-draggable-drag-overlay"
+                                prop.children [ renderItemContent { render with IsDragging = true } ]
+                            ]
+                        | None -> Html.none
+                )
             ]
         ]

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -22,6 +22,39 @@ module private FolderedDraggableListHelper =
         | Some expandedFolderId when expandedFolderId = folderId -> Set.empty
         | _ -> Set.singleton folderId
 
+    let appendItemToFolder targetFolderId item folders =
+        folders
+        |> List.map (fun folder ->
+            if folder.Id = targetFolderId then
+                {
+                    folder with
+                        Items = folder.Items @ [ item ]
+                }
+            else
+                folder
+        )
+
+    let canAcceptExternalDrop
+        (expandedFolder: FolderedDraggableFolder<'payload> option)
+        (tryCreateItemFromExternalDrop: FolderedDraggableExternalDropHandler<'payload> option)
+        (onFoldersChange: (FolderedDraggableFolder<'payload> list -> unit) option)
+        =
+        expandedFolder.IsSome
+        && tryCreateItemFromExternalDrop.IsSome
+        && onFoldersChange.IsSome
+
+    let isShelfDrop shelfDropId (event: DndKit.IDndKitEvent) =
+        not (isNull event.over) && string event.over.id = shelfDropId
+
+    let activeId (event: DndKit.IDndKitEvent) =
+        if isNull event.active then "" else string event.active.id
+
+    let activeData (event: DndKit.IDndKitEvent) =
+        if isNull event.active || isNull event.active.data then
+            null
+        else
+            event.active.data.current
+
     let colorSwatch color =
         match color with
         | Some color when color <> "" ->
@@ -216,10 +249,17 @@ type FolderedDraggableList =
             ?defaultExpandedFolderIds: Set<string>,
             ?onExpandedFolderIdsChange: Set<string> -> unit,
             ?renderItemContent: FolderedDraggableItemRenderFn<'payload>,
+            ?shelfDropId: string,
+            ?tryCreateItemFromExternalDrop: FolderedDraggableExternalDropHandler<'payload>,
+            ?onFoldersChange: FolderedDraggableFolder<'payload> list -> unit,
             ?className: string,
             ?debug: bool
         ) =
         let debug = defaultArg debug false
+        let generatedShelfDropId = React.useId ()
+
+        let shelfDropId =
+            defaultArg shelfDropId $"foldered-draggable-list-shelf-{generatedShelfDropId}"
 
         let localExpanded, setLocalExpanded =
             React.useState (defaultArg defaultExpandedFolderIds Set.empty)
@@ -233,6 +273,20 @@ type FolderedDraggableList =
         let expandedFolder =
             folders |> List.tryFind (fun folder -> Some folder.Id = expandedFolderId)
 
+        let canAcceptExternalDrop =
+            FolderedDraggableListHelper.canAcceptExternalDrop
+                expandedFolder
+                tryCreateItemFromExternalDrop
+                onFoldersChange
+
+        let shelfDroppable =
+            DndKit.useDroppable (
+                {|
+                    id = shelfDropId
+                    disabled = not canAcceptExternalDrop
+                |}
+            )
+
         let setExpanded next =
             onExpandedFolderIdsChange |> Option.iter (fun fn -> fn next)
 
@@ -242,6 +296,31 @@ type FolderedDraggableList =
         let renderItemContent =
             renderItemContent
             |> Option.defaultValue FolderedDraggableListHelper.defaultItemContent
+
+        DndKit.useDndMonitor (
+            {|
+                onDragEnd =
+                    fun (event: DndKit.IDndKitEvent) ->
+                        match expandedFolder, tryCreateItemFromExternalDrop, onFoldersChange with
+                        | Some targetFolder, Some tryCreateItemFromExternalDrop, Some onFoldersChange when
+                            FolderedDraggableListHelper.isShelfDrop shelfDropId event
+                            ->
+                            let drop: FolderedDraggableExternalDrop<'payload> = {
+                                TargetFolder = targetFolder
+                                ActiveId = FolderedDraggableListHelper.activeId event
+                                ActiveData = FolderedDraggableListHelper.activeData event
+                                Folders = folders
+                            }
+
+                            match tryCreateItemFromExternalDrop drop with
+                            | Some item ->
+                                folders
+                                |> FolderedDraggableListHelper.appendItemToFolder targetFolder.Id item
+                                |> onFoldersChange
+                            | None -> ()
+                        | _ -> ()
+            |}
+        )
 
         Html.section [
             prop.className [
@@ -276,8 +355,14 @@ type FolderedDraggableList =
                     ]
                 ]
                 Html.div [
-                    prop.className
-                        "swt:min-h-24 swt:min-w-0 swt:rounded-lg swt:border swt:border-dashed swt:border-base-300 swt:bg-base-200/40 swt:p-3"
+                    prop.ref shelfDroppable.setNodeRef
+                    prop.className [
+                        "swt:min-h-24 swt:min-w-0 swt:rounded-lg swt:border swt:border-dashed swt:p-3 swt:transition-colors"
+                        if canAcceptExternalDrop && shelfDroppable.isOver then
+                            "swt:border-primary swt:bg-primary/10"
+                        else
+                            "swt:border-base-300 swt:bg-base-200/40"
+                    ]
                     if debug then
                         prop.testId "foldered-draggable-item-shelf"
                     prop.children [

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -3,12 +3,13 @@ namespace Swate.Components.Composite.FolderedDraggableList
 open Fable.Core
 open Fable.Core.JsInterop
 open Feliz
+open Swate.Components
 open Swate.Components.JsBindings
 open Swate.Components.Composite.FolderedDraggableList.Types
 
 module private FolderedDraggableListHelper =
 
-    let effectiveColor folder item =
+    let effectiveColor (folder: FolderedDraggableFolder<'payload>) (item: FolderedDraggableItem<'payload>) =
         item.Color |> Option.orElse folder.Color
 
     let toggleExpanded allowMultipleOpen folderId (expanded: Set<string>) =

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -1,0 +1,255 @@
+namespace Swate.Components.Composite.FolderedDraggableList
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Feliz
+open Swate.Components.JsBindings
+open Swate.Components.Composite.FolderedDraggableList.Types
+
+module private FolderedDraggableListHelper =
+
+    let effectiveColor folder item =
+        item.Color |> Option.orElse folder.Color
+
+    let toggleExpanded allowMultipleOpen folderId (expanded: Set<string>) =
+        if expanded.Contains folderId then expanded.Remove folderId
+        elif allowMultipleOpen then expanded.Add folderId
+        else Set.singleton folderId
+
+    let colorSwatch color =
+        match color with
+        | Some color when color <> "" ->
+            Html.span [
+                prop.className "swt:size-2.5 swt:shrink-0 swt:rounded-full swt:border swt:border-base-300"
+                prop.custom ("data-foldered-color-swatch", "true")
+                prop.style [ style.backgroundColor color ]
+            ]
+        | _ -> Html.none
+
+    let defaultItemContent (render: FolderedDraggableItemRender<'payload>) =
+        React.Fragment [
+            colorSwatch render.DragData.EffectiveColor
+            Html.span [
+                prop.className "swt:min-w-0 swt:truncate swt:text-left"
+                prop.text render.Item.Label
+            ]
+            match render.Item.Badge with
+            | Some badge when badge <> "" ->
+                Html.span [
+                    prop.className "swt:badge swt:badge-xs swt:shrink-0"
+                    prop.text badge
+                ]
+            | _ -> Html.none
+        ]
+
+[<Erase; Mangle(false)>]
+type FolderedDraggableList =
+
+    [<ReactComponent>]
+    static member private Item<'payload>
+        (
+            folder: FolderedDraggableFolder<'payload>,
+            item: FolderedDraggableItem<'payload>,
+            dragId: FolderedDraggableFolder<'payload> -> FolderedDraggableItem<'payload> -> string,
+            renderItemContent: FolderedDraggableItemRenderFn<'payload>,
+            ?debug: bool,
+            ?key: string
+        ) =
+        let dragData: FolderedDraggableData<'payload> = {
+            FolderId = folder.Id
+            FolderName = folder.Name
+            FolderColor = folder.Color
+            ItemId = item.Id
+            ItemLabel = item.Label
+            ItemColor = item.Color
+            EffectiveColor = FolderedDraggableListHelper.effectiveColor folder item
+            Payload = item.Payload
+        }
+
+        let draggable =
+            DndKit.useDraggable (
+                {|
+                    id = dragId folder item
+                    data = dragData
+                    disabled = item.Disabled
+                |}
+            )
+
+        let renderProps: FolderedDraggableItemRender<'payload> = {
+            Folder = folder
+            Item = item
+            DragData = dragData
+            IsDragging = draggable.isDragging
+        }
+
+        Html.button [
+            match key with
+            | Some key -> prop.key key
+            | None -> ()
+            prop.type'.button
+            prop.disabled item.Disabled
+            if not item.Disabled then
+                prop.ref draggable.setNodeRef
+                yield! prop.spread (!!draggable.attributes)
+                yield! prop.spread (!!draggable.listeners)
+            prop.className [
+                "swt:btn swt:btn-sm swt:h-auto swt:min-h-8 swt:w-fit swt:max-w-full swt:shrink swt:min-w-0 swt:justify-start swt:gap-2 swt:overflow-hidden swt:px-3 swt:py-1.5 swt:text-xs swt:normal-case"
+                if item.Disabled then
+                    "swt:btn-disabled swt:cursor-not-allowed"
+                else
+                    "swt:btn-outline swt:bg-base-100 swt:cursor-grab active:swt:cursor-grabbing"
+                if draggable.isDragging then
+                    "swt:opacity-60 swt:ring-2 swt:ring-primary swt:ring-offset-2 swt:ring-offset-base-100"
+                match item.Tooltip with
+                | Some tooltip when tooltip <> "" -> "swt:tooltip swt:tooltip-right"
+                | _ -> ()
+            ]
+            prop.ariaLabel $"Drag {item.Label}"
+            match item.Tooltip with
+            | Some tooltip when tooltip <> "" ->
+                prop.custom ("data-tip", tooltip)
+                prop.title tooltip
+            | _ -> ()
+            if defaultArg debug false then
+                prop.testId $"foldered-draggable-item-{item.Id}"
+            prop.children [ renderItemContent renderProps ]
+        ]
+
+    [<ReactComponent>]
+    static member private Folder<'payload>
+        (
+            folder: FolderedDraggableFolder<'payload>,
+            isExpanded: bool,
+            onToggle: unit -> unit,
+            dragId: FolderedDraggableFolder<'payload> -> FolderedDraggableItem<'payload> -> string,
+            renderItemContent: FolderedDraggableItemRenderFn<'payload>,
+            ?debug: bool,
+            ?key: string
+        ) =
+        Html.div [
+            match key with
+            | Some key -> prop.key key
+            | None -> ()
+            prop.className "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
+            if defaultArg debug false then
+                prop.testId $"foldered-draggable-folder-{folder.Id}"
+            prop.children [
+                Html.button [
+                    prop.type'.button
+                    prop.className
+                        "swt:btn swt:btn-sm swt:btn-ghost swt:min-h-8 swt:h-auto swt:w-full swt:justify-start swt:gap-2 swt:px-2 swt:py-1 swt:text-left"
+                    prop.custom ("aria-expanded", isExpanded)
+                    prop.ariaLabel (
+                        if isExpanded then
+                            $"Collapse {folder.Name}"
+                        else
+                            $"Expand {folder.Name}"
+                    )
+                    prop.onClick (fun _ -> onToggle ())
+                    prop.children [
+                        Html.i [
+                            prop.className [
+                                "swt:iconify swt:size-4 swt:shrink-0"
+                                if isExpanded then
+                                    "swt:fluent--chevron-down-20-regular"
+                                else
+                                    "swt:fluent--chevron-right-20-regular"
+                            ]
+                        ]
+                        FolderedDraggableListHelper.colorSwatch folder.Color
+                        Html.i [
+                            prop.className [
+                                "swt:iconify swt:size-4 swt:shrink-0"
+                                if isExpanded then
+                                    "swt:fluent--folder-open-24-regular"
+                                else
+                                    "swt:fluent--folder-24-regular"
+                            ]
+                        ]
+                        Html.span [
+                            prop.className "swt:min-w-0 swt:truncate swt:font-medium"
+                            prop.text folder.Name
+                        ]
+                        Html.span [
+                            prop.className "swt:badge swt:badge-xs swt:ml-auto swt:shrink-0"
+                            prop.text (string folder.Items.Length)
+                        ]
+                    ]
+                ]
+                if isExpanded then
+                    Html.div [
+                        prop.className "swt:flex swt:flex-wrap swt:gap-2 swt:pl-6"
+                        prop.children [
+                            for item in folder.Items do
+                                FolderedDraggableList.Item(
+                                    folder,
+                                    item,
+                                    dragId,
+                                    renderItemContent,
+                                    ?debug = debug,
+                                    key = $"{folder.Id}:{item.Id}"
+                                )
+                        ]
+                    ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member FolderedDraggableList<'payload>
+        (
+            folders: FolderedDraggableFolder<'payload> list,
+            dragId: FolderedDraggableFolder<'payload> -> FolderedDraggableItem<'payload> -> string,
+            ?expandedFolderIds: Set<string>,
+            ?defaultExpandedFolderIds: Set<string>,
+            ?onExpandedFolderIdsChange: Set<string> -> unit,
+            ?allowMultipleOpen: bool,
+            ?renderItemContent: FolderedDraggableItemRenderFn<'payload>,
+            ?className: string,
+            ?debug: bool
+        ) =
+        let allowMultipleOpen = defaultArg allowMultipleOpen true
+        let debug = defaultArg debug false
+
+        let localExpanded, setLocalExpanded =
+            React.useState (defaultArg defaultExpandedFolderIds Set.empty)
+
+        let expanded = expandedFolderIds |> Option.defaultValue localExpanded
+
+        let setExpanded next =
+            onExpandedFolderIdsChange |> Option.iter (fun fn -> fn next)
+
+            if expandedFolderIds.IsNone then
+                setLocalExpanded next
+
+        let renderItemContent =
+            renderItemContent
+            |> Option.defaultValue FolderedDraggableListHelper.defaultItemContent
+
+        Html.section [
+            prop.className [
+                "swt:flex swt:min-w-0 swt:flex-col swt:gap-3"
+                match className with
+                | Some className -> className
+                | None -> ()
+            ]
+            if debug then
+                prop.testId "foldered-draggable-list"
+            prop.children [
+                for folder in folders do
+                    let isExpanded = expanded.Contains folder.Id
+
+                    FolderedDraggableList.Folder(
+                        folder,
+                        isExpanded,
+                        (fun () ->
+                            expanded
+                            |> FolderedDraggableListHelper.toggleExpanded allowMultipleOpen folder.Id
+                            |> setExpanded
+                        ),
+                        dragId,
+                        renderItemContent,
+                        debug = debug,
+                        key = folder.Id
+                    )
+            ]
+        ]

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -5,9 +5,20 @@ open Fable.Core.JsInterop
 open Feliz
 open Swate.Components
 open Swate.Components.JsBindings
+open Swate.Components.Primitive.Popover
 open Swate.Components.Composite.FolderedDraggableList.Types
 
 module private FolderedDraggableListHelper =
+
+    let fallbackColor = "#2563eb"
+
+    let currentOrFallback color =
+        match color with
+        | Some c when c <> "" -> c
+        | _ -> fallbackColor
+
+    [<Emit("$0.target && $0.target.closest && $0.target.closest('[data-folder-color-control]') !== null")>]
+    let isFolderColorControlEvent (_event: Browser.Types.Event) : bool = jsNative
 
     let effectiveColor (folder: FolderedDraggableFolder<'payload>) (item: FolderedDraggableItem<'payload>) =
         item.Color |> Option.orElse folder.Color
@@ -64,6 +75,35 @@ module private FolderedDraggableListHelper =
                 prop.style [ style.backgroundColor color ]
             ]
         | _ -> Html.none
+
+    let colorPickerContent ariaLabel (draftColor: string) (setDraftColor: string -> unit) onSetColor =
+        Html.div [
+            prop.className "swt:flex swt:items-center swt:gap-2 swt:p-2"
+            prop.children [
+                Html.input [
+                    prop.custom ("type", "color")
+                    prop.className "swt:h-8 swt:w-10 swt:cursor-pointer swt:rounded swt:border swt:border-base-300"
+                    prop.value draftColor
+                    prop.ariaLabel ariaLabel
+                    prop.onChange (fun (color: string) -> setDraftColor color)
+                ]
+                Html.button [
+                    prop.type'.button
+                    prop.className "swt:btn swt:btn-xs swt:btn-primary swt:min-h-0 swt:py-0"
+                    prop.text "Select"
+                    prop.onClick (fun _ -> onSetColor (Some draftColor))
+                ]
+                Html.button [
+                    prop.type'.button
+                    prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:min-h-0 swt:py-0"
+                    prop.text "Clear"
+                    prop.onClick (fun _ ->
+                        setDraftColor fallbackColor
+                        onSetColor None
+                    )
+                ]
+            ]
+        ]
 
     let defaultItemContent (render: FolderedDraggableItemRender<'payload>) =
         React.Fragment [
@@ -173,84 +213,172 @@ type FolderedDraggableList =
         ]
 
     [<ReactComponent>]
+    static member private FolderColorButton<'payload>
+        (folder: FolderedDraggableFolder<'payload>, onSetColor: string option -> unit, ?key: string)
+        =
+        let draftColor, setDraftColor =
+            React.useState (FolderedDraggableListHelper.currentOrFallback folder.Color)
+
+        React.useEffect (
+            (fun () -> setDraftColor (FolderedDraggableListHelper.currentOrFallback folder.Color)),
+            [| box folder.Color |]
+        )
+
+        let trigger =
+            Html.button [
+                match key with
+                | Some key -> prop.key key
+                | None -> ()
+                prop.type'.button
+                prop.custom ("data-folder-color-control", "true")
+                prop.custom ("data-foldered-color-swatch", "true")
+                prop.className
+                    "swt:size-3 swt:shrink-0 swt:cursor-pointer swt:rounded-full swt:border swt:border-base-300 swt:bg-base-100 swt:p-0 swt:shadow-sm"
+                match folder.Color with
+                | Some color when color <> "" -> prop.style [ style.backgroundColor color ]
+                | _ -> ()
+                prop.ariaLabel $"Set color for folder {folder.Name}"
+            ]
+
+        let content =
+            FolderedDraggableListHelper.colorPickerContent
+                $"Choose color for folder {folder.Name}"
+                draftColor
+                setDraftColor
+                onSetColor
+
+        Popover.Popover(
+            children =
+                React.Fragment [
+                    Popover.Trigger(
+                        trigger,
+                        className = "swt:inline-flex swt:shrink-0",
+                        props = [ prop.custom ("data-folder-color-control", "true") ]
+                    )
+                    Popover.Content(
+                        children =
+                            Html.div [
+                                prop.className "swt:flex swt:flex-col swt:gap-2"
+                                prop.children [
+                                    Html.div [
+                                        prop.className "swt:flex swt:items-start swt:justify-between swt:gap-2"
+                                        prop.children [
+                                            Html.div [ prop.className "swt:flex-1"; prop.children content ]
+                                            Popover.Close()
+                                        ]
+                                    ]
+                                ]
+                            ]
+                    )
+                ]
+        )
+
+    [<ReactComponent>]
     static member private Folder<'payload>
-        (folder: FolderedDraggableFolder<'payload>, isExpanded: bool, onToggle: unit -> unit, ?debug: bool, ?key: string) =
-        Html.button [
+        (
+            folder: FolderedDraggableFolder<'payload>,
+            isExpanded: bool,
+            onToggle: unit -> unit,
+            ?onSetColor: string option -> unit,
+            ?debug: bool,
+            ?key: string
+        ) =
+        Html.div [
             match key with
             | Some key -> prop.key key
             | None -> ()
-            prop.type'.button
-            prop.className [
-                "swt:btn swt:h-32 swt:w-36 swt:min-w-36 swt:flex-none swt:flex-col swt:items-stretch swt:justify-between swt:gap-2 swt:overflow-hidden swt:rounded-lg swt:border swt:p-3 swt:text-left swt:normal-case swt:shadow-sm swt:transition-all"
-                if isExpanded then
-                    "swt:border-primary swt:bg-primary/10 swt:text-primary swt:ring-2 swt:ring-primary/20"
-                else
-                    "swt:border-base-300 swt:bg-base-100 hover:swt:border-primary/60 hover:swt:bg-base-200"
-            ]
+            prop.className "swt:relative swt:h-32 swt:w-36 swt:min-w-36 swt:flex-none"
             match folder.Color with
-            | Some color when color <> "" ->
-                prop.custom ("data-foldered-folder-color", color)
-
-                if not isExpanded then
-                    prop.style [ style.borderColor color ]
+            | Some color when color <> "" -> prop.custom ("data-foldered-folder-color", color)
             | _ -> ()
             prop.custom ("aria-expanded", isExpanded)
-            prop.title folder.Name
-            prop.ariaLabel (
-                if isExpanded then
-                    $"Collapse {folder.Name}"
-                else
-                    $"Expand {folder.Name}"
-            )
-            prop.onClick (fun _ -> onToggle ())
             if defaultArg debug false then
                 prop.testId $"foldered-draggable-folder-{folder.Id}"
             prop.children [
-                Html.div [
-                    prop.className "swt:flex swt:items-start swt:justify-between swt:gap-2"
-                    prop.children [
-                        Html.i [
-                            prop.className [
-                                "swt:iconify swt:size-14 swt:shrink-0"
-                                if isExpanded then
-                                    "swt:fluent--folder-open-24-regular"
-                                else
-                                    "swt:fluent--folder-24-regular"
-                            ]
-                            match folder.Color with
-                            | Some color when color <> "" -> prop.style [ style.color color ]
-                            | _ -> ()
-                        ]
-                        Html.span [
-                            prop.className "swt:badge swt:badge-sm swt:shrink-0"
-                            prop.text (string folder.Items.Length)
-                        ]
+                Html.button [
+                    prop.type'.button
+                    prop.className [
+                        "swt:btn swt:h-full swt:w-full swt:flex-col swt:items-stretch swt:justify-between swt:gap-2 swt:overflow-hidden swt:rounded-lg swt:border swt:p-3 swt:text-left swt:normal-case swt:shadow-sm swt:transition-all"
+                        if isExpanded then
+                            "swt:border-primary swt:bg-primary/10 swt:text-primary swt:ring-2 swt:ring-primary/20"
+                        else
+                            "swt:border-base-300 swt:bg-base-100 hover:swt:border-primary/60 hover:swt:bg-base-200"
                     ]
-                ]
-                Html.div [
-                    prop.className "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
+                    match folder.Color with
+                    | Some color when color <> "" && not isExpanded -> prop.style [ style.borderColor color ]
+                    | _ -> ()
+                    prop.custom ("aria-expanded", isExpanded)
+                    prop.title folder.Name
+                    prop.ariaLabel (
+                        if isExpanded then
+                            $"Collapse {folder.Name}"
+                        else
+                            $"Expand {folder.Name}"
+                    )
+                    prop.onClick (fun _ -> onToggle ())
                     prop.children [
-                        Html.span [
-                            prop.className "swt:w-full swt:truncate swt:text-sm swt:font-semibold"
-                            prop.text folder.Name
+                        Html.div [
+                            prop.className "swt:flex swt:items-start swt:justify-between swt:gap-2"
+                            prop.children [
+                                Html.i [
+                                    prop.className [
+                                        "swt:iconify swt:size-14 swt:shrink-0"
+                                        if isExpanded then
+                                            "swt:fluent--folder-open-24-regular"
+                                        else
+                                            "swt:fluent--folder-24-regular"
+                                    ]
+                                    match folder.Color with
+                                    | Some color when color <> "" -> prop.style [ style.color color ]
+                                    | _ -> ()
+                                ]
+                                Html.span [
+                                    prop.className "swt:badge swt:badge-sm swt:shrink-0"
+                                    prop.text (string folder.Items.Length)
+                                ]
+                            ]
                         ]
                         Html.div [
-                            prop.className "swt:flex swt:items-center swt:gap-2"
+                            prop.className "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
                             prop.children [
-                                FolderedDraggableListHelper.colorSwatch folder.Color
                                 Html.span [
-                                    prop.className "swt:text-xs swt:font-normal swt:text-base-content/70"
-                                    prop.text (
-                                        if folder.Items.Length = 1 then
-                                            "1 item"
-                                        else
-                                            $"{folder.Items.Length} items"
-                                    )
+                                    prop.className "swt:w-full swt:truncate swt:text-sm swt:font-semibold"
+                                    prop.text folder.Name
+                                ]
+                                Html.div [
+                                    prop.className "swt:flex swt:items-center swt:gap-2"
+                                    prop.children [
+                                        match onSetColor with
+                                        | Some _ ->
+                                            Html.span [
+                                                prop.className "swt:size-3 swt:shrink-0"
+                                                prop.custom ("aria-hidden", true)
+                                            ]
+                                        | None -> FolderedDraggableListHelper.colorSwatch folder.Color
+                                        Html.span [
+                                            prop.className "swt:text-xs swt:font-normal swt:text-base-content/70"
+                                            prop.text (
+                                                if folder.Items.Length = 1 then
+                                                    "1 item"
+                                                else
+                                                    $"{folder.Items.Length} items"
+                                            )
+                                        ]
+                                    ]
                                 ]
                             ]
                         ]
                     ]
                 ]
+                match onSetColor with
+                | Some setColor ->
+                    Html.div [
+                        prop.className "swt:absolute swt:bottom-3 swt:left-3 swt:z-10 swt:flex swt:items-center"
+                        prop.children [
+                            FolderedDraggableList.FolderColorButton(folder, setColor, key = $"{folder.Id}:color")
+                        ]
+                    ]
+                | None -> Html.none
             ]
         ]
 
@@ -266,6 +394,7 @@ type FolderedDraggableList =
             ?shelfDropId: string,
             ?tryCreateItemFromExternalDrop: FolderedDraggableExternalDropHandler<'payload>,
             ?onFoldersChange: FolderedDraggableFolder<'payload> list -> unit,
+            ?onSetFolderColor: string -> string option -> unit,
             ?className: string,
             ?debug: bool
         ) =
@@ -358,6 +487,10 @@ type FolderedDraggableList =
                         for folder in folders do
                             let isExpanded = Some folder.Id = expandedFolderId
 
+                            let onSetColor =
+                                onSetFolderColor
+                                |> Option.map (fun setFolderColor -> fun color -> setFolderColor folder.Id color)
+
                             FolderedDraggableList.Folder(
                                 folder,
                                 isExpanded,
@@ -366,6 +499,7 @@ type FolderedDraggableList =
                                     |> FolderedDraggableListHelper.toggleExpanded folder.Id
                                     |> setExpanded
                                 ),
+                                ?onSetColor = onSetColor,
                                 debug = debug,
                                 key = folder.Id
                             )

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -195,6 +195,7 @@ type FolderedDraggableList =
                     prop.style [ style.borderColor color ]
             | _ -> ()
             prop.custom ("aria-expanded", isExpanded)
+            prop.title folder.Name
             prop.ariaLabel (
                 if isExpanded then
                     $"Collapse {folder.Name}"

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DndContext, useDroppable, type DragEndEvent } from '@dnd-kit/core';
+import { DndContext, useDraggable, useDroppable, type DragEndEvent } from '@dnd-kit/core';
 import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
 import { FolderedDraggableList } from './FolderedDraggableList.fs.js';
 import { ofArray, type FSharpList } from '../../fable_modules/fable-library-ts.5.0.0-alpha.21/List.ts';
@@ -38,8 +38,18 @@ type StoryListProps = {
   expandedFolderIds?: FSharpSet<string>;
   defaultExpandedFolderIds?: FSharpSet<string>;
   onExpandedFolderIdsChange?: (expandedFolderIds: FSharpSet<string>) => void;
+  shelfDropId?: string;
+  tryCreateItemFromExternalDrop?: (drop: StoryExternalDrop) => StoryItem | undefined;
+  onFoldersChange?: (folders: FSharpList<StoryFolder>) => void;
   className?: string;
   debug?: boolean;
+};
+
+type StoryExternalDrop = {
+  TargetFolder: StoryFolder;
+  ActiveId: string;
+  ActiveData: unknown;
+  Folders: FSharpList<StoryFolder>;
 };
 
 type StoryDragData = {
@@ -51,6 +61,13 @@ type StoryDragData = {
   ItemColor?: string;
   EffectiveColor?: string;
   Payload: PropertyPayload;
+};
+
+type ExternalPropertyDragData = {
+  Kind: 'external-property';
+  Id: string;
+  Label: string;
+  Origin: string;
 };
 
 const StoryFolderedDraggableList = FolderedDraggableList as React.ComponentType<StoryListProps>;
@@ -158,6 +175,31 @@ function DropZone() {
   );
 }
 
+function OutsideProperty() {
+  const draggable = useDraggable({
+    id: 'outside-property-temperature',
+    data: {
+      Kind: 'external-property',
+      Id: 'temperature',
+      Label: 'Temperature',
+      Origin: 'outside-source',
+    } satisfies ExternalPropertyDragData,
+  });
+
+  return (
+    <button
+      ref={draggable.setNodeRef}
+      type="button"
+      data-testid="outside-property-temperature"
+      className="swt:btn swt:btn-sm swt:btn-outline swt:w-fit swt:cursor-grab active:swt:cursor-grabbing"
+      {...draggable.attributes}
+      {...draggable.listeners}
+    >
+      External temperature
+    </button>
+  );
+}
+
 function UpdatingHarness() {
   const [folders, setFolders] = React.useState(() => initialFolders());
 
@@ -222,6 +264,46 @@ function UpdatingHarness() {
       <DndContext>
         <StoryFolderedDraggableList folders={folders} dragId={dragId} debug />
       </DndContext>
+    </div>
+  );
+}
+
+function OutsideDropHarness() {
+  const [folders, setFolders] = React.useState(() => initialFolders());
+
+  const targetFolder = Array.from(folders).find((candidate) => candidate.Id === 'layer-b');
+  const targetFolderCount = targetFolder ? Array.from(targetFolder.Items).length : 0;
+
+  const tryCreateItemFromExternalDrop = (drop: StoryExternalDrop): StoryItem | undefined => {
+    const activeData = drop.ActiveData as Partial<ExternalPropertyDragData> | undefined;
+
+    if (activeData?.Kind !== 'external-property' || !activeData.Id || !activeData.Label) {
+      return undefined;
+    }
+
+    return propertyItem(
+      `${drop.TargetFolder.Id}-${activeData.Id}`,
+      activeData.Label,
+      drop.TargetFolder.Id,
+      activeData.Origin ?? 'outside-source'
+    );
+  };
+
+  return (
+    <div className="swt:flex swt:w-96 swt:flex-col swt:gap-3">
+      <DndContext>
+        <OutsideProperty />
+        <StoryFolderedDraggableList
+          folders={folders}
+          dragId={dragId}
+          defaultExpandedFolderIds={fsSet(['layer-b'])}
+          shelfDropId="story-foldered-shelf"
+          tryCreateItemFromExternalDrop={tryCreateItemFromExternalDrop}
+          onFoldersChange={setFolders}
+          debug
+        />
+      </DndContext>
+      <pre data-testid="layer-b-count">{targetFolderCount}</pre>
     </div>
   );
 }
@@ -507,6 +589,31 @@ export const UpdatesWhenFoldersPropChanges: Story = {
       .querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
     expect(folderSwatch).not.toBeNull();
     expect(folderSwatch!).toHaveStyle({ backgroundColor: '#7c3aed' });
+  },
+};
+
+export const AcceptsOutsideDropsIntoExpandedShelf: Story = {
+  render: () => <OutsideDropHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
+
+    expect(within(shelf).queryByTestId('foldered-draggable-item-layer-b-temperature')).not.toBeInTheDocument();
+    expect(canvas.getByTestId('layer-b-count')).toHaveTextContent('2');
+
+    await dragByPointer(canvas.getByTestId('outside-property-temperature'), shelf);
+
+    await waitFor(() => {
+      const addedItem = within(shelf).getByTestId('foldered-draggable-item-layer-b-temperature');
+      expect(addedItem).toBeVisible();
+      expect(canvas.getByTestId('layer-b-count')).toHaveTextContent('3');
+    });
+
+    const addedSwatch = canvas
+      .getByTestId('foldered-draggable-item-layer-b-temperature')
+      .querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
+    expect(addedSwatch).not.toBeNull();
+    expect(addedSwatch!).toHaveStyle({ backgroundColor: '#d97706' });
   },
 };
 

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
@@ -38,7 +38,6 @@ type StoryListProps = {
   expandedFolderIds?: FSharpSet<string>;
   defaultExpandedFolderIds?: FSharpSet<string>;
   onExpandedFolderIdsChange?: (expandedFolderIds: FSharpSet<string>) => void;
-  allowMultipleOpen?: boolean;
   className?: string;
   debug?: boolean;
 };
@@ -114,6 +113,28 @@ function initialFolders() {
       propertyItem('layer-b-archived', 'Archived method', 'layer-b', 'upstream-layer', '#6b7280', 'disabled', true),
     ]),
   ]);
+}
+
+function overflowingFolders() {
+  return fsList(
+    Array.from({ length: 8 }, (_, folderIndex) =>
+      folder(
+        `wide-layer-${folderIndex + 1}`,
+        `Wide Layer ${folderIndex + 1}`,
+        folderIndex % 2 === 0 ? '#2563eb' : '#d97706',
+        Array.from({ length: 8 }, (_, itemIndex) =>
+          propertyItem(
+            `wide-layer-${folderIndex + 1}-property-${itemIndex + 1}`,
+            `Property ${itemIndex + 1}`,
+            `wide-layer-${folderIndex + 1}`,
+            'overflow-story',
+            itemIndex % 2 === 0 ? '#16a34a' : undefined,
+            `${itemIndex + 1}`
+          )
+        )
+      )
+    )
+  );
 }
 
 function dragId(_folder: StoryFolder, item: StoryItem) {
@@ -222,7 +243,6 @@ function ControlledExpansionHarness() {
           dragId={dragId}
           expandedFolderIds={expandedFolderIds}
           onExpandedFolderIdsChange={handleExpandedChange}
-          allowMultipleOpen={false}
           debug
         />
       </DndContext>
@@ -269,7 +289,7 @@ function DragHarness() {
   );
 }
 
-async function dragByPointer(source: Element, target: Element) {
+function getPointerGeometry(source: Element, target: Element) {
   const from = source.getBoundingClientRect();
   const to = target.getBoundingClientRect();
   const fromX = from.left + from.width / 2;
@@ -281,11 +301,18 @@ async function dragByPointer(source: Element, target: Element) {
   const distance = Math.hypot(deltaX, deltaY) || 1;
   const activationX = fromX + (deltaX / distance) * 8;
   const activationY = fromY + (deltaY / distance) * 8;
-  const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+
+  return { fromX, fromY, toX, toY, activationX, activationY };
+}
+
+const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+
+async function beginDragByPointer(source: Element, target: Element = source) {
+  const geometry = getPointerGeometry(source, target);
 
   fireEvent.pointerDown(source, {
-    clientX: fromX,
-    clientY: fromY,
+    clientX: geometry.fromX,
+    clientY: geometry.fromY,
     button: 0,
     buttons: 1,
     isPrimary: true,
@@ -295,8 +322,8 @@ async function dragByPointer(source: Element, target: Element) {
   await nextFrame();
 
   fireEvent.pointerMove(target, {
-    clientX: activationX,
-    clientY: activationY,
+    clientX: geometry.activationX,
+    clientY: geometry.activationY,
     button: 0,
     buttons: 1,
     isPrimary: true,
@@ -305,9 +332,15 @@ async function dragByPointer(source: Element, target: Element) {
 
   await nextFrame();
 
-  fireEvent.pointerMove(document, {
-    clientX: toX,
-    clientY: toY,
+  return geometry;
+}
+
+async function dragByPointer(source: Element, target: Element) {
+  const geometry = await beginDragByPointer(source, target);
+
+  fireEvent.pointerMove(target, {
+    clientX: geometry.toX,
+    clientY: geometry.toY,
     button: 0,
     buttons: 1,
     isPrimary: true,
@@ -317,8 +350,8 @@ async function dragByPointer(source: Element, target: Element) {
   await nextFrame();
 
   fireEvent.pointerUp(target, {
-    clientX: toX,
-    clientY: toY,
+    clientX: geometry.toX,
+    clientY: geometry.toY,
     button: 0,
     buttons: 0,
     isPrimary: true,
@@ -346,20 +379,30 @@ export const TogglesFolders: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
 
-    expect(canvas.queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+    expect(shelf).toBeVisible();
+    expect(within(shelf).queryByRole('button', { name: /Drag/i })).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
 
-    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
-    expect(canvas.getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
+    expect(within(shelf).queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
     expect(canvas.getByText('Species')).toBeVisible();
     expect(within(canvas.getByTestId('foldered-draggable-item-layer-a-species')).getByText('2')).toBeVisible();
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Collapse Layer A' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
 
     await waitFor(() => {
-      expect(canvas.queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+      expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+      expect(within(shelf).getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
+    });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Collapse Layer B' }));
+
+    await waitFor(() => {
+      expect(within(shelf).queryByRole('button', { name: /Drag/i })).not.toBeInTheDocument();
     });
   },
 };
@@ -379,9 +422,10 @@ export const DefaultExpansionOpensInitialFolders: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
 
-    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
-    expect(canvas.queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+    expect(within(shelf).queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
   },
 };
 
@@ -389,17 +433,47 @@ export const ControlledExpansionFollowsProps: Story = {
   render: () => <ControlledExpansionHarness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
 
-    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
-    expect(canvas.queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+    expect(within(shelf).queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
 
     await waitFor(() => {
-      expect(canvas.queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
-      expect(canvas.getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
+      expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+      expect(within(shelf).getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
       expect(canvas.getByTestId('last-expanded')).toHaveTextContent('layer-b');
     });
+  },
+};
+
+export const HorizontalRowsScrollWhenOverflowing: Story = {
+  render: () => (
+    <DndContext>
+      <div className="swt:w-72">
+        <StoryFolderedDraggableList folders={overflowingFolders()} dragId={dragId} debug />
+      </div>
+    </DndContext>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const folderRow = canvas.getByTestId('foldered-draggable-folder-row');
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
+
+    expect(folderRow).toHaveClass('swt:flex-row');
+    expect(folderRow).toHaveClass('swt:flex-nowrap');
+    expect(folderRow).toHaveClass('swt:overflow-x-auto');
+    expect(shelf).toBeVisible();
+    expect(canvas.getAllByRole('button', { name: /Wide Layer/i })).toHaveLength(8);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Wide Layer 1' }));
+
+    const itemRow = canvas.getByTestId('foldered-draggable-item-row');
+    expect(itemRow).toHaveClass('swt:flex-row');
+    expect(itemRow).toHaveClass('swt:flex-nowrap');
+    expect(itemRow).toHaveClass('swt:overflow-x-auto');
+    expect(within(itemRow).getAllByRole('button', { name: /Drag Property/i })).toHaveLength(8);
   },
 };
 
@@ -407,12 +481,13 @@ export const UpdatesWhenFoldersPropChanges: Story = {
   render: () => <UpdatingHarness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
 
     await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
-    expect(canvas.getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Add replicate' }));
-    expect(await canvas.findByTestId('foldered-draggable-item-layer-a-replicate')).toBeVisible();
+    expect(await within(shelf).findByTestId('foldered-draggable-item-layer-a-replicate')).toBeVisible();
     const replicateSwatch = canvas
       .getByTestId('foldered-draggable-item-layer-a-replicate')
       .querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
@@ -421,9 +496,9 @@ export const UpdatesWhenFoldersPropChanges: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: 'Remove species' }));
     await waitFor(() => {
-      expect(canvas.queryByTestId('foldered-draggable-item-layer-a-species')).not.toBeInTheDocument();
+      expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-species')).not.toBeInTheDocument();
     });
-    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Rename and recolor Layer A' }));
     expect(canvas.getByRole('button', { name: 'Collapse Layer Alpha' })).toBeVisible();
@@ -481,10 +556,41 @@ export const CarriesFolderFallbackColor: Story = {
   },
 };
 
+export const ShowsDragPreviewAndRestoresUnacceptedDrag: Story = {
+  render: () => <DragHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
+    const source = within(shelf).getByTestId('foldered-draggable-item-layer-a-mass');
+    const geometry = await beginDragByPointer(source);
+
+    await waitFor(() => {
+      expect(source).not.toBeVisible();
+      expect(within(document.body).getByTestId('foldered-draggable-drag-overlay')).toBeVisible();
+    });
+
+    fireEvent.pointerUp(document, {
+      clientX: geometry.activationX,
+      clientY: geometry.activationY,
+      button: 0,
+      buttons: 0,
+      isPrimary: true,
+      pointerId: 1,
+    });
+
+    await waitFor(() => {
+      expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+      expect(within(document.body).queryByTestId('foldered-draggable-drag-overlay')).not.toBeInTheDocument();
+    });
+  },
+};
+
 export const DisabledItemsDoNotDrag: Story = {
   render: () => <DragHarness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
 
     const disabledItem = canvas.getByTestId('foldered-draggable-item-layer-b-archived');
     expect(disabledItem).toBeDisabled();

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
@@ -256,7 +256,12 @@ function DragHarness() {
   return (
     <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
       <DndContext onDragEnd={onDragEnd}>
-        <StoryFolderedDraggableList folders={initialFolders()} dragId={dragId} debug />
+        <StoryFolderedDraggableList
+          folders={initialFolders()}
+          dragId={dragId}
+          defaultExpandedFolderIds={fsSet(['layer-a', 'layer-b'])}
+          debug
+        />
         <DropZone />
       </DndContext>
       <pre data-testid="last-drag">{lastDrag}</pre>
@@ -265,17 +270,60 @@ function DragHarness() {
 }
 
 async function dragByPointer(source: Element, target: Element) {
-  const sourceBox = source.getBoundingClientRect();
-  const targetBox = target.getBoundingClientRect();
-  const sourceX = sourceBox.left + sourceBox.width / 2;
-  const sourceY = sourceBox.top + sourceBox.height / 2;
-  const targetX = targetBox.left + targetBox.width / 2;
-  const targetY = targetBox.top + targetBox.height / 2;
+  const from = source.getBoundingClientRect();
+  const to = target.getBoundingClientRect();
+  const fromX = from.left + from.width / 2;
+  const fromY = from.top + from.height / 2;
+  const toX = to.left + to.width / 2;
+  const toY = to.top + to.height / 2;
+  const deltaX = toX - fromX;
+  const deltaY = toY - fromY;
+  const distance = Math.hypot(deltaX, deltaY) || 1;
+  const activationX = fromX + (deltaX / distance) * 8;
+  const activationY = fromY + (deltaY / distance) * 8;
+  const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
 
-  fireEvent.pointerDown(source, { clientX: sourceX, clientY: sourceY, pointerId: 1 });
-  fireEvent.pointerMove(document, { clientX: sourceX + 8, clientY: sourceY + 8, pointerId: 1 });
-  fireEvent.pointerMove(document, { clientX: targetX, clientY: targetY, pointerId: 1 });
-  fireEvent.pointerUp(document, { clientX: targetX, clientY: targetY, pointerId: 1 });
+  fireEvent.pointerDown(source, {
+    clientX: fromX,
+    clientY: fromY,
+    button: 0,
+    buttons: 1,
+    isPrimary: true,
+    pointerId: 1,
+  });
+
+  await nextFrame();
+
+  fireEvent.pointerMove(target, {
+    clientX: activationX,
+    clientY: activationY,
+    button: 0,
+    buttons: 1,
+    isPrimary: true,
+    pointerId: 1,
+  });
+
+  await nextFrame();
+
+  fireEvent.pointerMove(document, {
+    clientX: toX,
+    clientY: toY,
+    button: 0,
+    buttons: 1,
+    isPrimary: true,
+    pointerId: 1,
+  });
+
+  await nextFrame();
+
+  fireEvent.pointerUp(target, {
+    clientX: toX,
+    clientY: toY,
+    button: 0,
+    buttons: 0,
+    isPrimary: true,
+    pointerId: 1,
+  });
 }
 
 const meta = {
@@ -306,7 +354,7 @@ export const TogglesFolders: Story = {
     expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
     expect(canvas.getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
     expect(canvas.getByText('Species')).toBeVisible();
-    expect(canvas.getByText('2')).toBeVisible();
+    expect(within(canvas.getByTestId('foldered-draggable-item-layer-a-species')).getByText('2')).toBeVisible();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Collapse Layer A' }));
 
@@ -392,7 +440,6 @@ export const CarriesStructuredDragDataAndColor: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
     await dragByPointer(
       canvas.getByTestId('foldered-draggable-item-layer-a-species'),
       canvas.getByTestId('outside-drop')
@@ -419,7 +466,6 @@ export const CarriesFolderFallbackColor: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
     await dragByPointer(
       canvas.getByTestId('foldered-draggable-item-layer-a-mass'),
       canvas.getByTestId('outside-drop')
@@ -440,7 +486,6 @@ export const DisabledItemsDoNotDrag: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
     const disabledItem = canvas.getByTestId('foldered-draggable-item-layer-b-archived');
     expect(disabledItem).toBeDisabled();
 

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
@@ -1,0 +1,451 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DndContext, useDroppable, type DragEndEvent } from '@dnd-kit/core';
+import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
+import { FolderedDraggableList } from './FolderedDraggableList.fs.js';
+import { ofArray, type FSharpList } from '../../fable_modules/fable-library-ts.5.0.0-alpha.21/List.ts';
+import { ofArray as setOfArray, type FSharpSet } from '../../fable_modules/fable-library-ts.5.0.0-alpha.21/Set.ts';
+import { comparePrimitives } from '../../fable_modules/fable-library-ts.5.0.0-alpha.21/Util.ts';
+
+type PropertyPayload = {
+  LayerId: string;
+  Origin: string;
+  Header: string;
+  Connections: string[];
+};
+
+type StoryItem = {
+  Id: string;
+  Label: string;
+  DragKey: string;
+  Payload: PropertyPayload;
+  Color?: string;
+  Badge?: string;
+  Tooltip?: string;
+  Disabled: boolean;
+};
+
+type StoryFolder = {
+  Id: string;
+  Name: string;
+  Color?: string;
+  Items: FSharpList<StoryItem>;
+};
+
+type StoryListProps = {
+  folders: FSharpList<StoryFolder>;
+  dragId: (folder: StoryFolder, item: StoryItem) => string;
+  expandedFolderIds?: FSharpSet<string>;
+  defaultExpandedFolderIds?: FSharpSet<string>;
+  onExpandedFolderIdsChange?: (expandedFolderIds: FSharpSet<string>) => void;
+  allowMultipleOpen?: boolean;
+  className?: string;
+  debug?: boolean;
+};
+
+type StoryDragData = {
+  FolderId: string;
+  FolderName: string;
+  FolderColor?: string;
+  ItemId: string;
+  ItemLabel: string;
+  ItemColor?: string;
+  EffectiveColor?: string;
+  Payload: PropertyPayload;
+};
+
+const StoryFolderedDraggableList = FolderedDraggableList as React.ComponentType<StoryListProps>;
+
+const stringComparer = {
+  Compare: (x: string, y: string) => comparePrimitives(x, y),
+};
+
+function fsList<T>(items: T[]): FSharpList<T> {
+  return ofArray(items);
+}
+
+function fsSet(items: string[]): FSharpSet<string> {
+  return setOfArray(items, stringComparer);
+}
+
+function propertyItem(
+  id: string,
+  label: string,
+  layerId: string,
+  origin: string,
+  color?: string,
+  badge?: string,
+  disabled = false
+): StoryItem {
+  return {
+    Id: id,
+    Label: label,
+    DragKey: `story-drag-${id}`,
+    Payload: {
+      LayerId: layerId,
+      Origin: origin,
+      Header: label,
+      Connections: [`connection:${id}`],
+    },
+    Color: color,
+    Badge: badge,
+    Tooltip: `${origin} / ${label}`,
+    Disabled: disabled,
+  };
+}
+
+function folder(id: string, name: string, color: string | undefined, items: StoryItem[]): StoryFolder {
+  return {
+    Id: id,
+    Name: name,
+    Color: color,
+    Items: fsList(items),
+  };
+}
+
+function initialFolders() {
+  return fsList([
+    folder('layer-a', 'Layer A', '#2563eb', [
+      propertyItem('layer-a-mass', 'Mass', 'layer-a', 'previous-table', undefined, '3'),
+      propertyItem('layer-a-species', 'Species', 'layer-a', 'previous-table', '#16a34a', '2'),
+    ]),
+    folder('layer-b', 'Layer B', '#d97706', [
+      propertyItem('layer-b-instrument', 'Instrument', 'layer-b', 'upstream-layer', undefined, '1'),
+      propertyItem('layer-b-archived', 'Archived method', 'layer-b', 'upstream-layer', '#6b7280', 'disabled', true),
+    ]),
+  ]);
+}
+
+function dragId(_folder: StoryFolder, item: StoryItem) {
+  // Opaque stable identity only. Consumers must read metadata from event.active.data.current.
+  return item.DragKey;
+}
+
+function DropZone() {
+  const droppable = useDroppable({ id: 'outside-drop' });
+
+  return (
+    <div
+      ref={droppable.setNodeRef}
+      data-testid="outside-drop"
+      className={`swt:min-h-16 swt:rounded swt:border swt:border-dashed swt:p-3 ${
+        droppable.isOver ? 'swt:border-primary swt:bg-primary/10' : 'swt:border-base-300'
+      }`}
+    >
+      Drop outside
+    </div>
+  );
+}
+
+function UpdatingHarness() {
+  const [folders, setFolders] = React.useState(() => initialFolders());
+
+  const addReplicate = () => {
+    setFolders(
+      fsList([
+        folder('layer-a', 'Layer A', '#2563eb', [
+          propertyItem('layer-a-mass', 'Mass', 'layer-a', 'previous-table', undefined, '3'),
+          propertyItem('layer-a-species', 'Species', 'layer-a', 'previous-table', '#16a34a', '2'),
+          propertyItem('layer-a-replicate', 'Replicate', 'layer-a', 'previous-table', '#dc2626', '4'),
+        ]),
+        folder('layer-b', 'Layer B', '#d97706', [
+          propertyItem('layer-b-instrument', 'Instrument', 'layer-b', 'upstream-layer', undefined, '1'),
+          propertyItem('layer-b-archived', 'Archived method', 'layer-b', 'upstream-layer', '#6b7280', 'disabled', true),
+        ]),
+      ])
+    );
+  };
+
+  const removeSpecies = () => {
+    setFolders(
+      fsList([
+        folder('layer-a', 'Layer A', '#2563eb', [
+          propertyItem('layer-a-mass', 'Mass', 'layer-a', 'previous-table', undefined, '3'),
+        ]),
+        folder('layer-b', 'Layer B', '#d97706', [
+          propertyItem('layer-b-instrument', 'Instrument', 'layer-b', 'upstream-layer', undefined, '1'),
+          propertyItem('layer-b-archived', 'Archived method', 'layer-b', 'upstream-layer', '#6b7280', 'disabled', true),
+        ]),
+      ])
+    );
+  };
+
+  const renameAndRecolorLayerA = () => {
+    setFolders(
+      fsList([
+        folder('layer-a', 'Layer Alpha', '#7c3aed', [
+          propertyItem('layer-a-mass', 'Mass', 'layer-a', 'previous-table', undefined, '3'),
+          propertyItem('layer-a-species', 'Species', 'layer-a', 'previous-table', '#16a34a', '2'),
+        ]),
+        folder('layer-b', 'Layer B', '#d97706', [
+          propertyItem('layer-b-instrument', 'Instrument', 'layer-b', 'upstream-layer', undefined, '1'),
+          propertyItem('layer-b-archived', 'Archived method', 'layer-b', 'upstream-layer', '#6b7280', 'disabled', true),
+        ]),
+      ])
+    );
+  };
+
+  return (
+    <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
+      <div className="swt:flex swt:gap-2">
+        <button type="button" className="swt:btn swt:btn-xs swt:btn-outline" onClick={addReplicate}>
+          Add replicate
+        </button>
+        <button type="button" className="swt:btn swt:btn-xs swt:btn-outline" onClick={removeSpecies}>
+          Remove species
+        </button>
+        <button type="button" className="swt:btn swt:btn-xs swt:btn-outline" onClick={renameAndRecolorLayerA}>
+          Rename and recolor Layer A
+        </button>
+      </div>
+      <DndContext>
+        <StoryFolderedDraggableList folders={folders} dragId={dragId} debug />
+      </DndContext>
+    </div>
+  );
+}
+
+function ControlledExpansionHarness() {
+  const [expandedFolderIds, setExpandedFolderIds] = React.useState(() => fsSet(['layer-a']));
+  const [lastExpanded, setLastExpanded] = React.useState('layer-a');
+
+  const handleExpandedChange = (nextExpandedFolderIds: FSharpSet<string>) => {
+    setExpandedFolderIds(nextExpandedFolderIds);
+    setLastExpanded(Array.from(nextExpandedFolderIds).join(',') || 'none');
+  };
+
+  return (
+    <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
+      <DndContext>
+        <StoryFolderedDraggableList
+          folders={initialFolders()}
+          dragId={dragId}
+          expandedFolderIds={expandedFolderIds}
+          onExpandedFolderIdsChange={handleExpandedChange}
+          allowMultipleOpen={false}
+          debug
+        />
+      </DndContext>
+      <pre data-testid="last-expanded">{lastExpanded}</pre>
+    </div>
+  );
+}
+
+function DragHarness() {
+  const [lastDrag, setLastDrag] = React.useState('none');
+
+  const onDragEnd = (event: DragEndEvent) => {
+    const current = event.active.data.current as StoryDragData;
+    setLastDrag(
+      JSON.stringify({
+        overId: event.over?.id ?? null,
+        folderId: current.FolderId,
+        folderName: current.FolderName,
+        folderColor: current.FolderColor ?? null,
+        itemId: current.ItemId,
+        itemLabel: current.ItemLabel,
+        itemColor: current.ItemColor ?? null,
+        effectiveColor: current.EffectiveColor ?? null,
+        layerId: current.Payload.LayerId,
+        origin: current.Payload.Origin,
+        header: current.Payload.Header,
+      })
+    );
+  };
+
+  return (
+    <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
+      <DndContext onDragEnd={onDragEnd}>
+        <StoryFolderedDraggableList folders={initialFolders()} dragId={dragId} debug />
+        <DropZone />
+      </DndContext>
+      <pre data-testid="last-drag">{lastDrag}</pre>
+    </div>
+  );
+}
+
+async function dragByPointer(source: Element, target: Element) {
+  const sourceBox = source.getBoundingClientRect();
+  const targetBox = target.getBoundingClientRect();
+  const sourceX = sourceBox.left + sourceBox.width / 2;
+  const sourceY = sourceBox.top + sourceBox.height / 2;
+  const targetX = targetBox.left + targetBox.width / 2;
+  const targetY = targetBox.top + targetBox.height / 2;
+
+  fireEvent.pointerDown(source, { clientX: sourceX, clientY: sourceY, pointerId: 1 });
+  fireEvent.pointerMove(document, { clientX: sourceX + 8, clientY: sourceY + 8, pointerId: 1 });
+  fireEvent.pointerMove(document, { clientX: targetX, clientY: targetY, pointerId: 1 });
+  fireEvent.pointerUp(document, { clientX: targetX, clientY: targetY, pointerId: 1 });
+}
+
+const meta = {
+  title: 'Composite Components/FolderedDraggableList',
+  component: StoryFolderedDraggableList,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof StoryFolderedDraggableList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const TogglesFolders: Story = {
+  render: () => (
+    <DndContext>
+      <div className="swt:w-96">
+        <StoryFolderedDraggableList folders={initialFolders()} dragId={dragId} debug />
+      </div>
+    </DndContext>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
+
+    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+    expect(canvas.getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
+    expect(canvas.getByText('Species')).toBeVisible();
+    expect(canvas.getByText('2')).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Collapse Layer A' }));
+
+    await waitFor(() => {
+      expect(canvas.queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const DefaultExpansionOpensInitialFolders: Story = {
+  render: () => (
+    <DndContext>
+      <div className="swt:w-96">
+        <StoryFolderedDraggableList
+          folders={initialFolders()}
+          dragId={dragId}
+          defaultExpandedFolderIds={fsSet(['layer-a'])}
+          debug
+        />
+      </div>
+    </DndContext>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+    expect(canvas.queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
+  },
+};
+
+export const ControlledExpansionFollowsProps: Story = {
+  render: () => <ControlledExpansionHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+    expect(canvas.queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
+
+    await waitFor(() => {
+      expect(canvas.queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+      expect(canvas.getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
+      expect(canvas.getByTestId('last-expanded')).toHaveTextContent('layer-b');
+    });
+  },
+};
+
+export const UpdatesWhenFoldersPropChanges: Story = {
+  render: () => <UpdatingHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
+    expect(canvas.getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add replicate' }));
+    expect(await canvas.findByTestId('foldered-draggable-item-layer-a-replicate')).toBeVisible();
+    const replicateSwatch = canvas
+      .getByTestId('foldered-draggable-item-layer-a-replicate')
+      .querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
+    expect(replicateSwatch).not.toBeNull();
+    expect(replicateSwatch!).toHaveStyle({ backgroundColor: '#dc2626' });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Remove species' }));
+    await waitFor(() => {
+      expect(canvas.queryByTestId('foldered-draggable-item-layer-a-species')).not.toBeInTheDocument();
+    });
+    expect(canvas.getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Rename and recolor Layer A' }));
+    expect(canvas.getByRole('button', { name: 'Collapse Layer Alpha' })).toBeVisible();
+    const folderSwatch = canvas
+      .getByTestId('foldered-draggable-folder-layer-a')
+      .querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
+    expect(folderSwatch).not.toBeNull();
+    expect(folderSwatch!).toHaveStyle({ backgroundColor: '#7c3aed' });
+  },
+};
+
+export const CarriesStructuredDragDataAndColor: Story = {
+  render: () => <DragHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
+    await dragByPointer(
+      canvas.getByTestId('foldered-draggable-item-layer-a-species'),
+      canvas.getByTestId('outside-drop')
+    );
+
+    await waitFor(() => {
+      const lastDrag = canvas.getByTestId('last-drag');
+      expect(lastDrag).toHaveTextContent('"overId":"outside-drop"');
+      expect(lastDrag).toHaveTextContent('"folderId":"layer-a"');
+      expect(lastDrag).toHaveTextContent('"folderName":"Layer A"');
+      expect(lastDrag).toHaveTextContent('"folderColor":"#2563eb"');
+      expect(lastDrag).toHaveTextContent('"itemId":"layer-a-species"');
+      expect(lastDrag).toHaveTextContent('"itemColor":"#16a34a"');
+      expect(lastDrag).toHaveTextContent('"effectiveColor":"#16a34a"');
+      expect(lastDrag).toHaveTextContent('"layerId":"layer-a"');
+      expect(lastDrag).toHaveTextContent('"origin":"previous-table"');
+      expect(lastDrag).toHaveTextContent('"header":"Species"');
+    });
+  },
+};
+
+export const CarriesFolderFallbackColor: Story = {
+  render: () => <DragHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
+    await dragByPointer(
+      canvas.getByTestId('foldered-draggable-item-layer-a-mass'),
+      canvas.getByTestId('outside-drop')
+    );
+
+    await waitFor(() => {
+      const lastDrag = canvas.getByTestId('last-drag');
+      expect(lastDrag).toHaveTextContent('"overId":"outside-drop"');
+      expect(lastDrag).toHaveTextContent('"itemId":"layer-a-mass"');
+      expect(lastDrag).toHaveTextContent('"itemColor":null');
+      expect(lastDrag).toHaveTextContent('"effectiveColor":"#2563eb"');
+    });
+  },
+};
+
+export const DisabledItemsDoNotDrag: Story = {
+  render: () => <DragHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
+    const disabledItem = canvas.getByTestId('foldered-draggable-item-layer-b-archived');
+    expect(disabledItem).toBeDisabled();
+
+    await dragByPointer(disabledItem, canvas.getByTestId('outside-drop'));
+
+    expect(canvas.getByTestId('last-drag')).toHaveTextContent('none');
+  },
+};

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
@@ -371,6 +371,50 @@ function DragHarness() {
   );
 }
 
+function removeItemFromFolders(folders: FSharpList<StoryFolder>, itemId: string) {
+  return fsList(
+    Array.from(folders).map((candidate) =>
+      folder(
+        candidate.Id,
+        candidate.Name,
+        candidate.Color,
+        Array.from(candidate.Items).filter((item) => item.Id !== itemId)
+      )
+    )
+  );
+}
+
+function ParentRemovalHarness() {
+  const [folders, setFolders] = React.useState(() => initialFolders());
+  const [lastDrop, setLastDrop] = React.useState('none');
+
+  const onDragEnd = (event: DragEndEvent) => {
+    const current = event.active.data.current as StoryDragData;
+
+    if (event.over?.id === 'outside-drop') {
+      setFolders((currentFolders) => removeItemFromFolders(currentFolders, current.ItemId));
+      setLastDrop(`accepted:${current.ItemId}`);
+    } else {
+      setLastDrop(`rejected:${current.ItemId}`);
+    }
+  };
+
+  return (
+    <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
+      <DndContext onDragEnd={onDragEnd}>
+        <StoryFolderedDraggableList
+          folders={folders}
+          dragId={dragId}
+          defaultExpandedFolderIds={fsSet(['layer-a'])}
+          debug
+        />
+        <DropZone />
+      </DndContext>
+      <pre data-testid="last-drop">{lastDrop}</pre>
+    </div>
+  );
+}
+
 function getPointerGeometry(source: Element, target: Element) {
   const from = source.getBoundingClientRect();
   const to = target.getBoundingClientRect();
@@ -688,6 +732,74 @@ export const ShowsDragPreviewAndRestoresUnacceptedDrag: Story = {
     await waitFor(() => {
       expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
       expect(within(document.body).queryByTestId('foldered-draggable-drag-overlay')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const SecondItemDragPreviewStartsAtGrabbedItem: Story = {
+  render: () => <DragHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
+    const firstItem = within(shelf).getByTestId('foldered-draggable-item-layer-a-mass');
+    const secondItem = within(shelf).getByTestId('foldered-draggable-item-layer-a-species');
+    const firstRect = firstItem.getBoundingClientRect();
+    const secondRect = secondItem.getBoundingClientRect();
+    const geometry = await beginDragByPointer(secondItem);
+
+    const overlay = await waitFor(() => within(document.body).getByTestId('foldered-draggable-drag-overlay'));
+    expect(overlay).toHaveTextContent('Species');
+
+    const overlayRect = overlay.getBoundingClientRect();
+    expect(overlayRect.left).toBeGreaterThan(firstRect.right);
+    expect(Math.abs(overlayRect.left - (secondRect.left + (geometry.activationX - geometry.fromX)))).toBeLessThan(24);
+
+    fireEvent.pointerUp(document, {
+      clientX: geometry.activationX,
+      clientY: geometry.activationY,
+      button: 0,
+      buttons: 0,
+      isPrimary: true,
+      pointerId: 1,
+    });
+  },
+};
+
+export const ParentControlsAcceptedDropRemoval: Story = {
+  render: () => <ParentRemovalHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
+    const source = within(shelf).getByTestId('foldered-draggable-item-layer-a-species');
+    const geometry = await beginDragByPointer(source);
+
+    await waitFor(() => {
+      expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-species')).not.toBeInTheDocument();
+      expect(within(document.body).getByTestId('foldered-draggable-drag-overlay')).toBeVisible();
+    });
+
+    fireEvent.pointerUp(document, {
+      clientX: geometry.activationX,
+      clientY: geometry.activationY,
+      button: 0,
+      buttons: 0,
+      isPrimary: true,
+      pointerId: 1,
+    });
+
+    await waitFor(() => {
+      expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
+      expect(canvas.getByTestId('last-drop')).toHaveTextContent('rejected:layer-a-species');
+    });
+
+    await dragByPointer(
+      within(shelf).getByTestId('foldered-draggable-item-layer-a-species'),
+      canvas.getByTestId('outside-drop')
+    );
+
+    await waitFor(() => {
+      expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-species')).not.toBeInTheDocument();
+      expect(canvas.getByTestId('last-drop')).toHaveTextContent('accepted:layer-a-species');
     });
   },
 };

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
@@ -41,6 +41,7 @@ type StoryListProps = {
   shelfDropId?: string;
   tryCreateItemFromExternalDrop?: (drop: StoryExternalDrop) => StoryItem | undefined;
   onFoldersChange?: (folders: FSharpList<StoryFolder>) => void;
+  onSetFolderColor?: (folderId: string, color?: string) => void;
   className?: string;
   debug?: boolean;
 };
@@ -263,6 +264,33 @@ function UpdatingHarness() {
       </div>
       <DndContext>
         <StoryFolderedDraggableList folders={folders} dragId={dragId} debug />
+      </DndContext>
+    </div>
+  );
+}
+
+function FolderColorHarness() {
+  const [folders, setFolders] = React.useState(() => initialFolders());
+
+  const setFolderColor = (folderId: string, color?: string) => {
+    setFolders((current) =>
+      fsList(
+        Array.from(current).map((currentFolder) =>
+          currentFolder.Id === folderId
+            ? {
+                ...currentFolder,
+                Color: color,
+              }
+            : currentFolder,
+        ),
+      ),
+    );
+  };
+
+  return (
+    <div className="swt:flex swt:w-96 swt:flex-col swt:gap-3">
+      <DndContext>
+        <StoryFolderedDraggableList folders={folders} dragId={dragId} onSetFolderColor={setFolderColor} debug />
       </DndContext>
     </div>
   );
@@ -633,6 +661,44 @@ export const UpdatesWhenFoldersPropChanges: Story = {
       .querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
     expect(folderSwatch).not.toBeNull();
     expect(folderSwatch!).toHaveStyle({ backgroundColor: '#7c3aed' });
+  },
+};
+
+export const SetsFolderColorFromPreview: Story = {
+  render: () => <FolderColorHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Set color for folder Layer A' });
+    const triggerTarget = trigger.parentElement!;
+    const folderCard = canvas.getByTestId('foldered-draggable-folder-layer-a');
+    const folderToggle = canvas.getByRole('button', { name: 'Expand Layer A' });
+
+    expect(folderCard).not.toHaveAttribute('role', 'button');
+    expect(folderCard).not.toHaveAttribute('tabindex');
+    expect(folderCard).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(triggerTarget);
+    expect(folderCard).toHaveAttribute('aria-expanded', 'false');
+    expect(folderCard).not.toHaveFocus();
+    expect(folderToggle).not.toHaveFocus();
+
+    const body = within(document.body);
+    const colorInput = await waitFor(() => body.getByLabelText('Choose color for folder Layer A'));
+    fireEvent.change(colorInput, { target: { value: '#be185d' } });
+    await userEvent.click(body.getByRole('button', { name: 'Select' }));
+
+    await waitFor(() => {
+      expect(canvas.getByRole('button', { name: 'Set color for folder Layer A' })).toHaveStyle({
+        backgroundColor: '#be185d',
+      });
+    });
+
+    expect(canvas.getByTestId('foldered-draggable-folder-layer-a')).toHaveAttribute(
+      'data-foldered-folder-color',
+      '#be185d',
+    );
+    expect(canvas.getByTestId('foldered-draggable-folder-layer-a')).not.toHaveFocus();
+    expect(folderToggle).not.toHaveFocus();
   },
 };
 

--- a/src/Components/src/Composite/FolderedDraggableList/Types.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/Types.fs
@@ -30,6 +30,13 @@ type FolderedDraggableData<'payload> = {
     Payload: 'payload
 }
 
+type FolderedDraggableExternalDrop<'payload> = {
+    TargetFolder: FolderedDraggableFolder<'payload>
+    ActiveId: string
+    ActiveData: obj
+    Folders: FolderedDraggableFolder<'payload> list
+}
+
 type FolderedDraggableItemRender<'payload> = {
     Folder: FolderedDraggableFolder<'payload>
     Item: FolderedDraggableItem<'payload>
@@ -38,3 +45,6 @@ type FolderedDraggableItemRender<'payload> = {
 }
 
 type FolderedDraggableItemRenderFn<'payload> = FolderedDraggableItemRender<'payload> -> ReactElement
+
+type FolderedDraggableExternalDropHandler<'payload> =
+    FolderedDraggableExternalDrop<'payload> -> FolderedDraggableItem<'payload> option

--- a/src/Components/src/Composite/FolderedDraggableList/Types.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/Types.fs
@@ -1,0 +1,40 @@
+module Swate.Components.Composite.FolderedDraggableList.Types
+
+open Feliz
+
+type FolderedDraggableItem<'payload> = {
+    Id: string
+    Label: string
+    Payload: 'payload
+    Color: string option
+    Badge: string option
+    Tooltip: string option
+    Disabled: bool
+}
+
+type FolderedDraggableFolder<'payload> = {
+    Id: string
+    Name: string
+    Color: string option
+    Items: FolderedDraggableItem<'payload> list
+}
+
+type FolderedDraggableData<'payload> = {
+    FolderId: string
+    FolderName: string
+    FolderColor: string option
+    ItemId: string
+    ItemLabel: string
+    ItemColor: string option
+    EffectiveColor: string option
+    Payload: 'payload
+}
+
+type FolderedDraggableItemRender<'payload> = {
+    Folder: FolderedDraggableFolder<'payload>
+    Item: FolderedDraggableItem<'payload>
+    DragData: FolderedDraggableData<'payload>
+    IsDragging: bool
+}
+
+type FolderedDraggableItemRenderFn<'payload> = FolderedDraggableItemRender<'payload> -> ReactElement

--- a/src/Components/src/JsBindings/DndKit.fs
+++ b/src/Components/src/JsBindings/DndKit.fs
@@ -49,9 +49,20 @@ module DndKit =
         abstract member x: float
         abstract member y: float
 
+    [<AllowNullLiteral>]
+    type IDndKitActiveData =
+        abstract member current: obj
+
+    [<AllowNullLiteral>]
+    type IDndKitActive =
+        abstract member id: obj
+        abstract member data: IDndKitActiveData
+
     type IDndKitEvent =
-        abstract member active: HTMLElement
-        abstract member over: HTMLElement
+        abstract member active: IDndKitActive
+        /// DnD Kit returns null when the drag ends outside every droppable.
+        /// Consumers must null-check before reading over.id or over.data.
+        abstract member over: IDndKitActive
         abstract member delta: ICoordinates
 
     type IDndKitMoveEvent =

--- a/src/Components/src/JsBindings/DndKit.fs
+++ b/src/Components/src/JsBindings/DndKit.fs
@@ -109,6 +109,9 @@ type DndKit =
     [<Import("useDraggable", "@dnd-kit/core")>]
     static member useDraggable(props: obj) : IDraggable = jsNative
 
+    [<Import("useDndMonitor", "@dnd-kit/core")>]
+    static member useDndMonitor(props: obj) : unit = jsNative
+
     [<Import("useSensor", "@dnd-kit/core")>]
     static member useSensor(sensor, ?props) : ISensor = jsNative
 

--- a/src/Components/src/Page/Metadata/FormComponents/InputSequence.fs
+++ b/src/Components/src/Page/Metadata/FormComponents/InputSequence.fs
@@ -93,8 +93,8 @@ type InputSequence =
             let over = event.over
 
             if isNull over |> not && active.id <> over.id then
-                let oldIndex = getIndexFromId active.id
-                let newIndex = getIndexFromId over.id
+                let oldIndex = getIndexFromId (string active.id)
+                let newIndex = getIndexFromId (string over.id)
 
                 if oldIndex >= 0 && newIndex >= 0 then
                     DndKit.arrayMove (inputs, oldIndex, newIndex) |> validateSetter

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
@@ -26,7 +26,6 @@ type private MeasuredConnector = {
 type ConnectorOverlayState = {
     ExpandedGroup: (ProvenanceSide * string) option
     SelectedConnectionId: string option
-    ManualResolutionPairs: ManualResolutionPair list
     ExpandedProperties: Set<ProvenanceLayerId * ProvenanceSide * GroupingKey>
 }
 
@@ -46,7 +45,6 @@ module ConnectorOverlayState =
         {
             ExpandedGroup = expandedGroup
             SelectedConnectionId = selectedConnectionId
-            ManualResolutionPairs = uiState.ManualResolutionPairs
             ExpandedProperties = uiState.ExpandedProperties
         }
 
@@ -187,39 +185,82 @@ module private ConnectorPaths =
         Color = color
     }
 
-    let private isManuallyResolving layerId side groupId overlayState =
-        overlayState.ManualResolutionPairs
-        |> List.exists (fun resolution ->
-            resolution.LayerId = layerId
-            && ((side = ProvenanceSide.Input && resolution.InputGroupId = groupId)
-                || (side = ProvenanceSide.Output && resolution.OutputGroupId = groupId))
-        )
-
-    let private isConnectedToExpanded connections side groupId overlayState =
-        connections
-        |> List.exists (fun connection ->
+    let private groupById (inputGroups: DisplayGroup list) (outputGroups: DisplayGroup list) side groupId =
+        let groups =
             match side with
-            | ProvenanceSide.Input ->
-                connection.SourceGroupId = groupId
-                && ConnectorOverlayState.isGroupExpanded ProvenanceSide.Output connection.TargetGroupId overlayState
-            | ProvenanceSide.Output ->
-                connection.TargetGroupId = groupId
-                && ConnectorOverlayState.isGroupExpanded ProvenanceSide.Input connection.SourceGroupId overlayState
-        )
+            | ProvenanceSide.Input -> inputGroups
+            | ProvenanceSide.Output -> outputGroups
 
-    let private isGroupExpanded layerId connections side groupId overlayState =
+        groups |> List.tryFind (fun group -> group.Id = groupId)
+
+    let private isGroupedCard (inputGroups: DisplayGroup list) (outputGroups: DisplayGroup list) side groupId =
+        groupById inputGroups outputGroups side groupId
+        |> Option.exists (fun group -> group.GroupingValues |> List.isEmpty |> not)
+
+    let private isConnectedToExpanded
+        (inputGroups: DisplayGroup list)
+        (outputGroups: DisplayGroup list)
+        connections
+        side
+        groupId
+        overlayState
+        =
+        isGroupedCard inputGroups outputGroups side groupId
+        && (connections
+            |> List.exists (fun connection ->
+                match side with
+                | ProvenanceSide.Input ->
+                    connection.SourceGroupId = groupId
+                    && ConnectorOverlayState.isGroupExpanded
+                        ProvenanceSide.Output
+                        connection.TargetGroupId
+                        overlayState
+                | ProvenanceSide.Output ->
+                    connection.TargetGroupId = groupId
+                    && ConnectorOverlayState.isGroupExpanded ProvenanceSide.Input connection.SourceGroupId overlayState
+            ))
+
+    let private isGroupExpanded
+        (inputGroups: DisplayGroup list)
+        (outputGroups: DisplayGroup list)
+        connections
+        side
+        groupId
+        overlayState
+        =
         ConnectorOverlayState.isGroupExpanded side groupId overlayState
-        || isManuallyResolving layerId side groupId overlayState
-        || isConnectedToExpanded connections side groupId overlayState
+        || isConnectedToExpanded inputGroups outputGroups connections side groupId overlayState
 
-    let groupConnections context layerId connections overlayState =
+    let groupConnections
+        context
+        (inputGroups: DisplayGroup list)
+        (outputGroups: DisplayGroup list)
+        connections
+        overlayState
+        =
         connections
         // Expanded endpoints swap the aggregate group connector for the
         // member-level connectors, so the group line disappears instead of
         // doubling up underneath them.
         |> List.filter (fun connection ->
-            not (isGroupExpanded layerId connections ProvenanceSide.Input connection.SourceGroupId overlayState)
-            && not (isGroupExpanded layerId connections ProvenanceSide.Output connection.TargetGroupId overlayState)
+            not (
+                isGroupExpanded
+                    inputGroups
+                    outputGroups
+                    connections
+                    ProvenanceSide.Input
+                    connection.SourceGroupId
+                    overlayState
+            )
+            && not (
+                isGroupExpanded
+                    inputGroups
+                    outputGroups
+                    connections
+                    ProvenanceSide.Output
+                    connection.TargetGroupId
+                    overlayState
+            )
         )
         |> List.choose (fun connection ->
             ConnectorMeasure.pathBetweenHandles
@@ -239,14 +280,33 @@ module private ConnectorPaths =
             )
         )
 
-    let memberConnections context layerId (model: ProvenanceModel) connections overlayState =
+    let memberConnections
+        context
+        (model: ProvenanceModel)
+        (inputGroups: DisplayGroup list)
+        (outputGroups: DisplayGroup list)
+        connections
+        overlayState
+        =
         connections
         |> List.collect (fun displayConnection ->
             let inputExpanded =
-                isGroupExpanded layerId connections ProvenanceSide.Input displayConnection.SourceGroupId overlayState
+                isGroupExpanded
+                    inputGroups
+                    outputGroups
+                    connections
+                    ProvenanceSide.Input
+                    displayConnection.SourceGroupId
+                    overlayState
 
             let outputExpanded =
-                isGroupExpanded layerId connections ProvenanceSide.Output displayConnection.TargetGroupId overlayState
+                isGroupExpanded
+                    inputGroups
+                    outputGroups
+                    connections
+                    ProvenanceSide.Output
+                    displayConnection.TargetGroupId
+                    overlayState
 
             if not inputExpanded && not outputExpanded then
                 []
@@ -494,8 +554,8 @@ module private ConnectorPaths =
                     colorByHeader
                     overlayState
                     showPropertyHeaderConnectors
-            yield! groupConnections context layerId connections overlayState
-            yield! memberConnections context layerId model connections overlayState
+            yield! groupConnections context inputGroups outputGroups connections overlayState
+            yield! memberConnections context model inputGroups outputGroups connections overlayState
         ]
 
 module private ConnectorSvg =
@@ -789,7 +849,6 @@ type ConnectorOverlay =
                 box inputRailProjection
                 box outputRailProjection
                 box overlayState.ExpandedGroup
-                box overlayState.ManualResolutionPairs
                 box overlayState.ExpandedProperties
                 box showPropertyHeaderConnectors
             |]

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
@@ -27,7 +27,7 @@ type ConnectorOverlayState = {
     ExpandedGroup: (ProvenanceSide * string) option
     SelectedConnectionId: string option
     ManualResolutionPairs: ManualResolutionPair list
-    ExpandedProperties: Set<ProvenancePairId * ProvenanceSide * GroupingKey>
+    ExpandedProperties: Set<ProvenanceLayerId * ProvenanceSide * GroupingKey>
 }
 
 module ConnectorOverlayState =
@@ -53,8 +53,8 @@ module ConnectorOverlayState =
     let isGroupExpanded side groupId state =
         state.ExpandedGroup = Some(side, groupId)
 
-    let isPropertyExpanded pairId side header state =
-        state.ExpandedProperties.Contains(pairId, side, { Header = header })
+    let isPropertyExpanded layerId side header state =
+        state.ExpandedProperties.Contains(layerId, side, { Header = header })
 
 type private ConnectorMeasureContext = {
     Container: HTMLElement
@@ -187,10 +187,10 @@ module private ConnectorPaths =
         Color = color
     }
 
-    let private isManuallyResolving pairId side groupId overlayState =
+    let private isManuallyResolving layerId side groupId overlayState =
         overlayState.ManualResolutionPairs
         |> List.exists (fun resolution ->
-            resolution.PairId = pairId
+            resolution.LayerId = layerId
             && ((side = ProvenanceSide.Input && resolution.InputGroupId = groupId)
                 || (side = ProvenanceSide.Output && resolution.OutputGroupId = groupId))
         )
@@ -207,19 +207,19 @@ module private ConnectorPaths =
                 && ConnectorOverlayState.isGroupExpanded ProvenanceSide.Input connection.SourceGroupId overlayState
         )
 
-    let private isGroupExpanded pairId connections side groupId overlayState =
+    let private isGroupExpanded layerId connections side groupId overlayState =
         ConnectorOverlayState.isGroupExpanded side groupId overlayState
-        || isManuallyResolving pairId side groupId overlayState
+        || isManuallyResolving layerId side groupId overlayState
         || isConnectedToExpanded connections side groupId overlayState
 
-    let groupConnections context pairId connections overlayState =
+    let groupConnections context layerId connections overlayState =
         connections
         // Expanded endpoints swap the aggregate group connector for the
         // member-level connectors, so the group line disappears instead of
         // doubling up underneath them.
         |> List.filter (fun connection ->
-            not (isGroupExpanded pairId connections ProvenanceSide.Input connection.SourceGroupId overlayState)
-            && not (isGroupExpanded pairId connections ProvenanceSide.Output connection.TargetGroupId overlayState)
+            not (isGroupExpanded layerId connections ProvenanceSide.Input connection.SourceGroupId overlayState)
+            && not (isGroupExpanded layerId connections ProvenanceSide.Output connection.TargetGroupId overlayState)
         )
         |> List.choose (fun connection ->
             ConnectorMeasure.pathBetweenHandles
@@ -239,14 +239,14 @@ module private ConnectorPaths =
             )
         )
 
-    let memberConnections context pairId (model: ProvenanceModel) connections overlayState =
+    let memberConnections context layerId (model: ProvenanceModel) connections overlayState =
         connections
         |> List.collect (fun displayConnection ->
             let inputExpanded =
-                isGroupExpanded pairId connections ProvenanceSide.Input displayConnection.SourceGroupId overlayState
+                isGroupExpanded layerId connections ProvenanceSide.Input displayConnection.SourceGroupId overlayState
 
             let outputExpanded =
-                isGroupExpanded pairId connections ProvenanceSide.Output displayConnection.TargetGroupId overlayState
+                isGroupExpanded layerId connections ProvenanceSide.Output displayConnection.TargetGroupId overlayState
 
             if not inputExpanded && not outputExpanded then
                 []
@@ -308,7 +308,7 @@ module private ConnectorPaths =
     /// draw one line per same-side group containing any value for that property.
     let private railConnectionsForSide
         context
-        pairId
+        layerId
         (model: ProvenanceModel)
         side
         groups
@@ -317,7 +317,7 @@ module private ConnectorPaths =
         overlayState
         =
         railProjection.Headers
-        |> List.filter (fun header -> not (ConnectorOverlayState.isPropertyExpanded pairId side header overlayState))
+        |> List.filter (fun header -> not (ConnectorOverlayState.isPropertyExpanded layerId side header overlayState))
         |> List.collect (fun header ->
             let color =
                 railProjection.ColorByHeader
@@ -352,7 +352,7 @@ module private ConnectorPaths =
 
     let private valueRailConnectionsForSide
         context
-        pairId
+        layerId
         (model: ProvenanceModel)
         side
         groups
@@ -361,7 +361,7 @@ module private ConnectorPaths =
         overlayState
         =
         railProjection.Headers
-        |> List.filter (fun header -> ConnectorOverlayState.isPropertyExpanded pairId side header overlayState)
+        |> List.filter (fun header -> ConnectorOverlayState.isPropertyExpanded layerId side header overlayState)
         |> List.collect (fun header ->
             let color =
                 railProjection.ColorByHeader
@@ -396,7 +396,7 @@ module private ConnectorPaths =
 
     let railConnections
         context
-        pairId
+        layerId
         model
         inputGroups
         outputGroups
@@ -411,7 +411,7 @@ module private ConnectorPaths =
                 yield!
                     railConnectionsForSide
                         context
-                        pairId
+                        layerId
                         model
                         ProvenanceSide.Input
                         inputGroups
@@ -422,7 +422,7 @@ module private ConnectorPaths =
                 yield!
                     railConnectionsForSide
                         context
-                        pairId
+                        layerId
                         model
                         ProvenanceSide.Output
                         outputGroups
@@ -432,7 +432,7 @@ module private ConnectorPaths =
             yield!
                 valueRailConnectionsForSide
                     context
-                    pairId
+                    layerId
                     model
                     ProvenanceSide.Input
                     inputGroups
@@ -442,7 +442,7 @@ module private ConnectorPaths =
             yield!
                 valueRailConnectionsForSide
                     context
-                    pairId
+                    layerId
                     model
                     ProvenanceSide.Output
                     outputGroups
@@ -470,7 +470,7 @@ module private ConnectorPaths =
 
     let all
         context
-        pairId
+        layerId
         model
         inputGroups
         outputGroups
@@ -485,7 +485,7 @@ module private ConnectorPaths =
             yield!
                 railConnections
                     context
-                    pairId
+                    layerId
                     model
                     inputGroups
                     outputGroups
@@ -494,8 +494,8 @@ module private ConnectorPaths =
                     colorByHeader
                     overlayState
                     showPropertyHeaderConnectors
-            yield! groupConnections context pairId connections overlayState
-            yield! memberConnections context pairId model connections overlayState
+            yield! groupConnections context layerId connections overlayState
+            yield! memberConnections context layerId model connections overlayState
         ]
 
 module private ConnectorSvg =
@@ -693,7 +693,7 @@ type ConnectorOverlay =
     static member Main
         (
             containerRef: IRefValue<HTMLElement option>,
-            pairId: ProvenancePairId,
+            layerId: ProvenanceLayerId,
             model: ProvenanceModel,
             inputGroups: DisplayGroup list,
             outputGroups: DisplayGroup list,
@@ -727,7 +727,7 @@ type ConnectorOverlay =
 
                 ConnectorPaths.all
                     context
-                    pairId
+                    layerId
                     model
                     inputGroups
                     outputGroups
@@ -781,7 +781,7 @@ type ConnectorOverlay =
                     )
             ),
             [|
-                box pairId
+                box layerId
                 box model
                 box inputGroups
                 box outputGroups

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
@@ -319,7 +319,11 @@ module private ConnectorPaths =
         railProjection.Headers
         |> List.filter (fun header -> not (ConnectorOverlayState.isPropertyExpanded pairId side header overlayState))
         |> List.collect (fun header ->
-            let color = colorByHeader |> Map.tryFind header |> Option.bind id
+            let color =
+                railProjection.ColorByHeader
+                |> Map.tryFind header
+                |> Option.bind id
+                |> Option.orElseWith (fun () -> colorByHeader |> Map.tryFind header |> Option.bind id)
 
             groupsMatching model (fun propertyValue -> propertyValue.Header = header) groups
             |> List.choose (fun group ->
@@ -359,7 +363,11 @@ module private ConnectorPaths =
         railProjection.Headers
         |> List.filter (fun header -> ConnectorOverlayState.isPropertyExpanded pairId side header overlayState)
         |> List.collect (fun header ->
-            let color = colorByHeader |> Map.tryFind header |> Option.bind id
+            let color =
+                railProjection.ColorByHeader
+                |> Map.tryFind header
+                |> Option.bind id
+                |> Option.orElseWith (fun () -> colorByHeader |> Map.tryFind header |> Option.bind id)
 
             railProjection.ValuesByHeader
             |> Map.tryFind header

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
@@ -20,6 +20,7 @@ type private MeasuredConnector = {
     StrokeDasharray: string option
     InteractiveConnection: DisplayConnection option
     AriaLabel: string option
+    Color: string option
 }
 
 type ConnectorOverlayState = {
@@ -174,7 +175,7 @@ module private ConnectorHandles =
 /// Projects model/UI state into concrete connector path definitions.
 module private ConnectorPaths =
 
-    let private measured key testId className strokeWidth strokeDasharray interactiveConnection ariaLabel path = {
+    let private measured key testId className strokeWidth strokeDasharray interactiveConnection ariaLabel color path = {
         Key = key
         Path = path
         TestId = testId
@@ -183,6 +184,7 @@ module private ConnectorPaths =
         StrokeDasharray = strokeDasharray
         InteractiveConnection = interactiveConnection
         AriaLabel = ariaLabel
+        Color = color
     }
 
     let private isManuallyResolving pairId side groupId overlayState =
@@ -233,6 +235,7 @@ module private ConnectorPaths =
                     None
                     (Some connection)
                     (Some $"Select connection {connection.Id}")
+                    None
             )
         )
 
@@ -285,6 +288,7 @@ module private ConnectorPaths =
                                 None
                                 (Some singleConnection)
                                 (Some $"Select connection {displayConnection.Id}")
+                                None
                         )
                     )
                 )
@@ -309,11 +313,14 @@ module private ConnectorPaths =
         side
         groups
         (railProjection: PropertyRails.RailProjection)
+        (colorByHeader: Map<ProvenancePropertyHeader, string option>)
         overlayState
         =
         railProjection.Headers
         |> List.filter (fun header -> not (ConnectorOverlayState.isPropertyExpanded pairId side header overlayState))
         |> List.collect (fun header ->
+            let color = colorByHeader |> Map.tryFind header |> Option.bind id
+
             groupsMatching model (fun propertyValue -> propertyValue.Header = header) groups
             |> List.choose (fun group ->
                 ConnectorMeasure.pathBetweenDistantHandles
@@ -329,6 +336,7 @@ module private ConnectorPaths =
                         (Some "4 4")
                         None
                         None
+                        color
                 )
             )
         )
@@ -345,11 +353,14 @@ module private ConnectorPaths =
         side
         groups
         (railProjection: PropertyRails.RailProjection)
+        (colorByHeader: Map<ProvenancePropertyHeader, string option>)
         overlayState
         =
         railProjection.Headers
         |> List.filter (fun header -> ConnectorOverlayState.isPropertyExpanded pairId side header overlayState)
         |> List.collect (fun header ->
+            let color = colorByHeader |> Map.tryFind header |> Option.bind id
+
             railProjection.ValuesByHeader
             |> Map.tryFind header
             |> Option.defaultValue []
@@ -369,6 +380,7 @@ module private ConnectorPaths =
                             (Some "4 4")
                             None
                             None
+                            color
                     )
                 )
             )
@@ -382,6 +394,7 @@ module private ConnectorPaths =
         outputGroups
         inputRailProjection
         outputRailProjection
+        (colorByHeader: Map<ProvenancePropertyHeader, string option>)
         overlayState
         showPropertyHeaderConnectors
         =
@@ -395,6 +408,7 @@ module private ConnectorPaths =
                         ProvenanceSide.Input
                         inputGroups
                         inputRailProjection
+                        colorByHeader
                         overlayState
 
                 yield!
@@ -405,6 +419,7 @@ module private ConnectorPaths =
                         ProvenanceSide.Output
                         outputGroups
                         outputRailProjection
+                        colorByHeader
                         overlayState
             yield!
                 valueRailConnectionsForSide
@@ -414,6 +429,7 @@ module private ConnectorPaths =
                     ProvenanceSide.Input
                     inputGroups
                     inputRailProjection
+                    colorByHeader
                     overlayState
             yield!
                 valueRailConnectionsForSide
@@ -423,6 +439,7 @@ module private ConnectorPaths =
                     ProvenanceSide.Output
                     outputGroups
                     outputRailProjection
+                    colorByHeader
                     overlayState
         ]
 
@@ -439,6 +456,7 @@ module private ConnectorPaths =
                     (Some "6 4")
                     None
                     None
+                    None
             )
         )
 
@@ -451,6 +469,7 @@ module private ConnectorPaths =
         connections
         inputRailProjection
         outputRailProjection
+        (colorByHeader: Map<ProvenancePropertyHeader, string option>)
         overlayState
         showPropertyHeaderConnectors
         =
@@ -464,6 +483,7 @@ module private ConnectorPaths =
                     outputGroups
                     inputRailProjection
                     outputRailProjection
+                    colorByHeader
                     overlayState
                     showPropertyHeaderConnectors
             yield! groupConnections context pairId connections overlayState
@@ -479,6 +499,7 @@ module private ConnectorSvg =
     ]
 
     let strokeElements measured strokeWidth strokeOpacity debug =
+        let strokeColor = measured.Color |> Option.defaultValue "currentColor"
         let debugAttributes = debugAttributes debug measured
 
         [
@@ -497,13 +518,16 @@ module private ConnectorSvg =
             Svg.path [
                 svg.d measured.Path
                 svg.fill "none"
-                svg.stroke "currentColor"
+                svg.stroke strokeColor
                 svg.strokeWidth strokeWidth
                 svg.strokeLineCap "round"
                 svg.custom ("strokeOpacity", strokeOpacity)
                 svg.className measured.ClassName
                 match measured.StrokeDasharray with
                 | Some dash -> svg.custom ("strokeDasharray", dash)
+                | None -> ()
+                match measured.Color with
+                | Some color -> svg.custom ("data-provenance-color", color)
                 | None -> ()
                 if measured.InteractiveConnection.IsNone then
                     yield! debugAttributes
@@ -673,12 +697,14 @@ type ConnectorOverlay =
             liveDragStore: LiveDrag.Store,
             onSelect: DisplayConnection -> unit,
             ?onRemove: DisplayConnection -> unit,
-            ?debug: bool
+            ?debug: bool,
+            ?railColorByHeader: Map<ProvenancePropertyHeader, string option>
         ) =
         let paths, setPaths = React.useStateWithUpdater ([]: MeasuredConnector list)
         let hoveredKey, setHoveredKey = React.useState<string option> None
         let pendingFrame = React.useRef (None: float option)
         let debugEnabled = defaultArg debug false
+        let colorByHeader = defaultArg railColorByHeader Map.empty
 
         let setMeasuredPaths next =
             setPaths (fun current -> if current = next then current else next)
@@ -700,6 +726,7 @@ type ConnectorOverlay =
                     connections
                     inputRailProjection
                     outputRailProjection
+                    colorByHeader
                     overlayState
                     showPropertyHeaderConnectors
                 |> setMeasuredPaths

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
@@ -32,18 +32,13 @@ type ConnectorOverlayState = {
 module ConnectorOverlayState =
 
     let fromUiState (uiState: UiState) =
-        let expandedGroup =
-            match uiState.Detail with
-            | Some(ProvenanceDetail.Group(side, groupId)) -> Some(side, groupId)
-            | _ -> None
-
         let selectedConnectionId =
             match uiState.Detail with
             | Some(ProvenanceDetail.Connection connectionId) -> Some connectionId
             | _ -> None
 
         {
-            ExpandedGroup = expandedGroup
+            ExpandedGroup = uiState.ExpandedGroup
             SelectedConnectionId = selectedConnectionId
             ExpandedProperties = uiState.ExpandedProperties
         }

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -327,7 +327,9 @@ type Controls =
             ?stats: PropertyStats,
             ?badge: PropertyCountBadge,
             ?color: ProvenanceColor,
-            ?origins: Set<PropertyOrigin>
+            ?origins: Set<PropertyOrigin>,
+            ?onSetColor: ProvenanceColor option -> unit,
+            ?sourceInfoForValue: ProvenancePropertyValue -> PropertyValueSourceInfo option
         ) =
         let draggable =
             DndKit.useDraggable (
@@ -564,6 +566,11 @@ type Controls =
                     ]
                 ]
 
+        let colorButton =
+            match onSetColor with
+            | Some setColor -> Controls.PropertyColorButton(header, setColor)
+            | None -> Html.none
+
         // The secondary controls leave the layout entirely until their row is
         // hovered or holds focus, so idle rows are only as wide as their label.
         let rowControls =
@@ -576,12 +583,14 @@ type Controls =
                 prop.children [
                     match side with
                     | ProvenanceSide.Input ->
+                        colorButton
                         swapButton
                         bothButton
 
                     | ProvenanceSide.Output ->
                         bothButton
                         swapButton
+                        colorButton
                 ]
             ]
 
@@ -637,6 +646,9 @@ type Controls =
                             prop.testId $"provenance-property-values-{side}-{header.Category.Name}"
                         prop.children [
                             for propertyValue in propertyValues do
+                                let sourceInfo =
+                                    sourceInfoForValue |> Option.bind (fun resolver -> resolver propertyValue)
+
                                 Controls.ValueChip(
                                     propertyValue,
                                     onDragChanged = setIsValueChipDragging,
@@ -644,6 +656,7 @@ type Controls =
                                     showHeader = false,
                                     anchorSide = side,
                                     ?debug = debug,
+                                    ?sourceInfo = sourceInfo,
                                     key = DragDrop.propertyValueIdentity propertyValue
                                 )
                             Controls.AddValuePopover(
@@ -676,6 +689,12 @@ type Controls =
             onAddValue: ProvenancePropertyHeader -> ProvenanceValue -> ProvenanceTerm option -> unit,
             canSwitch: ProvenancePropertyHeader -> bool,
             setIsValueChipDragging: bool -> unit,
+            statsForHeader: ProvenancePropertyHeader -> PropertyStats option,
+            badgeForHeader: ProvenancePropertyHeader -> PropertyCountBadge option,
+            colorForHeader: ProvenancePropertyHeader -> ProvenanceColor option,
+            originsForHeader: ProvenancePropertyHeader -> Set<PropertyOrigin> option,
+            onSetColor: ProvenancePropertyHeader -> ProvenanceColor option -> unit,
+            sourceInfoForValue: ProvenancePropertyValue -> PropertyValueSourceInfo option,
             ?debug: bool
         ) =
         let droppable =
@@ -743,6 +762,12 @@ type Controls =
                         onToggleExpanded,
                         onAddValue,
                         setIsValueChipDragging,
+                        ?stats = statsForHeader header,
+                        ?badge = badgeForHeader header,
+                        ?color = colorForHeader header,
+                        ?origins = originsForHeader header,
+                        onSetColor = onSetColor header,
+                        sourceInfoForValue = sourceInfoForValue,
                         debug = defaultArg debug false,
                         key = DragDrop.propertyHeaderIdentity header
                     )
@@ -983,13 +1008,14 @@ type Controls =
 
     [<ReactComponent>]
     static member ValueLabel
-        (propertyValue: ProvenancePropertyValue, ?debug: bool, ?key: string, ?sourceInfo: PropertyValueSourceInfo option) : ReactElement =
+        (propertyValue: ProvenancePropertyValue, ?debug: bool, ?key: string, ?sourceInfo: PropertyValueSourceInfo)
+        : ReactElement =
         let label =
             $"{propertyValue.Header.Category.Name}: {Formatting.formatValue propertyValue.Value propertyValue.Unit}"
 
         let sourceTitle =
             match sourceInfo with
-            | Some(Some info) ->
+            | Some info ->
                 let parts = [
                     match info.TableName with
                     | Some tn -> $"Table: {tn}"
@@ -1012,13 +1038,23 @@ type Controls =
             | Some key -> prop.key key
             | None -> ()
             prop.className
-                "swt:flex swt:items-center swt:gap-1 swt:rounded swt:bg-base-200 swt:px-2 swt:py-1 swt:text-xs"
+                "swt:group swt:relative swt:flex swt:items-center swt:gap-1 swt:rounded swt:bg-base-200 swt:px-2 swt:py-1 swt:text-xs"
             match sourceTitle with
             | Some title -> prop.title title
             | None -> ()
             if defaultArg debug false then
                 prop.testId $"provenance-value-{propertyValue.Id}"
-            prop.children [ Html.span [ prop.text label ] ]
+            prop.children [
+                Html.span [ prop.text label ]
+                match sourceInfo with
+                | Some info ->
+                    Html.div [
+                        prop.className
+                            "swt:pointer-events-none swt:absolute swt:left-0 swt:top-full swt:z-30 swt:mt-1 swt:hidden swt:w-72 swt:rounded-md swt:border swt:border-base-300 swt:bg-base-100 swt:p-2 swt:shadow-lg group-hover:swt:block group-focus-within:swt:block"
+                        prop.children [ Controls.SourceInfoPopover(Some info) ]
+                    ]
+                | None -> Html.none
+            ]
         ]
 
     [<ReactComponent>]
@@ -1031,7 +1067,7 @@ type Controls =
             ?anchorSide: ProvenanceSide,
             ?debug: bool,
             ?key: string,
-            ?sourceInfo: PropertyValueSourceInfo option
+            ?sourceInfo: PropertyValueSourceInfo
         ) : ReactElement =
         let canDrag = defaultArg draggable true
         let showHeader = defaultArg showHeader true
@@ -1094,7 +1130,7 @@ type Controls =
                 yield! prop.spread (!!drag.attributes)
                 yield! prop.spread (!!drag.listeners)
             prop.className [
-                "swt:relative"
+                "swt:group swt:relative"
                 yield! Styles.propertyValueButtonClasses density drag.isDragging
                 if not canDrag then
                     "swt:cursor-default"
@@ -1104,7 +1140,7 @@ type Controls =
                 prop.testId $"provenance-value-{propertyValue.Id}"
             prop.ariaLabel $"Drag {propertyValue.Header.Category.Name} value"
             match sourceInfo with
-            | Some(Some info) ->
+            | Some info ->
                 let parts = [
                     match info.TableName with
                     | Some tn -> $"Table: {tn}"
@@ -1127,6 +1163,14 @@ type Controls =
                     prop.className "swt:grow swt:min-w-0 swt:truncate swt:text-left"
                     prop.text label
                 ]
+                match sourceInfo with
+                | Some info ->
+                    Html.div [
+                        prop.className
+                            "swt:pointer-events-none swt:absolute swt:left-0 swt:top-full swt:z-30 swt:mt-1 swt:hidden swt:w-72 swt:rounded-md swt:border swt:border-base-300 swt:bg-base-100 swt:p-2 swt:shadow-lg group-hover:swt:block group-focus-within:swt:block"
+                        prop.children [ Controls.SourceInfoPopover(Some info) ]
+                    ]
+                | None -> Html.none
             ]
         ]
 

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -754,6 +754,7 @@ type Controls =
             onToggleExpanded: ProvenancePropertyHeader -> unit,
             onAddValue: ProvenancePropertyHeader -> ProvenanceValue -> ProvenanceTerm option -> unit,
             canSwitch: ProvenancePropertyHeader -> bool,
+            isDropRejected: bool,
             setIsValueChipDragging: bool -> unit,
             statsForHeader: ProvenancePropertyHeader -> PropertyStats option,
             badgeForHeader: ProvenancePropertyHeader -> PropertyCountBadge option,
@@ -797,15 +798,23 @@ type Controls =
 
         let hiddenHeaderCount = headers.Length - visibleHeaders.Length
 
+        let dropState =
+            if droppable.isOver && isDropRejected then "rejecting"
+            elif droppable.isOver then "over"
+            else "idle"
+
         Html.aside [
             prop.ref droppable.setNodeRef
             prop.className [
                 "swt:flex swt:min-w-0 swt:flex-col swt:gap-2 swt:rounded swt:border swt:border-dashed swt:border-base-content/25 swt:border-2 swt:p-3 swt:transition-colors"
-                if droppable.isOver then
+                if dropState = "rejecting" then
+                    "swt:border-warning swt:bg-warning/10 swt:ring-2 swt:ring-warning/30"
+                elif droppable.isOver then
                     "swt:border-primary swt:bg-primary/10"
                 if headers.IsEmpty then
                     "swt:items-center swt:justify-center"
             ]
+            prop.custom ("data-provenance-drop-state", dropState)
             if defaultArg debug false then
                 prop.testId $"provenance-property-rail-{side}"
 

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -167,8 +167,13 @@ type Controls =
 
     [<ReactComponent>]
     static member LayerTabs
-        (session: ProvenanceSession, onSelect: ProvenancePairId -> unit, onAddLayer: unit -> unit, ?debug: bool)
-        =
+        (
+            session: ProvenanceSession,
+            onSelect: ProvenancePairId -> unit,
+            onAddLayer: unit -> unit,
+            ?debug: bool,
+            ?layerColors: Map<ProvenanceLayerId, ProvenanceColor>
+        ) =
         Html.div [
             prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
             prop.children [
@@ -176,6 +181,12 @@ type Controls =
                     let pair = session.Pairs.[pairId]
                     let left = session.Layers |> List.find (fun layer -> layer.Id = pair.LeftLayerId)
                     let right = session.Layers |> List.find (fun layer -> layer.Id = pair.RightLayerId)
+
+                    let leftColor =
+                        layerColors |> Option.bind (fun colors -> colors |> Map.tryFind left.Id)
+
+                    let rightColor =
+                        layerColors |> Option.bind (fun colors -> colors |> Map.tryFind right.Id)
 
                     Html.button [
                         prop.title $"View provenance for {left.Label} and {right.Label}"
@@ -189,8 +200,32 @@ type Controls =
                         prop.ariaLabel $"View provenance for {left.Label} and {right.Label}"
                         if defaultArg debug false then
                             prop.testId $"provenance-pair-{pairId}"
+                            let lc = leftColor |> Option.defaultValue ""
+                            let rc = rightColor |> Option.defaultValue ""
+                            prop.custom ("data-provenance-layer-color", $"{lc}|{rc}")
                         prop.onClick (fun _ -> onSelect pairId)
-                        prop.text $"{left.Label} -> {right.Label}"
+                        prop.children [
+                            match leftColor with
+                            | Some c when c <> "" ->
+                                Html.span [
+                                    prop.className "swt:size-3 swt:shrink-0 swt:rounded"
+                                    prop.style [ style.backgroundColor c ]
+                                ]
+                            | _ -> Html.none
+                            Html.span left.Label
+                            Html.i [
+                                prop.className
+                                    "swt:iconify swt:fluent--arrow-right-20-regular swt:size-3 swt:shrink-0 swt:mx-0.5"
+                            ]
+                            match rightColor with
+                            | Some c when c <> "" ->
+                                Html.span [
+                                    prop.className "swt:size-3 swt:shrink-0 swt:rounded"
+                                    prop.style [ style.backgroundColor c ]
+                                ]
+                            | _ -> Html.none
+                            Html.span right.Label
+                        ]
                     ]
                 Html.button [
                     prop.title "Add layer"
@@ -207,6 +242,44 @@ type Controls =
                 ]
             ]
         ]
+
+    [<ReactComponent>]
+    static member LayerColorButton
+        (layerId: ProvenanceLayerId, currentColor: ProvenanceColor option, onSetColor: ProvenanceColor option -> unit)
+        =
+        Popover.Simple(
+            trigger =
+                Html.button [
+                    prop.type'.button
+                    prop.className
+                        "swt:size-4 swt:shrink-0 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer swt:align-middle"
+                    match currentColor with
+                    | Some c when c <> "" -> prop.style [ style.backgroundColor c ]
+                    | _ -> ()
+                    prop.ariaLabel $"Set color for layer {layerId}"
+                ],
+            content =
+                Html.div [
+                    prop.className "swt:flex swt:flex-wrap swt:gap-1 swt:p-1"
+                    prop.children [
+                        for color in State.PropertyColors.palette do
+                            Html.button [
+                                prop.type'.button
+                                prop.className
+                                    "swt:size-6 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer"
+                                prop.style [ style.backgroundColor color ]
+                                prop.ariaLabel $"Set layer color {color}"
+                                prop.onClick (fun _ -> onSetColor (Some color))
+                            ]
+                        Html.button [
+                            prop.type'.button
+                            prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:min-h-0 swt:py-0"
+                            prop.text "None"
+                            prop.onClick (fun _ -> onSetColor None)
+                        ]
+                    ]
+                ]
+        )
 
     [<ReactComponent>]
     static member private PropertySwapButton
@@ -250,7 +323,11 @@ type Controls =
             onAddValue: ProvenancePropertyHeader -> ProvenanceValue -> ProvenanceTerm option -> unit,
             setIsValueChipDragging: bool -> unit,
             ?debug: bool,
-            ?key: string
+            ?key: string,
+            ?stats: PropertyStats,
+            ?badge: PropertyCountBadge,
+            ?color: ProvenanceColor,
+            ?origins: Set<PropertyOrigin>
         ) =
         let draggable =
             DndKit.useDraggable (
@@ -328,10 +405,72 @@ type Controls =
                 prop.onClick (fun _ -> onToggleSide header)
                 prop.children [
                     propertyAnchor
+                    match color with
+                    | Some c when c <> "" ->
+                        Html.span [
+                            prop.className "swt:size-2.5 swt:shrink-0 swt:rounded"
+                            prop.style [ style.backgroundColor c ]
+                        ]
+                    | _ -> Html.none
                     Html.span [
                         prop.className "swt:min-w-0 swt:truncate swt:text-left"
                         prop.text header.Category.Name
                     ]
+                    match badge with
+                    | Some badge ->
+                        match badge with
+                        | PropertyCountBadge.Hide -> Html.none
+                        | PropertyCountBadge.DistinctValues n ->
+                            Html.span [
+                                prop.className "swt:badge swt:badge-xs swt:shrink-0"
+                                prop.text (string n)
+                            ]
+                        | PropertyCountBadge.Coverage(setsWithValue, total) ->
+                            Html.span [
+                                prop.className "swt:badge swt:badge-xs swt:badge-warning swt:shrink-0"
+                                prop.text $"{setsWithValue}/{total}"
+                            ]
+                    | None -> Html.none
+                    match origins with
+                    | Some origins ->
+                        let hasCurrent =
+                            origins
+                            |> Set.exists (
+                                function
+                                | PropertyOrigin.Current _ -> true
+                                | _ -> false
+                            )
+
+                        let hasUpstream =
+                            origins
+                            |> Set.exists (
+                                function
+                                | PropertyOrigin.UpstreamLayer _
+                                | PropertyOrigin.PreviousContext _ -> true
+                                | _ -> false
+                            )
+
+                        if hasCurrent && hasUpstream then
+                            Html.i [
+                                prop.className
+                                    "swt:iconify swt:fluent--layer-diagonal-20-regular swt:size-3 swt:shrink-0 swt:text-base-content/60"
+                                prop.title "Current and upstream"
+                            ]
+                        elif hasCurrent then
+                            Html.i [
+                                prop.className
+                                    "swt:iconify swt:fluent--target-arrow-20-regular swt:size-3 swt:shrink-0 swt:text-base-content/60"
+                                prop.title "Current"
+                            ]
+                        elif hasUpstream then
+                            Html.i [
+                                prop.className
+                                    "swt:iconify swt:fluent--arrow-trending-lines-20-regular swt:size-3 swt:shrink-0 swt:text-base-content/60"
+                                prop.title "Upstream"
+                            ]
+                        else
+                            Html.none
+                    | None -> Html.none
                 ]
             ]
 
@@ -843,9 +982,30 @@ type Controls =
         )
 
     [<ReactComponent>]
-    static member ValueLabel(propertyValue: ProvenancePropertyValue, ?debug: bool, ?key: string) : ReactElement =
+    static member ValueLabel
+        (propertyValue: ProvenancePropertyValue, ?debug: bool, ?key: string, ?sourceInfo: PropertyValueSourceInfo option) : ReactElement =
         let label =
             $"{propertyValue.Header.Category.Name}: {Formatting.formatValue propertyValue.Value propertyValue.Unit}"
+
+        let sourceTitle =
+            match sourceInfo with
+            | Some(Some info) ->
+                let parts = [
+                    match info.TableName with
+                    | Some tn -> $"Table: {tn}"
+                    | None -> ()
+                    match info.ProcessName with
+                    | Some pn -> $"Process: {pn}"
+                    | None -> ()
+                    if info.IsCurrentTable then
+                        "Current table"
+                ]
+
+                if parts.IsEmpty then
+                    None
+                else
+                    Some(System.String.Join("; ", parts))
+            | _ -> None
 
         Html.div [
             match key with
@@ -853,6 +1013,9 @@ type Controls =
             | None -> ()
             prop.className
                 "swt:flex swt:items-center swt:gap-1 swt:rounded swt:bg-base-200 swt:px-2 swt:py-1 swt:text-xs"
+            match sourceTitle with
+            | Some title -> prop.title title
+            | None -> ()
             if defaultArg debug false then
                 prop.testId $"provenance-value-{propertyValue.Id}"
             prop.children [ Html.span [ prop.text label ] ]
@@ -867,7 +1030,8 @@ type Controls =
             ?showHeader: bool,
             ?anchorSide: ProvenanceSide,
             ?debug: bool,
-            ?key: string
+            ?key: string,
+            ?sourceInfo: PropertyValueSourceInfo option
         ) : ReactElement =
         let canDrag = defaultArg draggable true
         let showHeader = defaultArg showHeader true
@@ -939,6 +1103,22 @@ type Controls =
             if defaultArg debug false then
                 prop.testId $"provenance-value-{propertyValue.Id}"
             prop.ariaLabel $"Drag {propertyValue.Header.Category.Name} value"
+            match sourceInfo with
+            | Some(Some info) ->
+                let parts = [
+                    match info.TableName with
+                    | Some tn -> $"Table: {tn}"
+                    | None -> ()
+                    match info.ProcessName with
+                    | Some pn -> $"Process: {pn}"
+                    | None -> ()
+                    if info.IsCurrentTable then
+                        "Current table"
+                ]
+
+                if not parts.IsEmpty then
+                    prop.title (System.String.Join("; ", parts))
+            | _ -> ()
             prop.children [
                 match valueAnchor with
                 | Some anchor -> anchor
@@ -1095,3 +1275,212 @@ type Controls =
                  else
                      None)
         )
+
+    [<ReactComponent>]
+    static member FilterToolbar
+        (
+            filters: FilterState,
+            onSearch: string -> unit,
+            onPropertySort: PropertySort -> unit,
+            onGroupSort: GroupSort -> unit,
+            onValueCountFilter: PropertyValueCountFilter -> unit,
+            onOriginFilter: PropertyOriginFilter -> unit,
+            ?debug: bool
+        ) =
+        Html.div [
+            prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2 swt:p-2"
+            prop.children [
+                Html.div [
+                    prop.className "swt:relative swt:flex swt:items-center"
+                    prop.children [
+                        Html.i [
+                            prop.className
+                                "swt:iconify swt:fluent--search-20-regular swt:absolute swt:left-2 swt:size-4 swt:text-base-content/50"
+                        ]
+                        Html.input [
+                            prop.className "swt:input swt:input-bordered swt:input-sm swt:pl-8"
+                            prop.placeholder "Search properties & values..."
+                            prop.value filters.SearchText
+                            prop.onChange onSearch
+                        ]
+                    ]
+                ]
+                Html.select [
+                    prop.className "swt:select swt:select-bordered swt:select-sm"
+                    prop.value (
+                        match filters.PropertySort with
+                        | PropertySort.ValueCountDesc -> "ValueCountDesc"
+                        | PropertySort.NameAsc -> "NameAsc"
+                        | PropertySort.Origin -> "Origin"
+                    )
+                    prop.onChange (fun v ->
+                        match v with
+                        | "ValueCountDesc" -> onPropertySort PropertySort.ValueCountDesc
+                        | "NameAsc" -> onPropertySort PropertySort.NameAsc
+                        | "Origin" -> onPropertySort PropertySort.Origin
+                        | _ -> ()
+                    )
+                    prop.children [
+                        Html.option [ prop.value "ValueCountDesc"; prop.text "Value count" ]
+                        Html.option [ prop.value "NameAsc"; prop.text "Name" ]
+                        Html.option [ prop.value "Origin"; prop.text "Origin" ]
+                    ]
+                ]
+                Html.select [
+                    prop.className "swt:select swt:select-bordered swt:select-sm"
+                    prop.value (
+                        match filters.GroupSort with
+                        | GroupSort.NameAsc -> "NameAsc"
+                        | GroupSort.MemberCountDesc -> "MemberCountDesc"
+                        | GroupSort.ConnectionCountDesc -> "ConnectionCountDesc"
+                    )
+                    prop.onChange (fun v ->
+                        match v with
+                        | "NameAsc" -> onGroupSort GroupSort.NameAsc
+                        | "MemberCountDesc" -> onGroupSort GroupSort.MemberCountDesc
+                        | "ConnectionCountDesc" -> onGroupSort GroupSort.ConnectionCountDesc
+                        | _ -> ()
+                    )
+                    prop.children [
+                        Html.option [ prop.value "NameAsc"; prop.text "Name" ]
+                        Html.option [ prop.value "MemberCountDesc"; prop.text "Members" ]
+                        Html.option [
+                            prop.value "ConnectionCountDesc"
+                            prop.text "Connections"
+                        ]
+                    ]
+                ]
+                Html.select [
+                    prop.className "swt:select swt:select-bordered swt:select-sm"
+                    prop.value (
+                        match filters.ValueCountFilter with
+                        | PropertyValueCountFilter.Any -> "Any"
+                        | PropertyValueCountFilter.Singleton -> "Singleton"
+                        | PropertyValueCountFilter.Multiple -> "Multiple"
+                        | PropertyValueCountFilter.CoverageGap -> "CoverageGap"
+                    )
+                    prop.onChange (fun v ->
+                        match v with
+                        | "Any" -> onValueCountFilter PropertyValueCountFilter.Any
+                        | "Singleton" -> onValueCountFilter PropertyValueCountFilter.Singleton
+                        | "Multiple" -> onValueCountFilter PropertyValueCountFilter.Multiple
+                        | "CoverageGap" -> onValueCountFilter PropertyValueCountFilter.CoverageGap
+                        | _ -> ()
+                    )
+                    prop.children [
+                        Html.option [ prop.value "Any"; prop.text "Any" ]
+                        Html.option [ prop.value "Singleton"; prop.text "1 value" ]
+                        Html.option [ prop.value "Multiple"; prop.text "2+ values" ]
+                        Html.option [ prop.value "CoverageGap"; prop.text "Coverage gap" ]
+                    ]
+                ]
+                Html.select [
+                    prop.className "swt:select swt:select-bordered swt:select-sm"
+                    prop.value (
+                        match filters.OriginFilter with
+                        | PropertyOriginFilter.AnyOrigin -> "AnyOrigin"
+                        | PropertyOriginFilter.CurrentOnly -> "CurrentOnly"
+                        | PropertyOriginFilter.AnyUpstream -> "AnyUpstream"
+                        | PropertyOriginFilter.UpstreamLayer _ -> "UpstreamLayer"
+                        | PropertyOriginFilter.PreviousContext _ -> "PreviousContext"
+                    )
+                    prop.onChange (fun v ->
+                        match v with
+                        | "AnyOrigin" -> onOriginFilter PropertyOriginFilter.AnyOrigin
+                        | "CurrentOnly" -> onOriginFilter PropertyOriginFilter.CurrentOnly
+                        | "AnyUpstream" -> onOriginFilter PropertyOriginFilter.AnyUpstream
+                        | _ -> ()
+                    )
+                    prop.children [
+                        Html.option [ prop.value "AnyOrigin"; prop.text "Any" ]
+                        Html.option [ prop.value "CurrentOnly"; prop.text "Current only" ]
+                        Html.option [ prop.value "AnyUpstream"; prop.text "Upstream" ]
+                    ]
+                ]
+                if defaultArg debug false then
+                    Html.span [ prop.testId "provenance-filter-toolbar" ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member PropertyColorButton(header: ProvenancePropertyHeader, onSetColor: ProvenanceColor option -> unit) =
+        Popover.Simple(
+            trigger =
+                Html.button [
+                    prop.type'.button
+                    prop.className
+                        "swt:size-5 swt:shrink-0 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer swt:align-middle"
+                    prop.ariaLabel $"Set color for property {header.Category.Name}"
+                ],
+            content =
+                Html.div [
+                    prop.className "swt:flex swt:flex-wrap swt:gap-1 swt:p-1"
+                    prop.children [
+                        for color in State.PropertyColors.palette do
+                            Html.button [
+                                prop.type'.button
+                                prop.className
+                                    "swt:size-6 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer"
+                                prop.style [ style.backgroundColor color ]
+                                prop.ariaLabel $"Set property color {color}"
+                                prop.onClick (fun _ -> onSetColor (Some color))
+                            ]
+                        Html.button [
+                            prop.type'.button
+                            prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:min-h-0 swt:py-0"
+                            prop.text "None"
+                            prop.onClick (fun _ -> onSetColor None)
+                        ]
+                    ]
+                ]
+        )
+
+    [<ReactComponent>]
+    static member SourceInfoPopover(sourceInfo: PropertyValueSourceInfo option) =
+        match sourceInfo with
+        | None -> Html.none
+        | Some info ->
+            Html.div [
+                prop.className "swt:text-xs swt:space-y-1 swt:p-1"
+                prop.children [
+                    if info.IsCurrentTable then
+                        Html.span [
+                            prop.className "swt:font-semibold"
+                            prop.text "Current table"
+                        ]
+                    else
+                        match info.TableName with
+                        | Some tableName ->
+                            Html.span [
+                                prop.className "swt:font-semibold"
+                                prop.text $"Table: {tableName}"
+                            ]
+                        | None -> Html.none
+
+                    match info.ProcessName with
+                    | Some processName -> Html.span [ prop.text $"Process: {processName}" ]
+                    | None -> Html.none
+
+                    if not info.InputNames.IsEmpty then
+                        Html.div [
+                            prop.children [
+                                Html.span [ prop.className "swt:font-medium"; prop.text "Inputs:" ]
+                                for inputName in info.InputNames do
+                                    Html.span [ prop.text $" {inputName}" ]
+                            ]
+                        ]
+                    else
+                        Html.none
+
+                    if not info.OutputNames.IsEmpty then
+                        Html.div [
+                            prop.children [
+                                Html.span [ prop.className "swt:font-medium"; prop.text "Outputs:" ]
+                                for outputName in info.OutputNames do
+                                    Html.span [ prop.text $" {outputName}" ]
+                            ]
+                        ]
+                    else
+                        Html.none
+                ]
+            ]

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -1180,9 +1180,6 @@ type Controls =
             [| box drag.isDragging |]
         )
 
-        // let isdragging = setIsValueChipDragging drag.isDragging
-
-
         let text = Formatting.formatValue propertyValue.Value propertyValue.Unit
 
         let label =

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -1281,6 +1281,7 @@ type Controls =
             ?key: string
         ) =
         let sideName = SideLabels.sideName side
+        let isOpen, setIsOpen = React.useState false
         let name, setName = React.useState ""
 
         let availableKinds =
@@ -1312,83 +1313,108 @@ type Controls =
             else
                 None
 
-        Popover.Simple(
-            trigger =
-                Html.button [
-                    prop.type'.button
-                    prop.className Styles.addPropertyValueButtonClasses
-                    if defaultArg debug false then
-                        prop.testId $"provenance-add-{sideName}-trigger"
-                    prop.ariaLabel $"Add {sideName}"
-                    prop.children [
-                        Html.i [
-                            prop.className "swt:iconify swt:fluent--add-20-regular swt:size-5 swt:shrink-0"
-                        ]
-                        Html.span [ prop.text $"Add {sideName}" ]
-                    ]
-                ],
-            content =
-                Html.form [
-                    prop.className "swt:flex swt:flex-col swt:gap-2"
-                    prop.onSubmit (fun event ->
-                        event.preventDefault ()
+        let content =
+            Html.form [
+                prop.className "swt:flex swt:flex-col swt:gap-2"
+                prop.onSubmit (fun event ->
+                    event.preventDefault ()
 
-                        if nameError.IsNone then
-                            onCreate {
-                                Side = side
-                                Header = selectedKind |> Endpoints.endpointHeader side
-                                Name = trimmedName
-                            }
-                    )
-                    prop.children [
-                        Html.label [ prop.className "swt:label"; prop.text "Endpoint name" ]
-                        Html.input [
-                            prop.ariaLabel "Endpoint name"
-                            prop.className [
-                                "swt:input swt:input-bordered swt:input-sm"
-                                if nameError.IsSome then
-                                    "swt:input-error"
-                            ]
-                            prop.required true
-                            prop.value name
-                            prop.onChange setName
+                    onCreate {
+                        Side = side
+                        Header = selectedKind |> Endpoints.endpointHeader side
+                        Name = trimmedName
+                    }
+
+                    setName ""
+                    setSelectedKindId availableKinds.Head.Id
+                    setIsOpen false
+                )
+                prop.children [
+                    Html.label [ prop.className "swt:label"; prop.text "Endpoint name" ]
+                    Html.input [
+                        prop.ariaLabel "Endpoint name"
+                        prop.className [
+                            "swt:input swt:input-bordered swt:input-sm"
+                            if nameError.IsSome then
+                                "swt:input-error"
                         ]
-                        match nameError with
-                        | Some error ->
-                            Html.p [
-                                prop.className "swt:text-xs swt:text-error"
-                                prop.text error
-                            ]
-                        | None -> Html.none
-                        Html.label [ prop.className "swt:label"; prop.text "Endpoint kind" ]
-                        Html.select [
-                            prop.ariaLabel "Endpoint kind"
-                            prop.className "swt:select swt:select-bordered swt:select-sm"
-                            prop.value selectedKind.Id
-                            prop.onChange setSelectedKindId
-                            prop.children [
-                                for kind in availableKinds do
-                                    Html.option [
-                                        prop.value kind.Id
-                                        prop.text (ProvenanceKind.displayName kind)
-                                    ]
-                            ]
+                        prop.required true
+                        prop.value name
+                        prop.onChange setName
+                    ]
+                    match nameError with
+                    | Some error ->
+                        Html.p [
+                            prop.className "swt:text-xs swt:text-error"
+                            prop.text error
                         ]
-                        Html.button [
-                            prop.type'.submit
-                            prop.className "swt:btn swt:btn-primary swt:btn-sm"
-                            prop.disabled nameError.IsSome
-                            if defaultArg debug false then
-                                prop.testId $"provenance-create-{sideName}"
-                            prop.text "Create endpoint"
+                    | None -> Html.none
+                    Html.label [ prop.className "swt:label"; prop.text "Endpoint kind" ]
+                    Html.select [
+                        prop.ariaLabel "Endpoint kind"
+                        prop.className "swt:select swt:select-bordered swt:select-sm"
+                        prop.value selectedKind.Id
+                        prop.onChange setSelectedKindId
+                        prop.children [
+                            for kind in availableKinds do
+                                Html.option [
+                                    prop.value kind.Id
+                                    prop.text (ProvenanceKind.displayName kind)
+                                ]
                         ]
                     ]
-                ],
+                    Html.button [
+                        prop.type'.submit
+                        prop.className "swt:btn swt:btn-primary swt:btn-sm"
+                        prop.disabled nameError.IsSome
+                        if defaultArg debug false then
+                            prop.testId $"provenance-create-{sideName}"
+                        prop.text "Create endpoint"
+                    ]
+                ]
+            ]
+
+        Popover.Popover(
+            isOpen = isOpen,
+            onOpenChange = setIsOpen,
             ?debug =
                 (if defaultArg debug false then
                      Some $"provenance-add-{sideName}"
                  else
-                     None)
+                     None),
+            children =
+                React.Fragment [
+                    Popover.Trigger(
+                        Html.button [
+                            prop.type'.button
+                            prop.className Styles.addPropertyValueButtonClasses
+                            if defaultArg debug false then
+                                prop.testId $"provenance-add-{sideName}-trigger"
+                            prop.ariaLabel $"Add {sideName}"
+                            prop.children [
+                                Html.i [
+                                    prop.className "swt:iconify swt:fluent--add-20-regular swt:size-5 swt:shrink-0"
+                                ]
+                                Html.span [ prop.text $"Add {sideName}" ]
+                            ]
+                        ]
+                    )
+                    Popover.Content(
+                        children =
+                            Html.div [
+                                prop.className "swt:flex swt:flex-col swt:gap-2"
+                                prop.children [
+                                    Html.div [
+                                        prop.className "swt:flex swt:items-start swt:justify-between swt:gap-2"
+                                        prop.children [
+                                            Html.div [ prop.className "swt:flex-1"; prop.children content ]
+                                            Popover.Close()
+                                        ]
+                                    ]
+                                ]
+                            ]
+                    )
+                ]
         )
 
     [<ReactComponent>]

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -800,9 +800,11 @@ type Controls =
         Html.aside [
             prop.ref droppable.setNodeRef
             prop.className [
-                "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
+                "swt:flex swt:min-w-0 swt:flex-col swt:gap-2 swt:rounded swt:border swt:border-dashed swt:border-base-content/25 swt:border-2 swt:p-3 swt:transition-colors"
                 if droppable.isOver then
-                    "swt:ring-2 swt:ring-primary swt:rounded"
+                    "swt:border-primary swt:bg-primary/10"
+                if headers.IsEmpty then
+                    "swt:items-center swt:justify-center"
             ]
             if defaultArg debug false then
                 prop.testId $"provenance-property-rail-{side}"
@@ -811,65 +813,81 @@ type Controls =
                 | Some sideId -> prop.custom ("data-provenance-side-id", sideId)
                 | None -> ()
             prop.children [
-                Html.h3 [
-                    prop.className [
-                        "swt:text-sm swt:font-semibold swt:text-primary"
-                        if side = ProvenanceSide.Output then
-                            "swt:self-end"
+                if headers.IsEmpty then
+                    Html.p [
+                        prop.className "swt:text-sm swt:text-base-content/60 swt:text-center swt:py-8"
+                        prop.text "Drag Properties here to use them for grouping"
                     ]
-                    prop.text "Properties"
-                ]
-                for header in visibleHeaders do
-                    Controls.PropertyRailItem(
-                        side,
-                        header,
-                        valuesForHeader header,
-                        active,
-                        canSwitch header,
-                        isExpanded header,
-                        onToggleSide,
-                        onToggleBoth,
-                        onSwitch,
-                        onToggleExpanded,
-                        onAddValue,
-                        setIsValueChipDragging,
-                        ?stats = statsForHeader header,
-                        ?badge = badgeForHeader header,
-                        ?color = colorForHeader header,
-                        ?origins = originsForHeader header,
-                        onSetColor = onSetColor header,
-                        sourceInfoForValue = sourceInfoForValue,
-                        debug = defaultArg debug false,
-                        key = DragDrop.propertyHeaderIdentity header
-                    )
-                if hiddenHeaderCount > 0 || showAllHeaders && headers.Length > collapseThreshold then
-                    Html.button [
-                        prop.type'.button
+
+                    Html.div [
+                        prop.className "swt:w-fit"
+                        prop.children [
+                            Controls.AddValuePopover(None, onAddValue, label = "Add property", ?debug = debug)
+                        ]
+                    ]
+                else
+                    Html.h3 [
                         prop.className [
-                            "swt:btn swt:btn-ghost swt:btn-xs swt:w-fit"
+                            "swt:text-sm swt:font-semibold swt:text-primary"
                             if side = ProvenanceSide.Output then
                                 "swt:self-end"
                         ]
-                        if defaultArg debug false then
-                            prop.testId $"provenance-property-overflow-{side}"
-                        prop.onClick (fun _ -> setShowAllHeaders (not showAllHeaders))
-                        prop.text (
-                            if showAllHeaders then
-                                "Show fewer"
-                            else
-                                $"+{hiddenHeaderCount} more"
+                        prop.text "Properties"
+                    ]
+
+                    for header in visibleHeaders do
+                        Controls.PropertyRailItem(
+                            side,
+                            header,
+                            valuesForHeader header,
+                            active,
+                            canSwitch header,
+                            isExpanded header,
+                            onToggleSide,
+                            onToggleBoth,
+                            onSwitch,
+                            onToggleExpanded,
+                            onAddValue,
+                            setIsValueChipDragging,
+                            ?stats = statsForHeader header,
+                            ?badge = badgeForHeader header,
+                            ?color = colorForHeader header,
+                            ?origins = originsForHeader header,
+                            onSetColor = onSetColor header,
+                            sourceInfoForValue = sourceInfoForValue,
+                            debug = defaultArg debug false,
+                            key = DragDrop.propertyHeaderIdentity header
                         )
+
+                    if hiddenHeaderCount > 0 || showAllHeaders && headers.Length > collapseThreshold then
+                        Html.button [
+                            prop.type'.button
+                            prop.className [
+                                "swt:btn swt:btn-ghost swt:btn-xs swt:w-fit"
+                                if side = ProvenanceSide.Output then
+                                    "swt:self-end"
+                            ]
+                            if defaultArg debug false then
+                                prop.testId $"provenance-property-overflow-{side}"
+                            prop.onClick (fun _ -> setShowAllHeaders (not showAllHeaders))
+                            prop.text (
+                                if showAllHeaders then
+                                    "Show fewer"
+                                else
+                                    $"+{hiddenHeaderCount} more"
+                            )
+                        ]
+
+                    Html.div [
+                        prop.className [
+                            "swt:w-fit"
+                            if side = ProvenanceSide.Output then
+                                "swt:self-end"
+                        ]
+                        prop.children [
+                            Controls.AddValuePopover(None, onAddValue, label = "Add property", ?debug = debug)
+                        ]
                     ]
-                Html.div [
-                    prop.className [
-                        "swt:w-fit"
-                        if side = ProvenanceSide.Output then
-                            "swt:self-end"
-                    ]
-                    prop.children [
-                        Controls.AddValuePopover(None, onAddValue, label = "Add property", ?debug = debug)
-                    ]
-                ]
             ]
         ]
 

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -7,6 +7,7 @@ open Feliz
 open Swate.Components
 open Swate.Components.JsBindings
 open Swate.Components.Primitive.Buttons
+open Swate.Components.Primitive.Dropdown
 open Swate.Components.Primitive.Popover
 open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Grouping
@@ -66,6 +67,30 @@ module private ColorPicker =
                         onSetColor None
                     )
                 ]
+            ]
+        ]
+
+module private OriginSymbols =
+
+    let upstreamIcon size =
+        Html.i [
+            prop.className [ "swt:iconify swt:fluent--arrow-up-20-regular"; size ]
+        ]
+
+    let currentIcon size =
+        Html.i [
+            prop.className [ "swt:iconify swt:fluent--circle-20-filled"; size ]
+        ]
+
+    let bothIcons size =
+        Html.span [
+            prop.className "swt:inline-flex swt:items-center swt:gap-1"
+            prop.children [
+                upstreamIcon size
+                Html.span [
+                    prop.className "swt:h-4 swt:w-px swt:bg-current swt:opacity-60"
+                ]
+                currentIcon size
             ]
         ]
 
@@ -492,22 +517,22 @@ type Controls =
                             )
 
                         if hasCurrent && hasUpstream then
-                            Html.i [
-                                prop.className
-                                    "swt:iconify swt:fluent--layer-diagonal-20-regular swt:size-3 swt:shrink-0 swt:text-base-content/60"
+                            Html.span [
+                                prop.className "swt:shrink-0 swt:text-base-content/60"
                                 prop.title "Current and upstream"
+                                prop.children [ OriginSymbols.bothIcons "swt:size-3" ]
                             ]
                         elif hasCurrent then
-                            Html.i [
-                                prop.className
-                                    "swt:iconify swt:fluent--target-arrow-20-regular swt:size-3 swt:shrink-0 swt:text-base-content/60"
+                            Html.span [
+                                prop.className "swt:shrink-0 swt:text-base-content/60"
                                 prop.title "Current"
+                                prop.children [ OriginSymbols.currentIcon "swt:size-3" ]
                             ]
                         elif hasUpstream then
-                            Html.i [
-                                prop.className
-                                    "swt:iconify swt:fluent--arrow-trending-lines-20-regular swt:size-3 swt:shrink-0 swt:text-base-content/60"
+                            Html.span [
+                                prop.className "swt:shrink-0 swt:text-base-content/60"
                                 prop.title "Upstream"
+                                prop.children [ OriginSymbols.upstreamIcon "swt:size-3" ]
                             ]
                         else
                             Html.none
@@ -1372,13 +1397,58 @@ type Controls =
             filters: FilterState,
             onSearch: string -> unit,
             onPropertySort: PropertySort -> unit,
-            onGroupSort: GroupSort -> unit,
+            _onGroupSort: GroupSort -> unit,
             onValueCountFilter: PropertyValueCountFilter -> unit,
             onOriginFilter: PropertyOriginFilter -> unit,
             ?debug: bool
         ) =
+        let sortOpen, setSortOpen = React.useState false
+
+        let propertySortOption sort label =
+            let active = filters.PropertySort = sort
+
+            Html.li [
+                Html.button [
+                    prop.type'.button
+                    prop.className [
+                        "swt:btn swt:btn-sm swt:w-full swt:justify-start"
+                        if active then "swt:btn-primary" else "swt:btn-ghost"
+                    ]
+                    prop.ariaLabel label
+                    prop.onClick (fun _ -> onPropertySort sort)
+                    prop.children [ Html.span label ]
+                ]
+            ]
+
+        let originActive filter =
+            match filter, filters.OriginFilter with
+            | PropertyOriginFilter.AnyOrigin, PropertyOriginFilter.AnyOrigin -> true
+            | PropertyOriginFilter.CurrentOnly, PropertyOriginFilter.CurrentOnly -> true
+            | PropertyOriginFilter.AnyUpstream, PropertyOriginFilter.AnyUpstream
+            | PropertyOriginFilter.AnyUpstream, PropertyOriginFilter.UpstreamLayer _
+            | PropertyOriginFilter.AnyUpstream, PropertyOriginFilter.PreviousContext _ -> true
+            | _ -> false
+
+        let originButton filter label icon =
+            Html.button [
+                prop.type'.button
+                prop.className [
+                    "swt:btn swt:btn-sm swt:join-item swt:w-11 swt:px-0"
+                    if originActive filter then
+                        "swt:btn-primary"
+                    else
+                        "swt:btn-outline"
+                ]
+                prop.ariaLabel label
+                prop.title label
+                prop.onClick (fun _ -> onOriginFilter filter)
+                prop.children [ icon ]
+            ]
+
         Html.div [
             prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2 swt:p-2"
+            if defaultArg debug false then
+                prop.testId "provenance-filter-toolbar"
             prop.children [
                 Html.div [
                     prop.className "swt:relative swt:flex swt:items-center"
@@ -1395,53 +1465,33 @@ type Controls =
                         ]
                     ]
                 ]
-                Html.select [
-                    prop.className "swt:select swt:select-bordered swt:select-sm"
-                    prop.value (
-                        match filters.PropertySort with
-                        | PropertySort.ValueCountDesc -> "ValueCountDesc"
-                        | PropertySort.NameAsc -> "NameAsc"
-                        | PropertySort.Origin -> "Origin"
-                    )
-                    prop.onChange (fun v ->
-                        match v with
-                        | "ValueCountDesc" -> onPropertySort PropertySort.ValueCountDesc
-                        | "NameAsc" -> onPropertySort PropertySort.NameAsc
-                        | "Origin" -> onPropertySort PropertySort.Origin
-                        | _ -> ()
-                    )
-                    prop.children [
-                        Html.option [ prop.value "ValueCountDesc"; prop.text "Value count" ]
-                        Html.option [ prop.value "NameAsc"; prop.text "Name" ]
-                        Html.option [ prop.value "Origin"; prop.text "Origin" ]
-                    ]
-                ]
-                Html.select [
-                    prop.className "swt:select swt:select-bordered swt:select-sm"
-                    prop.value (
-                        match filters.GroupSort with
-                        | GroupSort.NameAsc -> "NameAsc"
-                        | GroupSort.MemberCountDesc -> "MemberCountDesc"
-                        | GroupSort.ConnectionCountDesc -> "ConnectionCountDesc"
-                    )
-                    prop.onChange (fun v ->
-                        match v with
-                        | "NameAsc" -> onGroupSort GroupSort.NameAsc
-                        | "MemberCountDesc" -> onGroupSort GroupSort.MemberCountDesc
-                        | "ConnectionCountDesc" -> onGroupSort GroupSort.ConnectionCountDesc
-                        | _ -> ()
-                    )
-                    prop.children [
-                        Html.option [ prop.value "NameAsc"; prop.text "Name" ]
-                        Html.option [ prop.value "MemberCountDesc"; prop.text "Members" ]
-                        Html.option [
-                            prop.value "ConnectionCountDesc"
-                            prop.text "Connections"
+                Dropdown.Main(
+                    sortOpen,
+                    setSortOpen,
+                    Html.button [
+                        prop.type'.button
+                        prop.className "swt:btn swt:btn-sm swt:btn-outline"
+                        prop.ariaLabel "Sort By"
+                        prop.custom ("aria-expanded", sortOpen)
+                        prop.onClick (fun _ -> setSortOpen (not sortOpen))
+                        prop.children [
+                            Html.i [
+                                prop.className "swt:iconify swt:fluent--arrow-sort-20-regular swt:size-4"
+                            ]
+                            Html.span "Sort By"
                         ]
-                    ]
-                ]
+                    ],
+                    React.Fragment [
+                        propertySortOption PropertySort.ValueCountDesc "Property Value Count"
+                        propertySortOption PropertySort.NameAsc "Name"
+                        propertySortOption PropertySort.ConnectionCountDesc "Connection Count"
+                    ],
+                    contentClassName =
+                        "swt:w-52 swt:max-w-none swt:menu swt:bg-base-200 swt:rounded-box swt:z-99 swt:p-2 swt:shadow-sm swt:top-110%"
+                )
                 Html.select [
                     prop.className "swt:select swt:select-bordered swt:select-sm"
+                    prop.ariaLabel "Filter by property value count"
                     prop.value (
                         match filters.ValueCountFilter with
                         | PropertyValueCountFilter.Any -> "Any"
@@ -1464,31 +1514,23 @@ type Controls =
                         Html.option [ prop.value "CoverageGap"; prop.text "Coverage gap" ]
                     ]
                 ]
-                Html.select [
-                    prop.className "swt:select swt:select-bordered swt:select-sm"
-                    prop.value (
-                        match filters.OriginFilter with
-                        | PropertyOriginFilter.AnyOrigin -> "AnyOrigin"
-                        | PropertyOriginFilter.CurrentOnly -> "CurrentOnly"
-                        | PropertyOriginFilter.AnyUpstream -> "AnyUpstream"
-                        | PropertyOriginFilter.UpstreamLayer _ -> "UpstreamLayer"
-                        | PropertyOriginFilter.PreviousContext _ -> "PreviousContext"
-                    )
-                    prop.onChange (fun v ->
-                        match v with
-                        | "AnyOrigin" -> onOriginFilter PropertyOriginFilter.AnyOrigin
-                        | "CurrentOnly" -> onOriginFilter PropertyOriginFilter.CurrentOnly
-                        | "AnyUpstream" -> onOriginFilter PropertyOriginFilter.AnyUpstream
-                        | _ -> ()
-                    )
+                Html.div [
+                    prop.className "swt:join"
                     prop.children [
-                        Html.option [ prop.value "AnyOrigin"; prop.text "Any" ]
-                        Html.option [ prop.value "CurrentOnly"; prop.text "Current only" ]
-                        Html.option [ prop.value "AnyUpstream"; prop.text "Upstream" ]
+                        originButton
+                            PropertyOriginFilter.AnyUpstream
+                            "Show upstream properties"
+                            (OriginSymbols.upstreamIcon "swt:size-4")
+                        originButton
+                            PropertyOriginFilter.CurrentOnly
+                            "Show current properties"
+                            (OriginSymbols.currentIcon "swt:size-4")
+                        originButton
+                            PropertyOriginFilter.AnyOrigin
+                            "Show current and upstream properties"
+                            (OriginSymbols.bothIcons "swt:size-4")
                     ]
                 ]
-                if defaultArg debug false then
-                    Html.span [ prop.testId "provenance-filter-toolbar" ]
             ]
         ]
 

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -30,6 +30,45 @@ module private SideLabels =
         | ProvenanceSide.Input -> "input"
         | ProvenanceSide.Output -> "output"
 
+module private ColorPicker =
+
+    let fallbackColor =
+        State.PropertyColors.palette |> Array.tryHead |> Option.defaultValue "#2563eb"
+
+    let currentOrFallback color =
+        match color with
+        | Some c when c <> "" -> c
+        | _ -> fallbackColor
+
+    let content ariaLabel (draftColor: string) (setDraftColor: string -> unit) onSetColor =
+        Html.div [
+            prop.className "swt:flex swt:items-center swt:gap-2 swt:p-2"
+            prop.children [
+                Html.input [
+                    prop.custom ("type", "color")
+                    prop.className "swt:h-8 swt:w-10 swt:cursor-pointer swt:rounded swt:border swt:border-base-300"
+                    prop.value draftColor
+                    prop.ariaLabel ariaLabel
+                    prop.onChange (fun (color: string) -> setDraftColor color)
+                ]
+                Html.button [
+                    prop.type'.button
+                    prop.className "swt:btn swt:btn-xs swt:btn-primary swt:min-h-0 swt:py-0"
+                    prop.text "Select"
+                    prop.onClick (fun _ -> onSetColor (Some draftColor))
+                ]
+                Html.button [
+                    prop.type'.button
+                    prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:min-h-0 swt:py-0"
+                    prop.text "Clear"
+                    prop.onClick (fun _ ->
+                        setDraftColor fallbackColor
+                        onSetColor None
+                    )
+                ]
+            ]
+        ]
+
 /// Converts between draft form state and typed provenance values.
 module private ValueDrafts =
 
@@ -172,7 +211,8 @@ type Controls =
             onSelect: ProvenanceLayerId -> unit,
             onAddLayer: unit -> unit,
             ?debug: bool,
-            ?layerColors: Map<ProvenanceLayerId, ProvenanceColor>
+            ?layerColors: Map<ProvenanceLayerId, ProvenanceColor>,
+            ?onSetLayerColor: ProvenanceLayerId -> ProvenanceColor option -> unit
         ) =
         Html.div [
             prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
@@ -183,29 +223,52 @@ type Controls =
                     let layerColor =
                         layerColors |> Option.bind (fun colors -> colors |> Map.tryFind layer.Id)
 
-                    Html.button [
-                        prop.title $"View provenance layer {layer.Label}"
-                        prop.className [
-                            "swt:btn swt:btn-sm"
-                            if layerId = session.ActiveLayerId then
-                                "swt:btn-primary"
-                            else
-                                "swt:btn-outline"
+                    let layerButtonClasses = [
+                        "swt:btn swt:btn-sm swt:join-item"
+                        if layerId = session.ActiveLayerId then
+                            "swt:btn-primary"
+                        else
+                            "swt:btn-outline"
+                    ]
+
+                    let swatchButtonClass =
+                        [
+                            yield! layerButtonClasses
+                            "swt:min-h-8 swt:w-8 swt:px-0"
                         ]
-                        prop.ariaLabel $"View provenance layer {layer.Label}"
-                        if defaultArg debug false then
-                            prop.testId $"provenance-layer-{layerId}"
-                            prop.custom ("data-provenance-layer-color", layerColor |> Option.defaultValue "")
-                        prop.onClick (fun _ -> onSelect layerId)
+                        |> String.concat " "
+
+                    Html.div [
+                        prop.className "swt:join"
                         prop.children [
-                            match layerColor with
-                            | Some color when color <> "" ->
+                            match onSetLayerColor with
+                            | Some setLayerColor ->
+                                Controls.LayerColorButton(
+                                    layer.Id,
+                                    layerColor,
+                                    setLayerColor layer.Id,
+                                    triggerClassName = swatchButtonClass
+                                )
+                            | None ->
                                 Html.span [
-                                    prop.className "swt:size-3 swt:shrink-0 swt:rounded"
-                                    prop.style [ style.backgroundColor color ]
+                                    prop.className [
+                                        yield! layerButtonClasses
+                                        "swt:min-h-8 swt:w-8 swt:px-0"
+                                    ]
+                                    match layerColor with
+                                    | Some color when color <> "" -> prop.style [ style.backgroundColor color ]
+                                    | _ -> ()
                                 ]
-                            | _ -> Html.none
-                            Html.span layer.Label
+                            Html.button [
+                                prop.title $"View provenance layer {layer.Label}"
+                                prop.className layerButtonClasses
+                                prop.ariaLabel $"View provenance layer {layer.Label}"
+                                if defaultArg debug false then
+                                    prop.testId $"provenance-layer-{layerId}"
+                                    prop.custom ("data-provenance-layer-color", layerColor |> Option.defaultValue "")
+                                prop.onClick (fun _ -> onSelect layerId)
+                                prop.children [ Html.span layer.Label ]
+                            ]
                         ]
                     ]
                 Html.button [
@@ -226,40 +289,33 @@ type Controls =
 
     [<ReactComponent>]
     static member LayerColorButton
-        (layerId: ProvenanceLayerId, currentColor: ProvenanceColor option, onSetColor: ProvenanceColor option -> unit)
-        =
+        (
+            layerId: ProvenanceLayerId,
+            currentColor: ProvenanceColor option,
+            onSetColor: ProvenanceColor option -> unit,
+            ?triggerClassName: string
+        ) : ReactElement =
+        let draftColor, setDraftColor =
+            React.useState (ColorPicker.currentOrFallback currentColor)
+
+        React.useEffect ((fun () -> setDraftColor (ColorPicker.currentOrFallback currentColor)), [| box currentColor |])
+
+        let triggerClassName =
+            defaultArg
+                triggerClassName
+                "swt:size-4 swt:shrink-0 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer swt:align-middle"
+
         Popover.Simple(
             trigger =
                 Html.button [
                     prop.type'.button
-                    prop.className
-                        "swt:size-4 swt:shrink-0 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer swt:align-middle"
+                    prop.className triggerClassName
                     match currentColor with
                     | Some c when c <> "" -> prop.style [ style.backgroundColor c ]
                     | _ -> ()
                     prop.ariaLabel $"Set color for layer {layerId}"
                 ],
-            content =
-                Html.div [
-                    prop.className "swt:flex swt:flex-wrap swt:gap-1 swt:p-1"
-                    prop.children [
-                        for color in State.PropertyColors.palette do
-                            Html.button [
-                                prop.type'.button
-                                prop.className
-                                    "swt:size-6 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer"
-                                prop.style [ style.backgroundColor color ]
-                                prop.ariaLabel $"Set layer color {color}"
-                                prop.onClick (fun _ -> onSetColor (Some color))
-                            ]
-                        Html.button [
-                            prop.type'.button
-                            prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:min-h-0 swt:py-0"
-                            prop.text "None"
-                            prop.onClick (fun _ -> onSetColor None)
-                        ]
-                    ]
-                ]
+            content = ColorPicker.content $"Choose color for layer {layerId}" draftColor setDraftColor onSetColor
         )
 
     [<ReactComponent>]
@@ -549,7 +605,7 @@ type Controls =
 
         let colorButton =
             match onSetColor with
-            | Some setColor -> Controls.PropertyColorButton(header, setColor)
+            | Some setColor -> Controls.PropertyColorButton(header, color, setColor)
             | None -> Html.none
 
         // The secondary controls leave the layout entirely until their row is
@@ -1433,36 +1489,34 @@ type Controls =
         ]
 
     [<ReactComponent>]
-    static member PropertyColorButton(header: ProvenancePropertyHeader, onSetColor: ProvenanceColor option -> unit) =
+    static member PropertyColorButton
+        (
+            header: ProvenancePropertyHeader,
+            currentColor: ProvenanceColor option,
+            onSetColor: ProvenanceColor option -> unit
+        ) =
+        let draftColor, setDraftColor =
+            React.useState (ColorPicker.currentOrFallback currentColor)
+
+        React.useEffect ((fun () -> setDraftColor (ColorPicker.currentOrFallback currentColor)), [| box currentColor |])
+
         Popover.Simple(
             trigger =
                 Html.button [
                     prop.type'.button
                     prop.className
                         "swt:size-5 swt:shrink-0 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer swt:align-middle"
+                    match currentColor with
+                    | Some c when c <> "" -> prop.style [ style.backgroundColor c ]
+                    | _ -> ()
                     prop.ariaLabel $"Set color for property {header.Category.Name}"
                 ],
             content =
-                Html.div [
-                    prop.className "swt:flex swt:flex-wrap swt:gap-1 swt:p-1"
-                    prop.children [
-                        for color in State.PropertyColors.palette do
-                            Html.button [
-                                prop.type'.button
-                                prop.className
-                                    "swt:size-6 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer"
-                                prop.style [ style.backgroundColor color ]
-                                prop.ariaLabel $"Set property color {color}"
-                                prop.onClick (fun _ -> onSetColor (Some color))
-                            ]
-                        Html.button [
-                            prop.type'.button
-                            prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:min-h-0 swt:py-0"
-                            prop.text "None"
-                            prop.onClick (fun _ -> onSetColor None)
-                        ]
-                    ]
-                ]
+                ColorPicker.content
+                    $"Choose color for property {header.Category.Name}"
+                    draftColor
+                    setDraftColor
+                    onSetColor
         )
 
     [<ReactComponent>]

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -331,7 +331,7 @@ type Controls =
         Html.button [
             prop.title $"Move {header.Category.Name} grouping from {sideName}"
             prop.type'.button
-            prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:btn-square swt:btn-outline swt:z-10"
+            prop.className "swt:btn swt:btn-xs swt:btn-ghost swt:btn-square swt:btn-outline swt:z-10 swt:bg-base-100/90"
             prop.ariaLabel $"Move {header.Category.Name} grouping from {sideName}"
             if defaultArg debug false then
                 prop.testId $"provenance-property-drag-{side}-{header.Category.Name}"
@@ -434,6 +434,8 @@ type Controls =
                         "swt:btn-primary"
                     else
                         "swt:btn-outline"
+                    if not sideSelected then
+                        "swt:bg-base-100/90"
                     if canSwitch then
                         yield! Styles.draggableButtonClasses draggable.isDragging
 
@@ -517,7 +519,7 @@ type Controls =
             Html.button [
                 prop.type'.button
                 prop.className [
-                    "swt:btn swt:btn-xs swt:btn-square swt:z-10 swt:btn-outline"
+                    "swt:btn swt:btn-xs swt:btn-square swt:z-10 swt:btn-outline swt:bg-base-100/90"
 
                     match side with
                     | ProvenanceSide.Input -> " swt:rounded-r-none swt:border-r-0"
@@ -572,6 +574,8 @@ type Controls =
                         "swt:btn-primary"
                     else
                         "swt:btn-outline"
+                    if not bothSelected then
+                        "swt:bg-base-100/90"
                 ]
                 if defaultArg debug false then
                     prop.testId $"provenance-property-both-{side}-{header.Category.Name}"
@@ -592,7 +596,7 @@ type Controls =
                     prop.type'.button
                     prop.disabled true
                     prop.className
-                        "swt:btn swt:btn-xs swt:btn-ghost swt:btn-square swt:z-10 swt:btn-outline swt:border-white"
+                        "swt:btn swt:btn-xs swt:btn-ghost swt:btn-square swt:z-10 swt:btn-outline swt:border-white swt:bg-base-100/90"
                     prop.ariaLabel $"Move {header.Category.Name} grouping from {sideName}"
                     if defaultArg debug false then
                         prop.testId $"provenance-property-drag-{side}-{header.Category.Name}"
@@ -1505,7 +1509,7 @@ type Controls =
                 Html.button [
                     prop.type'.button
                     prop.className
-                        "swt:size-5 swt:shrink-0 swt:rounded swt:border swt:border-base-300 swt:cursor-pointer swt:align-middle"
+                        "swt:btn swt:btn-xs swt:btn-square swt:z-10 swt:btn-outline swt:shrink-0 swt:bg-base-100/90"
                     match currentColor with
                     | Some c when c <> "" -> prop.style [ style.backgroundColor c ]
                     | _ -> ()
@@ -1516,7 +1520,8 @@ type Controls =
                     $"Choose color for property {header.Category.Name}"
                     draftColor
                     setDraftColor
-                    onSetColor
+                    onSetColor,
+            triggerClassName = "swt:relative swt:z-10 swt:shrink-0"
         )
 
     [<ReactComponent>]

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -169,7 +169,7 @@ type Controls =
     static member LayerTabs
         (
             session: ProvenanceSession,
-            onSelect: ProvenancePairId -> unit,
+            onSelect: ProvenanceLayerId -> unit,
             onAddLayer: unit -> unit,
             ?debug: bool,
             ?layerColors: Map<ProvenanceLayerId, ProvenanceColor>
@@ -177,54 +177,35 @@ type Controls =
         Html.div [
             prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
             prop.children [
-                for pairId in session.PairOrder do
-                    let pair = session.Pairs.[pairId]
-                    let left = session.Layers |> List.find (fun layer -> layer.Id = pair.LeftLayerId)
-                    let right = session.Layers |> List.find (fun layer -> layer.Id = pair.RightLayerId)
+                for layerId in session.LayerOrder do
+                    let layer = Session.layerById layerId session
 
-                    let leftColor =
-                        layerColors |> Option.bind (fun colors -> colors |> Map.tryFind left.Id)
-
-                    let rightColor =
-                        layerColors |> Option.bind (fun colors -> colors |> Map.tryFind right.Id)
+                    let layerColor =
+                        layerColors |> Option.bind (fun colors -> colors |> Map.tryFind layer.Id)
 
                     Html.button [
-                        prop.title $"View provenance for {left.Label} and {right.Label}"
+                        prop.title $"View provenance layer {layer.Label}"
                         prop.className [
                             "swt:btn swt:btn-sm"
-                            if pairId = session.ActivePairId then
+                            if layerId = session.ActiveLayerId then
                                 "swt:btn-primary"
                             else
                                 "swt:btn-outline"
                         ]
-                        prop.ariaLabel $"View provenance for {left.Label} and {right.Label}"
+                        prop.ariaLabel $"View provenance layer {layer.Label}"
                         if defaultArg debug false then
-                            prop.testId $"provenance-pair-{pairId}"
-                            let lc = leftColor |> Option.defaultValue ""
-                            let rc = rightColor |> Option.defaultValue ""
-                            prop.custom ("data-provenance-layer-color", $"{lc}|{rc}")
-                        prop.onClick (fun _ -> onSelect pairId)
+                            prop.testId $"provenance-layer-{layerId}"
+                            prop.custom ("data-provenance-layer-color", layerColor |> Option.defaultValue "")
+                        prop.onClick (fun _ -> onSelect layerId)
                         prop.children [
-                            match leftColor with
-                            | Some c when c <> "" ->
+                            match layerColor with
+                            | Some color when color <> "" ->
                                 Html.span [
                                     prop.className "swt:size-3 swt:shrink-0 swt:rounded"
-                                    prop.style [ style.backgroundColor c ]
+                                    prop.style [ style.backgroundColor color ]
                                 ]
                             | _ -> Html.none
-                            Html.span left.Label
-                            Html.i [
-                                prop.className
-                                    "swt:iconify swt:fluent--arrow-right-20-regular swt:size-3 swt:shrink-0 swt:mx-0.5"
-                            ]
-                            match rightColor with
-                            | Some c when c <> "" ->
-                                Html.span [
-                                    prop.className "swt:size-3 swt:shrink-0 swt:rounded"
-                                    prop.style [ style.backgroundColor c ]
-                                ]
-                            | _ -> Html.none
-                            Html.span right.Label
+                            Html.span layer.Label
                         ]
                     ]
                 Html.button [
@@ -695,6 +676,7 @@ type Controls =
             originsForHeader: ProvenancePropertyHeader -> Set<PropertyOrigin> option,
             onSetColor: ProvenancePropertyHeader -> ProvenanceColor option -> unit,
             sourceInfoForValue: ProvenancePropertyValue -> PropertyValueSourceInfo option,
+            ?sideId: ProvenanceLayerSideId,
             ?debug: bool
         ) =
         let droppable =
@@ -739,6 +721,10 @@ type Controls =
             ]
             if defaultArg debug false then
                 prop.testId $"provenance-property-rail-{side}"
+
+                match sideId with
+                | Some sideId -> prop.custom ("data-provenance-side-id", sideId)
+                | None -> ()
             prop.children [
                 Html.h3 [
                     prop.className [

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -397,6 +397,7 @@ type Controls =
             DndKit.useDraggable (
                 {|
                     id = DragDrop.propertyDragId side header
+                    data = {| label = header.Category.Name |}
                 |}
             )
 

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -339,24 +339,6 @@ type GroupCard =
             articleRef.current <- (if isNull element then None else Some(unbox element))
             droppable.setNodeRef element
 
-        // let dnd = DndKit.use()
-
-        // let isValueChipDragging =
-        //     match dnd.active with
-        //     | Some active ->
-        //         active.data.current?type = DragDrop.PropertyValue
-        //     | None ->
-        //         false
-
-        // let dnd = DndKit.use()
-
-        // let isValueChipDragging =
-        //     match dnd.active with
-        //     | Some active ->
-        //         active.data.current?type = DragDrop.PropertyValue
-        //     | None ->
-        //         false
-
         // Two anchors at opposite card edges: the group-facing edge carries the draggable
         // group connection handle, the property-facing edge is measurement-only and is
         // where property/value connectors from the same-side rail attach.

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -8,6 +8,7 @@ open Swate.Components.Primitive.Buttons
 open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Edit
 open Swate.Components.Shared.ProvenanceGrouping.Grouping
+open Swate.Components.Shared.ProvenanceGrouping.Session
 open Swate.Components.Page.ProvenanceGrouping.Types
 
 /// Maps loaded endpoint kinds (Source, Sample, Data, ...) to a display label and icon.
@@ -290,6 +291,7 @@ type GroupCard =
             onExpand: unit -> unit,
             isValueChipDragging: bool,
             ?connectionCount: int,
+            ?sourceInfoForValue: ProvenancePropertyValue -> PropertyValueSourceInfo option,
             ?debug: bool,
             ?key: string
         ) =
@@ -682,8 +684,13 @@ type GroupCard =
                                                             prop.className "swt:flex swt:flex-wrap swt:gap-1"
                                                             prop.children [
                                                                 for value in memberValues do
+                                                                    let sourceInfo =
+                                                                        sourceInfoForValue
+                                                                        |> Option.bind (fun resolver -> resolver value)
+
                                                                     Controls.ValueLabel(
                                                                         value,
+                                                                        ?sourceInfo = sourceInfo,
                                                                         key =
                                                                             $"member:{member'.SetId}:{DragDrop.propertyValueIdentity value}"
                                                                     )

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -4,7 +4,6 @@ open Fable.Core
 open Feliz
 open Swate.Components
 open Swate.Components.JsBindings
-open Swate.Components.Primitive.Buttons
 open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Edit
 open Swate.Components.Shared.ProvenanceGrouping.Grouping
@@ -130,6 +129,20 @@ module private TabText =
         if trimmed.Length = 0 then "", ""
         elif trimmed.Length = 1 then trimmed, ""
         else trimmed.Substring(0, 1), trimmed.Substring(1)
+
+module private SelectionSurface =
+
+    [<Emit("$0.closest($1)")>]
+    let private closest (_element: Browser.Types.Element) (_selector: string) : Browser.Types.Element = jsNative
+
+    let shouldSelect (event: Browser.Types.MouseEvent) =
+        let targetObj: obj = box event.target
+
+        if isNull targetObj then
+            false
+        else
+            let target = unbox<Browser.Types.Element> targetObj
+            isNull (closest target "button,[role='button'],a,input,select,textarea")
 
 type private OrganizerTabMode =
     | Responsive
@@ -375,6 +388,10 @@ type GroupCard =
             | ProvenanceSide.Input -> "swt:left-full swt:ml-2"
             | ProvenanceSide.Output -> "swt:right-full swt:mr-2"
 
+        let handleSelectionClick (event: Browser.Types.MouseEvent) =
+            if SelectionSurface.shouldSelect event then
+                onSelect ()
+
         Html.article [
             match key with
             | Some key -> prop.key key
@@ -421,21 +438,15 @@ type GroupCard =
                         ]
                     | _ -> Html.none
 
-                let selectButton =
-                    Buttons.QuickAccessButton(
-                        Html.i [
-                            prop.className "swt:iconify swt:fluent--checkmark-circle-20-regular swt:size-4"
-                        ],
-                        "Select group",
-                        (fun _ -> onSelect ())
-                    )
-
                 match tabs with
                 | [] ->
                     // A card without grouping values is always a single loaded endpoint,
                     // so the type line sits above its name to mirror the expanded member rows.
                     Html.div [
-                        prop.className "swt:flex swt:items-start swt:gap-2"
+                        prop.className "swt:flex swt:cursor-pointer swt:items-start swt:gap-2"
+                        prop.onClick handleSelectionClick
+                        if defaultArg debug false then
+                            prop.testId $"provenance-group-select-surface-{side}-{group.Id}"
                         prop.children [
                             Html.div [
                                 prop.className "swt:flex swt:min-w-0 swt:grow swt:flex-col swt:gap-0.5"
@@ -451,7 +462,6 @@ type GroupCard =
                                 ]
                             ]
                             connectionBadge
-                            selectButton
                         ]
                     ]
                 | tabs ->
@@ -501,7 +511,10 @@ type GroupCard =
                     |]
 
                     Html.div [
-                        prop.className "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
+                        prop.className "swt:flex swt:min-w-0 swt:cursor-pointer swt:flex-col swt:gap-2"
+                        prop.onClick handleSelectionClick
+                        if defaultArg debug false then
+                            prop.testId $"provenance-group-select-surface-{side}-{group.Id}"
                         prop.children [
                             Html.div [
                                 prop.className [
@@ -595,7 +608,6 @@ type GroupCard =
                                         ]
                                     ]
                                     connectionBadge
-                                    selectButton
                                 ]
                             ]
                         ]

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -563,7 +563,8 @@ type GroupCard =
                                         prop.ariaLabel "Show members"
                                         prop.title "Show members"
                                         prop.onClick (fun _ -> onExpand ())
-                                        prop.className "swt:group swt:relative swt:min-w-0 swt:grow swt:cursor-pointer"
+                                        prop.className
+                                            "swt:group swt:relative swt:w-fit swt:max-w-full swt:cursor-pointer"
                                         prop.children [
                                             Html.span [
                                                 prop.ariaHidden true

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -101,6 +101,9 @@ module DragDrop =
     let propertyDragId side header =
         $"provenance-property|{side}|{encode (propertyHeaderIdentity header)}"
 
+    let folderPropertyDragId side header =
+        $"provenance-folder-property|{side}|{encode (propertyHeaderIdentity header)}"
+
     let propertyRailDropId side = $"provenance-property-drop|{side}"
 
     let groupDragId side groupId =
@@ -145,6 +148,7 @@ module DragDrop =
     type Payload =
         | PropertyValue of ProvenancePropertyValueId
         | PropertyHeader of ProvenanceSide * string
+        | FolderPropertyHeader of ProvenanceSide * string
         | Group of ProvenanceSide * string
         | ConnectionHandle of ConnectionHandleRef
 
@@ -173,6 +177,10 @@ module DragDrop =
             Some(Payload.PropertyHeader(ProvenanceSide.Input, decode headerId))
         | [| "provenance-property"; "Output"; headerId |] ->
             Some(Payload.PropertyHeader(ProvenanceSide.Output, decode headerId))
+        | [| "provenance-folder-property"; "Input"; headerId |] ->
+            Some(Payload.FolderPropertyHeader(ProvenanceSide.Input, decode headerId))
+        | [| "provenance-folder-property"; "Output"; headerId |] ->
+            Some(Payload.FolderPropertyHeader(ProvenanceSide.Output, decode headerId))
         | [| "provenance-group"; "Input"; groupId |] -> Some(Payload.Group(ProvenanceSide.Input, decode groupId))
         | [| "provenance-group"; "Output"; groupId |] -> Some(Payload.Group(ProvenanceSide.Output, decode groupId))
         | [| "provenance-connection-drag"; kind; side; sourceId; parent |] ->

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -573,13 +573,14 @@ module PropertyProjection =
         match sort with
         | PropertySort.ValueCountDesc ->
             headers
-            |> List.sortByDescending (fun header ->
-                statsByHeader.TryFind header
-                |> Option.map (fun stats -> stats.DistinctValueCount)
-                |> Option.defaultValue 0
+            |> List.sortBy (fun header ->
+                let count =
+                    statsByHeader.TryFind header
+                    |> Option.map (fun stats -> stats.DistinctValueCount)
+                    |> Option.defaultValue 0
+
+                -count, header.Category.Name, header.Kind.Id
             )
-            |> List.sortBy (fun header -> header.Category.Name)
-            |> List.sortBy (fun header -> header.Kind.Id)
         | PropertySort.NameAsc -> headers |> List.sortBy (fun header -> header.Category.Name, header.Kind.Id)
         | PropertySort.Origin -> headers |> List.sortBy (fun header -> header.Category.Name)
 
@@ -631,14 +632,31 @@ module PropertyProjection =
 
         let badgeByHeader = statsByHeader |> Map.map (fun _ stats -> badgeForStats stats)
 
+        let stableSourceColor (source: PropertyValueSourceInfo) =
+            let key =
+                [
+                    source.TableName |> Option.defaultValue ""
+                    source.ProcessName |> Option.defaultValue ""
+                    yield! source.InputNames
+                    yield! source.OutputNames
+                ]
+                |> String.concat "|"
+
+            let index = (hash key |> abs) % State.PropertyColors.palette.Length
+            State.PropertyColors.palette.[index]
+
+        let resolvedColorForHeader header origins =
+            match uiState.PropertyColors.ManualPropertyColors |> Map.tryFind { Header = header } with
+            | Some color -> Some color
+            | None ->
+                match origins |> Set.toList with
+                | [ PropertyOrigin.UpstreamLayer layerId ] -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
+                | [ PropertyOrigin.PreviousContext source ] -> Some(stableSourceColor source)
+                | _ -> None
+
         let colorByHeader =
             headers
-            |> List.map (fun header ->
-                let manual =
-                    uiState.PropertyColors.ManualPropertyColors |> Map.tryFind { Header = header }
-
-                header, manual
-            )
+            |> List.map (fun header -> header, resolvedColorForHeader header originByHeader.[header])
             |> Map.ofList
 
         let filtered =
@@ -776,6 +794,7 @@ module ValueAssignment =
     open Swate.Components.Shared.ProvenanceGrouping.Types
     open Swate.Components.Shared.ProvenanceGrouping.Edit
     open Swate.Components.Shared.ProvenanceGrouping.Grouping
+    open Swate.Components.Shared.ProvenanceGrouping.Session
     open Swate.Components.Page.ProvenanceGrouping.Types
 
     let private targetForGroup side (group: DisplayGroup) =
@@ -875,6 +894,35 @@ module ValueAssignment =
                 )
             )
             (Ok { Adds = []; Overwrites = [] })
+
+    let selectedTargetGroupsForDrop
+        (pairId: ProvenancePairId)
+        (dropSide: ProvenanceSide)
+        (dropGroupId: string)
+        (selectedInputs: Set<ProvenancePairId * string>)
+        (selectedOutputs: Set<ProvenancePairId * string>)
+        (findGroup: ProvenanceSide -> string -> DisplayGroup option)
+        : DisplayGroup list =
+        let idsForPair selected =
+            selected
+            |> Set.filter (fun (currentPairId, _) -> currentPairId = pairId)
+            |> Set.map snd
+
+        let inputIds = idsForPair selectedInputs
+        let outputIds = idsForPair selectedOutputs
+
+        let dropIsSelected =
+            match dropSide with
+            | ProvenanceSide.Input -> inputIds.Contains dropGroupId
+            | ProvenanceSide.Output -> outputIds.Contains dropGroupId
+
+        if dropIsSelected && (not inputIds.IsEmpty || not outputIds.IsEmpty) then
+            [
+                yield! inputIds |> Set.toList |> List.choose (findGroup ProvenanceSide.Input)
+                yield! outputIds |> Set.toList |> List.choose (findGroup ProvenanceSide.Output)
+            ]
+        else
+            findGroup dropSide dropGroupId |> Option.toList
 
 /// Builds property-value views with source and origin info for display.
 module PropertyValueViewing =

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -771,8 +771,19 @@ module PropertyProjection =
             match uiState.PropertyColors.ManualPropertyColors |> Map.tryFind { Header = header } with
             | Some color -> Some color
             | None ->
-                match origins |> Set.toList with
-                | [ PropertyOrigin.UpstreamLayer layerId ] -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
+                let layerOrigins =
+                    origins
+                    |> Set.toList
+                    |> List.choose (
+                        function
+                        | PropertyOrigin.Current(layerId, _) -> Some layerId
+                        | PropertyOrigin.UpstreamLayer layerId -> Some layerId
+                        | PropertyOrigin.PreviousContext _ -> None
+                    )
+                    |> List.distinct
+
+                match layerOrigins with
+                | [ layerId ] -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
                 | _ -> None
 
         let colorByHeader =
@@ -1083,3 +1094,43 @@ module PropertyValueViewing =
             Origin = origin
             Color = color
         }
+
+[<Fable.Core.Mangle(false)>]
+module Exports =
+
+    open Swate.Components.Shared.ProvenanceGrouping.Types
+    open Swate.Components.Shared.ProvenanceGrouping.Session
+    open Swate.Components.Page.ProvenanceGrouping.Types
+
+    let private sideFromName =
+        function
+        | "Input" -> ProvenanceSide.Input
+        | "Output" -> ProvenanceSide.Output
+        | side -> failwithf "Unknown provenance side '%s'." side
+
+    let private propertyHeaderByName propertyName (model: ProvenanceModel) =
+        model.PropertyValues
+        |> Map.toList
+        |> List.map (fun (_, value) -> value.Header)
+        |> List.distinct
+        |> List.find (fun header -> header.Category.Name = propertyName)
+
+    let sampleDroppedPropertyRailColor sideName propertyName layerColor =
+        let session = StoryFixtures.createSampleSession ()
+        let layer = Session.activeLayer session
+        let side = sideFromName sideName
+        let header = propertyHeaderByName propertyName layer.Model
+
+        let uiState =
+            State.init session
+            |> State.Sides.ensure session
+            |> State.PropertyPlacement.place layer.Id side header
+            |> State.PropertyColors.setLayerColor layer.Id layerColor
+
+        let projection =
+            PropertyProjection.railProjectionWithFilters session layer.Id side layer.Model uiState
+
+        projection.ColorByHeader
+        |> Map.tryFind header
+        |> Option.bind id
+        |> Option.defaultValue ""

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -361,9 +361,6 @@ module PropertyRails =
     let headersForSide side (model: ProvenanceModel) =
         headersFromSets ProvenanceSet.effectivePropertyValueIds side model
 
-    let ownedHeadersForSide side (model: ProvenanceModel) =
-        headersFromSets (fun set -> set.PropertyValueIds) side model
-
     let headersForModel (model: ProvenanceModel) =
         [
             yield! headersForSide ProvenanceSide.Input model
@@ -462,9 +459,6 @@ module PropertyRails =
         )
         |> List.sortBy (fun header -> header.Category.Name)
 
-    let propertyRailHeadersForSide layerId side model uiState =
-        propertyRailHeadersForSideUsing (fun header -> defaultRailSide header model) layerId side model uiState
-
     let propertyRailHeadersForSideInSession session layerId side model uiState =
         propertyRailHeadersForSideUsing
             (fun header -> defaultRailSideInSession session layerId header model)
@@ -489,37 +483,6 @@ module PropertyRails =
         |> List.groupBy (fun propertyValue -> propertyValue.Value, propertyValue.Unit)
         |> List.map (fun (_, values) -> values |> List.sortBy (fun value -> value.Id) |> List.head)
         |> List.sortBy (fun propertyValue -> Formatting.formatValue propertyValue.Value propertyValue.Unit)
-
-    let railProjection layerId side model uiState =
-        let headers = propertyRailHeadersForSide layerId side model uiState
-
-        let valuesByHeader =
-            headers
-            |> List.map (fun header -> header, propertyValuesForSideHeader layerId side header model uiState)
-            |> Map.ofList
-
-        let expandedHeaders =
-            headers
-            |> List.filter (fun header -> State.PropertyExpansion.isExpanded layerId side header uiState)
-            |> Set.ofList
-
-        let canSwitchHeaders =
-            headers
-            |> List.filter (fun header -> canSwitchHeader header model)
-            |> Set.ofList
-
-        {
-            Headers = headers
-            ValuesByHeader = valuesByHeader
-            ExpandedHeaders = expandedHeaders
-            CanSwitchHeaders = canSwitchHeaders
-            StatsByHeader = Map.empty
-            ConnectionCountByHeader = Map.empty
-            BadgeByHeader = Map.empty
-            ColorByHeader = Map.empty
-            OriginByHeader = Map.empty
-            OriginFilterOptions = []
-        }
 
 module Search =
 
@@ -1063,37 +1026,6 @@ module ValueAssignment =
             ]
         else
             findGroup dropSide dropGroupId |> Option.toList
-
-/// Builds property-value views with source and origin info for display.
-module PropertyValueViewing =
-
-    open Swate.Components.Shared.ProvenanceGrouping.Types
-    open Swate.Components.Shared.ProvenanceGrouping.Session
-    open Swate.Components.Page.ProvenanceGrouping.Types
-
-    type PropertyValueView = {
-        Value: ProvenancePropertyValue
-        SourceInfo: PropertyValueSourceInfo option
-        Origin: PropertyOrigin option
-        Color: ProvenanceColor option
-    }
-
-    let buildPropertyValueView
-        (layerId: ProvenanceLayerId)
-        (side: ProvenanceSide)
-        (session: ProvenanceSession)
-        (color: ProvenanceColor option)
-        (value: ProvenancePropertyValue)
-        : PropertyValueView =
-        let sourceInfo = Session.propertyValueSourceInfo (Session.activeLayer session) value
-        let origin = Session.propertyValueOriginInSession layerId side value.Id session
-
-        {
-            Value = value
-            SourceInfo = sourceInfo
-            Origin = origin
-            Color = color
-        }
 
 [<Fable.Core.Mangle(false)>]
 module Exports =

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -370,21 +370,21 @@ module PropertyRails =
         hasHeaderForSide ProvenanceSide.Input header model
         && hasHeaderForSide ProvenanceSide.Output header model
 
-    let private placedHeadersForSide pairId side (uiState: UiState) =
+    let private placedHeadersForSide layerId side (uiState: UiState) =
         uiState.PropertyRailPlacements
         |> Map.toList
-        |> List.choose (fun ((currentPairId, key), targetSide) ->
-            if currentPairId = pairId && targetSide = side then
+        |> List.choose (fun ((currentLayerId, key), targetSide) ->
+            if currentLayerId = layerId && targetSide = side then
                 Some key.Header
             else
                 None
         )
 
-    let private railPlacement pairId header (uiState: UiState) =
-        uiState.PropertyRailPlacements |> Map.tryFind (pairId, { Header = header })
+    let private railPlacement layerId header (uiState: UiState) =
+        uiState.PropertyRailPlacements |> Map.tryFind (layerId, { Header = header })
 
-    let private hasPaletteHeaderForSide pairId side header uiState =
-        State.Palette.headersForSide pairId side uiState |> List.contains header
+    let private hasPaletteHeaderForSide layerId side header uiState =
+        State.Palette.headersForSide layerId side uiState |> List.contains header
 
     let private defaultRailSide header model =
         if hasHeaderForSide ProvenanceSide.Output header model then
@@ -404,63 +404,63 @@ module PropertyRails =
         |> List.choose (fun propertyValueId -> model.PropertyValues.TryFind propertyValueId)
         |> List.filter (fun propertyValue -> propertyValue.Header = header)
 
-    let private hasPreviousOrigin session pairId header model =
+    let private hasPreviousOrigin session layerId header model =
         referencedPropertyValuesForHeader header model
         |> List.exists (fun propertyValue ->
-            match Session.propertyValueOriginInSession pairId ProvenanceSide.Input propertyValue.Id session with
+            match Session.propertyValueOriginInSession layerId ProvenanceSide.Input propertyValue.Id session with
             | Some(PropertyOrigin.UpstreamLayer _)
             | Some(PropertyOrigin.PreviousContext _) -> true
             | _ -> false
         )
 
-    let private defaultRailSideInSession session pairId header model =
-        if hasPreviousOrigin session pairId header model then
+    let private defaultRailSideInSession session layerId header model =
+        if hasPreviousOrigin session layerId header model then
             Some ProvenanceSide.Input
         else
             defaultRailSide header model
 
-    let private isValidRailSide pairId side header model uiState =
+    let private isValidRailSide layerId side header model uiState =
         hasHeaderForSide side header model
-        || hasPaletteHeaderForSide pairId side header uiState
+        || hasPaletteHeaderForSide layerId side header uiState
 
-    let private propertyRailHeadersForSideUsing defaultSideForHeader pairId side model uiState =
-        let paletteHeaders = State.Palette.headersForSide pairId side uiState
+    let private propertyRailHeadersForSideUsing defaultSideForHeader layerId side model uiState =
+        let paletteHeaders = State.Palette.headersForSide layerId side uiState
 
         let knownHeaders =
             [ yield! headersForModel model; yield! paletteHeaders ] |> List.distinct
 
         [
             yield! headersForModel model
-            yield! placedHeadersForSide pairId side uiState
+            yield! placedHeadersForSide layerId side uiState
             yield! paletteHeaders
         ]
         |> List.distinct
         |> List.filter (fun header -> knownHeaders |> List.contains header)
         |> List.filter (fun header ->
-            match railPlacement pairId header uiState with
-            | Some targetSide when isValidRailSide pairId targetSide header model uiState -> targetSide = side
+            match railPlacement layerId header uiState with
+            | Some targetSide when isValidRailSide layerId targetSide header model uiState -> targetSide = side
             | Some _ ->
                 defaultSideForHeader header = Some side
-                || hasPaletteHeaderForSide pairId side header uiState
+                || hasPaletteHeaderForSide layerId side header uiState
             | None ->
                 defaultSideForHeader header = Some side
                 || (defaultSideForHeader header).IsNone
-                   && hasPaletteHeaderForSide pairId side header uiState
+                   && hasPaletteHeaderForSide layerId side header uiState
         )
         |> List.sortBy (fun header -> header.Category.Name)
 
-    let propertyRailHeadersForSide pairId side model uiState =
-        propertyRailHeadersForSideUsing (fun header -> defaultRailSide header model) pairId side model uiState
+    let propertyRailHeadersForSide layerId side model uiState =
+        propertyRailHeadersForSideUsing (fun header -> defaultRailSide header model) layerId side model uiState
 
-    let propertyRailHeadersForSideInSession session pairId side model uiState =
+    let propertyRailHeadersForSideInSession session layerId side model uiState =
         propertyRailHeadersForSideUsing
-            (fun header -> defaultRailSideInSession session pairId header model)
-            pairId
+            (fun header -> defaultRailSideInSession session layerId header model)
+            layerId
             side
             model
             uiState
 
-    let propertyValuesForSideHeader pairId side header (model: ProvenanceModel) uiState =
+    let propertyValuesForSideHeader layerId side header (model: ProvenanceModel) uiState =
         let modelValues =
             setsForSide side model
             |> Map.toList
@@ -471,23 +471,23 @@ module PropertyRails =
 
         [
             yield! modelValues
-            yield! State.Palette.valuesForHeader pairId side header uiState
+            yield! State.Palette.valuesForHeader layerId side header uiState
         ]
         |> List.groupBy (fun propertyValue -> propertyValue.Value, propertyValue.Unit)
         |> List.map (fun (_, values) -> values |> List.sortBy (fun value -> value.Id) |> List.head)
         |> List.sortBy (fun propertyValue -> Formatting.formatValue propertyValue.Value propertyValue.Unit)
 
-    let railProjection pairId side model uiState =
-        let headers = propertyRailHeadersForSide pairId side model uiState
+    let railProjection layerId side model uiState =
+        let headers = propertyRailHeadersForSide layerId side model uiState
 
         let valuesByHeader =
             headers
-            |> List.map (fun header -> header, propertyValuesForSideHeader pairId side header model uiState)
+            |> List.map (fun header -> header, propertyValuesForSideHeader layerId side header model uiState)
             |> Map.ofList
 
         let expandedHeaders =
             headers
-            |> List.filter (fun header -> State.PropertyExpansion.isExpanded pairId side header uiState)
+            |> List.filter (fun header -> State.PropertyExpansion.isExpanded layerId side header uiState)
             |> Set.ofList
 
         let canSwitchHeaders =
@@ -650,21 +650,20 @@ module PropertyProjection =
 
     let railProjectionWithFilters
         (session: ProvenanceSession)
-        (pairId: ProvenancePairId)
+        (layerId: ProvenanceLayerId)
         (side: ProvenanceSide)
         (model: ProvenanceModel)
         (uiState: UiState)
         : PropertyRails.RailProjection =
-        let pair = Session.activePair session
         let filters = uiState.Filters
 
         let headers =
-            PropertyRails.propertyRailHeadersForSideInSession session pairId side model uiState
+            PropertyRails.propertyRailHeadersForSideInSession session layerId side model uiState
 
         let valuesByHeader =
             headers
             |> List.map (fun header ->
-                header, PropertyRails.propertyValuesForSideHeader pairId side header model uiState
+                header, PropertyRails.propertyValuesForSideHeader layerId side header model uiState
             )
             |> Map.ofList
 
@@ -680,7 +679,7 @@ module PropertyProjection =
 
                 let origins =
                     values
-                    |> List.choose (fun pv -> Session.propertyValueOriginInSession pairId side pv.Id session)
+                    |> List.choose (fun pv -> Session.propertyValueOriginInSession layerId side pv.Id session)
                     |> Set.ofList
 
                 header, origins
@@ -732,7 +731,7 @@ module PropertyProjection =
 
         let expandedHeaders =
             sorted
-            |> List.filter (fun header -> State.PropertyExpansion.isExpanded pairId side header uiState)
+            |> List.filter (fun header -> State.PropertyExpansion.isExpanded layerId side header uiState)
             |> Set.ofList
 
         let canSwitchHeaders =
@@ -781,7 +780,7 @@ module Endpoints =
             Text = $"{prefix} [{label}]"
         }
 
-/// Projects the active session pair into renderable groups, connections, and layer commands.
+/// Projects the active session layer into renderable groups, connections, and layer commands.
 module Display =
 
     open Swate.Components.Shared.ProvenanceGrouping.Types
@@ -789,7 +788,7 @@ module Display =
     open Swate.Components.Shared.ProvenanceGrouping.Session
     open Swate.Components.Page.ProvenanceGrouping.Types
 
-    let displayPair session uiState =
+    let displayLayer session uiState =
         let layer = Session.activeLayer session
         let inputState = State.Sides.get layer.InputSideId uiState
         let outputState = State.Sides.get layer.OutputSideId uiState
@@ -809,21 +808,21 @@ module Display =
 
         layer, inputs, outputs, displayConnections layer.Model inputs outputs
 
-    let setsInGroups pairId (groups: DisplayGroup list) selectedIds =
+    let setsInGroups layerId (groups: DisplayGroup list) selectedIds =
         groups
-        |> List.filter (fun (group: DisplayGroup) -> selectedIds |> Set.contains (pairId, group.Id))
+        |> List.filter (fun (group: DisplayGroup) -> selectedIds |> Set.contains (layerId, group.Id))
         |> List.collect (fun (group: DisplayGroup) ->
             group.Members |> List.map (fun (member': DisplayMember) -> member'.SetId)
         )
         |> List.distinct
 
-    let layerCommand pairId inputGroups outputGroups uiState =
+    let layerCommand layerId inputGroups outputGroups uiState =
         let inputs =
-            setsInGroups pairId inputGroups uiState.SelectedInputs
+            setsInGroups layerId inputGroups uiState.SelectedInputs
             |> List.map (fun id -> ProvenanceSide.Input, id)
 
         let outputs =
-            setsInGroups pairId outputGroups uiState.SelectedOutputs
+            setsInGroups layerId outputGroups uiState.SelectedOutputs
             |> List.map (fun id -> ProvenanceSide.Output, id)
 
         {
@@ -954,20 +953,20 @@ module ValueAssignment =
             (Ok { Adds = []; Overwrites = [] })
 
     let selectedTargetGroupsForDrop
-        (pairId: ProvenancePairId)
+        (layerId: ProvenanceLayerId)
         (dropSide: ProvenanceSide)
         (dropGroupId: string)
-        (selectedInputs: Set<ProvenancePairId * string>)
-        (selectedOutputs: Set<ProvenancePairId * string>)
+        (selectedInputs: Set<ProvenanceLayerId * string>)
+        (selectedOutputs: Set<ProvenanceLayerId * string>)
         (findGroup: ProvenanceSide -> string -> DisplayGroup option)
         : DisplayGroup list =
-        let idsForPair selected =
+        let idsForLayer selected =
             selected
-            |> Set.filter (fun (currentPairId, _) -> currentPairId = pairId)
+            |> Set.filter (fun (currentLayerId, _) -> currentLayerId = layerId)
             |> Set.map snd
 
-        let inputIds = idsForPair selectedInputs
-        let outputIds = idsForPair selectedOutputs
+        let inputIds = idsForLayer selectedInputs
+        let outputIds = idsForLayer selectedOutputs
 
         let dropIsSelected =
             match dropSide with
@@ -997,14 +996,14 @@ module PropertyValueViewing =
     }
 
     let buildPropertyValueView
-        (pairId: ProvenancePairId)
+        (layerId: ProvenanceLayerId)
         (side: ProvenanceSide)
         (session: ProvenanceSession)
         (color: ProvenanceColor option)
         (value: ProvenancePropertyValue)
         : PropertyValueView =
-        let sourceInfo = Session.propertyValueSourceInfo (Session.activePair session) value
-        let origin = Session.propertyValueOriginInSession pairId side value.Id session
+        let sourceInfo = Session.propertyValueSourceInfo (Session.activeLayer session) value
+        let origin = Session.propertyValueOriginInSession layerId side value.Id session
 
         {
             Value = value

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -620,9 +620,43 @@ module PropertyProjection =
                 | _ -> false
             )
 
+    let private headerNameSortKey (header: ProvenancePropertyHeader) =
+        header.Category.Name.Trim().ToLowerInvariant(), header.Category.Name, header.Kind.Id
+
+    let private setHasHeader header model (set: ProvenanceSet) =
+        ProvenanceSet.effectivePropertyValueIds set
+        |> List.exists (fun propertyValueId ->
+            model.PropertyValues.TryFind propertyValueId
+            |> Option.exists (fun propertyValue -> propertyValue.Header = header)
+        )
+
+    let connectionCountForSideHeader
+        (side: ProvenanceSide)
+        (header: ProvenancePropertyHeader)
+        (model: ProvenanceModel)
+        =
+        let sets = PropertyRails.setsForSide side model
+
+        model.Connections
+        |> Map.toList
+        |> List.sumBy (fun (_, connection) ->
+            if connection.TableName <> model.LoadedTableName then
+                0
+            else
+                let setId =
+                    match side with
+                    | ProvenanceSide.Input -> connection.InputSetId
+                    | ProvenanceSide.Output -> connection.OutputSetId
+
+                match sets.TryFind setId with
+                | Some set when setHasHeader header model set -> 1
+                | _ -> 0
+        )
+
     let sortHeaders
         (sort: PropertySort)
         (statsByHeader: Map<ProvenancePropertyHeader, PropertyStats>)
+        (connectionCountsByHeader: Map<ProvenancePropertyHeader, int>)
         (headers: ProvenancePropertyHeader list)
         =
         match sort with
@@ -634,10 +668,20 @@ module PropertyProjection =
                     |> Option.map (fun stats -> stats.DistinctValueCount)
                     |> Option.defaultValue 0
 
-                -count, header.Category.Name, header.Kind.Id
+                let name, rawName, kindId = headerNameSortKey header
+
+                -count, name, rawName, kindId
             )
-        | PropertySort.NameAsc -> headers |> List.sortBy (fun header -> header.Category.Name, header.Kind.Id)
-        | PropertySort.Origin -> headers |> List.sortBy (fun header -> header.Category.Name)
+        | PropertySort.NameAsc -> headers |> List.sortBy headerNameSortKey
+        | PropertySort.ConnectionCountDesc ->
+            headers
+            |> List.sortBy (fun header ->
+                let count = connectionCountsByHeader.TryFind header |> Option.defaultValue 0
+
+                let name, rawName, kindId = headerNameSortKey header
+
+                -count, name, rawName, kindId
+            )
 
     let originFilterOptions
         (_originByHeader: Map<ProvenancePropertyHeader, Set<PropertyOrigin>>)
@@ -670,6 +714,11 @@ module PropertyProjection =
         let statsByHeader =
             headers
             |> List.map (fun header -> header, propertyStatsForSide side header model)
+            |> Map.ofList
+
+        let connectionCountsByHeader =
+            headers
+            |> List.map (fun header -> header, connectionCountForSideHeader side header model)
             |> Map.ofList
 
         let originByHeader =
@@ -713,7 +762,8 @@ module PropertyProjection =
                 && originFilterMatches filters.OriginFilter origins
             )
 
-        let sorted = sortHeaders filters.PropertySort statsByHeader filtered
+        let sorted =
+            sortHeaders filters.PropertySort statsByHeader connectionCountsByHeader filtered
 
         let expandedHeaders =
             sorted

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -790,23 +790,24 @@ module Display =
     open Swate.Components.Page.ProvenanceGrouping.Types
 
     let displayPair session uiState =
-        let pair = Session.activePair session
-        let leftState = State.Sides.get pair.InputSideId uiState
-        let rightState = State.Sides.get pair.OutputSideId uiState
+        let layer = Session.activeLayer session
+        let inputState = State.Sides.get layer.InputSideId uiState
+        let outputState = State.Sides.get layer.OutputSideId uiState
 
         let assignments =
             [
-                yield! leftState.GroupingAssignments
-                yield! rightState.GroupingAssignments
+                yield! inputState.GroupingAssignments
+                yield! outputState.GroupingAssignments
             ]
             |> List.distinct
 
-        let inputs = displayGroupsForAssignments pair.Model ProvenanceSide.Input assignments
+        let inputs =
+            displayGroupsForAssignments layer.Model ProvenanceSide.Input assignments
 
         let outputs =
-            displayGroupsForAssignments pair.Model ProvenanceSide.Output assignments
+            displayGroupsForAssignments layer.Model ProvenanceSide.Output assignments
 
-        pair, inputs, outputs, displayConnections pair.Model inputs outputs
+        layer, inputs, outputs, displayConnections layer.Model inputs outputs
 
     let setsInGroups pairId (groups: DisplayGroup list) selectedIds =
         groups

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -688,26 +688,12 @@ module PropertyProjection =
 
         let badgeByHeader = statsByHeader |> Map.map (fun _ stats -> badgeForStats stats)
 
-        let stableSourceColor (source: PropertyValueSourceInfo) =
-            let key =
-                [
-                    source.TableName |> Option.defaultValue ""
-                    source.ProcessName |> Option.defaultValue ""
-                    yield! source.InputNames
-                    yield! source.OutputNames
-                ]
-                |> String.concat "|"
-
-            let index = (hash key |> abs) % State.PropertyColors.palette.Length
-            State.PropertyColors.palette.[index]
-
         let resolvedColorForHeader header origins =
             match uiState.PropertyColors.ManualPropertyColors |> Map.tryFind { Header = header } with
             | Some color -> Some color
             | None ->
                 match origins |> Set.toList with
                 | [ PropertyOrigin.UpstreamLayer layerId ] -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
-                | [ PropertyOrigin.PreviousContext source ] -> Some(stableSourceColor source)
                 | _ -> None
 
         let colorByHeader =

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -313,6 +313,7 @@ module PropertyRails =
 
     open Swate.Components.Shared.ProvenanceGrouping.Types
     open Swate.Components.Shared.ProvenanceGrouping.Grouping
+    open Swate.Components.Shared.ProvenanceGrouping.Session
     open Swate.Components.Page.ProvenanceGrouping.Types
 
     type RailProjection = {
@@ -320,9 +321,14 @@ module PropertyRails =
         ValuesByHeader: Map<ProvenancePropertyHeader, ProvenancePropertyValue list>
         ExpandedHeaders: Set<ProvenancePropertyHeader>
         CanSwitchHeaders: Set<ProvenancePropertyHeader>
+        StatsByHeader: Map<ProvenancePropertyHeader, PropertyStats>
+        BadgeByHeader: Map<ProvenancePropertyHeader, PropertyCountBadge>
+        ColorByHeader: Map<ProvenancePropertyHeader, ProvenanceColor option>
+        OriginByHeader: Map<ProvenancePropertyHeader, Set<PropertyOrigin>>
+        OriginFilterOptions: PropertyOriginFilter list
     }
 
-    let private setsForSide side (model: ProvenanceModel) =
+    let setsForSide side (model: ProvenanceModel) =
         if side = ProvenanceSide.Input then
             model.InputSets
         else
@@ -439,6 +445,236 @@ module PropertyRails =
             ValuesByHeader = valuesByHeader
             ExpandedHeaders = expandedHeaders
             CanSwitchHeaders = canSwitchHeaders
+            StatsByHeader = Map.empty
+            BadgeByHeader = Map.empty
+            ColorByHeader = Map.empty
+            OriginByHeader = Map.empty
+            OriginFilterOptions = []
+        }
+
+module Search =
+
+    let contains (needle: string) (haystack: string) =
+        let needle = if isNull needle then "" else needle.Trim()
+
+        if System.String.IsNullOrWhiteSpace needle then
+            true
+        elif isNull haystack then
+            false
+        else
+            haystack.ToLowerInvariant().Contains(needle.ToLowerInvariant())
+
+module PropertyProjection =
+
+    open Swate.Components.Shared.ProvenanceGrouping.Types
+    open Swate.Components.Shared.ProvenanceGrouping.Session
+    open Swate.Components.Page.ProvenanceGrouping.Types
+
+    let propertyStatsForSide
+        (side: ProvenanceSide)
+        (header: ProvenancePropertyHeader)
+        (model: ProvenanceModel)
+        : PropertyStats =
+        let sets = PropertyRails.setsForSide side model
+        let setCount = sets.Count
+
+        let distinctValues =
+            sets
+            |> Map.toList
+            |> List.collect (fun (_, set) ->
+                ProvenanceSet.effectivePropertyValueIds set
+                |> List.choose (fun id -> model.PropertyValues.TryFind id)
+                |> List.filter (fun pv -> pv.Header = header)
+                |> List.map (fun pv -> pv.Value, pv.Unit)
+            )
+            |> List.distinct
+
+        let setsWithValue =
+            sets
+            |> Map.toList
+            |> List.filter (fun (_, set) ->
+                ProvenanceSet.effectivePropertyValueIds set
+                |> List.exists (fun id ->
+                    model.PropertyValues.TryFind id |> Option.exists (fun pv -> pv.Header = header)
+                )
+            )
+            |> List.length
+
+        {
+            Header = header
+            DistinctValueCount = distinctValues.Length
+            SetsWithValueCount = setsWithValue
+            TotalSetCount = setCount
+        }
+
+    let badgeForStats (stats: PropertyStats) : PropertyCountBadge =
+        if stats.DistinctValueCount = 1 && stats.SetsWithValueCount = stats.TotalSetCount then
+            Hide
+        elif stats.DistinctValueCount = 1 && stats.SetsWithValueCount < stats.TotalSetCount then
+            Coverage(stats.SetsWithValueCount, stats.TotalSetCount)
+        else
+            DistinctValues stats.DistinctValueCount
+
+    let headerMatchesProjectedValues
+        (searchText: string)
+        (header: ProvenancePropertyHeader)
+        (projectedValues: ProvenancePropertyValue list)
+        =
+        Search.contains searchText header.Category.Name
+        || Search.contains searchText header.Kind.Id
+        || Search.contains searchText (ProvenanceKind.displayName header.Kind)
+        || projectedValues
+           |> List.exists (fun propertyValue ->
+               Search.contains searchText (Formatting.formatValue propertyValue.Value propertyValue.Unit)
+           )
+
+    let valueCountFilterMatches (filter: PropertyValueCountFilter) (badge: PropertyCountBadge) =
+        match filter, badge with
+        | PropertyValueCountFilter.Any, _ -> true
+        | PropertyValueCountFilter.Singleton, PropertyCountBadge.Hide -> true
+        | PropertyValueCountFilter.Singleton, PropertyCountBadge.Coverage _ -> true
+        | PropertyValueCountFilter.Multiple, PropertyCountBadge.DistinctValues n -> n > 1
+        | PropertyValueCountFilter.CoverageGap, PropertyCountBadge.Coverage _ -> true
+        | _ -> false
+
+    let originFilterMatches (filter: PropertyOriginFilter) (origins: Set<PropertyOrigin>) =
+        match filter with
+        | PropertyOriginFilter.AnyOrigin -> true
+        | PropertyOriginFilter.CurrentOnly ->
+            origins
+            |> Set.exists (
+                function
+                | PropertyOrigin.Current _ -> true
+                | _ -> false
+            )
+        | PropertyOriginFilter.AnyUpstream ->
+            origins
+            |> Set.exists (
+                function
+                | PropertyOrigin.UpstreamLayer _
+                | PropertyOrigin.PreviousContext _ -> true
+                | _ -> false
+            )
+        | PropertyOriginFilter.UpstreamLayer layerId -> origins |> Set.contains (PropertyOrigin.UpstreamLayer layerId)
+        | PropertyOriginFilter.PreviousContext(tableName, processName) ->
+            origins
+            |> Set.exists (
+                function
+                | PropertyOrigin.PreviousContext source ->
+                    source.TableName = Some tableName && source.ProcessName = processName
+                | _ -> false
+            )
+
+    let sortHeaders
+        (sort: PropertySort)
+        (statsByHeader: Map<ProvenancePropertyHeader, PropertyStats>)
+        (headers: ProvenancePropertyHeader list)
+        =
+        match sort with
+        | PropertySort.ValueCountDesc ->
+            headers
+            |> List.sortByDescending (fun header ->
+                statsByHeader.TryFind header
+                |> Option.map (fun stats -> stats.DistinctValueCount)
+                |> Option.defaultValue 0
+            )
+            |> List.sortBy (fun header -> header.Category.Name)
+            |> List.sortBy (fun header -> header.Kind.Id)
+        | PropertySort.NameAsc -> headers |> List.sortBy (fun header -> header.Category.Name, header.Kind.Id)
+        | PropertySort.Origin -> headers |> List.sortBy (fun header -> header.Category.Name)
+
+    let originFilterOptions
+        (_originByHeader: Map<ProvenancePropertyHeader, Set<PropertyOrigin>>)
+        : PropertyOriginFilter list =
+        [
+            PropertyOriginFilter.AnyOrigin
+            PropertyOriginFilter.CurrentOnly
+            PropertyOriginFilter.AnyUpstream
+        ]
+
+    let railProjectionWithFilters
+        (session: ProvenanceSession)
+        (pairId: ProvenancePairId)
+        (side: ProvenanceSide)
+        (model: ProvenanceModel)
+        (uiState: UiState)
+        : PropertyRails.RailProjection =
+        let pair = Session.activePair session
+        let filters = uiState.Filters
+        let headers = PropertyRails.propertyRailHeadersForSide pairId side model uiState
+
+        let valuesByHeader =
+            headers
+            |> List.map (fun header ->
+                header, PropertyRails.propertyValuesForSideHeader pairId side header model uiState
+            )
+            |> Map.ofList
+
+        let statsByHeader =
+            headers
+            |> List.map (fun header -> header, propertyStatsForSide side header model)
+            |> Map.ofList
+
+        let originByHeader =
+            headers
+            |> List.map (fun header ->
+                let values = valuesByHeader.[header]
+
+                let origins =
+                    values
+                    |> List.choose (fun pv -> Session.propertyValueOriginInSession pairId side pv.Id session)
+                    |> Set.ofList
+
+                header, origins
+            )
+            |> Map.ofList
+
+        let badgeByHeader = statsByHeader |> Map.map (fun _ stats -> badgeForStats stats)
+
+        let colorByHeader =
+            headers
+            |> List.map (fun header ->
+                let manual =
+                    uiState.PropertyColors.ManualPropertyColors |> Map.tryFind { Header = header }
+
+                header, manual
+            )
+            |> Map.ofList
+
+        let filtered =
+            headers
+            |> List.filter (fun header ->
+                let badge = badgeByHeader.[header]
+                let values = valuesByHeader.[header]
+                let origins = originByHeader.[header]
+
+                headerMatchesProjectedValues filters.SearchText header values
+                && valueCountFilterMatches filters.ValueCountFilter badge
+                && originFilterMatches filters.OriginFilter origins
+            )
+
+        let sorted = sortHeaders filters.PropertySort statsByHeader filtered
+
+        let expandedHeaders =
+            sorted
+            |> List.filter (fun header -> State.PropertyExpansion.isExpanded pairId side header uiState)
+            |> Set.ofList
+
+        let canSwitchHeaders =
+            sorted
+            |> List.filter (fun header -> PropertyRails.canSwitchHeader header model)
+            |> Set.ofList
+
+        {
+            Headers = sorted
+            ValuesByHeader = sorted |> List.map (fun header -> header, valuesByHeader.[header]) |> Map.ofList
+            StatsByHeader = statsByHeader
+            BadgeByHeader = badgeByHeader
+            ColorByHeader = sorted |> List.map (fun header -> header, colorByHeader.[header]) |> Map.ofList
+            OriginByHeader = originByHeader
+            OriginFilterOptions = originFilterOptions originByHeader
+            ExpandedHeaders = expandedHeaders
+            CanSwitchHeaders = canSwitchHeaders
         }
 
 /// Derives endpoint defaults, identities, and display headers for empty-side creation.
@@ -517,6 +753,22 @@ module Display =
         {
             AddLayerCommand.SelectedSets = inputs @ outputs
         }
+
+    let sortGroups (sort: GroupSort) (connections: DisplayConnection list) (groups: DisplayGroup list) =
+        match sort with
+        | GroupSort.NameAsc -> groups |> List.sortBy (fun group -> group.Id)
+        | GroupSort.MemberCountDesc -> groups |> List.sortByDescending (fun group -> group.Members.Length)
+        | GroupSort.ConnectionCountDesc ->
+            groups
+            |> List.sortByDescending (fun group ->
+                connections
+                |> List.sumBy (fun connection ->
+                    if connection.SourceGroupId = group.Id || connection.TargetGroupId = group.Id then
+                        connection.ConnectionIds.Length
+                    else
+                        0
+                )
+            )
 
 /// Plans how dropped property values should be added or overwritten across a target group.
 module ValueAssignment =

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -322,6 +322,7 @@ module PropertyRails =
         ExpandedHeaders: Set<ProvenancePropertyHeader>
         CanSwitchHeaders: Set<ProvenancePropertyHeader>
         StatsByHeader: Map<ProvenancePropertyHeader, PropertyStats>
+        ConnectionCountByHeader: Map<ProvenancePropertyHeader, int>
         BadgeByHeader: Map<ProvenancePropertyHeader, PropertyCountBadge>
         ColorByHeader: Map<ProvenancePropertyHeader, ProvenanceColor option>
         OriginByHeader: Map<ProvenancePropertyHeader, Set<PropertyOrigin>>
@@ -386,6 +387,10 @@ module PropertyRails =
     let private hasPaletteHeaderForSide layerId side header uiState =
         State.Palette.headersForSide layerId side uiState |> List.contains header
 
+    let private hasPaletteHeader layerId header uiState =
+        hasPaletteHeaderForSide layerId ProvenanceSide.Input header uiState
+        || hasPaletteHeaderForSide layerId ProvenanceSide.Output header uiState
+
     let private defaultRailSide header model =
         if hasHeaderForSide ProvenanceSide.Output header model then
             Some ProvenanceSide.Output
@@ -420,8 +425,8 @@ module PropertyRails =
             defaultRailSide header model
 
     let private isValidRailSide layerId side header model uiState =
-        hasHeaderForSide side header model
-        || hasPaletteHeaderForSide layerId side header uiState
+        headersForModel model |> List.contains header
+        || hasPaletteHeader layerId header uiState
 
     let private propertyRailHeadersForSideUsing defaultSideForHeader layerId side model uiState =
         let paletteHeaders = State.Palette.headersForSide layerId side uiState
@@ -501,6 +506,7 @@ module PropertyRails =
             ExpandedHeaders = expandedHeaders
             CanSwitchHeaders = canSwitchHeaders
             StatsByHeader = Map.empty
+            ConnectionCountByHeader = Map.empty
             BadgeByHeader = Map.empty
             ColorByHeader = Map.empty
             OriginByHeader = Map.empty
@@ -653,6 +659,22 @@ module PropertyProjection =
                 | _ -> 0
         )
 
+    let originForProjectedValue
+        (layerId: ProvenanceLayerId)
+        (side: ProvenanceSide)
+        (session: ProvenanceSession)
+        (uiState: UiState)
+        (propertyValue: ProvenancePropertyValue)
+        =
+        let isPaletteValue =
+            State.Palette.valuesForSide layerId side uiState
+            |> List.exists (fun value -> value.Id = propertyValue.Id)
+
+        if isPaletteValue then
+            Some(PropertyOrigin.Current(layerId, side))
+        else
+            Session.propertyValueOriginInSession layerId side propertyValue.Id session
+
     let sortHeaders
         (sort: PropertySort)
         (statsByHeader: Map<ProvenancePropertyHeader, PropertyStats>)
@@ -728,7 +750,7 @@ module PropertyProjection =
 
                 let origins =
                     values
-                    |> List.choose (fun pv -> Session.propertyValueOriginInSession layerId side pv.Id session)
+                    |> List.choose (originForProjectedValue layerId side session uiState)
                     |> Set.ofList
 
                 header, origins
@@ -762,8 +784,13 @@ module PropertyProjection =
                 && originFilterMatches filters.OriginFilter origins
             )
 
-        let sorted =
+        let defaultSorted =
             sortHeaders filters.PropertySort statsByHeader connectionCountsByHeader filtered
+
+        let sorted =
+            match State.RailOrder.tryGet layerId side uiState with
+            | Some order -> State.RailOrder.apply order defaultSorted
+            | None -> defaultSorted
 
         let expandedHeaders =
             sorted
@@ -779,6 +806,7 @@ module PropertyProjection =
             Headers = sorted
             ValuesByHeader = sorted |> List.map (fun header -> header, valuesByHeader.[header]) |> Map.ofList
             StatsByHeader = statsByHeader
+            ConnectionCountByHeader = connectionCountsByHeader
             BadgeByHeader = badgeByHeader
             ColorByHeader = sorted |> List.map (fun header -> header, colorByHeader.[header]) |> Map.ofList
             OriginByHeader = originByHeader

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -206,6 +206,52 @@ module DragDrop =
             tryParseHandleParts kind side sourceId parent
         | _ -> None
 
+/// Stable keys for the property shelf folders that can own fallback colors.
+module PropertyFolderColors =
+
+    open System
+    open Swate.Components.Shared.ProvenanceGrouping.Types
+    open Swate.Components.Shared.ProvenanceGrouping.Session
+
+    let private slug (value: string) =
+        let text = if isNull value then "" else value.Trim()
+
+        let chars =
+            text
+            |> Seq.map (fun character ->
+                if Char.IsLetterOrDigit character || character = '-' || character = '_' then
+                    Char.ToLowerInvariant character
+                else
+                    '-'
+            )
+            |> Seq.toArray
+
+        let compact =
+            String(chars).Split([| '-' |], StringSplitOptions.RemoveEmptyEntries)
+            |> String.concat "-"
+
+        if String.IsNullOrWhiteSpace compact then
+            "unknown"
+        else
+            compact
+
+    let layerFolderId (layerId: ProvenanceLayerId) = $"layer-{slug layerId}"
+
+    let previousContextFolderId (tableName: ProvenanceTableName option) (processName: ProvenanceProcessName option) =
+        let table = tableName |> Option.map slug |> Option.defaultValue "unknown-table"
+
+        let processSlug =
+            processName |> Option.map slug |> Option.defaultValue "unknown-process"
+
+        $"context-{processSlug}-{table}"
+
+    let unknownFolderId = "unknown-origin"
+
+    let tryOriginFolderId =
+        function
+        | PropertyOrigin.PreviousContext source -> Some(previousContextFolderId source.TableName source.ProcessName)
+        | _ -> None
+
 /// Keeps transient connector dragging outside editor state so pointer moves only
 /// repaint the overlay layer that needs the live path.
 module LiveDrag =
@@ -745,8 +791,15 @@ module PropertyProjection =
                     )
                     |> List.distinct
 
-                match layerOrigins with
-                | [ layerId ] -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
+                let folderOrigins =
+                    origins
+                    |> Set.toList
+                    |> List.choose PropertyFolderColors.tryOriginFolderId
+                    |> List.distinct
+
+                match layerOrigins, folderOrigins with
+                | [ layerId ], [] -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
+                | [], [ folderId ] -> uiState.PropertyColors.FolderColors |> Map.tryFind folderId
                 | _ -> None
 
         let colorByHeader =

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -834,3 +834,75 @@ module ValueAssignment =
                 )
             else
                 Error(ValueAssignmentError.MixedPropertyValueCounts source.Header)
+
+    let private combineGroupsForAssignment (groups: DisplayGroup list) : DisplayGroup option =
+        match groups with
+        | [] -> None
+        | head :: _ ->
+            let allMembers =
+                groups
+                |> List.collect (fun g -> g.Members)
+                |> List.distinctBy (fun m -> m.SetId)
+
+            Some { head with Members = allMembers }
+
+    let planPropertyValueDropToGroups
+        (source: ValueAssignmentSource)
+        (groups: DisplayGroup list)
+        (model: ProvenanceModel)
+        : Result<PropertyAssignmentBatch, ValueAssignmentError> =
+        groups
+        |> List.groupBy (fun group -> group.Side)
+        |> List.fold
+            (fun result (side, sideGroups) ->
+                result
+                |> Result.bind (fun (batch: PropertyAssignmentBatch) ->
+                    match combineGroupsForAssignment sideGroups with
+                    | None -> Ok batch
+                    | Some combinedGroup ->
+                        planPropertyValueDrop source combinedGroup model
+                        |> Result.map (fun plan ->
+                            match plan with
+                            | AddCurrent command -> {
+                                batch with
+                                    Adds = batch.Adds @ [ command ]
+                              }
+                            | ConfirmOverwrite warning -> {
+                                batch with
+                                    Overwrites = batch.Overwrites @ [ warning ]
+                              }
+                        )
+                )
+            )
+            (Ok { Adds = []; Overwrites = [] })
+
+/// Builds property-value views with source and origin info for display.
+module PropertyValueViewing =
+
+    open Swate.Components.Shared.ProvenanceGrouping.Types
+    open Swate.Components.Shared.ProvenanceGrouping.Session
+    open Swate.Components.Page.ProvenanceGrouping.Types
+
+    type PropertyValueView = {
+        Value: ProvenancePropertyValue
+        SourceInfo: PropertyValueSourceInfo option
+        Origin: PropertyOrigin option
+        Color: ProvenanceColor option
+    }
+
+    let buildPropertyValueView
+        (pairId: ProvenancePairId)
+        (side: ProvenanceSide)
+        (session: ProvenanceSession)
+        (color: ProvenanceColor option)
+        (value: ProvenancePropertyValue)
+        : PropertyValueView =
+        let sourceInfo = Session.propertyValueSourceInfo (Session.activePair session) value
+        let origin = Session.propertyValueOriginInSession pairId side value.Id session
+
+        {
+            Value = value
+            SourceInfo = sourceInfo
+            Origin = origin
+            Color = color
+        }

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -791,8 +791,8 @@ module Display =
 
     let displayPair session uiState =
         let pair = Session.activePair session
-        let leftState = State.Layers.get pair.LeftLayerId uiState
-        let rightState = State.Layers.get pair.RightLayerId uiState
+        let leftState = State.Sides.get pair.InputSideId uiState
+        let rightState = State.Sides.get pair.OutputSideId uiState
 
         let assignments =
             [

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -383,15 +383,54 @@ module PropertyRails =
     let private railPlacement pairId header (uiState: UiState) =
         uiState.PropertyRailPlacements |> Map.tryFind (pairId, { Header = header })
 
-    let propertyRailHeadersForSide pairId side model uiState =
-        let ownHeaders = ownedHeadersForSide side model
+    let private hasPaletteHeaderForSide pairId side header uiState =
+        State.Palette.headersForSide pairId side uiState |> List.contains header
+
+    let private defaultRailSide header model =
+        if hasHeaderForSide ProvenanceSide.Output header model then
+            Some ProvenanceSide.Output
+        elif hasHeaderForSide ProvenanceSide.Input header model then
+            Some ProvenanceSide.Input
+        else
+            None
+
+    let private referencedPropertyValuesForHeader header model =
+        [
+            yield! setsForSide ProvenanceSide.Input model |> Map.toList
+            yield! setsForSide ProvenanceSide.Output model |> Map.toList
+        ]
+        |> List.collect (fun (_, set) -> ProvenanceSet.effectivePropertyValueIds set)
+        |> List.distinct
+        |> List.choose (fun propertyValueId -> model.PropertyValues.TryFind propertyValueId)
+        |> List.filter (fun propertyValue -> propertyValue.Header = header)
+
+    let private hasPreviousOrigin session pairId header model =
+        referencedPropertyValuesForHeader header model
+        |> List.exists (fun propertyValue ->
+            match Session.propertyValueOriginInSession pairId ProvenanceSide.Input propertyValue.Id session with
+            | Some(PropertyOrigin.UpstreamLayer _)
+            | Some(PropertyOrigin.PreviousContext _) -> true
+            | _ -> false
+        )
+
+    let private defaultRailSideInSession session pairId header model =
+        if hasPreviousOrigin session pairId header model then
+            Some ProvenanceSide.Input
+        else
+            defaultRailSide header model
+
+    let private isValidRailSide pairId side header model uiState =
+        hasHeaderForSide side header model
+        || hasPaletteHeaderForSide pairId side header uiState
+
+    let private propertyRailHeadersForSideUsing defaultSideForHeader pairId side model uiState =
         let paletteHeaders = State.Palette.headersForSide pairId side uiState
 
         let knownHeaders =
             [ yield! headersForModel model; yield! paletteHeaders ] |> List.distinct
 
         [
-            yield! ownHeaders
+            yield! headersForModel model
             yield! placedHeadersForSide pairId side uiState
             yield! paletteHeaders
         ]
@@ -399,11 +438,27 @@ module PropertyRails =
         |> List.filter (fun header -> knownHeaders |> List.contains header)
         |> List.filter (fun header ->
             match railPlacement pairId header uiState with
-            | Some targetSide when hasHeaderForSide targetSide header model -> targetSide = side
-            | Some _ -> ownHeaders |> List.contains header
-            | None -> true
+            | Some targetSide when isValidRailSide pairId targetSide header model uiState -> targetSide = side
+            | Some _ ->
+                defaultSideForHeader header = Some side
+                || hasPaletteHeaderForSide pairId side header uiState
+            | None ->
+                defaultSideForHeader header = Some side
+                || (defaultSideForHeader header).IsNone
+                   && hasPaletteHeaderForSide pairId side header uiState
         )
         |> List.sortBy (fun header -> header.Category.Name)
+
+    let propertyRailHeadersForSide pairId side model uiState =
+        propertyRailHeadersForSideUsing (fun header -> defaultRailSide header model) pairId side model uiState
+
+    let propertyRailHeadersForSideInSession session pairId side model uiState =
+        propertyRailHeadersForSideUsing
+            (fun header -> defaultRailSideInSession session pairId header model)
+            pairId
+            side
+            model
+            uiState
 
     let propertyValuesForSideHeader pairId side header (model: ProvenanceModel) uiState =
         let modelValues =
@@ -602,7 +657,9 @@ module PropertyProjection =
         : PropertyRails.RailProjection =
         let pair = Session.activePair session
         let filters = uiState.Filters
-        let headers = PropertyRails.propertyRailHeadersForSide pairId side model uiState
+
+        let headers =
+            PropertyRails.propertyRailHeadersForSideInSession session pairId side model uiState
 
         let valuesByHeader =
             headers

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -650,6 +650,7 @@ module private EditorSurface =
 
     let propertyRail
         side
+        sideId
         (projection: PropertyRails.RailProjection)
         activeAssignments
         toggleSide
@@ -682,6 +683,7 @@ module private EditorSurface =
             (fun header -> projection.OriginByHeader |> Map.tryFind header),
             setPropertyColor,
             sourceInfoForValue,
+            sideId = sideId,
             debug = debug
         )
 
@@ -1077,24 +1079,27 @@ type ProvenanceGrouping =
             setOpenRail (if openRail = Some side then None else Some side)
 
         let railPanel side =
-            let layerId, oppositeLayerId, targetSide =
+            let layer = Session.activeLayer session
+
+            let sideId, oppositeSideId, targetSide =
                 match side with
-                | ProvenanceSide.Input -> pair.InputSideId, pair.OutputSideId, ProvenanceSide.Output
-                | ProvenanceSide.Output -> pair.OutputSideId, pair.InputSideId, ProvenanceSide.Input
+                | ProvenanceSide.Input -> layer.InputSideId, layer.OutputSideId, ProvenanceSide.Output
+                | ProvenanceSide.Output -> layer.OutputSideId, layer.InputSideId, ProvenanceSide.Input
 
             EditorSurface.propertyRail
                 side
+                sideId
                 (match side with
                  | ProvenanceSide.Input -> inputRailProjection
                  | ProvenanceSide.Output -> outputRailProjection)
-                (State.Sides.get layerId uiState).GroupingAssignments
-                (fun header -> toggleSideGrouping layerId side header)
+                (State.Sides.get sideId uiState).GroupingAssignments
+                (fun header -> toggleSideGrouping sideId side header)
                 (fun header ->
-                    State.GroupingAssignments.toggleBoth pair.InputSideId pair.OutputSideId header uiState
+                    State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId header uiState
                     |> setUiState
                 )
                 (fun header ->
-                    State.GroupingAssignments.move pair.Id layerId oppositeLayerId targetSide header uiState
+                    State.GroupingAssignments.move layer.Id sideId oppositeSideId targetSide header uiState
                     |> setUiState
                 )
                 (fun header -> togglePropertyExpanded side header)
@@ -1386,7 +1391,7 @@ type ProvenanceGrouping =
                                 prop.children [
                                     Controls.LayerTabs(
                                         session,
-                                        (fun pairId -> Session.selectPair pairId session |> publish),
+                                        (fun layerId -> Session.selectLayer layerId session |> publish),
                                         (fun () ->
                                             EditorActions.addLayer
                                                 session
@@ -1402,7 +1407,9 @@ type ProvenanceGrouping =
                                     Html.div [
                                         prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-1"
                                         prop.children [
-                                            for layer in session.Layers do
+                                            for layerId in session.LayerOrder do
+                                                let layer = Session.layerById layerId session
+
                                                 Controls.LayerColorButton(
                                                     layer.Id,
                                                     uiState.PropertyColors.LayerColors |> Map.tryFind layer.Id,

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -314,20 +314,14 @@ module private DragHandlers =
     let private routePropertyValueDrop context side groupId propertyValueId =
         match context.Lookups.FindPropertyValue propertyValueId with
         | Some propertyValue ->
-            let selectedIds =
-                (match side with
-                 | ProvenanceSide.Input -> context.UiState.SelectedInputs
-                 | ProvenanceSide.Output -> context.UiState.SelectedOutputs)
-                |> Set.filter (fun (pid, _) -> pid = context.Pair.Id)
-
-            let targetGroupIds =
-                if selectedIds.IsEmpty then
-                    [ groupId ]
-                else
-                    selectedIds |> Set.toList |> List.map snd
-
             let targetGroups =
-                targetGroupIds |> List.choose (fun gid -> context.Lookups.FindGroup side gid)
+                ValueAssignment.selectedTargetGroupsForDrop
+                    context.Pair.Id
+                    side
+                    groupId
+                    context.UiState.SelectedInputs
+                    context.UiState.SelectedOutputs
+                    context.Lookups.FindGroup
 
             match
                 ValueAssignment.planPropertyValueDropToGroups
@@ -338,6 +332,20 @@ module private DragHandlers =
             | Ok batch ->
                 let affectedValueCount =
                     batch.Overwrites |> List.sumBy (fun w -> w.ExistingValueIds.Length)
+
+                let sideForTarget target =
+                    match target with
+                    | ProvenancePropertyTarget.InputSets _ -> Some ProvenanceSide.Input
+                    | ProvenancePropertyTarget.OutputSets _ -> Some ProvenanceSide.Output
+                    | ProvenancePropertyTarget.Connections _ -> None
+
+                let affectedSideCount =
+                    [
+                        yield! batch.Adds |> List.choose (fun command -> sideForTarget command.Target)
+                        yield! batch.Overwrites |> List.choose (fun warning -> sideForTarget warning.Target)
+                    ]
+                    |> List.distinct
+                    |> List.length
 
                 if batch.Overwrites.IsEmpty then
                     if not batch.Adds.IsEmpty then
@@ -355,7 +363,7 @@ module private DragHandlers =
                 else
                     let pendingBatch = {
                         Batch = batch
-                        AffectedSideCount = 1
+                        AffectedSideCount = affectedSideCount
                         AffectedValueCount = affectedValueCount
                     }
 
@@ -505,7 +513,7 @@ module private EditorPanels =
                         Html.span [
                             prop.className "swt:text-sm"
                             prop.text
-                                $"The selected targets already have {headerText}. Confirm to replace with {valueText} using the existing edit path."
+                                $"The selected targets already have {headerText}. Confirm to replace with {valueText} across {sideCount} side(s) using the existing edit path."
                         ]
                     ]
                 ]
@@ -649,6 +657,8 @@ module private EditorSurface =
         move
         toggleExpanded
         addPaletteValue
+        setPropertyColor
+        sourceInfoForValue
         debug
         setIsValueChipDragging
 
@@ -666,6 +676,12 @@ module private EditorSurface =
             addPaletteValue,
             (fun header -> projection.CanSwitchHeaders.Contains header),
             setIsValueChipDragging,
+            (fun header -> projection.StatsByHeader |> Map.tryFind header),
+            (fun header -> projection.BadgeByHeader |> Map.tryFind header),
+            (fun header -> projection.ColorByHeader |> Map.tryFind header |> Option.bind id),
+            (fun header -> projection.OriginByHeader |> Map.tryFind header),
+            setPropertyColor,
+            sourceInfoForValue,
             debug = debug
         )
 
@@ -682,6 +698,7 @@ module private EditorSurface =
         toggleSelection
         toggleDetail
         (connectionCountFor: string -> int option)
+        sourceInfoForValue
         debug
         isValueChipDragging
         =
@@ -722,6 +739,7 @@ module private EditorSurface =
                         (fun () -> toggleDetail side group.Id),
                         isValueChipDragging,
                         ?connectionCount = connectionCountFor group.Id,
+                        sourceInfoForValue = sourceInfoForValue,
                         debug = debug,
                         key = $"{keyPrefix}:{group.Id}"
                     )
@@ -807,25 +825,45 @@ type ProvenanceGrouping =
 
         let inputRailProjection =
             React.useMemo (
-                (fun () -> PropertyRails.railProjection pair.Id ProvenanceSide.Input pair.Model uiState),
+                (fun () ->
+                    PropertyProjection.railProjectionWithFilters
+                        session
+                        pair.Id
+                        ProvenanceSide.Input
+                        pair.Model
+                        uiState
+                ),
                 [|
+                    box session
                     box pair.Id
                     box pair.Model
                     box uiState.PropertyRailPlacements
                     box uiState.ExpandedProperties
                     box uiState.PaletteValues
+                    box uiState.PropertyColors
+                    box uiState.Filters
                 |]
             )
 
         let outputRailProjection =
             React.useMemo (
-                (fun () -> PropertyRails.railProjection pair.Id ProvenanceSide.Output pair.Model uiState),
+                (fun () ->
+                    PropertyProjection.railProjectionWithFilters
+                        session
+                        pair.Id
+                        ProvenanceSide.Output
+                        pair.Model
+                        uiState
+                ),
                 [|
+                    box session
                     box pair.Id
                     box pair.Model
                     box uiState.PropertyRailPlacements
                     box uiState.ExpandedProperties
                     box uiState.PaletteValues
+                    box uiState.PropertyColors
+                    box uiState.Filters
                 |]
             )
 
@@ -938,6 +976,25 @@ type ProvenanceGrouping =
         let toggleGroupDetail side groupId =
             State.Detail.toggleGroup side groupId uiState |> setUiState
 
+        let sourceInfoForValue value =
+            Session.propertyValueSourceInfo pair value
+
+        let setPropertyColor header color =
+            let update =
+                match color with
+                | Some selectedColor -> State.PropertyColors.setColor header selectedColor
+                | None -> State.PropertyColors.clearColor header
+
+            applyUiState update
+
+        let setLayerColor layerId color =
+            let update =
+                match color with
+                | Some selectedColor -> State.PropertyColors.setLayerColor layerId selectedColor
+                | None -> State.PropertyColors.clearLayerColor layerId
+
+            applyUiState update
+
         let confirmBatch (pending: PendingAssignmentBatch) =
             EditorActions.applyAssignmentBatch session publish pending.Batch
 
@@ -1042,6 +1099,8 @@ type ProvenanceGrouping =
                 )
                 (fun header -> togglePropertyExpanded side header)
                 (fun header value unit -> addPaletteValue side header value unit)
+                setPropertyColor
+                sourceInfoForValue
                 debug
                 setIsValueChipDragging
 
@@ -1096,6 +1155,7 @@ type ProvenanceGrouping =
                 toggleSelection
                 toggleGroupDetail
                 counts
+                sourceInfoForValue
                 debug
                 isValueChipDragging
 
@@ -1336,8 +1396,20 @@ type ProvenanceGrouping =
                                                 uiState
                                                 publish
                                         ),
+                                        layerColors = uiState.PropertyColors.LayerColors,
                                         debug = debug
                                     )
+                                    Html.div [
+                                        prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-1"
+                                        prop.children [
+                                            for layer in session.Layers do
+                                                Controls.LayerColorButton(
+                                                    layer.Id,
+                                                    uiState.PropertyColors.LayerColors |> Map.tryFind layer.Id,
+                                                    setLayerColor layer.Id
+                                                )
+                                        ]
+                                    ]
                                     Html.div [
                                         prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
                                         prop.children [
@@ -1419,6 +1491,15 @@ type ProvenanceGrouping =
                                     ]
                                 ]
                             ]
+                            Controls.FilterToolbar(
+                                uiState.Filters,
+                                (fun text -> applyUiState (State.Filters.setSearch text)),
+                                (fun sort -> applyUiState (State.Filters.setPropertySort sort)),
+                                (fun sort -> applyUiState (State.Filters.setGroupSort sort)),
+                                (fun filter -> applyUiState (State.Filters.setValueCountFilter filter)),
+                                (fun filter -> applyUiState (State.Filters.setOriginFilter filter)),
+                                debug = debug
+                            )
                             match uiState.Error with
                             | Some error -> EditorPanels.errorAlert error
                             | None -> Html.none

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -1075,29 +1075,25 @@ type ProvenanceGrouping =
                 EditorActions.allMemberPairs inputGroup outputGroup |> connectSetPairs
             | _ -> State.MemberResolution.clearPending uiState |> setUiState
 
-        let isManuallyResolving side groupId =
-            uiState.ManualResolutionPairs
-            |> List.exists (fun resolution ->
-                resolution.LayerId = layer.Id
-                && ((side = ProvenanceSide.Input && resolution.InputGroupId = groupId)
-                    || (side = ProvenanceSide.Output && resolution.OutputGroupId = groupId))
-            )
+        let isGroupedCard side groupId =
+            lookups.FindGroup side groupId
+            |> Option.exists (fun group -> group.GroupingValues |> List.isEmpty |> not)
 
         let isConnectedToExpanded side groupId =
-            connections
-            |> List.exists (fun connection ->
-                match side with
-                | ProvenanceSide.Input ->
-                    connection.SourceGroupId = groupId
-                    && State.Detail.isGroupExpanded ProvenanceSide.Output connection.TargetGroupId uiState
-                | ProvenanceSide.Output ->
-                    connection.TargetGroupId = groupId
-                    && State.Detail.isGroupExpanded ProvenanceSide.Input connection.SourceGroupId uiState
-            )
+            isGroupedCard side groupId
+            && (connections
+                |> List.exists (fun connection ->
+                    match side with
+                    | ProvenanceSide.Input ->
+                        connection.SourceGroupId = groupId
+                        && State.Detail.isGroupExpanded ProvenanceSide.Output connection.TargetGroupId uiState
+                    | ProvenanceSide.Output ->
+                        connection.TargetGroupId = groupId
+                        && State.Detail.isGroupExpanded ProvenanceSide.Input connection.SourceGroupId uiState
+                ))
 
         let isGroupExpanded side groupId =
             State.Detail.isGroupExpanded side groupId uiState
-            || isManuallyResolving side groupId
             || isConnectedToExpanded side groupId
 
         let dragContext = {

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -181,15 +181,10 @@ module private PropertyShelf =
 
     let private folderId =
         function
-        | LayerFolder layerId -> $"layer-{slug layerId}"
+        | LayerFolder layerId -> PropertyFolderColors.layerFolderId layerId
         | PreviousContextFolder(tableName, processName) ->
-            let table = tableName |> Option.map slug |> Option.defaultValue "unknown-table"
-
-            let processSlug =
-                processName |> Option.map slug |> Option.defaultValue "unknown-process"
-
-            $"context-{processSlug}-{table}"
-        | UnknownFolder -> "unknown-origin"
+            PropertyFolderColors.previousContextFolderId tableName processName
+        | UnknownFolder -> PropertyFolderColors.unknownFolderId
 
     let private folderName (session: ProvenanceSession) =
         function
@@ -209,8 +204,19 @@ module private PropertyShelf =
     let private folderColor (uiState: UiState) =
         function
         | LayerFolder layerId -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
-        | PreviousContextFolder _
-        | UnknownFolder -> None
+        | PreviousContextFolder _ as key -> uiState.PropertyColors.FolderColors |> Map.tryFind (folderId key)
+        | UnknownFolder as key -> uiState.PropertyColors.FolderColors |> Map.tryFind (folderId key)
+
+    let setFolderColor (session: ProvenanceSession) folderId color state =
+        let layerId =
+            session.LayerOrder
+            |> List.tryFind (fun layerId -> PropertyFolderColors.layerFolderId layerId = folderId)
+
+        match layerId, color with
+        | Some layerId, Some selectedColor -> State.PropertyColors.setLayerColor layerId selectedColor state
+        | Some layerId, None -> State.PropertyColors.clearLayerColor layerId state
+        | None, Some selectedColor -> State.PropertyColors.setFolderColor folderId selectedColor state
+        | None, None -> State.PropertyColors.clearFolderColor folderId state
 
     let private folderSort (session: ProvenanceSession) activeLayerId key =
         match key with
@@ -1162,6 +1168,12 @@ type ProvenanceGrouping =
         let activeLayerId = React.useRef layer.Id
         latestUiState.current <- uiState
         activeLayerId.current <- layer.Id
+
+        let applyUiState update =
+            let next = update latestUiState.current
+            latestUiState.current <- next
+            setUiState next
+
         let panelRatios = State.PanelLayout.get layer.Id uiState
 
         let endpointKinds = Endpoints.endpointKindOptions ()
@@ -1259,6 +1271,9 @@ type ProvenanceGrouping =
         let setPropertyShelfExpandedFolderIds folderIds =
             setPropertyShelfFolderExpansion (Some(layer.Id, folderIds))
 
+        let setPropertyShelfFolderColor folderId color =
+            applyUiState (PropertyShelf.setFolderColor session folderId color)
+
         let propertyShelf =
             Html.section [
                 prop.className
@@ -1327,16 +1342,12 @@ type ProvenanceGrouping =
                             (fun _ item -> DragDrop.folderPropertyDragId item.Payload.SourceSide item.Payload.Header),
                             expandedFolderIds = propertyShelfExpandedFolderIds,
                             onExpandedFolderIdsChange = setPropertyShelfExpandedFolderIds,
+                            onSetFolderColor = setPropertyShelfFolderColor,
                             className = "swt:min-w-0",
                             debug = debug
                         )
                 ]
             ]
-
-        let applyUiState update =
-            let next = update latestUiState.current
-            latestUiState.current <- next
-            setUiState next
 
         let commitUiState next =
             latestUiState.current <- next

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -1126,6 +1126,10 @@ type ProvenanceGrouping =
         let tier, setTier = React.useState LayoutTier.Wide
         let openRail, setOpenRail = React.useState<ProvenanceSide option> None
         let density, setDensity = React.useState Density.EditorDensity.Comfortable
+        let isPropertyShelfExpanded, setIsPropertyShelfExpanded = React.useState true
+
+        let propertyShelfFolderExpansion, setPropertyShelfFolderExpansion =
+            React.useState<(ProvenanceLayerId * Set<string>) option> None
 
         let showPropertyHeaderConnectors, setShowPropertyHeaderConnectors =
             React.useState true
@@ -1241,13 +1245,93 @@ type ProvenanceGrouping =
         let propertyShelfFolders =
             PropertyShelf.folders session layer uiState inputRailProjection outputRailProjection
 
+        let defaultPropertyShelfFolderIds =
+            propertyShelfFolders
+            |> List.tryHead
+            |> Option.map (fun folder -> Set.singleton folder.Id)
+            |> Option.defaultValue Set.empty
+
+        let propertyShelfExpandedFolderIds =
+            match propertyShelfFolderExpansion with
+            | Some(expandedLayerId, folderIds) when expandedLayerId = layer.Id -> folderIds
+            | _ -> defaultPropertyShelfFolderIds
+
+        let setPropertyShelfExpandedFolderIds folderIds =
+            setPropertyShelfFolderExpansion (Some(layer.Id, folderIds))
+
         let propertyShelf =
-            FolderedDraggableList.FolderedDraggableList<PropertyShelfItemPayload>(
-                propertyShelfFolders,
-                (fun _ item -> DragDrop.folderPropertyDragId item.Payload.SourceSide item.Payload.Header),
-                className = "swt:rounded-lg swt:border swt:border-base-300 swt:bg-base-100/80 swt:p-3 swt:shadow-sm",
-                debug = debug
-            )
+            Html.section [
+                prop.className
+                    "swt:flex swt:min-w-0 swt:flex-col swt:gap-3 swt:rounded-lg swt:border swt:border-base-300 swt:bg-base-100/80 swt:p-3 swt:shadow-sm"
+                if debug then
+                    prop.testId "provenance-property-shelf"
+                prop.children [
+                    Html.div [
+                        prop.className "swt:flex swt:min-w-0 swt:items-center swt:justify-between swt:gap-2"
+                        prop.children [
+                            Html.div [
+                                prop.className
+                                    "swt:flex swt:min-w-0 swt:items-center swt:gap-2 swt:text-sm swt:font-medium"
+                                prop.children [
+                                    Html.i [
+                                        prop.className [
+                                            "swt:iconify swt:size-5 swt:shrink-0"
+                                            if isPropertyShelfExpanded then
+                                                "swt:fluent--folder-open-24-regular"
+                                            else
+                                                "swt:fluent--folder-24-regular"
+                                        ]
+                                    ]
+                                    Html.span [
+                                        prop.className "swt:min-w-0 swt:truncate"
+                                        prop.text "Available properties"
+                                    ]
+                                ]
+                            ]
+                            Html.button [
+                                prop.title (
+                                    if isPropertyShelfExpanded then
+                                        "Minimize property folders"
+                                    else
+                                        "Expand property folders"
+                                )
+                                prop.type'.button
+                                prop.className "swt:btn swt:btn-ghost swt:btn-xs swt:size-8 swt:p-0"
+                                prop.custom ("aria-expanded", isPropertyShelfExpanded)
+                                prop.ariaLabel (
+                                    if isPropertyShelfExpanded then
+                                        "Minimize property folders"
+                                    else
+                                        "Expand property folders"
+                                )
+                                if debug then
+                                    prop.testId "provenance-property-shelf-toggle"
+                                prop.onClick (fun _ -> setIsPropertyShelfExpanded (not isPropertyShelfExpanded))
+                                prop.children [
+                                    Html.i [
+                                        prop.className [
+                                            "swt:iconify swt:size-4"
+                                            if isPropertyShelfExpanded then
+                                                "swt:fluent--chevron-up-20-regular"
+                                            else
+                                                "swt:fluent--chevron-down-20-regular"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                    if isPropertyShelfExpanded then
+                        FolderedDraggableList.FolderedDraggableList<PropertyShelfItemPayload>(
+                            propertyShelfFolders,
+                            (fun _ item -> DragDrop.folderPropertyDragId item.Payload.SourceSide item.Payload.Header),
+                            expandedFolderIds = propertyShelfExpandedFolderIds,
+                            onExpandedFolderIdsChange = setPropertyShelfExpandedFolderIds,
+                            className = "swt:min-w-0",
+                            debug = debug
+                        )
+                ]
+            ]
 
         let applyUiState update =
             let next = update latestUiState.current

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -1,9 +1,12 @@
 namespace Swate.Components.Page.ProvenanceGrouping
 
+open System
 open System.Globalization
 open Fable.Core
 open Fable.Core.JsInterop
 open Feliz
+open Swate.Components.Composite.FolderedDraggableList
+open Swate.Components.Composite.FolderedDraggableList.Types
 open Swate.Components.JsBindings
 open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Grouping
@@ -22,10 +25,16 @@ type private DragContext = {
     Session: ProvenanceSession
     Layer: ProvenanceLayer
     UiState: UiState
+    GetUiState: unit -> UiState
     Publish: SessionResult -> unit
     SetUiState: UiState -> unit
     Lookups: EditorLookups
     ConnectSetPairs: (ProvenanceSetId * ProvenanceSetId) list -> unit
+}
+
+type private PropertyShelfItemPayload = {
+    Header: ProvenancePropertyHeader
+    SourceSide: ProvenanceSide
 }
 
 /// Resizable three-panel surface helpers.
@@ -93,6 +102,225 @@ module private TierObserver =
     [<Emit("$0.disconnect()")>]
     let disconnect (observer: obj) : unit = jsNative
 
+module private PropertyShelf =
+
+    type private FolderKey =
+        | LayerFolder of ProvenanceLayerId
+        | PreviousContextFolder of ProvenanceTableName option * ProvenanceProcessName option
+        | UnknownFolder
+
+    let private slug (value: string) =
+        let text = if isNull value then "" else value.Trim()
+
+        let chars =
+            text
+            |> Seq.map (fun character ->
+                if Char.IsLetterOrDigit character || character = '-' || character = '_' then
+                    Char.ToLowerInvariant character
+                else
+                    '-'
+            )
+            |> Seq.toArray
+
+        let slug = String(chars).Trim('-')
+
+        if String.IsNullOrWhiteSpace slug then "item" else slug
+
+    let private badgeText (badge: PropertyCountBadge option) : string option =
+        match badge with
+        | Some PropertyCountBadge.Hide
+        | None -> None
+        | Some(PropertyCountBadge.DistinctValues count) -> Some(string count)
+        | Some(PropertyCountBadge.Coverage(withValue, total)) -> Some($"{withValue}/{total}")
+
+    let private headerIdentity (header: ProvenancePropertyHeader) = DragDrop.propertyHeaderIdentity header
+
+    let private headerId (header: ProvenancePropertyHeader) = headerIdentity header |> slug
+
+    let private sourceSideForHeader
+        (layerId: ProvenanceLayerId)
+        (inputProjection: PropertyRails.RailProjection)
+        (outputProjection: PropertyRails.RailProjection)
+        (uiState: UiState)
+        (header: ProvenancePropertyHeader)
+        =
+        match uiState.PropertyRailPlacements |> Map.tryFind (layerId, { Header = header }) with
+        | Some side -> side
+        | None when outputProjection.Headers |> List.contains header -> ProvenanceSide.Output
+        | _ -> ProvenanceSide.Input
+
+    let private originsForHeader
+        (layerId: ProvenanceLayerId)
+        (sourceSide: ProvenanceSide)
+        (inputProjection: PropertyRails.RailProjection)
+        (outputProjection: PropertyRails.RailProjection)
+        (header: ProvenancePropertyHeader)
+        =
+        [
+            inputProjection.OriginByHeader |> Map.tryFind header
+            outputProjection.OriginByHeader |> Map.tryFind header
+        ]
+        |> List.choose id
+        |> List.fold Set.union Set.empty
+        |> fun origins ->
+            if origins.IsEmpty then
+                Set.singleton (PropertyOrigin.Current(layerId, sourceSide))
+            else
+                origins
+
+    let private folderKeyForOrigin (origin: PropertyOrigin) =
+        match origin with
+        | PropertyOrigin.Current(layerId, _) -> LayerFolder layerId
+        | PropertyOrigin.UpstreamLayer layerId -> LayerFolder layerId
+        | PropertyOrigin.PreviousContext source -> PreviousContextFolder(source.TableName, source.ProcessName)
+
+    let private folderId =
+        function
+        | LayerFolder layerId -> $"layer-{slug layerId}"
+        | PreviousContextFolder(tableName, processName) ->
+            let table = tableName |> Option.map slug |> Option.defaultValue "unknown-table"
+
+            let processSlug =
+                processName |> Option.map slug |> Option.defaultValue "unknown-process"
+
+            $"context-{processSlug}-{table}"
+        | UnknownFolder -> "unknown-origin"
+
+    let private folderName (session: ProvenanceSession) =
+        function
+        | LayerFolder layerId ->
+            session.Layers
+            |> List.tryFind (fun layer -> layer.Id = layerId)
+            |> Option.map (fun layer -> layer.Label)
+            |> Option.defaultValue layerId
+        | PreviousContextFolder(tableName, processName) ->
+            match processName, tableName with
+            | Some processName, Some tableName -> $"{processName} / {tableName}"
+            | Some processName, None -> processName
+            | None, Some tableName -> tableName
+            | None, None -> "Previous context"
+        | UnknownFolder -> "Unknown origin"
+
+    let private folderColor (uiState: UiState) =
+        function
+        | LayerFolder layerId -> uiState.PropertyColors.LayerColors |> Map.tryFind layerId
+        | PreviousContextFolder _
+        | UnknownFolder -> None
+
+    let private folderSort (session: ProvenanceSession) activeLayerId key =
+        match key with
+        | LayerFolder layerId when layerId = activeLayerId -> 0, 0, folderName session key
+        | LayerFolder layerId ->
+            let layerIndex =
+                session.LayerOrder
+                |> List.tryFindIndex ((=) layerId)
+                |> Option.defaultValue Int32.MaxValue
+
+            1, layerIndex, folderName session key
+        | PreviousContextFolder _ -> 2, Int32.MaxValue, folderName session key
+        | UnknownFolder -> 3, Int32.MaxValue, folderName session key
+
+    let private manualColor (uiState: UiState) (header: ProvenancePropertyHeader) =
+        uiState.PropertyColors.ManualPropertyColors |> Map.tryFind { Header = header }
+
+    let private itemForHeader
+        (session: ProvenanceSession)
+        (sourceSide: ProvenanceSide)
+        (folderKey: FolderKey)
+        (inputProjection: PropertyRails.RailProjection)
+        (outputProjection: PropertyRails.RailProjection)
+        (uiState: UiState)
+        (header: ProvenancePropertyHeader)
+        : FolderedDraggableItem<PropertyShelfItemPayload> =
+        let badge =
+            outputProjection.BadgeByHeader
+            |> Map.tryFind header
+            |> Option.orElseWith (fun () -> inputProjection.BadgeByHeader |> Map.tryFind header)
+            |> badgeText
+
+        let tooltip =
+            [
+                ProvenanceKind.displayName header.Kind
+                folderName session folderKey
+            ]
+            |> List.filter (String.IsNullOrWhiteSpace >> not)
+            |> String.concat " · "
+
+        {
+            Id = $"{folderId folderKey}-{headerId header}"
+            Label = header.Category.Name
+            Payload = {
+                Header = header
+                SourceSide = sourceSide
+            }
+            Color = manualColor uiState header
+            Badge = badge
+            Tooltip =
+                if String.IsNullOrWhiteSpace tooltip then
+                    None
+                else
+                    Some tooltip
+            Disabled = false
+        }
+
+    let private dedupeItems (items: FolderedDraggableItem<PropertyShelfItemPayload> list) =
+        items
+        |> List.groupBy (fun item -> item.Id)
+        |> List.map (fun (_, matching) -> matching.Head)
+
+    let folders
+        session
+        (layer: ProvenanceLayer)
+        uiState
+        (inputProjection: PropertyRails.RailProjection)
+        (outputProjection: PropertyRails.RailProjection)
+        : FolderedDraggableFolder<PropertyShelfItemPayload> list =
+        let headers =
+            [
+                yield! inputProjection.Headers
+                yield! outputProjection.Headers
+            ]
+            |> List.distinct
+
+        let itemEntries =
+            headers
+            |> List.collect (fun header ->
+                let sourceSide =
+                    sourceSideForHeader layer.Id inputProjection outputProjection uiState header
+
+                originsForHeader layer.Id sourceSide inputProjection outputProjection header
+                |> Set.toList
+                |> List.map folderKeyForOrigin
+                |> List.distinct
+                |> List.map (fun folderKey ->
+                    folderKey,
+                    itemForHeader session sourceSide folderKey inputProjection outputProjection uiState header
+                )
+            )
+
+        let folderKeys =
+            [
+                yield LayerFolder layer.Id
+                yield! itemEntries |> List.map fst
+            ]
+            |> List.distinct
+            |> List.sortBy (folderSort session layer.Id)
+
+        folderKeys
+        |> List.map (fun key ->
+            let items =
+                itemEntries
+                |> List.choose (fun (itemFolderKey, item) -> if itemFolderKey = key then Some item else None)
+                |> dedupeItems
+
+            {
+                Id = folderId key
+                Name = folderName session key
+                Color = folderColor uiState key
+                Items = items
+            }
+        )
+
 /// Resolves drag payload ids and display ids against the active layer and UI palette.
 module private EditorLookups =
 
@@ -107,7 +335,12 @@ module private EditorLookups =
             groups |> List.tryFind (fun (group: DisplayGroup) -> group.Id = groupId)
 
         let findHeader headerId =
-            PropertyRails.headersForModel layer.Model
+            [
+                yield! PropertyRails.headersForModel layer.Model
+                yield! State.Palette.headersForSide layer.Id ProvenanceSide.Input uiState
+                yield! State.Palette.headersForSide layer.Id ProvenanceSide.Output uiState
+            ]
+            |> List.distinct
             |> List.tryFind (fun header -> DragDrop.propertyHeaderIdentity header = headerId)
 
         let findPropertyValue propertyValueId =
@@ -314,13 +547,15 @@ module private DragHandlers =
     let private routePropertyValueDrop context side groupId propertyValueId =
         match context.Lookups.FindPropertyValue propertyValueId with
         | Some propertyValue ->
+            let uiState = context.GetUiState()
+
             let targetGroups =
                 ValueAssignment.selectedTargetGroupsForDrop
                     context.Layer.Id
                     side
                     groupId
-                    context.UiState.SelectedInputs
-                    context.UiState.SelectedOutputs
+                    uiState.SelectedInputs
+                    uiState.SelectedOutputs
                     context.Lookups.FindGroup
 
             match
@@ -367,10 +602,10 @@ module private DragHandlers =
                         AffectedValueCount = affectedValueCount
                     }
 
-                    State.AssignmentBatch.set pendingBatch context.UiState |> context.SetUiState
+                    State.AssignmentBatch.set pendingBatch uiState |> context.SetUiState
             | Error error ->
                 context.SetUiState {
-                    context.UiState with
+                    uiState with
                         Error = Some(AssignmentErrors.text error)
                 }
         | _ -> ()
@@ -392,7 +627,7 @@ module private DragHandlers =
                         InputMemberCount = inputGroup.Members.Length
                         OutputMemberCount = outputGroup.Members.Length
                     }
-                    context.UiState
+                    (context.GetUiState())
                 |> context.SetUiState
         | _ -> ()
 
@@ -427,6 +662,13 @@ module private DragHandlers =
         match dragPayload, groupDrop, propertyDrop with
         | Some(DragDrop.Payload.PropertyValue propertyValueId), Some(side, groupId), _ ->
             routePropertyValueDrop context side groupId propertyValueId
+        | Some(DragDrop.Payload.FolderPropertyHeader(_, headerId)), _, Some targetSide ->
+            match context.Lookups.FindHeader headerId with
+            | Some header ->
+                context.GetUiState()
+                |> State.PropertyPlacement.place context.Layer.Id targetSide header
+                |> context.SetUiState
+            | _ -> ()
         | Some(DragDrop.Payload.PropertyHeader(sourceSide, headerId)), _, Some targetSide when sourceSide <> targetSide ->
             match context.Lookups.FindHeader headerId with
             | Some header when PropertyRails.canSwitchHeader header context.Layer.Model ->
@@ -436,7 +678,7 @@ module private DragHandlers =
                     (layerIdForSide context.Layer targetSide)
                     targetSide
                     header
-                    context.UiState
+                    (context.GetUiState())
                 |> context.SetUiState
             | _ -> ()
         | _ -> ()
@@ -647,6 +889,44 @@ module private EditorPanels =
 
 /// Render helpers for side rails, group columns, and drag overlays.
 module private EditorSurface =
+
+    let dropZoneProjection layerId side uiState activeAssignments (projection: PropertyRails.RailProjection) =
+        let activeHeaders =
+            [
+                yield!
+                    activeAssignments
+                    |> List.map (fun (assignment: GroupingAssignment) -> assignment.Key.Header)
+                yield!
+                    uiState.PropertyRailPlacements
+                    |> Map.toList
+                    |> List.choose (fun ((currentLayerId, key), placedSide) ->
+                        if currentLayerId = layerId && placedSide = side then
+                            Some key.Header
+                        else
+                            None
+                    )
+            ]
+            |> Set.ofList
+
+        let filterMap map =
+            map |> Map.filter (fun header _ -> activeHeaders.Contains header)
+
+        {
+            projection with
+                Headers = projection.Headers |> List.filter (fun header -> activeHeaders.Contains header)
+                ValuesByHeader = projection.ValuesByHeader |> filterMap
+                ExpandedHeaders =
+                    projection.ExpandedHeaders
+                    |> Set.filter (fun header -> activeHeaders.Contains header)
+                CanSwitchHeaders =
+                    projection.CanSwitchHeaders
+                    |> Set.filter (fun header -> activeHeaders.Contains header)
+                StatsByHeader = projection.StatsByHeader |> filterMap
+                ConnectionCountByHeader = projection.ConnectionCountByHeader |> filterMap
+                BadgeByHeader = projection.BadgeByHeader |> filterMap
+                ColorByHeader = projection.ColorByHeader |> filterMap
+                OriginByHeader = projection.OriginByHeader |> filterMap
+        }
 
     let propertyRail
         side
@@ -871,6 +1151,36 @@ type ProvenanceGrouping =
                 |]
             )
 
+        let inputSideState = State.Sides.get layer.InputSideId uiState
+        let outputSideState = State.Sides.get layer.OutputSideId uiState
+
+        let activeInputRailProjection =
+            EditorSurface.dropZoneProjection
+                layer.Id
+                ProvenanceSide.Input
+                uiState
+                inputSideState.GroupingAssignments
+                inputRailProjection
+
+        let activeOutputRailProjection =
+            EditorSurface.dropZoneProjection
+                layer.Id
+                ProvenanceSide.Output
+                uiState
+                outputSideState.GroupingAssignments
+                outputRailProjection
+
+        let propertyShelfFolders =
+            PropertyShelf.folders session layer uiState inputRailProjection outputRailProjection
+
+        let propertyShelf =
+            FolderedDraggableList.FolderedDraggableList<PropertyShelfItemPayload>(
+                propertyShelfFolders,
+                (fun _ item -> DragDrop.folderPropertyDragId item.Payload.SourceSide item.Payload.Header),
+                className = "swt:rounded-lg swt:border swt:border-base-300 swt:bg-base-100/80 swt:p-3 swt:shadow-sm",
+                debug = debug
+            )
+
         let applyUiState update =
             let next = update latestUiState.current
             latestUiState.current <- next
@@ -983,19 +1293,19 @@ type ProvenanceGrouping =
             EditorActions.createSet session publish command
 
         let addPaletteValue side header value unit =
-            State.Palette.addValue layer.Id side header value unit uiState |> setUiState
+            applyUiState (State.Palette.addValue layer.Id side header value unit)
 
         let toggleSideGrouping layerId side header =
-            State.GroupingAssignments.toggleSide layerId side header uiState |> setUiState
+            applyUiState (State.GroupingAssignments.toggleSide layerId side header)
 
         let togglePropertyExpanded side header =
-            State.PropertyExpansion.toggle layer.Id side header uiState |> setUiState
+            applyUiState (State.PropertyExpansion.toggle layer.Id side header)
 
         let toggleSelection side groupId =
-            State.Selection.toggle layer.Id side groupId uiState |> setUiState
+            applyUiState (State.Selection.toggle layer.Id side groupId)
 
         let toggleGroupDetail side groupId =
-            State.Detail.toggleGroup side groupId uiState |> setUiState
+            applyUiState (State.Detail.toggleGroup side groupId)
 
         let sourceInfoForValue value =
             Session.propertyValueSourceInfo layer value
@@ -1100,6 +1410,7 @@ type ProvenanceGrouping =
             Session = session
             Layer = layer
             UiState = uiState
+            GetUiState = fun () -> latestUiState.current
             Publish = publish
             SetUiState = commitUiState
             Lookups = lookups
@@ -1126,17 +1437,17 @@ type ProvenanceGrouping =
                 side
                 sideId
                 (match side with
-                 | ProvenanceSide.Input -> inputRailProjection
-                 | ProvenanceSide.Output -> outputRailProjection)
-                (State.Sides.get sideId uiState).GroupingAssignments
+                 | ProvenanceSide.Input -> activeInputRailProjection
+                 | ProvenanceSide.Output -> activeOutputRailProjection)
+                (match side with
+                 | ProvenanceSide.Input -> inputSideState.GroupingAssignments
+                 | ProvenanceSide.Output -> outputSideState.GroupingAssignments)
                 (fun header -> toggleSideGrouping sideId side header)
                 (fun header ->
-                    State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId header uiState
-                    |> setUiState
+                    applyUiState (State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId header)
                 )
                 (fun header ->
-                    State.GroupingAssignments.move layer.Id sideId oppositeSideId targetSide header uiState
-                    |> setUiState
+                    applyUiState (State.GroupingAssignments.move layer.Id sideId oppositeSideId targetSide header)
                 )
                 (fun header -> togglePropertyExpanded side header)
                 (fun header value unit -> addPaletteValue side header value unit)
@@ -1310,8 +1621,8 @@ type ProvenanceGrouping =
                 inputGroups,
                 outputGroups,
                 connections,
-                inputRailProjection,
-                outputRailProjection,
+                activeInputRailProjection,
+                activeOutputRailProjection,
                 ConnectorOverlayState.fromUiState uiState,
                 showPropertyHeaderConnectors,
                 liveDragStore.current,
@@ -1522,6 +1833,7 @@ type ProvenanceGrouping =
                                     ]
                                 ]
                             ]
+                            propertyShelf
                             Controls.FilterToolbar(
                                 uiState.Filters,
                                 (fun text -> applyUiState (State.Filters.setSearch text)),

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -32,6 +32,11 @@ type private DragContext = {
     ConnectSetPairs: (ProvenanceSetId * ProvenanceSetId) list -> unit
 }
 
+type private ActiveDrag = {
+    Payload: DragDrop.Payload
+    Label: string option
+}
+
 type private PropertyShelfItemPayload = {
     Header: ProvenancePropertyHeader
     SourceSide: ProvenanceSide
@@ -527,6 +532,26 @@ module private DropHitTesting =
 /// DnD event handlers that translate library events into session or UI state changes.
 module private DragHandlers =
 
+    let private activeLabel (event: DndKit.IDndKitEvent) =
+        if
+            isNull event.active
+            || isNull event.active.data
+            || isNull event.active.data.current
+        then
+            None
+        else
+            let labelObj: obj = event.active.data.current?label
+
+            if isNull labelObj then
+                None
+            else
+                let label = string labelObj
+
+                if String.IsNullOrWhiteSpace label || label = "undefined" then
+                    None
+                else
+                    Some label
+
     let handleStart
         (surfaceRef: IRefValue<Browser.Types.HTMLElement option>)
         setActiveDrag
@@ -534,7 +559,14 @@ module private DragHandlers =
         (event: DndKit.IDndKitEvent)
         =
         let payload = DragDrop.tryDragId (string event.active.id)
-        setActiveDrag payload
+
+        setActiveDrag (
+            payload
+            |> Option.map (fun payload -> {
+                Payload = payload
+                Label = activeLabel event
+            })
+        )
 
         match payload, surfaceRef.current with
         | Some(DragDrop.Payload.ConnectionHandle handle), Some surface ->
@@ -1055,10 +1087,27 @@ module private EditorSurface =
 
     let dragOverlay findPropertyValue debug activeDrag =
         match activeDrag with
-        | Some(DragDrop.Payload.PropertyValue propertyValueId) ->
+        | Some {
+                   Payload = DragDrop.Payload.PropertyValue propertyValueId
+               } ->
             match findPropertyValue propertyValueId with
             | Some propertyValue -> Controls.ValueDragPreview(propertyValue, showHeader = false, debug = debug)
             | None -> Html.none
+        | Some {
+                   Payload = DragDrop.Payload.PropertyHeader _
+                   Label = label
+               } ->
+            Html.div [
+                prop.className Styles.propertyValueOverlayClasses
+                if debug then
+                    prop.testId "provenance-drag-overlay-property"
+                prop.children [
+                    Html.span [
+                        prop.className "swt:min-w-0 swt:truncate"
+                        prop.text (label |> Option.defaultValue "Property")
+                    ]
+                ]
+            ]
         | _ -> Html.none
 
 [<Erase; Mangle(false)>]
@@ -1070,7 +1119,7 @@ type ProvenanceGrouping =
         =
         let debug = defaultArg debug false
         let rawUiState, setUiState = React.useState (State.init session)
-        let activeDrag, setActiveDrag = React.useState<DragDrop.Payload option> None
+        let activeDrag, setActiveDrag = React.useState<ActiveDrag option> None
         let surfaceRef = React.useElementRef ()
         let splitDrag = React.useRef (None: Splitter.SplitterSide option)
         let rootRef = React.useElementRef ()
@@ -1451,8 +1500,12 @@ type ProvenanceGrouping =
                     |> Option.exists (fun header -> PropertyRails.canSwitchHeader header layer.Model |> not))
 
             match activeDrag with
-            | Some(DragDrop.Payload.FolderPropertyHeader(sourceSide, headerId))
-            | Some(DragDrop.Payload.PropertyHeader(sourceSide, headerId)) -> headerCannotSwitch sourceSide headerId
+            | Some {
+                       Payload = DragDrop.Payload.FolderPropertyHeader(sourceSide, headerId)
+                   }
+            | Some {
+                       Payload = DragDrop.Payload.PropertyHeader(sourceSide, headerId)
+                   } -> headerCannotSwitch sourceSide headerId
             | _ -> false
 
         let railPanel side =

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -1402,21 +1402,9 @@ type ProvenanceGrouping =
                                                 publish
                                         ),
                                         layerColors = uiState.PropertyColors.LayerColors,
+                                        onSetLayerColor = setLayerColor,
                                         debug = debug
                                     )
-                                    Html.div [
-                                        prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-1"
-                                        prop.children [
-                                            for layerId in session.LayerOrder do
-                                                let layer = Session.layerById layerId session
-
-                                                Controls.LayerColorButton(
-                                                    layer.Id,
-                                                    uiState.PropertyColors.LayerColors |> Map.tryFind layer.Id,
-                                                    setLayerColor layer.Id
-                                                )
-                                        ]
-                                    ]
                                     Html.div [
                                         prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
                                         prop.children [

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -306,7 +306,7 @@ module private DragHandlers =
                 liveDragStore
         | None -> ()
 
-    let private layerIdForSide pair side =
+    let private layerIdForSide (pair: ProvenanceLayerPair) side =
         match side with
         | ProvenanceSide.Input -> pair.LeftLayerId
         | ProvenanceSide.Output -> pair.RightLayerId

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -20,7 +20,7 @@ type private EditorLookups = {
 
 type private DragContext = {
     Session: ProvenanceSession
-    Pair: ProvenanceLayerPair
+    Layer: ProvenanceLayer
     UiState: UiState
     Publish: SessionResult -> unit
     SetUiState: UiState -> unit
@@ -93,10 +93,10 @@ module private TierObserver =
     [<Emit("$0.disconnect()")>]
     let disconnect (observer: obj) : unit = jsNative
 
-/// Resolves drag payload ids and display ids against the active pair and UI palette.
+/// Resolves drag payload ids and display ids against the active layer and UI palette.
 module private EditorLookups =
 
-    let create pair uiState inputGroups outputGroups =
+    let create layer uiState inputGroups outputGroups =
         let findGroup side groupId =
             let groups: DisplayGroup list =
                 if side = ProvenanceSide.Input then
@@ -107,16 +107,16 @@ module private EditorLookups =
             groups |> List.tryFind (fun (group: DisplayGroup) -> group.Id = groupId)
 
         let findHeader headerId =
-            PropertyRails.headersForModel pair.Model
+            PropertyRails.headersForModel layer.Model
             |> List.tryFind (fun header -> DragDrop.propertyHeaderIdentity header = headerId)
 
         let findPropertyValue propertyValueId =
-            pair.Model.PropertyValues.TryFind propertyValueId
+            layer.Model.PropertyValues.TryFind propertyValueId
             |> Option.orElseWith (fun () -> State.Palette.tryFindValue propertyValueId uiState)
 
         let sourceForValue propertyValueId (propertyValue: ProvenancePropertyValue) : ValueAssignmentSource = {
             CopiedFrom =
-                if pair.Model.PropertyValues.ContainsKey propertyValueId then
+                if layer.Model.PropertyValues.ContainsKey propertyValueId then
                     Some propertyValueId
                 else
                     None
@@ -147,8 +147,8 @@ module private AssignmentErrors =
 /// Session-changing actions that publish patches back to the host component.
 module private EditorActions =
 
-    let addLayer session pairId inputGroups outputGroups uiState publish =
-        Display.layerCommand pairId inputGroups outputGroups uiState
+    let addLayer session layerId inputGroups outputGroups uiState publish =
+        Display.layerCommand layerId inputGroups outputGroups uiState
         |> fun command -> Session.addLayer command session
         |> publish
 
@@ -306,17 +306,17 @@ module private DragHandlers =
                 liveDragStore
         | None -> ()
 
-    let private layerIdForSide (pair: ProvenanceLayerPair) side =
+    let private layerIdForSide (layer: ProvenanceLayer) side =
         match side with
-        | ProvenanceSide.Input -> pair.InputSideId
-        | ProvenanceSide.Output -> pair.OutputSideId
+        | ProvenanceSide.Input -> layer.InputSideId
+        | ProvenanceSide.Output -> layer.OutputSideId
 
     let private routePropertyValueDrop context side groupId propertyValueId =
         match context.Lookups.FindPropertyValue propertyValueId with
         | Some propertyValue ->
             let targetGroups =
                 ValueAssignment.selectedTargetGroupsForDrop
-                    context.Pair.Id
+                    context.Layer.Id
                     side
                     groupId
                     context.UiState.SelectedInputs
@@ -327,7 +327,7 @@ module private DragHandlers =
                 ValueAssignment.planPropertyValueDropToGroups
                     (context.Lookups.SourceForValue propertyValueId propertyValue)
                     targetGroups
-                    context.Pair.Model
+                    context.Layer.Model
             with
             | Ok batch ->
                 let affectedValueCount =
@@ -386,7 +386,7 @@ module private DragHandlers =
             | None ->
                 State.MemberResolution.request
                     {
-                        PairId = context.Pair.Id
+                        LayerId = context.Layer.Id
                         InputGroupId = inputGroup.Id
                         OutputGroupId = outputGroup.Id
                         InputMemberCount = inputGroup.Members.Length
@@ -429,11 +429,11 @@ module private DragHandlers =
             routePropertyValueDrop context side groupId propertyValueId
         | Some(DragDrop.Payload.PropertyHeader(sourceSide, headerId)), _, Some targetSide when sourceSide <> targetSide ->
             match context.Lookups.FindHeader headerId with
-            | Some header when PropertyRails.canSwitchHeader header context.Pair.Model ->
+            | Some header when PropertyRails.canSwitchHeader header context.Layer.Model ->
                 State.GroupingAssignments.move
-                    context.Pair.Id
-                    (layerIdForSide context.Pair sourceSide)
-                    (layerIdForSide context.Pair targetSide)
+                    context.Layer.Id
+                    (layerIdForSide context.Layer sourceSide)
+                    (layerIdForSide context.Layer targetSide)
                     targetSide
                     header
                     context.UiState
@@ -689,7 +689,7 @@ module private EditorSurface =
 
     let groupColumn
         side
-        (pair: ProvenanceLayerPair)
+        (layer: ProvenanceLayer)
         model
         (groups: DisplayGroup list)
         endpointKinds
@@ -728,14 +728,14 @@ module private EditorSurface =
                     existingEndpointNames,
                     createSet,
                     debug = debug,
-                    key = $"{pair.Id}:{keyPrefix}:{endpointKindsKey}"
+                    key = $"{layer.Id}:{keyPrefix}:{endpointKindsKey}"
                 )
                 for group in groups do
                     GroupCard.Main(
                         side,
                         group,
                         model,
-                        State.Selection.contains pair.Id side group.Id uiState,
+                        State.Selection.contains layer.Id side group.Id uiState,
                         isExpanded side group.Id,
                         (fun () -> toggleSelection side group.Id),
                         (fun () -> toggleDetail side group.Id),
@@ -803,14 +803,14 @@ type ProvenanceGrouping =
 
         let uiState = State.Sides.ensure session rawUiState
 
-        let pair, inputGroups, outputGroups, connections =
-            React.useMemo ((fun () -> Display.displayPair session uiState), [| box session; box uiState.SideStates |])
+        let layer, inputGroups, outputGroups, connections =
+            React.useMemo ((fun () -> Display.displayLayer session uiState), [| box session; box uiState.SideStates |])
 
         let latestUiState = React.useRef uiState
-        let activePairId = React.useRef pair.Id
+        let activeLayerId = React.useRef layer.Id
         latestUiState.current <- uiState
-        activePairId.current <- pair.Id
-        let panelRatios = State.PanelLayout.get pair.Id uiState
+        activeLayerId.current <- layer.Id
+        let panelRatios = State.PanelLayout.get layer.Id uiState
 
         let endpointKinds = Endpoints.endpointKindOptions ()
 
@@ -823,22 +823,22 @@ type ProvenanceGrouping =
                 |> List.collect (fun group -> group.Members |> List.map (fun member' -> member'.Name))
         ]
 
-        let lookups = EditorLookups.create pair uiState inputGroups outputGroups
+        let lookups = EditorLookups.create layer uiState inputGroups outputGroups
 
         let inputRailProjection =
             React.useMemo (
                 (fun () ->
                     PropertyProjection.railProjectionWithFilters
                         session
-                        pair.Id
+                        layer.Id
                         ProvenanceSide.Input
-                        pair.Model
+                        layer.Model
                         uiState
                 ),
                 [|
                     box session
-                    box pair.Id
-                    box pair.Model
+                    box layer.Id
+                    box layer.Model
                     box uiState.PropertyRailPlacements
                     box uiState.ExpandedProperties
                     box uiState.PaletteValues
@@ -852,15 +852,15 @@ type ProvenanceGrouping =
                 (fun () ->
                     PropertyProjection.railProjectionWithFilters
                         session
-                        pair.Id
+                        layer.Id
                         ProvenanceSide.Output
-                        pair.Model
+                        layer.Model
                         uiState
                 ),
                 [|
                     box session
-                    box pair.Id
-                    box pair.Model
+                    box layer.Id
+                    box layer.Model
                     box uiState.PropertyRailPlacements
                     box uiState.ExpandedProperties
                     box uiState.PaletteValues
@@ -896,8 +896,8 @@ type ProvenanceGrouping =
 
                 let next =
                     match side with
-                    | Splitter.Left -> State.PanelLayout.setLeft activePairId.current splitPercent current
-                    | Splitter.Right -> State.PanelLayout.setRight activePairId.current (100 - splitPercent) current
+                    | Splitter.Left -> State.PanelLayout.setLeft activeLayerId.current splitPercent current
+                    | Splitter.Right -> State.PanelLayout.setRight activeLayerId.current (100 - splitPercent) current
 
                 latestUiState.current <- next
                 setUiState next
@@ -964,22 +964,22 @@ type ProvenanceGrouping =
             EditorActions.createSet session publish command
 
         let addPaletteValue side header value unit =
-            State.Palette.addValue pair.Id side header value unit uiState |> setUiState
+            State.Palette.addValue layer.Id side header value unit uiState |> setUiState
 
         let toggleSideGrouping layerId side header =
             State.GroupingAssignments.toggleSide layerId side header uiState |> setUiState
 
         let togglePropertyExpanded side header =
-            State.PropertyExpansion.toggle pair.Id side header uiState |> setUiState
+            State.PropertyExpansion.toggle layer.Id side header uiState |> setUiState
 
         let toggleSelection side groupId =
-            State.Selection.toggle pair.Id side groupId uiState |> setUiState
+            State.Selection.toggle layer.Id side groupId uiState |> setUiState
 
         let toggleGroupDetail side groupId =
             State.Detail.toggleGroup side groupId uiState |> setUiState
 
         let sourceInfoForValue value =
-            Session.propertyValueSourceInfo pair value
+            Session.propertyValueSourceInfo layer value
 
         let setPropertyColor header color =
             let update =
@@ -1038,7 +1038,7 @@ type ProvenanceGrouping =
         let isManuallyResolving side groupId =
             uiState.ManualResolutionPairs
             |> List.exists (fun resolution ->
-                resolution.PairId = pair.Id
+                resolution.LayerId = layer.Id
                 && ((side = ProvenanceSide.Input && resolution.InputGroupId = groupId)
                     || (side = ProvenanceSide.Output && resolution.OutputGroupId = groupId))
             )
@@ -1062,7 +1062,7 @@ type ProvenanceGrouping =
 
         let dragContext = {
             Session = session
-            Pair = pair
+            Layer = layer
             UiState = uiState
             Publish = publish
             SetUiState = commitUiState
@@ -1149,8 +1149,8 @@ type ProvenanceGrouping =
 
             EditorSurface.groupColumn
                 side
-                pair
-                pair.Model
+                layer
+                layer.Model
                 groups
                 endpointKinds
                 existingEndpointNames
@@ -1269,8 +1269,8 @@ type ProvenanceGrouping =
         let connectorOverlay =
             ConnectorOverlay.Main(
                 surfaceRef,
-                pair.Id,
-                pair.Model,
+                layer.Id,
+                layer.Model,
                 inputGroups,
                 outputGroups,
                 connections,
@@ -1395,7 +1395,7 @@ type ProvenanceGrouping =
                                         (fun () ->
                                             EditorActions.addLayer
                                                 session
-                                                pair.Id
+                                                layer.Id
                                                 inputGroups
                                                 outputGroups
                                                 uiState

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -676,9 +676,12 @@ module private DragHandlers =
         match dragPayload, groupDrop, propertyDrop with
         | Some(DragDrop.Payload.PropertyValue propertyValueId), Some(side, groupId), _ ->
             routePropertyValueDrop context side groupId propertyValueId
-        | Some(DragDrop.Payload.FolderPropertyHeader(_, headerId)), _, Some targetSide ->
+        | Some(DragDrop.Payload.FolderPropertyHeader(sourceSide, headerId)), _, Some targetSide ->
             match context.Lookups.FindHeader headerId with
-            | Some header ->
+            | Some header when
+                sourceSide = targetSide
+                || PropertyRails.canSwitchHeader header context.Layer.Model
+                ->
                 context.GetUiState()
                 |> State.PropertyPlacement.place context.Layer.Id targetSide header
                 |> context.SetUiState

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -308,8 +308,8 @@ module private DragHandlers =
 
     let private layerIdForSide (pair: ProvenanceLayerPair) side =
         match side with
-        | ProvenanceSide.Input -> pair.LeftLayerId
-        | ProvenanceSide.Output -> pair.RightLayerId
+        | ProvenanceSide.Input -> pair.InputSideId
+        | ProvenanceSide.Output -> pair.OutputSideId
 
     let private routePropertyValueDrop context side groupId propertyValueId =
         match context.Lookups.FindPropertyValue propertyValueId with
@@ -799,10 +799,10 @@ type ProvenanceGrouping =
             FsReact.createDisposable (fun () -> TierObserver.disconnect observer)
         )
 
-        let uiState = State.Layers.ensure session rawUiState
+        let uiState = State.Sides.ensure session rawUiState
 
         let pair, inputGroups, outputGroups, connections =
-            React.useMemo ((fun () -> Display.displayPair session uiState), [| box session; box uiState.LayerStates |])
+            React.useMemo ((fun () -> Display.displayPair session uiState), [| box session; box uiState.SideStates |])
 
         let latestUiState = React.useRef uiState
         let activePairId = React.useRef pair.Id
@@ -940,7 +940,7 @@ type ProvenanceGrouping =
             | Ok(next, patches) ->
                 LiveDrag.clear liveDragStore.current
 
-                let nextUiState = latestUiState.current |> State.Layers.ensure next
+                let nextUiState = latestUiState.current |> State.Sides.ensure next
 
                 commitUiState {
                     nextUiState with
@@ -1005,7 +1005,7 @@ type ProvenanceGrouping =
             | Ok(next, patches) ->
                 LiveDrag.clear liveDragStore.current
 
-                let nextUiState = latestUiState.current |> State.Layers.ensure next
+                let nextUiState = latestUiState.current |> State.Sides.ensure next
 
                 commitUiState {
                     nextUiState with
@@ -1079,18 +1079,18 @@ type ProvenanceGrouping =
         let railPanel side =
             let layerId, oppositeLayerId, targetSide =
                 match side with
-                | ProvenanceSide.Input -> pair.LeftLayerId, pair.RightLayerId, ProvenanceSide.Output
-                | ProvenanceSide.Output -> pair.RightLayerId, pair.LeftLayerId, ProvenanceSide.Input
+                | ProvenanceSide.Input -> pair.InputSideId, pair.OutputSideId, ProvenanceSide.Output
+                | ProvenanceSide.Output -> pair.OutputSideId, pair.InputSideId, ProvenanceSide.Input
 
             EditorSurface.propertyRail
                 side
                 (match side with
                  | ProvenanceSide.Input -> inputRailProjection
                  | ProvenanceSide.Output -> outputRailProjection)
-                (State.Layers.get layerId uiState).GroupingAssignments
+                (State.Sides.get layerId uiState).GroupingAssignments
                 (fun header -> toggleSideGrouping layerId side header)
                 (fun header ->
-                    State.GroupingAssignments.toggleBoth pair.LeftLayerId pair.RightLayerId header uiState
+                    State.GroupingAssignments.toggleBoth pair.InputSideId pair.OutputSideId header uiState
                     |> setUiState
                 )
                 (fun header ->

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -155,22 +155,31 @@ module private EditorActions =
     let createSet session publish command =
         Session.createLoadedSet command session |> publish
 
-    let confirmPendingOverwrite session publish setUiState uiState warning =
-        let rec apply current patches propertyValueIds =
-            match propertyValueIds with
-            | [] -> Ok(current, patches)
-            | propertyValueId :: rest ->
-                match Session.updatePropertyValue propertyValueId warning.Value warning.Unit current with
-                | Ok(next, addedPatches) -> apply next (patches @ addedPatches) rest
-                | Error error -> Error error
+    let private applyOverwrite result warning =
+        warning.ExistingValueIds
+        |> List.distinct
+        |> List.fold
+            (fun result propertyValueId ->
+                result
+                |> Result.bind (fun (currentSession, patches) ->
+                    Session.updatePropertyValue propertyValueId warning.Value warning.Unit currentSession
+                    |> Result.map (fun (next, added) -> next, patches @ added)
+                )
+            )
+            result
 
-        match warning.ExistingValueIds with
-        | [] ->
-            setUiState {
-                uiState with
-                    Error = Some "Cannot overwrite because the target value context is no longer available."
-            }
-        | propertyValueIds -> apply session [] propertyValueIds |> publish
+    let private applyAdd result command =
+        result
+        |> Result.bind (fun (currentSession, patches) ->
+            Session.createLoadedPropertyValue command currentSession
+            |> Result.map (fun (next, added) -> next, patches @ added)
+        )
+
+    let applyAssignmentBatch session publish batch =
+        batch.Overwrites
+        |> List.fold applyOverwrite (Ok(session, []))
+        |> Result.bind (fun afterOverwrites -> batch.Adds |> List.fold applyAdd (Ok afterOverwrites))
+        |> publish
 
     let connectSetPairs session publish pairs =
         pairs
@@ -303,19 +312,54 @@ module private DragHandlers =
         | ProvenanceSide.Output -> pair.RightLayerId
 
     let private routePropertyValueDrop context side groupId propertyValueId =
-        match context.Lookups.FindGroup side groupId, context.Lookups.FindPropertyValue propertyValueId with
-        | Some group, Some propertyValue ->
+        match context.Lookups.FindPropertyValue propertyValueId with
+        | Some propertyValue ->
+            let selectedIds =
+                (match side with
+                 | ProvenanceSide.Input -> context.UiState.SelectedInputs
+                 | ProvenanceSide.Output -> context.UiState.SelectedOutputs)
+                |> Set.filter (fun (pid, _) -> pid = context.Pair.Id)
+
+            let targetGroupIds =
+                if selectedIds.IsEmpty then
+                    [ groupId ]
+                else
+                    selectedIds |> Set.toList |> List.map snd
+
+            let targetGroups =
+                targetGroupIds |> List.choose (fun gid -> context.Lookups.FindGroup side gid)
+
             match
-                ValueAssignment.planPropertyValueDrop
+                ValueAssignment.planPropertyValueDropToGroups
                     (context.Lookups.SourceForValue propertyValueId propertyValue)
-                    group
+                    targetGroups
                     context.Pair.Model
             with
-            | Ok(ValueAssignmentPlan.AddCurrent command) ->
-                Session.createCurrentLoadedPropertyValue command context.Session
-                |> context.Publish
-            | Ok(ValueAssignmentPlan.ConfirmOverwrite warning) ->
-                State.Overwrite.set warning context.UiState |> context.SetUiState
+            | Ok batch ->
+                let affectedValueCount =
+                    batch.Overwrites |> List.sumBy (fun w -> w.ExistingValueIds.Length)
+
+                if batch.Overwrites.IsEmpty then
+                    if not batch.Adds.IsEmpty then
+                        batch.Adds
+                        |> List.fold
+                            (fun (result: SessionResult) cmd ->
+                                match result with
+                                | Ok(current, patches) ->
+                                    Session.createCurrentLoadedPropertyValue cmd current
+                                    |> Result.map (fun (next, added) -> next, patches @ added)
+                                | Error _ -> result
+                            )
+                            (Ok(context.Session, []))
+                        |> context.Publish
+                else
+                    let pendingBatch = {
+                        Batch = batch
+                        AffectedSideCount = 1
+                        AffectedValueCount = affectedValueCount
+                    }
+
+                    State.AssignmentBatch.set pendingBatch context.UiState |> context.SetUiState
             | Error error ->
                 context.SetUiState {
                     context.UiState with
@@ -423,9 +467,21 @@ module private EditorPanels =
             prop.text error
         ]
 
-    let overwriteWarning debug warning onConfirm onCancel =
-        let count = warning.ExistingValueIds.Length
-        let valueText = Formatting.formatValue warning.Value warning.Unit
+    let assignmentBatchWarning debug (pending: PendingAssignmentBatch) onConfirm onCancel =
+        let overwriteCount = pending.AffectedValueCount
+        let sideCount = pending.AffectedSideCount
+
+        let headerText =
+            pending.Batch.Overwrites
+            |> List.tryHead
+            |> Option.map (fun w -> w.Header.Category.Name)
+            |> Option.defaultValue "property"
+
+        let valueText =
+            pending.Batch.Overwrites
+            |> List.tryHead
+            |> Option.map (fun w -> Formatting.formatValue w.Value w.Unit)
+            |> Option.defaultValue "new value"
 
         Html.div [
             prop.className "swt:alert swt:alert-warning swt:flex-wrap swt:items-start"
@@ -440,16 +496,16 @@ module private EditorPanels =
                     prop.children [
                         Html.strong [
                             prop.text (
-                                if count > 1 then
-                                    $"Overwrite {count} {warning.Header.Category.Name} values?"
+                                if overwriteCount > 1 then
+                                    $"Overwrite {overwriteCount} {headerText} values?"
                                 else
-                                    $"Overwrite {warning.Header.Category.Name} value?"
+                                    $"Overwrite {headerText} value?"
                             )
                         ]
                         Html.span [
                             prop.className "swt:text-sm"
                             prop.text
-                                $"The selected targets already have {warning.Header.Category.Name}. Confirm to replace with {valueText} using the existing edit path."
+                                $"The selected targets already have {headerText}. Confirm to replace with {valueText} using the existing edit path."
                         ]
                     ]
                 ]
@@ -461,8 +517,8 @@ module private EditorPanels =
                             prop.className "swt:btn swt:btn-warning swt:btn-sm"
                             if debug then
                                 prop.testId "provenance-confirm-overwrite"
-                            prop.onPointerUp (fun _ -> onConfirm warning)
-                            prop.onClick (fun _ -> onConfirm warning)
+                            prop.onPointerUp (fun _ -> onConfirm pending)
+                            prop.onClick (fun _ -> onConfirm pending)
                             prop.text "Overwrite"
                         ]
                         Html.button [
@@ -851,7 +907,7 @@ type ProvenanceGrouping =
                 commitUiState {
                     nextUiState with
                         Error = None
-                        PendingOverwrite = None
+                        PendingAssignmentBatch = None
                         PendingMemberResolution = None
                 }
 
@@ -882,8 +938,8 @@ type ProvenanceGrouping =
         let toggleGroupDetail side groupId =
             State.Detail.toggleGroup side groupId uiState |> setUiState
 
-        let confirmPendingOverwrite =
-            EditorActions.confirmPendingOverwrite session publish setUiState uiState
+        let confirmBatch (pending: PendingAssignmentBatch) =
+            EditorActions.applyAssignmentBatch session publish pending.Batch
 
         let connectSetPairs = EditorActions.connectSetPairs session publish
 
@@ -897,7 +953,7 @@ type ProvenanceGrouping =
                 commitUiState {
                     nextUiState with
                         Error = None
-                        PendingOverwrite = None
+                        PendingAssignmentBatch = None
                         PendingMemberResolution = None
                         Detail = None
                 }
@@ -1014,10 +1070,12 @@ type ProvenanceGrouping =
             connectionCounts |> Map.tryFind (side, groupId) |> Option.defaultValue 0
 
         let groupColumnFor side withConnectionBadges =
-            let groups =
+            let unsorted =
                 match side with
                 | ProvenanceSide.Input -> inputGroups
                 | ProvenanceSide.Output -> outputGroups
+
+            let groups = Display.sortGroups uiState.Filters.GroupSort connections unsorted
 
             let counts groupId =
                 if withConnectionBadges then
@@ -1364,13 +1422,13 @@ type ProvenanceGrouping =
                             match uiState.Error with
                             | Some error -> EditorPanels.errorAlert error
                             | None -> Html.none
-                            match uiState.PendingOverwrite with
-                            | Some warning ->
-                                EditorPanels.overwriteWarning
+                            match uiState.PendingAssignmentBatch with
+                            | Some batch ->
+                                EditorPanels.assignmentBatchWarning
                                     debug
-                                    warning
-                                    confirmPendingOverwrite
-                                    (fun () -> State.Overwrite.clear uiState |> setUiState)
+                                    batch
+                                    confirmBatch
+                                    (fun () -> State.AssignmentBatch.clear uiState |> setUiState)
                             | None -> Html.none
                             match uiState.PendingMemberResolution with
                             | Some pending ->

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -957,6 +957,7 @@ module private EditorSurface =
         addPaletteValue
         setPropertyColor
         sourceInfoForValue
+        isDropRejected
         debug
         setIsValueChipDragging
 
@@ -973,6 +974,7 @@ module private EditorSurface =
             toggleExpanded,
             addPaletteValue,
             (fun header -> projection.CanSwitchHeaders.Contains header),
+            isDropRejected,
             setIsValueChipDragging,
             (fun header -> projection.StatsByHeader |> Map.tryFind header),
             (fun header -> projection.BadgeByHeader |> Map.tryFind header),
@@ -1442,6 +1444,17 @@ type ProvenanceGrouping =
         let toggleRail side =
             setOpenRail (if openRail = Some side then None else Some side)
 
+        let isRejectedPropertyRailDrop targetSide =
+            let headerCannotSwitch sourceSide headerId =
+                sourceSide <> targetSide
+                && (lookups.FindHeader headerId
+                    |> Option.exists (fun header -> PropertyRails.canSwitchHeader header layer.Model |> not))
+
+            match activeDrag with
+            | Some(DragDrop.Payload.FolderPropertyHeader(sourceSide, headerId))
+            | Some(DragDrop.Payload.PropertyHeader(sourceSide, headerId)) -> headerCannotSwitch sourceSide headerId
+            | _ -> false
+
         let railPanel side =
             let layer = Session.activeLayer session
 
@@ -1470,6 +1483,7 @@ type ProvenanceGrouping =
                 (fun header value unit -> addPaletteValue side header value unit)
                 setPropertyColor
                 sourceInfoForValue
+                (isRejectedPropertyRailDrop side)
                 debug
                 setIsValueChipDragging
 

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -840,6 +840,7 @@ type ProvenanceGrouping =
                     box layer.Id
                     box layer.Model
                     box uiState.PropertyRailPlacements
+                    box uiState.PropertyRailOrders
                     box uiState.ExpandedProperties
                     box uiState.PaletteValues
                     box uiState.PropertyColors
@@ -862,6 +863,7 @@ type ProvenanceGrouping =
                     box layer.Id
                     box layer.Model
                     box uiState.PropertyRailPlacements
+                    box uiState.PropertyRailOrders
                     box uiState.ExpandedProperties
                     box uiState.PaletteValues
                     box uiState.PropertyColors
@@ -877,6 +879,23 @@ type ProvenanceGrouping =
         let commitUiState next =
             latestUiState.current <- next
             setUiState next
+
+        React.useEffect (
+            (fun () ->
+                let next =
+                    latestUiState.current
+                    |> State.RailOrder.ensure layer.Id ProvenanceSide.Input inputRailProjection.Headers
+                    |> State.RailOrder.ensure layer.Id ProvenanceSide.Output outputRailProjection.Headers
+
+                if next <> latestUiState.current then
+                    commitUiState next
+            ),
+            [|
+                box layer.Id
+                box inputRailProjection.Headers
+                box outputRailProjection.Headers
+            |]
+        )
 
         let commitPanelRatio side clientX =
             match surfaceRef.current with
@@ -996,6 +1015,27 @@ type ProvenanceGrouping =
                 | None -> State.PropertyColors.clearLayerColor layerId
 
             applyUiState update
+
+        let setPropertySort sort =
+            let sortedInputHeaders =
+                PropertyProjection.sortHeaders
+                    sort
+                    inputRailProjection.StatsByHeader
+                    inputRailProjection.ConnectionCountByHeader
+                    inputRailProjection.Headers
+
+            let sortedOutputHeaders =
+                PropertyProjection.sortHeaders
+                    sort
+                    outputRailProjection.StatsByHeader
+                    outputRailProjection.ConnectionCountByHeader
+                    outputRailProjection.Headers
+
+            applyUiState (
+                State.Filters.setPropertySort sort
+                >> State.RailOrder.reorderVisible layer.Id ProvenanceSide.Input sortedInputHeaders
+                >> State.RailOrder.reorderVisible layer.Id ProvenanceSide.Output sortedOutputHeaders
+            )
 
         let confirmBatch (pending: PendingAssignmentBatch) =
             EditorActions.applyAssignmentBatch session publish pending.Batch
@@ -1489,7 +1529,7 @@ type ProvenanceGrouping =
                             Controls.FilterToolbar(
                                 uiState.Filters,
                                 (fun text -> applyUiState (State.Filters.setSearch text)),
-                                (fun sort -> applyUiState (State.Filters.setPropertySort sort)),
+                                setPropertySort,
                                 (fun sort -> applyUiState (State.Filters.setGroupSort sort)),
                                 (fun filter -> applyUiState (State.Filters.setValueCountFilter filter)),
                                 (fun filter -> applyUiState (State.Filters.setOriginFilter filter)),

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -223,6 +223,19 @@ module private PropertyShelf =
     let private manualColor (uiState: UiState) (header: ProvenancePropertyHeader) =
         uiState.PropertyColors.ManualPropertyColors |> Map.tryFind { Header = header }
 
+    let private isPlacedInCurrentLayer (layer: ProvenanceLayer) (uiState: UiState) header =
+        let key = State.Keys.groupingKey header
+
+        let placedInRail = uiState.PropertyRailPlacements |> Map.containsKey (layer.Id, key)
+
+        let groupedOnSide sideId =
+            (State.Sides.get sideId uiState).GroupingAssignments
+            |> List.exists (fun assignment -> assignment.Key = key)
+
+        placedInRail
+        || groupedOnSide layer.InputSideId
+        || groupedOnSide layer.OutputSideId
+
     let private itemForHeader
         (session: ProvenanceSession)
         (sourceSide: ProvenanceSide)
@@ -281,6 +294,7 @@ module private PropertyShelf =
                 yield! outputProjection.Headers
             ]
             |> List.distinct
+            |> List.filter (isPlacedInCurrentLayer layer uiState >> not)
 
         let itemEntries =
             headers

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -1286,6 +1286,30 @@ export const ManualMismatchResolutionExpandsMembersWithoutPatches: Story = {
   },
 };
 
+export const LayerTabsUseConceptualLayerColorsAndSideRails: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const layer1 = canvas.getByTestId('provenance-layer-layer-1');
+    const layerColor = layer1.getAttribute('data-provenance-layer-color') ?? '';
+
+    expect(layer1).toHaveClass('swt:btn-primary');
+    expect(layerColor).toMatch(/^#/);
+    expect(layerColor).not.toContain('|');
+    expect(canvas.queryByTestId('provenance-pair-pair-1')).not.toBeInTheDocument();
+
+    expect(canvas.getByTestId('provenance-property-rail-Input')).toHaveAttribute(
+      'data-provenance-side-id',
+      'layer-1-input',
+    );
+    expect(canvas.getByTestId('provenance-property-rail-Output')).toHaveAttribute(
+      'data-provenance-side-id',
+      'layer-1-output',
+    );
+  },
+};
+
 export const AddsLayerFromMixedSelection: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
@@ -1298,8 +1322,8 @@ export const AddsLayerFromMixedSelection: Story = {
     await userEvent.click(canvas.getByTestId('provenance-add-layer'));
 
     await waitFor(() => {
-      expect(canvas.getByTestId('provenance-pair-pair-2')).toHaveClass('swt:btn-primary');
-      expect(canvasElement).toHaveTextContent('Selection 3');
+      expect(canvas.getByTestId('provenance-layer-layer-2')).toHaveClass('swt:btn-primary');
+      expect(canvas.queryByText('Selection 3')).not.toBeInTheDocument();
       expect(canvasElement).toHaveTextContent('Input A');
       expect(canvasElement).toHaveTextContent('Output B');
     });

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -117,7 +117,7 @@ export const GroupsByPropertiesAndShowsMembers: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    await groupByProperty(canvas, 'Output', 'Species');
     const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
     expect(canvas.getByTestId('provenance-group-Output-output:Species=Chlamydomonas')).toBeInTheDocument();
 
@@ -138,7 +138,7 @@ export const ExpandedGroupsShowMemberHoverValues: Story = {
     expect(within(canvas.getByText('Output A').closest('article')!).queryByRole('button', { name: 'Show members' }))
       .not.toBeInTheDocument();
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    await groupByProperty(canvas, 'Output', 'Species');
     const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
 
     await userEvent.click(within(grouped).getByRole('button', { name: 'Show members' }));
@@ -162,7 +162,7 @@ export const ShowsEntityTypesAndCollapsedSymbols: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    await groupByProperty(canvas, 'Output', 'Species');
     const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
 
     // The collapsed card previews its member types as symbols instead of a bare "×3" count.
@@ -183,7 +183,7 @@ export const HoveringGroupTabHighlightsItAndKeepsFolderPreview: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    await groupByProperty(canvas, 'Output', 'Species');
     const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
     const tab = within(grouped).getByTestId('provenance-group-tab-Output-output:Species=Arabidopsis-0');
 
@@ -230,15 +230,15 @@ export const GroupsBothSidesFromOutputProperty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.hover(canvas.getByTestId('provenance-property-Output-Replicate'));
-    await userEvent.click(canvas.getByTestId('provenance-property-both-Output-Replicate'));
+    await showPropertyControls(canvas, 'Output', 'Replicate');
+    fireEvent.click(canvas.getByTestId('provenance-property-both-Output-Replicate'));
 
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-group-Input-input:Replicate=1 | 2')).toBeInTheDocument();
       expect(canvas.getByTestId('provenance-group-Output-output:Replicate=1 | 2')).toBeInTheDocument();
       expect(canvas.queryByTestId('provenance-group-Input-input:Replicate=1')).not.toBeInTheDocument();
       expect(canvas.queryByTestId('provenance-group-Output-output:Replicate=2')).not.toBeInTheDocument();
-    });
+    }, { timeout: 3000 });
   },
 };
 
@@ -247,10 +247,8 @@ export const MissingSecondGroupingKeyKeepsAvailableGroupingKeys: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.hover(canvas.getByTestId('provenance-property-Output-Species'));
-    await userEvent.click(canvas.getByTestId('provenance-property-both-Output-Species'));
-    await userEvent.hover(canvas.getByTestId('provenance-property-Output-Temperature'));
-    await userEvent.click(canvas.getByTestId('provenance-property-both-Output-Temperature'));
+    await groupByProperty(canvas, 'Input', 'Species');
+    await groupByProperty(canvas, 'Input', 'Temperature');
 
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis|Temperature=12 C'))
@@ -277,24 +275,21 @@ export const ConnectedOutputsKeepPropertiesInRailsAndConnections: Story = {
   },
 };
 
-export const GroupingPropertiesStayOnOwningSide: Story = {
+export const PropertiesStartInOriginFoldersAndSideDropZonesAreEmpty: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
-    const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
-    expect(inputRail.getByTestId('provenance-property-Input-Previous Treatment')).toBeInTheDocument();
-    expect(inputRail.queryByTestId('provenance-property-Input-Species')).not.toBeInTheDocument();
-    expect(inputRail.queryByTestId('provenance-property-Input-Temperature')).not.toBeInTheDocument();
-    expect(inputRail.queryByTestId('provenance-property-Input-Analysis')).not.toBeInTheDocument();
-    expect(inputRail.queryByTestId('provenance-property-Input-Replicate')).not.toBeInTheDocument();
+    expect(canvas.getByTestId('foldered-draggable-list')).toBeInTheDocument();
+    expect(canvas.getByTestId('foldered-draggable-folder-layer-layer-1')).toBeInTheDocument();
+    expect(canvas.getByTestId('provenance-property-rail-Input').querySelector('[data-testid^="provenance-property-Input-"]'))
+      .not.toBeInTheDocument();
+    expect(canvas.getByTestId('provenance-property-rail-Output').querySelector('[data-testid^="provenance-property-Output-"]'))
+      .not.toBeInTheDocument();
 
-    expect(outputRail.getByTestId('provenance-property-Output-Analysis')).toBeInTheDocument();
-    expect(outputRail.getByTestId('provenance-property-Output-Replicate')).toBeInTheDocument();
-    expect(outputRail.getByTestId('provenance-property-Output-Species')).toBeInTheDocument();
-    expect(outputRail.getByTestId('provenance-property-Output-Temperature')).toBeInTheDocument();
-    expect(outputRail.queryByTestId('provenance-property-Output-Previous Treatment')).not.toBeInTheDocument();
+    const species = await shelfProperty(canvas, 'Species');
+    expect(species).toBeInTheDocument();
+    expect(species).toHaveTextContent('Species');
   },
 };
 
@@ -330,8 +325,8 @@ export const SortsPropertiesByNameAndConnectionCount: Story = {
     await userEvent.click(toolbar.getByRole('button', { name: /^Sort By$/i }));
     await userEvent.click(toolbar.getByRole('button', { name: /^Name$/i }));
 
-    await waitFor(() => {
-      expect(propertyOrder(canvas, 'Output').slice(0, 4)).toEqual([
+    await waitFor(async () => {
+      expect((await shelfPropertyOrder(canvas)).slice(0, 4)).toEqual([
         'Analysis',
         'Replicate',
         'Species',
@@ -342,8 +337,8 @@ export const SortsPropertiesByNameAndConnectionCount: Story = {
     await userEvent.click(toolbar.getByRole('button', { name: /^Sort By$/i }));
     await userEvent.click(toolbar.getByRole('button', { name: /^Connection Count$/i }));
 
-    await waitFor(() => {
-      expect(propertyOrder(canvas, 'Output').slice(0, 4)).toEqual([
+    await waitFor(async () => {
+      expect((await shelfPropertyOrder(canvas)).slice(0, 4)).toEqual([
         'Species',
         'Analysis',
         'Temperature',
@@ -382,7 +377,7 @@ export const LayerFocusDoesNotResortInitializedRails: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const initialOutputOrder = propertyOrder(canvas, 'Output').slice(0, 4);
+    const initialOutputOrder = (await shelfPropertyOrder(canvas)).slice(0, 4);
 
     await selectGroup(canvas.getByText('Output A').closest('article')!);
     await userEvent.click(canvas.getByTestId('provenance-add-layer'));
@@ -394,7 +389,7 @@ export const LayerFocusDoesNotResortInitializedRails: Story = {
 
     await userEvent.click(canvas.getByTestId('provenance-layer-layer-1'));
     await waitFor(() => expect(canvas.getByTestId('provenance-layer-layer-1')).toHaveClass('swt:btn-primary'));
-    expect(propertyOrder(canvas, 'Output').slice(0, 4)).toEqual(initialOutputOrder);
+    expect((await shelfPropertyOrder(canvas)).slice(0, 4)).toEqual(initialOutputOrder);
   },
 };
 
@@ -462,6 +457,8 @@ export const SingleSidedPropertiesCannotSwitchSides: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
+    await ensurePropertyInRail(canvas, 'Output', 'Analysis');
+    await ensurePropertyInRail(canvas, 'Output', 'Replicate');
     expect(canvas.getByTestId('provenance-property-drag-Output-Analysis')).toBeDisabled();
     expect(canvas.getByTestId('provenance-property-drag-Output-Replicate')).toBeDisabled();
   },
@@ -472,11 +469,8 @@ export const SwitchesPropertyGroupingSideByDrag: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Output-Batch'));
-    await waitFor(() => {
-      expect(canvas.getByTestId('provenance-group-Output-output:Batch=A')).toBeInTheDocument();
-      expect(canvas.queryByTestId('provenance-group-Input-input:Batch=A')).not.toBeInTheDocument();
-    });
+    await groupByProperty(canvas, 'Output', 'Batch');
+    expect(canvas.queryByTestId('provenance-group-Input-input:Batch=A')).not.toBeInTheDocument();
 
     await dragByPointer(
       canvas.getByTestId('provenance-property-Output-Batch'),
@@ -499,6 +493,7 @@ export const SwitchesInheritedPropertyGroupingToInputSide: Story = {
     const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
     const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
+    await ensurePropertyInRail(canvas, 'Output', 'Species');
     expect(canvas.getByTestId('provenance-property-drag-Output-Species')).not.toBeDisabled();
     await dragByPointer(
       canvas.getByTestId('provenance-property-Output-Species'),
@@ -522,6 +517,7 @@ export const ClicksSwapHandleToSwitchGroupingSide: Story = {
     const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
     const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
+    await ensurePropertyInRail(canvas, 'Output', 'Species');
     await userEvent.hover(canvas.getByTestId('provenance-property-Output-Species'));
     await userEvent.click(canvas.getByTestId('provenance-property-drag-Output-Species'));
 
@@ -539,7 +535,7 @@ export const RegroupedValuesAreReadOnlyOnCards: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    await groupByProperty(canvas, 'Output', 'Species');
     const grouped = await waitFor(
       () => canvas.getByTestId('provenance-group-Output-output:Species=Chlamydomonas'),
       { timeout: 3000 },
@@ -566,7 +562,7 @@ export const RemeasuresConnectionsAfterGroupExpansion: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    fireEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    await groupByProperty(canvas, 'Output', 'Species');
 
     const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
 
@@ -671,6 +667,7 @@ export const ExpandedPropertyValuesConnectValueChipsToMatchingGroups: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
+    await ensurePropertyInRail(canvas, 'Output', 'Species');
     await waitFor(() => {
       const headerKeys = connectionKeys(canvas.getAllByTestId('provenance-property-connection'));
       expect(headerKeys.some((key) => key.includes('Species'))).toBe(true);
@@ -709,6 +706,7 @@ export const CollapsedPropertiesConnectToMatchingGroupsAutomatically: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
+    await ensurePropertyInRail(canvas, 'Output', 'Species');
     await waitFor(() => {
       const paths = canvas.getAllByTestId('provenance-property-connection');
       expect(paths.every((path) => path.getAttribute('d')?.startsWith('M '))).toBe(true);
@@ -1168,9 +1166,94 @@ async function startDragByPointer(source: Element) {
   await nextFrame();
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function shelfFolders(canvas: ReturnType<typeof within>) {
+  return Array.from(
+    canvas
+      .getByTestId('foldered-draggable-folder-row')
+      .querySelectorAll<HTMLElement>('[data-testid^="foldered-draggable-folder-"]'),
+  );
+}
+
+async function openShelfFolder(canvas: ReturnType<typeof within>, folder: HTMLElement) {
+  const folderTestId = folder.getAttribute('data-testid')!;
+  const currentFolder = () => canvas.getByTestId(folderTestId);
+
+  if (currentFolder().getAttribute('aria-expanded') !== 'true') {
+    await userEvent.click(currentFolder());
+  }
+
+  await waitFor(() => expect(currentFolder()).toHaveAttribute('aria-expanded', 'true'));
+  return within(canvas.getByTestId('foldered-draggable-item-row'));
+}
+
+async function shelfProperty(canvas: ReturnType<typeof within>, propertyName: string) {
+  const name = new RegExp(`^Drag ${escapeRegExp(propertyName)}$`);
+
+  for (const folder of shelfFolders(canvas)) {
+    const row = await openShelfFolder(canvas, folder);
+    const item = row.queryByRole('button', { name });
+
+    if (item) {
+      return item;
+    }
+  }
+
+  throw new Error(`Could not find shelf property "${propertyName}".`);
+}
+
+async function ensurePropertyInRail(
+  canvas: ReturnType<typeof within>,
+  side: 'Input' | 'Output',
+  propertyName: string,
+) {
+  const propertyId = `provenance-property-${side}-${propertyName}`;
+  const existing = canvas.queryByTestId(propertyId);
+
+  if (existing) {
+    return existing;
+  }
+
+  const source = await shelfProperty(canvas, propertyName);
+  await dragByPointer(source, canvas.getByTestId(`provenance-property-rail-${side}`));
+
+  await waitFor(() => expect(canvas.queryByTestId('foldered-draggable-drag-overlay')).not.toBeInTheDocument());
+  return waitFor(() => canvas.getByTestId(propertyId));
+}
+
+async function showPropertyControls(
+  canvas: ReturnType<typeof within>,
+  side: 'Input' | 'Output',
+  propertyName: string,
+) {
+  const property = await ensurePropertyInRail(canvas, side, propertyName);
+  property.focus();
+  await userEvent.hover(property);
+
+  const controls = canvas.getByTestId(`provenance-property-both-${side}-${propertyName}`).parentElement!;
+  await waitFor(() => expect(controls).not.toHaveClass('swt:hidden'));
+
+  return property;
+}
+
+async function shelfPropertyOrder(canvas: ReturnType<typeof within>) {
+  const folder = canvas.getByTestId('foldered-draggable-folder-layer-layer-1');
+  await openShelfFolder(canvas, folder);
+
+  return Array.from(
+    canvas
+      .getByTestId('foldered-draggable-item-row')
+      .querySelectorAll<HTMLElement>('[data-testid^="foldered-draggable-item-"]'),
+  ).map((element) => (element.getAttribute('aria-label') ?? '').replace(/^Drag\s+/, ''));
+}
+
 async function expandProperty(canvas: ReturnType<typeof within>, side: 'Input' | 'Output', propertyName: string) {
   const panelId = `provenance-property-values-${side}-${propertyName}`;
   const triggerId = `provenance-property-expand-${side}-${propertyName}`;
+  await ensurePropertyInRail(canvas, side, propertyName);
   // The row controls only enter the layout while the row is hovered or focused.
   await userEvent.hover(canvas.getByTestId(`provenance-property-${side}-${propertyName}`));
   for (let attempt = 0; attempt < 3 && !canvas.queryByTestId(panelId); attempt += 1) {
@@ -1187,6 +1270,7 @@ async function expandProperty(canvas: ReturnType<typeof within>, side: 'Input' |
 
 async function groupByProperty(canvas: ReturnType<typeof within>, side: 'Input' | 'Output', propertyName: string) {
   const groupedPattern = new RegExp(`^provenance-group-${side}-${side.toLowerCase()}:.*${propertyName}=`);
+  await ensurePropertyInRail(canvas, side, propertyName);
 
   for (let attempt = 0; attempt < 3 && canvas.queryAllByTestId(groupedPattern).length === 0; attempt += 1) {
     fireEvent.click(canvas.getByTestId(`provenance-property-${side}-${propertyName}`));
@@ -1214,13 +1298,6 @@ async function selectGroup(groupCard: HTMLElement) {
   }
 
   await waitFor(() => expect(groupCard).toHaveClass('swt:border-primary'), { timeout: 3000 });
-}
-
-function propertyOrder(canvas: ReturnType<typeof within>, side: 'Input' | 'Output') {
-  const prefix = `provenance-property-${side}-`;
-  const rail = canvas.getByTestId(`provenance-property-rail-${side}`);
-  return Array.from(rail.querySelectorAll<HTMLElement>(`[data-testid^="${prefix}"]`))
-    .map((element) => element.getAttribute('data-testid')!.slice(prefix.length));
 }
 
 async function railValue(

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -211,6 +211,20 @@ export const ShowsFileTypeForDataEndpoints: Story = {
   },
 };
 
+export const GroupCardsSelectFromCardSurface: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const outputA = canvas.getByText('Output A').closest('article')!;
+
+    expect(within(outputA).queryByRole('button', { name: 'Select group' })).not.toBeInTheDocument();
+
+    const selectionSurface = outputA.querySelector<HTMLElement>('[data-testid^="provenance-group-select-surface-"]')!;
+    await userEvent.click(selectionSurface);
+    await waitFor(() => expect(outputA).toHaveClass('swt:border-primary'));
+  },
+};
+
 export const GroupsBothSidesFromOutputProperty: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
@@ -1182,7 +1196,8 @@ async function groupByProperty(canvas: ReturnType<typeof within>, side: 'Input' 
 
 async function selectGroup(groupCard: HTMLElement) {
   for (let attempt = 0; attempt < 3 && !groupCard.classList.contains('swt:border-primary'); attempt += 1) {
-    await userEvent.click(within(groupCard).getByRole('button', { name: 'Select group' }));
+    const selectionSurface = groupCard.querySelector<HTMLElement>('[data-testid^="provenance-group-select-surface-"]');
+    await userEvent.click(selectionSurface ?? groupCard);
     await waitFor(() => expect(groupCard).toHaveClass('swt:border-primary'), { timeout: 1000 }).catch(() => undefined);
   }
 

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -318,6 +318,51 @@ export const SortsPropertiesByNameAndConnectionCount: Story = {
   },
 };
 
+export const AddedRailPropertiesAreCurrentAndPinnedToTheirSide: Story = {
+  render: () => <Harness inputOnly />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
+    const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
+
+    const source = await addRailProperty(canvas, 'Input', 'Treatment', 'Drought');
+    expect(inputRail.getByTestId('provenance-property-Input-Treatment')).toBeInTheDocument();
+    expect(within(inputRail.getByTestId('provenance-property-Input-Treatment')).getByTitle('Current')).toBeInTheDocument();
+    expect(outputRail.queryByTestId('provenance-property-Output-Treatment')).not.toBeInTheDocument();
+
+    await userEvent.click(within(canvas.getByTestId('provenance-filter-toolbar')).getByRole('button', { name: /^Show current properties$/i }));
+    await waitFor(() => expect(inputRail.getByTestId('provenance-property-Input-Treatment')).toBeInTheDocument());
+    expect(outputRail.queryByTestId('provenance-property-Output-Treatment')).not.toBeInTheDocument();
+
+    const target = canvas.getByText('Input Only A').closest('article')!;
+    await dragByPointer(source, target);
+
+    await waitFor(() =>
+      expect(canvas.getByTestId('provenance-patch-preview')).toHaveTextContent('AddLoadedPropertyValue'),
+    );
+  },
+};
+
+export const LayerFocusDoesNotResortInitializedRails: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const initialOutputOrder = propertyOrder(canvas, 'Output').slice(0, 4);
+
+    await selectGroup(canvas.getByText('Output A').closest('article')!);
+    await userEvent.click(canvas.getByTestId('provenance-add-layer'));
+    await waitFor(() => expect(canvas.getByTestId('provenance-layer-layer-2')).toHaveClass('swt:btn-primary'));
+
+    const toolbar = within(canvas.getByTestId('provenance-filter-toolbar'));
+    await userEvent.click(toolbar.getByRole('button', { name: /^Sort By$/i }));
+    await userEvent.click(toolbar.getByRole('button', { name: /^Connection Count$/i }));
+
+    await userEvent.click(canvas.getByTestId('provenance-layer-layer-1'));
+    await waitFor(() => expect(canvas.getByTestId('provenance-layer-layer-1')).toHaveClass('swt:btn-primary'));
+    expect(propertyOrder(canvas, 'Output').slice(0, 4)).toEqual(initialOutputOrder);
+  },
+};
+
 export const PropertyRailExpandsValuesAndAddControls: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -375,8 +375,23 @@ export const SingleSidedShelfPropertiesCannotDropOnOppositeSide: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const source = await shelfProperty(canvas, 'Analysis');
+    const inputRail = canvas.getByTestId('provenance-property-rail-Input');
 
-    await dragByPointer(source, canvas.getByTestId('provenance-property-rail-Input'));
+    await startDragByPointer(source);
+    const pointer = await moveDragPointerTo(inputRail);
+    await waitFor(() => {
+      expect(inputRail).toHaveAttribute('data-provenance-drop-state', 'rejecting');
+      expect(inputRail).toHaveClass('swt:border-warning');
+    });
+
+    fireEvent.pointerUp(inputRail, {
+      clientX: pointer.x,
+      clientY: pointer.y,
+      button: 0,
+      buttons: 0,
+      isPrimary: true,
+      pointerId: 1,
+    });
     await waitFor(() => expect(canvas.queryByTestId('foldered-draggable-drag-overlay')).not.toBeInTheDocument());
 
     expect(canvas.queryByTestId('provenance-property-Input-Analysis')).not.toBeInTheDocument();
@@ -1262,6 +1277,24 @@ async function startDragByPointer(source: Element) {
   await nextFrame();
 
   return { x: activationX, y: activationY };
+}
+
+async function moveDragPointerTo(target: Element) {
+  const to = target.getBoundingClientRect();
+  const toX = to.left + to.width / 2;
+  const toY = to.top + to.height / 2;
+  const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+  fireEvent.pointerMove(document, {
+    clientX: toX,
+    clientY: toY,
+    button: 0,
+    buttons: 1,
+    isPrimary: true,
+    pointerId: 1,
+  });
+  await nextFrame();
+
+  return { x: toX, y: toY };
 }
 
 function escapeRegExp(value: string) {

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -40,7 +40,6 @@ function Harness({
   debug = true,
   allowTermReplacement = false,
   allowEndpointReplacement = false,
-  resetKey,
 }: {
   inputOnly?: boolean;
   outputOnly?: boolean;
@@ -48,13 +47,13 @@ function Harness({
   debug?: boolean;
   allowTermReplacement?: boolean;
   allowEndpointReplacement?: boolean;
-  resetKey?: string;
 }) {
   const selected = inputOnly ? 'inputOnly' : outputOnly ? 'outputOnly' : fixture;
+  const id = React.useId();
 
   return (
     <HarnessState
-      key={`${selected}:${resetKey ?? ''}`}
+      key={`${selected}:${id}`}
       selected={selected}
       debug={debug}
       allowTermReplacement={allowTermReplacement}
@@ -252,7 +251,7 @@ export const GroupCardsSelectFromCardSurface: Story = {
 };
 
 export const GroupsBothSidesFromOutputProperty: Story = {
-  render: () => <Harness resetKey="groups-both-sides-from-output-property" />,
+  render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -342,7 +341,7 @@ export const DroppedShelfPropertyLeavesFolders: Story = {
 };
 
 export const DroppedShelfPropertyKeepsLayerColorAndSyncsUpdates: Story = {
-  render: () => <Harness resetKey="dropped-shelf-property-keeps-layer-color-and-syncs-updates" />,
+  render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const initialLayerColor = canvas.getByTestId('provenance-layer-layer-1').getAttribute('data-provenance-layer-color') ?? '';

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fireEvent, screen, userEvent, waitFor, within } from 'storybook/test';
 import { Main as ProvenanceGrouping } from './ProvenanceGrouping.fs.js';
+import { Exports_sampleDroppedPropertyRailColor as sampleDroppedPropertyRailColor } from './Helper.fs.js';
 import {
   Exports_createSampleSession as createSampleSession,
   Exports_createInputOnlySession as createInputOnlySession,
@@ -50,13 +51,36 @@ function Harness({
   resetKey?: string;
 }) {
   const selected = inputOnly ? 'inputOnly' : outputOnly ? 'outputOnly' : fixture;
+
+  return (
+    <HarnessState
+      key={`${selected}:${resetKey ?? ''}`}
+      selected={selected}
+      debug={debug}
+      allowTermReplacement={allowTermReplacement}
+      allowEndpointReplacement={allowEndpointReplacement}
+    />
+  );
+}
+
+function HarnessState({
+  selected,
+  debug,
+  allowTermReplacement,
+  allowEndpointReplacement,
+}: {
+  selected: Fixture;
+  debug: boolean;
+  allowTermReplacement: boolean;
+  allowEndpointReplacement: boolean;
+}) {
   const [session, setSession] = React.useState(() => createSessionForFixture(selected));
   const [patches, setPatches] = React.useState<string[]>([]);
 
   React.useEffect(() => {
     setSession(createSessionForFixture(selected));
     setPatches([]);
-  }, [selected, resetKey]);
+  }, [selected]);
 
   return (
     <div className="swt:flex swt:flex-col swt:gap-4 swt:min-h-screen swt:bg-base-200 swt:p-4">
@@ -232,8 +256,17 @@ export const GroupsBothSidesFromOutputProperty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await showPropertyControls(canvas, 'Output', 'Replicate');
-    await userEvent.click(canvas.getByTestId('provenance-property-both-Output-Replicate'));
+    for (
+      let attempt = 0;
+      attempt < 3 && !canvas.queryByTestId('provenance-group-Input-input:Replicate=1 | 2');
+      attempt += 1
+    ) {
+      await showPropertyControls(canvas, 'Output', 'Replicate');
+      fireEvent.click(canvas.getByTestId('provenance-property-both-Output-Replicate'));
+      await waitFor(() => expect(canvas.queryByTestId('provenance-group-Input-input:Replicate=1 | 2')).toBeInTheDocument(), {
+        timeout: 1000,
+      }).catch(() => undefined);
+    }
 
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-group-Input-input:Replicate=1 | 2')).toBeInTheDocument();
@@ -305,6 +338,19 @@ export const DroppedShelfPropertyLeavesFolders: Story = {
     expect(canvas.getByTestId('provenance-property-Output-Species')).toBeInTheDocument();
     const currentLayerShelf = await openShelfFolder(canvas, canvas.getByTestId('foldered-draggable-folder-layer-layer-1'));
     expect(currentLayerShelf.queryByRole('button', { name: /^Drag Species$/ })).not.toBeInTheDocument();
+  },
+};
+
+export const DroppedShelfPropertyKeepsLayerColorAndSyncsUpdates: Story = {
+  render: () => <Harness resetKey="dropped-shelf-property-keeps-layer-color-and-syncs-updates" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const initialLayerColor = canvas.getByTestId('provenance-layer-layer-1').getAttribute('data-provenance-layer-color') ?? '';
+
+    const property = await ensurePropertyInRail(canvas, 'Output', 'Species');
+    expect(propertyColorSwatch(property)).toHaveStyle({ backgroundColor: initialLayerColor });
+
+    expect(sampleDroppedPropertyRailColor('Output', 'Species', '#dc2626')).toBe('#dc2626');
   },
 };
 
@@ -1258,6 +1304,16 @@ async function ensurePropertyInRail(
 
   await waitFor(() => expect(canvas.queryByTestId('foldered-draggable-drag-overlay')).not.toBeInTheDocument());
   return waitFor(() => canvas.getByTestId(propertyId));
+}
+
+function propertyColorSwatch(property: HTMLElement) {
+  const swatch = property.querySelector<HTMLElement>('span[style*="background-color"]');
+
+  if (!swatch) {
+    throw new Error(`Property "${property.getAttribute('aria-label') ?? property.textContent}" has no color swatch.`);
+  }
+
+  return swatch;
 }
 
 async function showPropertyControls(

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -117,16 +117,16 @@ export const GroupsByPropertiesAndShowsMembers: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Input-Species'));
-    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
-    expect(canvas.getByTestId('provenance-group-Input-input:Species=Chlamydomonas')).toBeInTheDocument();
+    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
+    expect(canvas.getByTestId('provenance-group-Output-output:Species=Chlamydomonas')).toBeInTheDocument();
 
     // The grouping shows as an organizer tab "Category: Value" on top of the member folder.
-    const tab = within(grouped).getByTestId('provenance-group-tab-Input-input:Species=Arabidopsis-0');
+    const tab = within(grouped).getByTestId('provenance-group-tab-Output-output:Species=Arabidopsis-0');
     expect(tab).toHaveTextContent('Species: Arabidopsis');
 
     await userEvent.click(within(grouped).getByRole('button', { name: 'Show members' }));
-    await waitFor(() => expect(grouped).toHaveTextContent('Input A'));
+    await waitFor(() => expect(grouped).toHaveTextContent('Output A'));
   },
 };
 
@@ -135,22 +135,22 @@ export const ExpandedGroupsShowMemberHoverValues: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    expect(within(canvas.getByText('Input A').closest('article')!).queryByRole('button', { name: 'Show members' }))
+    expect(within(canvas.getByText('Output A').closest('article')!).queryByRole('button', { name: 'Show members' }))
       .not.toBeInTheDocument();
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Input-Species'));
-    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
+    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
 
     await userEvent.click(within(grouped).getByRole('button', { name: 'Show members' }));
-    const member = within(grouped).getByTestId('provenance-group-member-Input-input-a');
+    const member = within(grouped).getByTestId('provenance-group-member-Output-output-a');
 
-    expect(within(grouped).queryByTestId('provenance-member-values-Input-input-a')).not.toBeInTheDocument();
+    expect(within(grouped).queryByTestId('provenance-member-values-Output-output-a')).not.toBeInTheDocument();
     await userEvent.hover(member);
 
     await waitFor(() => {
-      const details = within(grouped).getByTestId('provenance-member-values-Input-input-a');
+      const details = within(grouped).getByTestId('provenance-member-values-Output-output-a');
       expect(details).toHaveTextContent('Species: Arabidopsis');
-      expect(details).toHaveTextContent('Temperature: 12 C');
+      expect(details).toHaveTextContent('Analysis: Mass Spectrometry');
     });
 
     await userEvent.unhover(member);
@@ -162,19 +162,19 @@ export const ShowsEntityTypesAndCollapsedSymbols: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Input-Species'));
-    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
+    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
 
     // The collapsed card previews its member types as symbols instead of a bare "×3" count.
-    expect(within(grouped).getByTestId('provenance-group-symbols-Input-input:Species=Arabidopsis'))
+    expect(within(grouped).getByTestId('provenance-group-symbols-Output-output:Species=Arabidopsis'))
       .toBeInTheDocument();
     expect(grouped).not.toHaveTextContent('×3');
 
     // Expanding shows each member with its endpoint type ("Sample") above the name.
     await userEvent.click(within(grouped).getByRole('button', { name: 'Show members' }));
-    const member = within(grouped).getByTestId('provenance-group-member-Input-input-a');
+    const member = within(grouped).getByTestId('provenance-group-member-Output-output-a');
     expect(member).toHaveTextContent('Sample');
-    expect(member).toHaveTextContent('Input A');
+    expect(member).toHaveTextContent('Output A');
   },
 };
 
@@ -183,16 +183,16 @@ export const HoveringGroupTabHighlightsItAndKeepsFolderPreview: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Input-Species'));
-    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
-    const tab = within(grouped).getByTestId('provenance-group-tab-Input-input:Species=Arabidopsis-0');
+    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
+    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
+    const tab = within(grouped).getByTestId('provenance-group-tab-Output-output:Species=Arabidopsis-0');
 
     expect(tab).toHaveAttribute('data-hovered', 'false');
 
     // Hovering the tab highlights it and the folder previews that tab's members.
     await userEvent.hover(tab);
     await waitFor(() => expect(tab).toHaveAttribute('data-hovered', 'true'));
-    expect(within(grouped).getByTestId('provenance-group-symbols-Input-input:Species=Arabidopsis'))
+    expect(within(grouped).getByTestId('provenance-group-symbols-Output-output:Species=Arabidopsis'))
       .toBeInTheDocument();
 
     await userEvent.unhover(tab);
@@ -249,15 +249,17 @@ export const GroupingPropertiesStayOnOwningSide: Story = {
     const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
     const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
-    expect(inputRail.getByTestId('provenance-property-Input-Species')).toBeInTheDocument();
-    expect(inputRail.getByTestId('provenance-property-Input-Temperature')).toBeInTheDocument();
+    expect(inputRail.getByTestId('provenance-property-Input-Previous Treatment')).toBeInTheDocument();
+    expect(inputRail.queryByTestId('provenance-property-Input-Species')).not.toBeInTheDocument();
+    expect(inputRail.queryByTestId('provenance-property-Input-Temperature')).not.toBeInTheDocument();
     expect(inputRail.queryByTestId('provenance-property-Input-Analysis')).not.toBeInTheDocument();
     expect(inputRail.queryByTestId('provenance-property-Input-Replicate')).not.toBeInTheDocument();
 
     expect(outputRail.getByTestId('provenance-property-Output-Analysis')).toBeInTheDocument();
     expect(outputRail.getByTestId('provenance-property-Output-Replicate')).toBeInTheDocument();
-    expect(outputRail.queryByTestId('provenance-property-Output-Species')).not.toBeInTheDocument();
-    expect(outputRail.queryByTestId('provenance-property-Output-Temperature')).not.toBeInTheDocument();
+    expect(outputRail.getByTestId('provenance-property-Output-Species')).toBeInTheDocument();
+    expect(outputRail.getByTestId('provenance-property-Output-Temperature')).toBeInTheDocument();
+    expect(outputRail.queryByTestId('provenance-property-Output-Previous Treatment')).not.toBeInTheDocument();
   },
 };
 
@@ -265,12 +267,12 @@ export const PropertyRailExpandsValuesAndAddControls: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
+    const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
-    expect(inputRail.queryByText('Arabidopsis')).not.toBeInTheDocument();
-    expect(inputRail.getByText('Add property')).toBeInTheDocument();
+    expect(outputRail.queryByText('Arabidopsis')).not.toBeInTheDocument();
+    expect(outputRail.getByText('Add property')).toBeInTheDocument();
 
-    const panel = await expandProperty(canvas, 'Input', 'Species');
+    const panel = await expandProperty(canvas, 'Output', 'Species');
     const arabidopsis = panel.getByText('Arabidopsis').closest('button, div')!;
     expect(arabidopsis).toBeInTheDocument();
     expect(arabidopsis).toHaveClass('swt:btn');
@@ -292,10 +294,10 @@ export const ExpandsPropertyValuesWithoutGrouping: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expandProperty(canvas, 'Input', 'Species');
+    await expandProperty(canvas, 'Output', 'Species');
 
-    expect(canvas.getByTestId('provenance-group-Input-input:input-a')).toBeInTheDocument();
-    expect(canvas.queryByTestId('provenance-group-Input-input:Species=Arabidopsis')).not.toBeInTheDocument();
+    expect(canvas.getByTestId('provenance-group-Output-output:output-a')).toBeInTheDocument();
+    expect(canvas.queryByTestId('provenance-group-Output-output:Species=Arabidopsis')).not.toBeInTheDocument();
   },
 };
 
@@ -335,45 +337,45 @@ export const SwitchesPropertyGroupingSideByDrag: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Input-Batch'));
+    await userEvent.click(canvas.getByTestId('provenance-property-Output-Batch'));
     await waitFor(() => {
-      expect(canvas.getByTestId('provenance-group-Input-input:Batch=A')).toBeInTheDocument();
-      expect(canvas.queryByTestId('provenance-group-Output-output:Batch=A')).not.toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Output-output:Batch=A')).toBeInTheDocument();
+      expect(canvas.queryByTestId('provenance-group-Input-input:Batch=A')).not.toBeInTheDocument();
     });
 
     await dragByPointer(
-      canvas.getByTestId('provenance-property-Input-Batch'),
-      canvas.getByTestId('provenance-property-rail-Output'),
+      canvas.getByTestId('provenance-property-Output-Batch'),
+      canvas.getByTestId('provenance-property-rail-Input'),
     );
 
     await waitFor(() => {
-      expect(canvas.queryByTestId('provenance-group-Input-input:Batch=A')).not.toBeInTheDocument();
-      expect(canvas.getByTestId('provenance-group-Input-input:input-a')).toBeInTheDocument();
-      expect(canvas.getByTestId('provenance-group-Output-output:Batch=A')).toBeInTheDocument();
-      expect(canvas.getByTestId('provenance-group-Output-output:Batch=B')).toBeInTheDocument();
+      expect(canvas.queryByTestId('provenance-group-Output-output:Batch=A')).not.toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Output-output:output-a')).toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:Batch=A')).toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:input-b')).toBeInTheDocument();
     });
   },
 };
 
-export const SwitchesInheritedInputPropertyGroupingToOutputSide: Story = {
+export const SwitchesInheritedPropertyGroupingToInputSide: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
     const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
-    expect(canvas.getByTestId('provenance-property-drag-Input-Species')).not.toBeDisabled();
+    expect(canvas.getByTestId('provenance-property-drag-Output-Species')).not.toBeDisabled();
     await dragByPointer(
-      canvas.getByTestId('provenance-property-Input-Species'),
-      canvas.getByTestId('provenance-property-rail-Output'),
+      canvas.getByTestId('provenance-property-Output-Species'),
+      canvas.getByTestId('provenance-property-rail-Input'),
     );
 
     await waitFor(() => {
-      expect(canvas.queryByTestId('provenance-group-Input-input:Species=Arabidopsis')).not.toBeInTheDocument();
-      expect(canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis')).toBeInTheDocument();
-      expect(canvas.getByTestId('provenance-group-Output-output:Species=Chlamydomonas')).toBeInTheDocument();
-      expect(outputRail.getByTestId('provenance-property-Output-Species')).toBeInTheDocument();
-      expect(inputRail.queryByTestId('provenance-property-Input-Species')).not.toBeInTheDocument();
+      expect(canvas.queryByTestId('provenance-group-Output-output:Species=Arabidopsis')).not.toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis')).toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:Species=Chlamydomonas')).toBeInTheDocument();
+      expect(inputRail.getByTestId('provenance-property-Input-Species')).toBeInTheDocument();
+      expect(outputRail.queryByTestId('provenance-property-Output-Species')).not.toBeInTheDocument();
     });
   },
 };
@@ -385,14 +387,14 @@ export const ClicksSwapHandleToSwitchGroupingSide: Story = {
     const inputRail = within(canvas.getByTestId('provenance-property-rail-Input'));
     const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
-    await userEvent.hover(canvas.getByTestId('provenance-property-Input-Species'));
-    await userEvent.click(canvas.getByTestId('provenance-property-drag-Input-Species'));
+    await userEvent.hover(canvas.getByTestId('provenance-property-Output-Species'));
+    await userEvent.click(canvas.getByTestId('provenance-property-drag-Output-Species'));
 
     await waitFor(() => {
-      expect(canvas.queryByTestId('provenance-group-Input-input:Species=Arabidopsis')).not.toBeInTheDocument();
-      expect(canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis')).toBeInTheDocument();
-      expect(outputRail.getByTestId('provenance-property-Output-Species')).toBeInTheDocument();
-      expect(inputRail.queryByTestId('provenance-property-Input-Species')).not.toBeInTheDocument();
+      expect(canvas.queryByTestId('provenance-group-Output-output:Species=Arabidopsis')).not.toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis')).toBeInTheDocument();
+      expect(inputRail.getByTestId('provenance-property-Input-Species')).toBeInTheDocument();
+      expect(outputRail.queryByTestId('provenance-property-Output-Species')).not.toBeInTheDocument();
     });
   },
 };
@@ -402,9 +404,9 @@ export const RegroupedValuesAreReadOnlyOnCards: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByTestId('provenance-property-Input-Species'));
+    await userEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
     const grouped = await waitFor(
-      () => canvas.getByTestId('provenance-group-Input-input:Species=Chlamydomonas'),
+      () => canvas.getByTestId('provenance-group-Output-output:Species=Chlamydomonas'),
       { timeout: 3000 },
     );
 
@@ -429,9 +431,9 @@ export const RemeasuresConnectionsAfterGroupExpansion: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    fireEvent.click(canvas.getByTestId('provenance-property-Input-Species'));
+    fireEvent.click(canvas.getByTestId('provenance-property-Output-Species'));
 
-    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
+    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
 
     const before = await waitFor(() => {
       const paths = canvas.getAllByTestId('provenance-connection').map((connector) => connector.getAttribute('d'));
@@ -489,9 +491,9 @@ export const ExpandedGroupsRenderMemberLevelConnections: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await groupByProperty(canvas, 'Input', 'Species');
+    await groupByProperty(canvas, 'Output', 'Species');
 
-    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
+    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
 
     await userEvent.click(within(grouped).getByRole('button', { name: 'Show members' }));
 
@@ -507,19 +509,19 @@ export const ExpandedGroupsHideGroupConnectionAnchors: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await groupByProperty(canvas, 'Input', 'Species');
+    await groupByProperty(canvas, 'Output', 'Species');
 
-    const groupId = 'input:Species=Arabidopsis';
-    const grouped = await waitFor(() => canvas.getByTestId(`provenance-group-Input-${groupId}`));
-    expect(within(grouped).getByTestId('provenance-connection-handle-Input-GroupCard')).toBeInTheDocument();
+    const groupId = 'output:Species=Arabidopsis';
+    const grouped = await waitFor(() => canvas.getByTestId(`provenance-group-Output-${groupId}`));
+    expect(within(grouped).getByTestId('provenance-connection-handle-Output-GroupCard')).toBeInTheDocument();
     expect(connectionKeys(canvas.getAllByTestId('provenance-connection')).some((key) => key.includes(groupId))).toBe(true);
 
     await userEvent.click(within(grouped).getByRole('button', { name: 'Show members' }));
 
     await waitFor(() => {
-      const expanded = canvas.getByTestId(`provenance-group-Input-${groupId}`);
-      expect(within(expanded).queryByTestId('provenance-connection-handle-Input-GroupCard')).not.toBeInTheDocument();
-      expect(within(expanded).getAllByTestId('provenance-connection-handle-Input-GroupMember').length).toBeGreaterThan(0);
+      const expanded = canvas.getByTestId(`provenance-group-Output-${groupId}`);
+      expect(within(expanded).queryByTestId('provenance-connection-handle-Output-GroupCard')).not.toBeInTheDocument();
+      expect(within(expanded).getAllByTestId('provenance-connection-handle-Output-GroupMember').length).toBeGreaterThan(0);
       expect(connectionKeys(canvas.queryAllByTestId('provenance-connection')).some((key) => key.includes(groupId))).toBe(false);
       expect(connectionKeys(canvas.getAllByTestId('provenance-member-connection')).some((key) => key.includes(groupId))).toBe(true);
     });
@@ -539,7 +541,7 @@ export const ExpandedPropertyValuesConnectValueChipsToMatchingGroups: Story = {
       expect(headerKeys.some((key) => key.includes('Species'))).toBe(true);
     });
 
-    const panel = await expandProperty(canvas, 'Input', 'Species');
+    const panel = await expandProperty(canvas, 'Output', 'Species');
 
     await waitFor(() => {
       const headerKeys = connectionKeys(canvas.queryAllByTestId('provenance-property-connection'));
@@ -551,15 +553,15 @@ export const ExpandedPropertyValuesConnectValueChipsToMatchingGroups: Story = {
       expect(canvas.getAllByTestId('provenance-value-connection').every((path) => path.getAttribute('d')?.startsWith('M '))).toBe(true);
     });
 
-    expect(panel.queryByTestId('provenance-connection-handle-Input-PropertyValue')).not.toBeInTheDocument();
+    expect(panel.queryByTestId('provenance-connection-handle-Output-PropertyValue')).not.toBeInTheDocument();
 
     // Collapsing again must restore header connectors and drop value connectors,
     // so the expanded-header filter cannot become a one-way switch.
-    await userEvent.hover(canvas.getByTestId('provenance-property-Input-Species'));
-    await userEvent.click(canvas.getByTestId('provenance-property-expand-Input-Species'));
+    await userEvent.hover(canvas.getByTestId('provenance-property-Output-Species'));
+    await userEvent.click(canvas.getByTestId('provenance-property-expand-Output-Species'));
 
     await waitFor(() => {
-      expect(canvas.queryByTestId('provenance-property-values-Input-Species')).not.toBeInTheDocument();
+      expect(canvas.queryByTestId('provenance-property-values-Output-Species')).not.toBeInTheDocument();
       const headerKeys = connectionKeys(canvas.getAllByTestId('provenance-property-connection'));
       expect(headerKeys.some((key) => key.includes('Species'))).toBe(true);
       expect(canvas.queryByTestId('provenance-value-connection')).not.toBeInTheDocument();
@@ -690,15 +692,15 @@ export const RemovesExpandedMemberConnectionFromContextMenu: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await groupByProperty(canvas, 'Input', 'Species');
+    await groupByProperty(canvas, 'Output', 'Species');
 
-    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
+    const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
     await userEvent.click(within(grouped).getByRole('button', { name: 'Show members' }));
 
     const connector = await waitFor(() => {
       const memberConnector = canvas
         .getAllByTestId('provenance-member-connection')
-        .find((path) => path.getAttribute('data-provenance-connection-key')?.includes('input:Species=Arabidopsis'));
+        .find((path) => path.getAttribute('data-provenance-connection-key')?.includes('output:Species=Arabidopsis'));
       expect(memberConnector).toBeTruthy();
       expect(memberConnector).toHaveAttribute('role', 'button');
       return memberConnector!;
@@ -737,9 +739,9 @@ export const WarnsBeforeOverwritingSingleValueFromRail: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const source = await railValue(canvas, 'Input', 'Species', 'Arabidopsis');
-    await groupByProperty(canvas, 'Input', 'Species');
-    const target = canvas.getByTestId('provenance-group-Input-input:Species=Chlamydomonas');
+    const source = await railValue(canvas, 'Output', 'Species', 'Arabidopsis');
+    await groupByProperty(canvas, 'Output', 'Species');
+    const target = canvas.getByTestId('provenance-group-Output-output:Species=Chlamydomonas');
 
     await dragByPointer(source, target);
 
@@ -1242,10 +1244,10 @@ export const MismatchedGroupConnectionPromptsForResolution: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await groupByProperty(canvas, 'Input', 'Species');
+    await groupByProperty(canvas, 'Output', 'Species');
 
-    const inputGroup = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
-    const outputGroup = canvas.getByText('Output E').closest('article')!;
+    const inputGroup = canvas.getByText('Input D').closest('article')!;
+    const outputGroup = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
     const outputHandle = within(outputGroup).getByTestId('provenance-connection-handle-Output-GroupCard');
 
     await dragByPointer(
@@ -1254,8 +1256,8 @@ export const MismatchedGroupConnectionPromptsForResolution: Story = {
     );
 
     await waitFor(() => expect(canvas.getByTestId('provenance-member-resolution-prompt')).toBeInTheDocument());
-    expect(canvas.getByTestId('provenance-member-resolution-prompt')).toHaveTextContent('3 input members');
-    expect(canvas.getByTestId('provenance-member-resolution-prompt')).toHaveTextContent('1 output member');
+    expect(canvas.getByTestId('provenance-member-resolution-prompt')).toHaveTextContent('1 input member');
+    expect(canvas.getByTestId('provenance-member-resolution-prompt')).toHaveTextContent('3 output members');
   },
 };
 
@@ -1263,10 +1265,10 @@ export const ManualMismatchResolutionExpandsMembersWithoutPatches: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await groupByProperty(canvas, 'Input', 'Species');
+    await groupByProperty(canvas, 'Output', 'Species');
 
-    const inputGroup = await waitFor(() => canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis'));
-    const outputGroup = canvas.getByText('Output E').closest('article')!;
+    const inputGroup = canvas.getByText('Input D').closest('article')!;
+    const outputGroup = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
     const outputHandle = within(outputGroup).getByTestId('provenance-connection-handle-Output-GroupCard');
 
     await dragByPointer(
@@ -1277,8 +1279,8 @@ export const ManualMismatchResolutionExpandsMembersWithoutPatches: Story = {
     await userEvent.click(canvas.getByTestId('provenance-member-resolution-manual'));
 
     await waitFor(() => {
-      const currentInputGroup = canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis');
-      const currentOutputGroup = canvas.getByTestId('provenance-group-Output-output:output-e');
+      const currentInputGroup = canvas.getByTestId('provenance-group-Input-input:input-d');
+      const currentOutputGroup = canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis');
       expect(within(currentInputGroup).getAllByTestId('provenance-connection-handle-Input-GroupMember').length).toBeGreaterThan(0);
       expect(within(currentOutputGroup).getAllByTestId('provenance-connection-handle-Output-GroupMember').length).toBeGreaterThan(0);
     });

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -1424,10 +1424,30 @@ export const ManualMismatchResolutionExpandsMembersWithoutPatches: Story = {
     await waitFor(() => {
       const currentInputGroup = canvas.getByTestId('provenance-group-Input-input:input-d');
       const currentOutputGroup = canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis');
-      expect(within(currentInputGroup).getAllByTestId('provenance-connection-handle-Input-GroupMember').length).toBeGreaterThan(0);
+      expect(within(currentInputGroup).queryByTestId('provenance-connection-handle-Input-GroupMember')).not.toBeInTheDocument();
       expect(within(currentOutputGroup).getAllByTestId('provenance-connection-handle-Output-GroupMember').length).toBeGreaterThan(0);
     });
+    expect(canvas.queryByTestId('provenance-member-resolution-prompt')).not.toBeInTheDocument();
     expect(canvas.getByTestId('provenance-patch-preview')).toHaveTextContent('No patches emitted.');
+  },
+};
+
+export const ExpandedGroupedCardsDoNotExpandConnectedSingleCards: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await groupByProperty(canvas, 'Output', 'Species');
+
+    const inputA = canvas.getByText('Input A').closest('article')!;
+    const outputGroup = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
+
+    await userEvent.click(within(outputGroup).getByRole('button', { name: 'Show members' }));
+
+    await waitFor(() => {
+      expect(within(outputGroup).getAllByTestId('provenance-connection-handle-Output-GroupMember').length).toBeGreaterThan(0);
+      expect(within(inputA).queryByTestId('provenance-group-member-Input-input-a')).not.toBeInTheDocument();
+      expect(within(inputA).queryByTestId('provenance-connection-handle-Input-GroupMember')).not.toBeInTheDocument();
+    });
   },
 };
 

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -320,6 +320,16 @@ export const PropertiesStartInOriginFoldersAndSideDropZonesAreEmpty: Story = {
       .not.toBeInTheDocument();
     expect(canvas.getByTestId('provenance-property-rail-Output').querySelector('[data-testid^="provenance-property-Output-"]'))
       .not.toBeInTheDocument();
+    expect(within(canvas.getByTestId('foldered-draggable-item-row')).getByRole('button', { name: /^Drag Species$/ }))
+      .toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Minimize property folders' }));
+    await waitFor(() => expect(canvas.queryByTestId('foldered-draggable-list')).not.toBeInTheDocument());
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand property folders' }));
+    await waitFor(() => expect(canvas.getByTestId('foldered-draggable-list')).toBeInTheDocument());
+    expect(within(canvas.getByTestId('foldered-draggable-item-row')).getByRole('button', { name: /^Drag Species$/ }))
+      .toBeVisible();
 
     const species = await shelfProperty(canvas, 'Species');
     expect(species).toBeInTheDocument();

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -842,13 +842,25 @@ export const RemovesExpandedMemberConnectionFromContextMenu: Story = {
     });
 
     const removedKey = connector.getAttribute('data-provenance-connection-key');
-    fireEvent.contextMenu(connector, { clientX: 360, clientY: 280, bubbles: true });
+    await userEvent.click(connector);
+
+    await waitFor(() => {
+      expect(canvas.getByTestId('provenance-connection-details')).toBeInTheDocument();
+      expect(within(grouped).getAllByTestId('provenance-connection-handle-Output-GroupMember').length).toBeGreaterThan(0);
+    });
+
+    const selectedConnector = canvas
+      .getAllByTestId('provenance-member-connection')
+      .find((path) => path.getAttribute('data-provenance-connection-key') === removedKey);
+    expect(selectedConnector).toBeTruthy();
+    fireEvent.contextMenu(selectedConnector!, { clientX: 360, clientY: 280, bubbles: true });
     const menu = await screen.findByTestId('context_menu');
     await userEvent.click(within(menu).getByRole('button', { name: /delete/i }));
 
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-patch-preview')).toHaveTextContent('RemoveLoadedConnection');
       expect(connectionKeys(canvas.queryAllByTestId('provenance-member-connection'))).not.toContain(removedKey);
+      expect(within(grouped).getAllByTestId('provenance-connection-handle-Output-GroupMember').length).toBeGreaterThan(0);
     });
   },
 };

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -370,6 +370,23 @@ export const RejectedShelfPropertyDropRestoresFolderItem: Story = {
   },
 };
 
+export const SingleSidedShelfPropertiesCannotDropOnOppositeSide: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const source = await shelfProperty(canvas, 'Analysis');
+
+    await dragByPointer(source, canvas.getByTestId('provenance-property-rail-Input'));
+    await waitFor(() => expect(canvas.queryByTestId('foldered-draggable-drag-overlay')).not.toBeInTheDocument());
+
+    expect(canvas.queryByTestId('provenance-property-Input-Analysis')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(within(canvas.getByTestId('foldered-draggable-item-row')).getByRole('button', { name: /^Drag Analysis$/ }))
+        .toBeVisible();
+    });
+  },
+};
+
 export const ToolbarUsesSinglePropertySortAndOriginButtons: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -39,6 +39,7 @@ function Harness({
   debug = true,
   allowTermReplacement = false,
   allowEndpointReplacement = false,
+  resetKey,
 }: {
   inputOnly?: boolean;
   outputOnly?: boolean;
@@ -46,6 +47,7 @@ function Harness({
   debug?: boolean;
   allowTermReplacement?: boolean;
   allowEndpointReplacement?: boolean;
+  resetKey?: string;
 }) {
   const selected = inputOnly ? 'inputOnly' : outputOnly ? 'outputOnly' : fixture;
   const [session, setSession] = React.useState(() => createSessionForFixture(selected));
@@ -54,7 +56,7 @@ function Harness({
   React.useEffect(() => {
     setSession(createSessionForFixture(selected));
     setPatches([]);
-  }, [selected]);
+  }, [selected, resetKey]);
 
   return (
     <div className="swt:flex swt:flex-col swt:gap-4 swt:min-h-screen swt:bg-base-200 swt:p-4">
@@ -226,19 +228,19 @@ export const GroupCardsSelectFromCardSurface: Story = {
 };
 
 export const GroupsBothSidesFromOutputProperty: Story = {
-  render: () => <Harness />,
+  render: () => <Harness resetKey="groups-both-sides-from-output-property" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     await showPropertyControls(canvas, 'Output', 'Replicate');
-    fireEvent.click(canvas.getByTestId('provenance-property-both-Output-Replicate'));
+    await userEvent.click(canvas.getByTestId('provenance-property-both-Output-Replicate'));
 
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-group-Input-input:Replicate=1 | 2')).toBeInTheDocument();
       expect(canvas.getByTestId('provenance-group-Output-output:Replicate=1 | 2')).toBeInTheDocument();
       expect(canvas.queryByTestId('provenance-group-Input-input:Replicate=1')).not.toBeInTheDocument();
       expect(canvas.queryByTestId('provenance-group-Output-output:Replicate=2')).not.toBeInTheDocument();
-    }, { timeout: 3000 });
+    }, { timeout: 6000 });
   },
 };
 
@@ -290,6 +292,36 @@ export const PropertiesStartInOriginFoldersAndSideDropZonesAreEmpty: Story = {
     const species = await shelfProperty(canvas, 'Species');
     expect(species).toBeInTheDocument();
     expect(species).toHaveTextContent('Species');
+  },
+};
+
+export const DroppedShelfPropertyLeavesFolders: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await ensurePropertyInRail(canvas, 'Output', 'Species');
+
+    expect(canvas.getByTestId('provenance-property-Output-Species')).toBeInTheDocument();
+    const currentLayerShelf = await openShelfFolder(canvas, canvas.getByTestId('foldered-draggable-folder-layer-layer-1'));
+    expect(currentLayerShelf.queryByRole('button', { name: /^Drag Species$/ })).not.toBeInTheDocument();
+  },
+};
+
+export const RejectedShelfPropertyDropRestoresFolderItem: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const source = await shelfProperty(canvas, 'Species');
+    const target = canvas.getByText('Input A').closest('article')!;
+
+    await dragByPointer(source, target);
+
+    await waitFor(() => {
+      expect(canvas.queryByTestId('foldered-draggable-drag-overlay')).not.toBeInTheDocument();
+      expect(within(canvas.getByTestId('foldered-draggable-item-row')).getByRole('button', { name: /^Drag Species$/ }))
+        .toBeVisible();
+    });
   },
 };
 
@@ -1145,6 +1177,8 @@ async function startDragByPointer(source: Element) {
   const from = source.getBoundingClientRect();
   const fromX = from.left + from.width / 2;
   const fromY = from.top + from.height / 2;
+  const activationX = fromX + 8;
+  const activationY = fromY;
   const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
   fireEvent.pointerDown(source, {
     clientX: fromX,
@@ -1156,14 +1190,16 @@ async function startDragByPointer(source: Element) {
   });
   await nextFrame();
   fireEvent.pointerMove(document, {
-    clientX: fromX + 8,
-    clientY: fromY,
+    clientX: activationX,
+    clientY: activationY,
     button: 0,
     buttons: 1,
     isPrimary: true,
     pointerId: 1,
   });
   await nextFrame();
+
+  return { x: activationX, y: activationY };
 }
 
 function escapeRegExp(value: string) {

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -1322,7 +1322,6 @@ export const AddsLayerFromMixedSelection: Story = {
 
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-layer-layer-2')).toHaveClass('swt:btn-primary');
-      expect(canvas.queryByText('Selection 3')).not.toBeInTheDocument();
       expect(canvasElement).toHaveTextContent('Input A');
       expect(canvasElement).toHaveTextContent('Output B');
     });

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -363,6 +363,47 @@ export const DroppedShelfPropertyKeepsLayerColorAndSyncsUpdates: Story = {
   },
 };
 
+export const FolderColorPreviewSyncsLayerTabAndRailProperty: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await setFolderPreviewColor(canvas.getByTestId('foldered-draggable-folder-layer-layer-1'), '#be185d');
+
+    await waitFor(() => {
+      expect(canvas.getByTestId('provenance-layer-layer-1')).toHaveAttribute(
+        'data-provenance-layer-color',
+        '#be185d',
+      );
+    });
+
+    const property = await ensurePropertyInRail(canvas, 'Output', 'Species');
+    expect(propertyColorSwatch(property)).toHaveStyle({ backgroundColor: '#be185d' });
+  },
+};
+
+export const NonLayerFolderColorAppliesToShelfAndRailProperties: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const previousContextFolder = canvas.getByTestId(
+      'foldered-draggable-folder-context-previous-process-previous-study-table',
+    );
+
+    await setFolderPreviewColor(previousContextFolder, '#0891b2');
+
+    const previousContextShelf = await openShelfFolder(canvas, previousContextFolder);
+    const shelfPropertyButton = previousContextShelf.getByRole('button', { name: /^Drag Previous Treatment$/ });
+    const shelfSwatch = shelfPropertyButton.querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
+
+    expect(shelfSwatch).not.toBeNull();
+    expect(shelfSwatch!).toHaveStyle({ backgroundColor: '#0891b2' });
+
+    const property = await ensurePropertyInRail(canvas, 'Input', 'Previous Treatment');
+    expect(propertyColorSwatch(property)).toHaveStyle({ backgroundColor: '#0891b2' });
+  },
+};
+
 export const RejectedShelfPropertyDropRestoresFolderItem: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
@@ -1324,7 +1365,7 @@ async function openShelfFolder(canvas: ReturnType<typeof within>, folder: HTMLEl
   const currentFolder = () => canvas.getByTestId(folderTestId);
 
   if (currentFolder().getAttribute('aria-expanded') !== 'true') {
-    await userEvent.click(currentFolder());
+    await userEvent.click(within(currentFolder()).getByRole('button', { name: /^Expand / }));
   }
 
   await waitFor(() => expect(currentFolder()).toHaveAttribute('aria-expanded', 'true'));
@@ -1373,6 +1414,20 @@ function propertyColorSwatch(property: HTMLElement) {
   }
 
   return swatch;
+}
+
+async function setFolderPreviewColor(folder: HTMLElement, color: string) {
+  const trigger = within(folder).getByRole('button', { name: /^Set color for folder / });
+  const triggerLabel = trigger.getAttribute('aria-label') ?? '';
+  const inputLabel = triggerLabel.replace(/^Set /, 'Choose ');
+
+  await userEvent.click(trigger);
+  const body = within(document.body);
+  const colorInput = await waitFor(() => body.getByLabelText(inputLabel));
+  fireEvent.change(colorInput, { target: { value: color } });
+  await userEvent.click(body.getByRole('button', { name: 'Select' }));
+
+  await waitFor(() => expect(trigger).toHaveStyle({ backgroundColor: color }));
 }
 
 async function showPropertyControls(

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -263,6 +263,61 @@ export const GroupingPropertiesStayOnOwningSide: Story = {
   },
 };
 
+export const ToolbarUsesSinglePropertySortAndOriginButtons: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toolbar = within(canvas.getByTestId('provenance-filter-toolbar'));
+
+    expect(toolbar.getByPlaceholderText('Search properties & values...')).toBeInTheDocument();
+
+    await userEvent.click(toolbar.getByRole('button', { name: /^Sort By$/i }));
+    expect(toolbar.getByRole('button', { name: /^Property Value Count$/i })).toBeInTheDocument();
+    expect(toolbar.getByRole('button', { name: /^Name$/i })).toBeInTheDocument();
+    expect(toolbar.getAllByRole('button', { name: /^Connection Count$/i })).toHaveLength(1);
+
+    expect(toolbar.getByRole('button', { name: /^Show upstream properties$/i }).querySelector('[class*="fluent--arrow-up-20"]'))
+      .toBeInTheDocument();
+    expect(toolbar.getByRole('button', { name: /^Show current properties$/i }).querySelector('[class*="fluent--circle-20-filled"]'))
+      .toBeInTheDocument();
+    const both = toolbar.getByRole('button', { name: /^Show current and upstream properties$/i });
+    expect(both.querySelector('[class*="fluent--arrow-up-20"]')).toBeInTheDocument();
+    expect(both.querySelector('[class*="fluent--circle-20-filled"]')).toBeInTheDocument();
+  },
+};
+
+export const SortsPropertiesByNameAndConnectionCount: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toolbar = within(canvas.getByTestId('provenance-filter-toolbar'));
+
+    await userEvent.click(toolbar.getByRole('button', { name: /^Sort By$/i }));
+    await userEvent.click(toolbar.getByRole('button', { name: /^Name$/i }));
+
+    await waitFor(() => {
+      expect(propertyOrder(canvas, 'Output').slice(0, 4)).toEqual([
+        'Analysis',
+        'Replicate',
+        'Species',
+        'Temperature',
+      ]);
+    });
+
+    await userEvent.click(toolbar.getByRole('button', { name: /^Sort By$/i }));
+    await userEvent.click(toolbar.getByRole('button', { name: /^Connection Count$/i }));
+
+    await waitFor(() => {
+      expect(propertyOrder(canvas, 'Output').slice(0, 4)).toEqual([
+        'Species',
+        'Analysis',
+        'Temperature',
+        'Replicate',
+      ]);
+    });
+  },
+};
+
 export const PropertyRailExpandsValuesAndAddControls: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
@@ -1066,6 +1121,13 @@ async function selectGroup(groupCard: HTMLElement) {
   }
 
   await waitFor(() => expect(groupCard).toHaveClass('swt:border-primary'), { timeout: 3000 });
+}
+
+function propertyOrder(canvas: ReturnType<typeof within>, side: 'Input' | 'Output') {
+  const prefix = `provenance-property-${side}-`;
+  const rail = canvas.getByTestId(`provenance-property-rail-${side}`);
+  return Array.from(rail.querySelectorAll<HTMLElement>(`[data-testid^="${prefix}"]`))
+    .map((element) => element.getAttribute('data-testid')!.slice(prefix.length));
 }
 
 async function railValue(

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -228,6 +228,27 @@ export const GroupsBothSidesFromOutputProperty: Story = {
   },
 };
 
+export const MissingSecondGroupingKeyKeepsAvailableGroupingKeys: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.hover(canvas.getByTestId('provenance-property-Output-Species'));
+    await userEvent.click(canvas.getByTestId('provenance-property-both-Output-Species'));
+    await userEvent.hover(canvas.getByTestId('provenance-property-Output-Temperature'));
+    await userEvent.click(canvas.getByTestId('provenance-property-both-Output-Temperature'));
+
+    await waitFor(() => {
+      expect(canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis|Temperature=12 C'))
+        .toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:Species=Arabidopsis|Temperature=24 C'))
+        .toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:Species=Chlamydomonas')).toBeInTheDocument();
+      expect(canvas.queryByTestId('provenance-group-Input-input:input-d')).not.toBeInTheDocument();
+    });
+  },
+};
+
 export const ConnectedOutputsKeepPropertiesInRailsAndConnections: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -874,7 +874,7 @@ export const CreatesNextLayerAndKeepsBoundaryEditsSynchronized: Story = {
     await userEvent.click(canvas.getByTestId('provenance-add-layer'));
 
     await waitFor(() => {
-      expect(canvas.getByTestId('provenance-pair-pair-2')).toHaveClass('swt:btn-primary');
+      expect(canvas.getByTestId('provenance-layer-layer-2')).toHaveClass('swt:btn-primary');
       expect(canvasElement).toHaveTextContent('Output A');
     });
 
@@ -884,13 +884,13 @@ export const CreatesNextLayerAndKeepsBoundaryEditsSynchronized: Story = {
     await dragByPointer(source, carried);
     await userEvent.click(canvas.getByTestId('provenance-confirm-overwrite'));
 
-    await userEvent.click(canvas.getByTestId('provenance-pair-pair-1'));
+    await userEvent.click(canvas.getByTestId('provenance-layer-layer-1'));
     await waitFor(() => expect(canvasElement).toHaveTextContent('Imaging'));
     expect(canvas.getByTestId('provenance-patch-preview')).not.toHaveTextContent('No patches emitted.');
   },
 };
 
-export const CompletesAnInputOnlyPair: Story = {
+export const CompletesAnInputOnlyLayer: Story = {
   render: () => <Harness inputOnly />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -1297,7 +1297,6 @@ export const LayerTabsUseConceptualLayerColorsAndSideRails: Story = {
     expect(layer1).toHaveClass('swt:btn-primary');
     expect(layerColor).toMatch(/^#/);
     expect(layerColor).not.toContain('|');
-    expect(canvas.queryByTestId('provenance-pair-pair-1')).not.toBeInTheDocument();
 
     expect(canvas.getByTestId('provenance-property-rail-Input')).toHaveAttribute(
       'data-provenance-side-id',
@@ -1330,7 +1329,7 @@ export const AddsLayerFromMixedSelection: Story = {
   },
 };
 
-export const DoesNotReuseSelectionForEqualGroupIdsInDifferentPairs: Story = {
+export const DoesNotReuseSelectionForEqualGroupIdsInDifferentLayers: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -1340,18 +1339,18 @@ export const DoesNotReuseSelectionForEqualGroupIdsInDifferentPairs: Story = {
     await userEvent.click(canvas.getByTestId('provenance-add-layer'));
 
     await userEvent.click(canvas.getByTestId('popover_trigger_provenance-add-output'));
-    await userEvent.type(screen.getByRole('textbox', { name: /Endpoint name/i }), 'Pair 2 Output');
+    await userEvent.type(screen.getByRole('textbox', { name: /Endpoint name/i }), 'Layer 2 Output');
     await userEvent.click(screen.getByRole('button', { name: /Create endpoint/i }));
-    const pair2Output = await waitFor(() => canvas.getByText('Pair 2 Output').closest('article')!);
+    const layer2Output = await waitFor(() => canvas.getByText('Layer 2 Output').closest('article')!);
 
-    await selectGroup(pair2Output);
+    await selectGroup(layer2Output);
     await userEvent.click(canvas.getByTestId('provenance-add-layer'));
 
     await userEvent.click(canvas.getByTestId('popover_trigger_provenance-add-output'));
-    await userEvent.type(screen.getByRole('textbox', { name: /Endpoint name/i }), 'Pair 3 Output');
+    await userEvent.type(screen.getByRole('textbox', { name: /Endpoint name/i }), 'Layer 3 Output');
     await userEvent.click(screen.getByRole('button', { name: /Create endpoint/i }));
-    const pair3Output = await waitFor(() => canvas.getByText('Pair 3 Output').closest('article')!);
+    const layer3Output = await waitFor(() => canvas.getByText('Layer 3 Output').closest('article')!);
 
-    expect(pair3Output).not.toHaveClass('swt:border-primary');
+    expect(layer3Output).not.toHaveClass('swt:border-primary');
   },
 };

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -151,15 +151,15 @@ module PropertyColors =
     }
 
     let ensureLayerColors (session: ProvenanceSession) (state: UiState) : PropertyColorSettings =
-        let liveLayerIds = session.Layers |> List.map _.Id |> Set.ofList
+        let liveLayerIds = session.LayerOrder |> Set.ofList
 
         let retained =
             state.PropertyColors.LayerColors
             |> Map.filter (fun layerId _ -> liveLayerIds.Contains layerId)
 
         let withMissingDefaults =
-            session.Layers
-            |> List.mapi (fun index layer -> layer.Id, automaticColorForLayer index)
+            session.LayerOrder
+            |> List.mapi (fun index layerId -> layerId, automaticColorForLayer index)
             |> List.fold
                 (fun (colors: Map<ProvenanceLayerId, ProvenanceColor>) (layerId, color) ->
                     if colors.ContainsKey layerId then

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -96,6 +96,7 @@ module PropertyColors =
     let empty = {
         ManualPropertyColors = Map.empty
         LayerColors = Map.empty
+        FolderColors = Map.empty
     }
 
     let private automaticColorForLayer layerIndex = palette.[layerIndex % palette.Length]
@@ -135,6 +136,22 @@ module PropertyColors =
             PropertyColors = {
                 state.PropertyColors with
                     LayerColors = state.PropertyColors.LayerColors |> Map.remove layerId
+            }
+    }
+
+    let setFolderColor folderId color state = {
+        state with
+            PropertyColors = {
+                state.PropertyColors with
+                    FolderColors = state.PropertyColors.FolderColors |> Map.add folderId color
+            }
+    }
+
+    let clearFolderColor folderId state = {
+        state with
+            PropertyColors = {
+                state.PropertyColors with
+                    FolderColors = state.PropertyColors.FolderColors |> Map.remove folderId
             }
     }
 

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -66,32 +66,19 @@ module MemberResolution =
     }
 
     let chooseManual (pending: PendingMemberResolution) state =
-        let pair: ManualResolutionPair = {
-            LayerId = pending.LayerId
-            InputGroupId = pending.InputGroupId
-            OutputGroupId = pending.OutputGroupId
-        }
-
-        let pairs =
-            if state.ManualResolutionPairs |> List.exists ((=) pair) then
-                state.ManualResolutionPairs
+        let detail =
+            if pending.OutputMemberCount > 1 then
+                Some(ProvenanceDetail.Group(ProvenanceSide.Output, pending.OutputGroupId))
+            elif pending.InputMemberCount > 1 then
+                Some(ProvenanceDetail.Group(ProvenanceSide.Input, pending.InputGroupId))
             else
-                state.ManualResolutionPairs @ [ pair ]
+                None
 
         {
             state with
                 PendingMemberResolution = None
-                ManualResolutionPairs = pairs
-                Detail = Some(ProvenanceDetail.Group(ProvenanceSide.Input, pending.InputGroupId))
+                Detail = detail
         }
-
-    let isManualPair layerId inputGroupId outputGroupId state =
-        state.ManualResolutionPairs
-        |> List.exists (fun (pair: ManualResolutionPair) ->
-            pair.LayerId = layerId
-            && pair.InputGroupId = inputGroupId
-            && pair.OutputGroupId = outputGroupId
-        )
 
 module PropertyColors =
 
@@ -277,10 +264,6 @@ module Sides =
             state.PendingMemberResolution
             |> Option.filter (fun pending -> currentLayerIds.Contains pending.LayerId)
 
-        let manualResolutionPairs =
-            state.ManualResolutionPairs
-            |> List.filter (fun pair -> currentLayerIds.Contains pair.LayerId)
-
         let propertyColors = PropertyColors.ensureLayerColors session state
 
         if
@@ -291,7 +274,6 @@ module Sides =
             && expandedProperties = state.ExpandedProperties
             && paletteValues = state.PaletteValues
             && pendingMemberResolution = state.PendingMemberResolution
-            && manualResolutionPairs = state.ManualResolutionPairs
             && propertyColors = state.PropertyColors
         then
             state
@@ -305,7 +287,6 @@ module Sides =
                     ExpandedProperties = expandedProperties
                     PaletteValues = paletteValues
                     PendingMemberResolution = pendingMemberResolution
-                    ManualResolutionPairs = manualResolutionPairs
                     PropertyColors = propertyColors
             }
 
@@ -675,7 +656,6 @@ let init (session: ProvenanceSession) = {
     PendingAssignmentBatch = None
     PanelRatios = Map.empty
     PendingMemberResolution = None
-    ManualResolutionPairs = []
     SelectedInputs = Set.empty
     SelectedOutputs = Set.empty
     Detail = None

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -387,16 +387,19 @@ module Palette =
                 Error = None
         }
 
-/// Manages overwrite confirmation state for dropped property values.
-module Overwrite =
+/// Manages batch assignment confirmation state for dropped property values.
+module AssignmentBatch =
 
-    let set warning state = {
+    let set (batch: PendingAssignmentBatch) state = {
         state with
-            PendingOverwrite = Some warning
+            PendingAssignmentBatch = Some batch
             Error = None
     }
 
-    let clear state = { state with PendingOverwrite = None }
+    let clear state = {
+        state with
+            PendingAssignmentBatch = None
+    }
 
 /// Updates grouping assignments and side placement for properties.
 module GroupingAssignments =
@@ -571,7 +574,7 @@ let init (session: ProvenanceSession) = {
     PropertyRailPlacements = Map.empty
     ExpandedProperties = Set.empty
     PaletteValues = Map.empty
-    PendingOverwrite = None
+    PendingAssignmentBatch = None
     PanelRatios = Map.empty
     PendingMemberResolution = None
     ManualResolutionPairs = []

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -66,18 +66,19 @@ module MemberResolution =
     }
 
     let chooseManual (pending: PendingMemberResolution) state =
-        let detail =
+        let expandedGroup =
             if pending.OutputMemberCount > 1 then
-                Some(ProvenanceDetail.Group(ProvenanceSide.Output, pending.OutputGroupId))
+                Some(ProvenanceSide.Output, pending.OutputGroupId)
             elif pending.InputMemberCount > 1 then
-                Some(ProvenanceDetail.Group(ProvenanceSide.Input, pending.InputGroupId))
+                Some(ProvenanceSide.Input, pending.InputGroupId)
             else
                 None
 
         {
             state with
                 PendingMemberResolution = None
-                Detail = detail
+                ExpandedGroup = expandedGroup
+                Detail = None
         }
 
 module PropertyColors =
@@ -620,16 +621,20 @@ module Selection =
 module Detail =
 
     let isGroupExpanded side groupId state =
-        state.Detail = Some(ProvenanceDetail.Group(side, groupId))
+        state.ExpandedGroup = Some(side, groupId)
 
     let toggleGroup side groupId state =
         let next =
             if isGroupExpanded side groupId state then
                 None
             else
-                Some(ProvenanceDetail.Group(side, groupId))
+                Some(side, groupId)
 
-        { state with Detail = next }
+        {
+            state with
+                ExpandedGroup = next
+                Detail = None
+        }
 
     let showConnection connectionId state = {
         state with
@@ -658,6 +663,7 @@ let init (session: ProvenanceSession) = {
     PendingMemberResolution = None
     SelectedInputs = Set.empty
     SelectedOutputs = Set.empty
+    ExpandedGroup = None
     Detail = None
     Error = None
     PropertyColors = PropertyColors.empty

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -93,6 +93,131 @@ module MemberResolution =
             && pair.OutputGroupId = outputGroupId
         )
 
+module PropertyColors =
+
+    let palette = [|
+        "#2563eb"
+        "#16a34a"
+        "#d97706"
+        "#dc2626"
+        "#7c3aed"
+        "#0891b2"
+        "#be185d"
+    |]
+
+    let empty = {
+        ManualPropertyColors = Map.empty
+        LayerColors = Map.empty
+    }
+
+    let private automaticColorForLayer layerIndex = palette.[layerIndex % palette.Length]
+
+    let setColor (header: ProvenancePropertyHeader) color state =
+        let key = Keys.groupingKey header
+
+        {
+            state with
+                PropertyColors = {
+                    state.PropertyColors with
+                        ManualPropertyColors = state.PropertyColors.ManualPropertyColors |> Map.add key color
+                }
+        }
+
+    let clearColor (header: ProvenancePropertyHeader) state =
+        let key = Keys.groupingKey header
+
+        {
+            state with
+                PropertyColors = {
+                    state.PropertyColors with
+                        ManualPropertyColors = state.PropertyColors.ManualPropertyColors |> Map.remove key
+                }
+        }
+
+    let setLayerColor (layerId: ProvenanceLayerId) color state = {
+        state with
+            PropertyColors = {
+                state.PropertyColors with
+                    LayerColors = state.PropertyColors.LayerColors |> Map.add layerId color
+            }
+    }
+
+    let clearLayerColor (layerId: ProvenanceLayerId) state = {
+        state with
+            PropertyColors = {
+                state.PropertyColors with
+                    LayerColors = state.PropertyColors.LayerColors |> Map.remove layerId
+            }
+    }
+
+    let ensureLayerColors (session: ProvenanceSession) (state: UiState) : PropertyColorSettings =
+        let liveLayerIds = session.Layers |> List.map _.Id |> Set.ofList
+
+        let retained =
+            state.PropertyColors.LayerColors
+            |> Map.filter (fun layerId _ -> liveLayerIds.Contains layerId)
+
+        let withMissingDefaults =
+            session.Layers
+            |> List.mapi (fun index layer -> layer.Id, automaticColorForLayer index)
+            |> List.fold
+                (fun (colors: Map<ProvenanceLayerId, ProvenanceColor>) (layerId, color) ->
+                    if colors.ContainsKey layerId then
+                        colors
+                    else
+                        colors |> Map.add layerId color
+                )
+                retained
+
+        {
+            state.PropertyColors with
+                LayerColors = withMissingDefaults
+        }
+
+module Filters =
+
+    let defaultState = {
+        SearchText = ""
+        PropertySort = PropertySort.ValueCountDesc
+        GroupSort = GroupSort.NameAsc
+        ValueCountFilter = PropertyValueCountFilter.Any
+        OriginFilter = PropertyOriginFilter.AnyOrigin
+    }
+
+    let setSearch text state = {
+        state with
+            Filters = { state.Filters with SearchText = text }
+    }
+
+    let setValueCountFilter filter state = {
+        state with
+            Filters = {
+                state.Filters with
+                    ValueCountFilter = filter
+            }
+    }
+
+    let setOriginFilter filter state = {
+        state with
+            Filters = {
+                state.Filters with
+                    OriginFilter = filter
+            }
+    }
+
+    let setPropertySort sort state = {
+        state with
+            Filters = {
+                state.Filters with
+                    PropertySort = sort
+            }
+    }
+
+    let setGroupSort sort state = {
+        state with
+            Filters = { state.Filters with GroupSort = sort }
+    }
+
 /// Creates, finds, and synchronizes layer-local state with the current session.
 module Layers =
 
@@ -144,6 +269,8 @@ module Layers =
             state.ManualResolutionPairs
             |> List.filter (fun pair -> currentPairIds.Contains pair.PairId)
 
+        let propertyColors = PropertyColors.ensureLayerColors session state
+
         if
             layerStates = state.LayerStates
             && propertyRailPlacements = state.PropertyRailPlacements
@@ -152,6 +279,7 @@ module Layers =
             && paletteValues = state.PaletteValues
             && pendingMemberResolution = state.PendingMemberResolution
             && manualResolutionPairs = state.ManualResolutionPairs
+            && propertyColors = state.PropertyColors
         then
             state
         else
@@ -164,6 +292,7 @@ module Layers =
                     PaletteValues = paletteValues
                     PendingMemberResolution = pendingMemberResolution
                     ManualResolutionPairs = manualResolutionPairs
+                    PropertyColors = propertyColors
             }
 
     let update layerId updateLayer state =
@@ -450,4 +579,6 @@ let init (session: ProvenanceSession) = {
     SelectedOutputs = Set.empty
     Detail = None
     Error = None
+    PropertyColors = PropertyColors.empty
+    Filters = Filters.defaultState
 }

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -218,33 +218,40 @@ module Filters =
             Filters = { state.Filters with GroupSort = sort }
     }
 
-/// Creates, finds, and synchronizes layer-local state with the current session.
-module Layers =
+/// Creates, finds, and synchronizes side-local state with the current session.
+module Sides =
 
     let empty = { GroupingAssignments = [] }
 
-    let get layerId state =
-        state.LayerStates |> Map.tryFind layerId |> Option.defaultValue empty
+    let private sideIdsForSession session =
+        session.LayerOrder
+        |> List.collect (fun layerId ->
+            let layer = Session.layerById layerId session
+            [ layer.InputSideId; layer.OutputSideId ]
+        )
 
-    let private retainCurrentLayers session state =
-        let currentIds = session.Layers |> List.map (fun layer -> layer.Id) |> Set.ofList
+    let get sideId state =
+        state.SideStates |> Map.tryFind sideId |> Option.defaultValue empty
 
-        let retained: Map<ProvenanceLayerId, LayerViewState> =
-            state.LayerStates |> Map.filter (fun id _ -> currentIds.Contains id)
+    let private retainCurrentSides session state =
+        let currentIds = sideIdsForSession session |> Set.ofList
 
-        session.Layers
+        let retained: Map<ProvenanceLayerSideId, SideViewState> =
+            state.SideStates |> Map.filter (fun id _ -> currentIds.Contains id)
+
+        sideIdsForSession session
         |> List.fold
-            (fun (map: Map<ProvenanceLayerId, LayerViewState>) layer ->
-                if map.ContainsKey layer.Id then
+            (fun (map: Map<ProvenanceLayerSideId, SideViewState>) sideId ->
+                if map.ContainsKey sideId then
                     map
                 else
-                    map |> Map.add layer.Id empty
+                    map |> Map.add sideId empty
             )
             retained
 
     let ensure (session: ProvenanceSession) state =
         let currentPairIds = session.PairOrder |> Set.ofList
-        let layerStates = retainCurrentLayers session state
+        let sideStates = retainCurrentSides session state
 
         let propertyRailPlacements =
             state.PropertyRailPlacements
@@ -272,7 +279,7 @@ module Layers =
         let propertyColors = PropertyColors.ensureLayerColors session state
 
         if
-            layerStates = state.LayerStates
+            sideStates = state.SideStates
             && propertyRailPlacements = state.PropertyRailPlacements
             && panelRatios = state.PanelRatios
             && expandedProperties = state.ExpandedProperties
@@ -285,7 +292,7 @@ module Layers =
         else
             {
                 state with
-                    LayerStates = layerStates
+                    SideStates = sideStates
                     PropertyRailPlacements = propertyRailPlacements
                     PanelRatios = panelRatios
                     ExpandedProperties = expandedProperties
@@ -295,13 +302,13 @@ module Layers =
                     PropertyColors = propertyColors
             }
 
-    let update layerId updateLayer state =
-        let current = get layerId state
-        let next = updateLayer current
+    let update sideId updateSide state =
+        let current = get sideId state
+        let next = updateSide current
 
         {
             state with
-                LayerStates = state.LayerStates |> Map.add layerId next
+                SideStates = state.SideStates |> Map.add sideId next
         }
 
 /// Tracks expanded property value panels on the side rails.
@@ -422,9 +429,9 @@ module GroupingAssignments =
         |> List.filter (fun current -> current.Key <> assignment.Key)
         |> fun retained -> retained @ [ assignment ]
 
-    let toggleSide layerId side header state =
-        Layers.update
-            layerId
+    let toggleSide sideId side header state =
+        Sides.update
+            sideId
             (fun current ->
                 let key = Keys.groupingKey header
                 let scope = scopeForSide side
@@ -447,19 +454,19 @@ module GroupingAssignments =
             )
             state
 
-    let toggleBoth leftLayerId rightLayerId header state =
+    let toggleBoth inputSideId outputSideId header state =
         let key = Keys.groupingKey header
 
         let isSelected =
-            [ leftLayerId; rightLayerId ]
-            |> List.exists (fun layerId ->
-                (Layers.get layerId state).GroupingAssignments
+            [ inputSideId; outputSideId ]
+            |> List.exists (fun sideId ->
+                (Sides.get sideId state).GroupingAssignments
                 |> List.exists (fun assignment -> assignment.Key = key && assignment.Scope = GroupingScope.Both)
             )
 
-        let setLayer state layerId =
-            Layers.update
-                layerId
+        let setSide state sideId =
+            Sides.update
+                sideId
                 (fun current ->
                     let nextAssignments =
                         if isSelected then
@@ -480,10 +487,10 @@ module GroupingAssignments =
                 )
                 state
 
-        let withLeft = setLayer state leftLayerId
-        setLayer withLeft rightLayerId
+        let withInput = setSide state inputSideId
+        setSide withInput outputSideId
 
-    let move pairId sourceLayerId targetLayerId targetSide header state =
+    let move layerId sourceSideId targetSideId targetSide header state =
         let key = Keys.groupingKey header
 
         let targetAssignment: GroupingAssignment = {
@@ -492,8 +499,8 @@ module GroupingAssignments =
         }
 
         let withoutSource =
-            Layers.update
-                sourceLayerId
+            Sides.update
+                sourceSideId
                 (fun current -> {
                     current with
                         GroupingAssignments = removeHeader header current.GroupingAssignments
@@ -501,8 +508,8 @@ module GroupingAssignments =
                 state
 
         let withTarget =
-            Layers.update
-                targetLayerId
+            Sides.update
+                targetSideId
                 (fun current -> {
                     current with
                         GroupingAssignments = upsert targetAssignment current.GroupingAssignments
@@ -511,7 +518,7 @@ module GroupingAssignments =
 
         {
             withTarget with
-                PropertyRailPlacements = withTarget.PropertyRailPlacements |> Map.add (pairId, key) targetSide
+                PropertyRailPlacements = withTarget.PropertyRailPlacements |> Map.add (layerId, key) targetSide
         }
 
 /// Tracks selected input/output groups for layer creation.
@@ -570,7 +577,17 @@ module Detail =
 
 /// Creates the complete UI state for a provenance session.
 let init (session: ProvenanceSession) = {
-    LayerStates = session.Layers |> List.map (fun layer -> layer.Id, Layers.empty) |> Map.ofList
+    SideStates =
+        session.LayerOrder
+        |> List.collect (fun layerId ->
+            let layer = Session.layerById layerId session
+
+            [
+                layer.InputSideId, Sides.empty
+                layer.OutputSideId, Sides.empty
+            ]
+        )
+        |> Map.ofList
     PropertyRailPlacements = Map.empty
     ExpandedProperties = Set.empty
     PaletteValues = Map.empty

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -364,6 +364,19 @@ module RailOrder =
 
         set layerId side next state
 
+/// Tracks explicit side drop-zone placement without changing grouping selection.
+module PropertyPlacement =
+
+    let place layerId side header state =
+        let key = Keys.groupingKey header
+
+        {
+            state with
+                PropertyRailPlacements = state.PropertyRailPlacements |> Map.add (layerId, key) side
+                Error = None
+        }
+        |> RailOrder.appendHeader layerId side header
+
 /// Tracks expanded property value panels on the side rails.
 module PropertyExpansion =
 

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -242,7 +242,7 @@ module Layers =
             )
             retained
 
-    let ensure session state =
+    let ensure (session: ProvenanceSession) state =
         let currentPairIds = session.PairOrder |> Set.ofList
         let layerStates = retainCurrentLayers session state
 

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -257,6 +257,10 @@ module Sides =
             state.PropertyRailPlacements
             |> Map.filter (fun (layerId, _) _ -> currentLayerIds.Contains layerId)
 
+        let propertyRailOrders =
+            state.PropertyRailOrders
+            |> Map.filter (fun (layerId, _) _ -> currentLayerIds.Contains layerId)
+
         let panelRatios =
             state.PanelRatios
             |> Map.filter (fun layerId _ -> currentLayerIds.Contains layerId)
@@ -282,6 +286,7 @@ module Sides =
         if
             sideStates = state.SideStates
             && propertyRailPlacements = state.PropertyRailPlacements
+            && propertyRailOrders = state.PropertyRailOrders
             && panelRatios = state.PanelRatios
             && expandedProperties = state.ExpandedProperties
             && paletteValues = state.PaletteValues
@@ -295,6 +300,7 @@ module Sides =
                 state with
                     SideStates = sideStates
                     PropertyRailPlacements = propertyRailPlacements
+                    PropertyRailOrders = propertyRailOrders
                     PanelRatios = panelRatios
                     ExpandedProperties = expandedProperties
                     PaletteValues = paletteValues
@@ -311,6 +317,70 @@ module Sides =
             state with
                 SideStates = state.SideStates |> Map.add sideId next
         }
+
+/// Stores visual rail order separately from filtering and writeback state.
+module RailOrder =
+
+    let private key layerId side = layerId, side
+
+    let private distinctHeaders headers = headers |> List.distinct
+
+    let tryGet layerId side state =
+        state.PropertyRailOrders |> Map.tryFind (key layerId side)
+
+    let get layerId side state =
+        tryGet layerId side state |> Option.defaultValue []
+
+    let apply (order: ProvenancePropertyHeader list) (headers: ProvenancePropertyHeader list) =
+        let headerSet = headers |> Set.ofList
+        let ordered = order |> List.filter (fun header -> headerSet.Contains header)
+        let orderedSet = ordered |> Set.ofList
+
+        let appended =
+            headers |> List.filter (fun header -> not (orderedSet.Contains header))
+
+        ordered @ appended
+
+    let set layerId side headers state =
+        let next = distinctHeaders headers
+
+        {
+            state with
+                PropertyRailOrders = state.PropertyRailOrders |> Map.add (key layerId side) next
+        }
+
+    let ensure layerId side headers state =
+        let next =
+            match tryGet layerId side state with
+            | Some current -> apply current headers
+            | None -> distinctHeaders headers
+
+        if tryGet layerId side state = Some next then
+            state
+        else
+            set layerId side next state
+
+    let reorderVisible layerId side sortedVisibleHeaders state =
+        let visibleSet = sortedVisibleHeaders |> Set.ofList
+
+        let retainedHidden =
+            get layerId side state
+            |> List.filter (fun header -> not (visibleSet.Contains header))
+
+        set layerId side (sortedVisibleHeaders @ retainedHidden) state
+
+    let removeHeader layerId side header state =
+        let next = get layerId side state |> List.filter ((<>) header)
+
+        set layerId side next state
+
+    let appendHeader layerId side header state =
+        let next =
+            get layerId side state
+            |> List.filter ((<>) header)
+            |> fun headers -> headers @ [ header ]
+
+        set layerId side next state
 
 /// Tracks expanded property value panels on the side rails.
 module PropertyExpansion =
@@ -391,9 +461,11 @@ module Palette =
         {
             state with
                 PaletteValues = state.PaletteValues |> Map.add key nextValues
+                PropertyRailPlacements = state.PropertyRailPlacements |> Map.add (layerId, Keys.groupingKey header) side
                 ExpandedProperties = state.ExpandedProperties |> Set.add (Keys.propertySlot layerId side header)
                 Error = None
         }
+        |> RailOrder.appendHeader layerId side header
 
 /// Manages batch assignment confirmation state for dropped property values.
 module AssignmentBatch =
@@ -494,6 +566,11 @@ module GroupingAssignments =
     let move layerId sourceSideId targetSideId targetSide header state =
         let key = Keys.groupingKey header
 
+        let sourceSide =
+            match targetSide with
+            | ProvenanceSide.Input -> ProvenanceSide.Output
+            | ProvenanceSide.Output -> ProvenanceSide.Input
+
         let targetAssignment: GroupingAssignment = {
             Key = key
             Scope = scopeForSide targetSide
@@ -521,6 +598,8 @@ module GroupingAssignments =
             withTarget with
                 PropertyRailPlacements = withTarget.PropertyRailPlacements |> Map.add (layerId, key) targetSide
         }
+        |> RailOrder.removeHeader layerId sourceSide header
+        |> RailOrder.appendHeader layerId targetSide header
 
 /// Tracks selected input/output groups for layer creation.
 module Selection =
@@ -590,6 +669,7 @@ let init (session: ProvenanceSession) = {
         )
         |> Map.ofList
     PropertyRailPlacements = Map.empty
+    PropertyRailOrders = Map.empty
     ExpandedProperties = Set.empty
     PaletteValues = Map.empty
     PendingAssignmentBatch = None

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -10,11 +10,11 @@ module Keys =
 
     let groupingKey header : GroupingKey = { Header = header }
 
-    let propertySlot pairId side header = pairId, side, groupingKey header
+    let propertySlot layerId side header = layerId, side, groupingKey header
 
-    let paletteKey pairId side = pairId, side
+    let paletteKey layerId side = layerId, side
 
-    let selectedGroup pairId groupId = pairId, groupId
+    let selectedGroup layerId groupId = layerId, groupId
 
 /// Stores and clamps the three-panel editor layout ratios.
 module PanelLayout =
@@ -35,21 +35,21 @@ module PanelLayout =
             Right = right
         }
 
-    let get pairId state =
-        state.PanelRatios |> Map.tryFind pairId |> Option.defaultValue defaultRatios
+    let get layerId state =
+        state.PanelRatios |> Map.tryFind layerId |> Option.defaultValue defaultRatios
 
-    let set pairId ratios state = {
+    let set layerId ratios state = {
         state with
-            PanelRatios = state.PanelRatios |> Map.add pairId (clamp ratios.Left ratios.Right)
+            PanelRatios = state.PanelRatios |> Map.add layerId (clamp ratios.Left ratios.Right)
     }
 
-    let setLeft pairId left state =
-        let current = get pairId state
-        set pairId { current with Left = left } state
+    let setLeft layerId left state =
+        let current = get layerId state
+        set layerId { current with Left = left } state
 
-    let setRight pairId right state =
-        let current = get pairId state
-        set pairId { current with Right = right } state
+    let setRight layerId right state =
+        let current = get layerId state
+        set layerId { current with Right = right } state
 
 /// Tracks the in-app prompt and expansion state for mismatched group connections.
 module MemberResolution =
@@ -67,7 +67,7 @@ module MemberResolution =
 
     let chooseManual (pending: PendingMemberResolution) state =
         let pair: ManualResolutionPair = {
-            PairId = pending.PairId
+            LayerId = pending.LayerId
             InputGroupId = pending.InputGroupId
             OutputGroupId = pending.OutputGroupId
         }
@@ -85,10 +85,10 @@ module MemberResolution =
                 Detail = Some(ProvenanceDetail.Group(ProvenanceSide.Input, pending.InputGroupId))
         }
 
-    let isManualPair pairId inputGroupId outputGroupId state =
+    let isManualPair layerId inputGroupId outputGroupId state =
         state.ManualResolutionPairs
         |> List.exists (fun (pair: ManualResolutionPair) ->
-            pair.PairId = pairId
+            pair.LayerId = layerId
             && pair.InputGroupId = inputGroupId
             && pair.OutputGroupId = outputGroupId
         )
@@ -250,31 +250,32 @@ module Sides =
             retained
 
     let ensure (session: ProvenanceSession) state =
-        let currentPairIds = session.PairOrder |> Set.ofList
+        let currentLayerIds = session.LayerOrder |> Set.ofList
         let sideStates = retainCurrentSides session state
 
         let propertyRailPlacements =
             state.PropertyRailPlacements
-            |> Map.filter (fun (pairId, _) _ -> currentPairIds.Contains pairId)
+            |> Map.filter (fun (layerId, _) _ -> currentLayerIds.Contains layerId)
 
         let panelRatios =
-            state.PanelRatios |> Map.filter (fun pairId _ -> currentPairIds.Contains pairId)
+            state.PanelRatios
+            |> Map.filter (fun layerId _ -> currentLayerIds.Contains layerId)
 
         let expandedProperties =
             state.ExpandedProperties
-            |> Set.filter (fun (pairId, _, _) -> currentPairIds.Contains pairId)
+            |> Set.filter (fun (layerId, _, _) -> currentLayerIds.Contains layerId)
 
         let paletteValues =
             state.PaletteValues
-            |> Map.filter (fun (pairId, _) _ -> currentPairIds.Contains pairId)
+            |> Map.filter (fun (layerId, _) _ -> currentLayerIds.Contains layerId)
 
         let pendingMemberResolution =
             state.PendingMemberResolution
-            |> Option.filter (fun pending -> currentPairIds.Contains pending.PairId)
+            |> Option.filter (fun pending -> currentLayerIds.Contains pending.LayerId)
 
         let manualResolutionPairs =
             state.ManualResolutionPairs
-            |> List.filter (fun pair -> currentPairIds.Contains pair.PairId)
+            |> List.filter (fun pair -> currentLayerIds.Contains pair.LayerId)
 
         let propertyColors = PropertyColors.ensureLayerColors session state
 
@@ -314,11 +315,11 @@ module Sides =
 /// Tracks expanded property value panels on the side rails.
 module PropertyExpansion =
 
-    let isExpanded pairId side header state =
-        state.ExpandedProperties |> Set.contains (Keys.propertySlot pairId side header)
+    let isExpanded layerId side header state =
+        state.ExpandedProperties |> Set.contains (Keys.propertySlot layerId side header)
 
-    let toggle pairId side header state =
-        let slot = Keys.propertySlot pairId side header
+    let toggle layerId side header state =
+        let slot = Keys.propertySlot layerId side header
 
         let expanded =
             if state.ExpandedProperties.Contains slot then
@@ -334,17 +335,17 @@ module PropertyExpansion =
 /// Stores property values that exist only in the rail until they are applied to a group.
 module Palette =
 
-    let valuesForSide pairId side state =
+    let valuesForSide layerId side state =
         state.PaletteValues
-        |> Map.tryFind (Keys.paletteKey pairId side)
+        |> Map.tryFind (Keys.paletteKey layerId side)
         |> Option.defaultValue []
 
-    let valuesForHeader pairId side header state =
-        valuesForSide pairId side state
+    let valuesForHeader layerId side header state =
+        valuesForSide layerId side state
         |> List.filter (fun propertyValue -> propertyValue.Header = header)
 
-    let headersForSide pairId side state =
-        valuesForSide pairId side state
+    let headersForSide layerId side state =
+        valuesForSide layerId side state
         |> List.map (fun propertyValue -> propertyValue.Header)
         |> List.distinct
         |> List.sortBy (fun header -> header.Category.Name)
@@ -355,7 +356,7 @@ module Palette =
         |> List.collect snd
         |> List.tryFind (fun propertyValue -> propertyValue.Id = propertyValueId)
 
-    let private nextValueId pairId side state =
+    let private nextValueId layerId side state =
         let sideText =
             match side with
             | ProvenanceSide.Input -> "input"
@@ -369,28 +370,28 @@ module Palette =
             |> Set.ofList
 
         let rec loop index =
-            let id = $"palette-{pairId}-{sideText}-{index}"
+            let id = $"palette-{layerId}-{sideText}-{index}"
             if existing.Contains id then loop (index + 1) else id
 
         loop (existing.Count + 1)
 
-    let addValue pairId side header value unit state =
-        let key = Keys.paletteKey pairId side
+    let addValue layerId side header value unit state =
+        let key = Keys.paletteKey layerId side
 
         let propertyValue: ProvenancePropertyValue = {
-            Id = nextValueId pairId side state
+            Id = nextValueId layerId side state
             Header = header
             Value = value
             Unit = unit
             Source = None
         }
 
-        let nextValues = valuesForSide pairId side state @ [ propertyValue ]
+        let nextValues = valuesForSide layerId side state @ [ propertyValue ]
 
         {
             state with
                 PaletteValues = state.PaletteValues |> Map.add key nextValues
-                ExpandedProperties = state.ExpandedProperties |> Set.add (Keys.propertySlot pairId side header)
+                ExpandedProperties = state.ExpandedProperties |> Set.add (Keys.propertySlot layerId side header)
                 Error = None
         }
 
@@ -524,15 +525,15 @@ module GroupingAssignments =
 /// Tracks selected input/output groups for layer creation.
 module Selection =
 
-    let contains pairId side groupId state =
-        let identity = Keys.selectedGroup pairId groupId
+    let contains layerId side groupId state =
+        let identity = Keys.selectedGroup layerId groupId
 
         match side with
         | ProvenanceSide.Input -> state.SelectedInputs.Contains identity
         | ProvenanceSide.Output -> state.SelectedOutputs.Contains identity
 
-    let toggle pairId side groupId state =
-        let identity = Keys.selectedGroup pairId groupId
+    let toggle layerId side groupId state =
+        let identity = Keys.selectedGroup layerId groupId
 
         match side with
         | ProvenanceSide.Input ->

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -154,6 +154,7 @@ type PropertyCountBadge =
 type UiState = {
     SideStates: Map<ProvenanceLayerSideId, SideViewState>
     PropertyRailPlacements: Map<ProvenanceLayerId * GroupingKey, ProvenanceSide>
+    PropertyRailOrders: Map<ProvenanceLayerId * ProvenanceSide, ProvenancePropertyHeader list>
     ExpandedProperties: Set<ProvenanceLayerId * ProvenanceSide * GroupingKey>
     PaletteValues: Map<ProvenanceLayerId * ProvenanceSide, ProvenancePropertyValue list>
     PendingAssignmentBatch: PendingAssignmentBatch option

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -86,6 +86,60 @@ type ManualResolutionPair = {
     OutputGroupId: string
 }
 
+type ProvenanceColor = string
+
+type PropertyColorSettings = {
+    ManualPropertyColors: Map<GroupingKey, ProvenanceColor>
+    LayerColors: Map<ProvenanceLayerId, ProvenanceColor>
+}
+
+[<RequireQualifiedAccess>]
+type PropertySort =
+    | ValueCountDesc
+    | NameAsc
+    | Origin
+
+[<RequireQualifiedAccess>]
+type GroupSort =
+    | NameAsc
+    | MemberCountDesc
+    | ConnectionCountDesc
+
+[<RequireQualifiedAccess>]
+type PropertyValueCountFilter =
+    | Any
+    | Singleton
+    | Multiple
+    | CoverageGap
+
+[<RequireQualifiedAccess>]
+type PropertyOriginFilter =
+    | AnyOrigin
+    | CurrentOnly
+    | AnyUpstream
+    | UpstreamLayer of ProvenanceLayerId
+    | PreviousContext of tableName: ProvenanceTableName * processName: ProvenanceProcessName option
+
+type FilterState = {
+    SearchText: string
+    PropertySort: PropertySort
+    GroupSort: GroupSort
+    ValueCountFilter: PropertyValueCountFilter
+    OriginFilter: PropertyOriginFilter
+}
+
+type PropertyStats = {
+    Header: ProvenancePropertyHeader
+    DistinctValueCount: int
+    SetsWithValueCount: int
+    TotalSetCount: int
+}
+
+type PropertyCountBadge =
+    | Hide
+    | DistinctValues of int
+    | Coverage of setsWithValueCount: int * totalSetCount: int
+
 type UiState = {
     LayerStates: Map<ProvenanceLayerId, LayerViewState>
     PropertyRailPlacements: Map<ProvenancePairId * GroupingKey, ProvenanceSide>
@@ -99,6 +153,8 @@ type UiState = {
     SelectedOutputs: Set<ProvenancePairId * string>
     Detail: ProvenanceDetail option
     Error: string option
+    PropertyColors: PropertyColorSettings
+    Filters: FilterState
 }
 
 /// Builds demo sessions used by ProvenanceGrouping stories and browser tests.

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -45,6 +45,17 @@ type ValueAssignmentError =
     | MixedPropertyValueCounts of ProvenancePropertyHeader
     | MultiplePropertyValues of ProvenancePropertyHeader * ProvenanceSetId list
 
+type PropertyAssignmentBatch = {
+    Adds: CreateLoadedPropertyValueCommand list
+    Overwrites: ValueAssignmentWarning list
+}
+
+type PendingAssignmentBatch = {
+    Batch: PropertyAssignmentBatch
+    AffectedSideCount: int
+    AffectedValueCount: int
+}
+
 type PanelRatios = { Left: int; Middle: int; Right: int }
 
 [<RequireQualifiedAccess>]
@@ -145,7 +156,7 @@ type UiState = {
     PropertyRailPlacements: Map<ProvenancePairId * GroupingKey, ProvenanceSide>
     ExpandedProperties: Set<ProvenancePairId * ProvenanceSide * GroupingKey>
     PaletteValues: Map<ProvenancePairId * ProvenanceSide, ProvenancePropertyValue list>
-    PendingOverwrite: ValueAssignmentWarning option
+    PendingAssignmentBatch: PendingAssignmentBatch option
     PanelRatios: Map<ProvenancePairId, PanelRatios>
     PendingMemberResolution: PendingMemberResolution option
     ManualResolutionPairs: ManualResolutionPair list

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -108,7 +108,7 @@ type PropertyColorSettings = {
 type PropertySort =
     | ValueCountDesc
     | NameAsc
-    | Origin
+    | ConnectionCountDesc
 
 [<RequireQualifiedAccess>]
 type GroupSort =

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -84,7 +84,7 @@ type LiveConnectionDrag = {
 }
 
 type PendingMemberResolution = {
-    PairId: ProvenancePairId
+    LayerId: ProvenanceLayerId
     InputGroupId: string
     OutputGroupId: string
     InputMemberCount: int
@@ -92,7 +92,7 @@ type PendingMemberResolution = {
 }
 
 type ManualResolutionPair = {
-    PairId: ProvenancePairId
+    LayerId: ProvenanceLayerId
     InputGroupId: string
     OutputGroupId: string
 }
@@ -153,15 +153,15 @@ type PropertyCountBadge =
 
 type UiState = {
     SideStates: Map<ProvenanceLayerSideId, SideViewState>
-    PropertyRailPlacements: Map<ProvenancePairId * GroupingKey, ProvenanceSide>
-    ExpandedProperties: Set<ProvenancePairId * ProvenanceSide * GroupingKey>
-    PaletteValues: Map<ProvenancePairId * ProvenanceSide, ProvenancePropertyValue list>
+    PropertyRailPlacements: Map<ProvenanceLayerId * GroupingKey, ProvenanceSide>
+    ExpandedProperties: Set<ProvenanceLayerId * ProvenanceSide * GroupingKey>
+    PaletteValues: Map<ProvenanceLayerId * ProvenanceSide, ProvenancePropertyValue list>
     PendingAssignmentBatch: PendingAssignmentBatch option
-    PanelRatios: Map<ProvenancePairId, PanelRatios>
+    PanelRatios: Map<ProvenanceLayerId, PanelRatios>
     PendingMemberResolution: PendingMemberResolution option
     ManualResolutionPairs: ManualResolutionPair list
-    SelectedInputs: Set<ProvenancePairId * string>
-    SelectedOutputs: Set<ProvenancePairId * string>
+    SelectedInputs: Set<ProvenanceLayerId * string>
+    SelectedOutputs: Set<ProvenanceLayerId * string>
     Detail: ProvenanceDetail option
     Error: string option
     PropertyColors: PropertyColorSettings

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -96,6 +96,7 @@ type ProvenanceColor = string
 type PropertyColorSettings = {
     ManualPropertyColors: Map<GroupingKey, ProvenanceColor>
     LayerColors: Map<ProvenanceLayerId, ProvenanceColor>
+    FolderColors: Map<string, ProvenanceColor>
 }
 
 [<RequireQualifiedAccess>]

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -91,12 +91,6 @@ type PendingMemberResolution = {
     OutputMemberCount: int
 }
 
-type ManualResolutionPair = {
-    LayerId: ProvenanceLayerId
-    InputGroupId: string
-    OutputGroupId: string
-}
-
 type ProvenanceColor = string
 
 type PropertyColorSettings = {
@@ -160,7 +154,6 @@ type UiState = {
     PendingAssignmentBatch: PendingAssignmentBatch option
     PanelRatios: Map<ProvenanceLayerId, PanelRatios>
     PendingMemberResolution: PendingMemberResolution option
-    ManualResolutionPairs: ManualResolutionPair list
     SelectedInputs: Set<ProvenanceLayerId * string>
     SelectedOutputs: Set<ProvenanceLayerId * string>
     Detail: ProvenanceDetail option

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -156,6 +156,7 @@ type UiState = {
     PendingMemberResolution: PendingMemberResolution option
     SelectedInputs: Set<ProvenanceLayerId * string>
     SelectedOutputs: Set<ProvenanceLayerId * string>
+    ExpandedGroup: (ProvenanceSide * string) option
     Detail: ProvenanceDetail option
     Error: string option
     PropertyColors: PropertyColorSettings

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -12,7 +12,7 @@ type ProvenanceEditorChange = {
     Patches: ProvenanceTablePatch list
 }
 
-type LayerViewState = {
+type SideViewState = {
     GroupingAssignments: GroupingAssignment list
 }
 
@@ -152,7 +152,7 @@ type PropertyCountBadge =
     | Coverage of setsWithValueCount: int * totalSetCount: int
 
 type UiState = {
-    LayerStates: Map<ProvenanceLayerId, LayerViewState>
+    SideStates: Map<ProvenanceLayerSideId, SideViewState>
     PropertyRailPlacements: Map<ProvenancePairId * GroupingKey, ProvenanceSide>
     ExpandedProperties: Set<ProvenancePairId * ProvenanceSide * GroupingKey>
     PaletteValues: Map<ProvenancePairId * ProvenanceSide, ProvenancePropertyValue list>

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -126,6 +126,8 @@
     <Compile Include="Composite\ThemeSelector\Context.fs" />
     <Compile Include="Composite\ThemeSelector\ThemeProvider.fs" />
     <Compile Include="Composite\ThemeSelector\ThemeSelector.fs" />
+    <Compile Include="Composite\FolderedDraggableList\Types.fs" />
+    <Compile Include="Composite\FolderedDraggableList\FolderedDraggableList.fs" />
     <Compile Include="Composite\TermSearch\Types.fs" />
     <Compile Include="Composite\TermSearch\Context\ActiveKeysContext.fs" />
     <Compile Include="Composite\TermSearch\Context\AllKeysContext.fs" />

--- a/src/Components/src/index.js
+++ b/src/Components/src/index.js
@@ -2,6 +2,8 @@ export { default as TermSearch } from './output/Composite/TermSearch/TermSearch.
 export { default as TemplateFilter } from './output/Composite/TemplateBrowser/TemplateFilter.fs.ts';
 export * as Icons from './output/Primitive/Icons.fs.ts';
 export { default as ThemeProvider } from './output/Composite/ThemeSelector/ThemeProvider.fs.ts';
+export { FolderedDraggableList } from './output/Composite/FolderedDraggableList/FolderedDraggableList.fs.ts';
+export * from './output/Composite/FolderedDraggableList/Types.fs.ts';
 export { default as AnnotationTable } from './output/Composite/AnnotationTable/AnnotationTable.fs.ts';
 export { default as DataMapTable } from './output/Composite/DataMapTable/DataMapTable.fs.ts';
 export { Viewer as GitDiffViewer } from './output/Page/GitComparison/GitDiffViewer.fs.ts';

--- a/src/Electron/src/Renderer/Components/MainContent/ProvenanceGroupingTarget.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/ProvenanceGroupingTarget.fs
@@ -236,11 +236,15 @@ let ProvenanceGroupingTarget () =
                                     prop.text "Loading provenance..."
                                 ]
                             | Some session, false ->
-                                Swate.Components.Page.ProvenanceGrouping.ProvenanceGrouping.Main(
-                                    session,
-                                    onChange,
-                                    height = 760
-                                )
+                                Html.div [
+                                    prop.className "swt:flex-1 swt:min-h-0 swt:min-w-0 swt:overflow-hidden"
+                                    prop.children [
+                                        Swate.Components.Page.ProvenanceGrouping.ProvenanceGrouping.Main(
+                                            session,
+                                            onChange
+                                        )
+                                    ]
+                                ]
                             | None, false ->
                                 Html.div [
                                     prop.className

--- a/src/Electron/src/Swate.Electron.Shared/DTOs/ProvenanceGroupingDto.fs
+++ b/src/Electron/src/Swate.Electron.Shared/DTOs/ProvenanceGroupingDto.fs
@@ -46,6 +46,7 @@ type ProvenanceValueDto = {
 
 type ProvenanceWritebackAnchorDto = {
     TableName: ProvenanceTableName
+    ProcessId: ProvenanceProcessId option
     ProcessName: ProvenanceProcessName option
     Header: ProvenancePropertyHeaderDto
     InputNames: string[]
@@ -72,6 +73,7 @@ type ProvenanceSetDto = {
 type ProvenanceConnectionDto = {
     Id: ProvenanceConnectionId
     TableName: ProvenanceTableName
+    ProcessId: ProvenanceProcessId option
     ProcessName: ProvenanceProcessName option
     InputSetId: ProvenanceSetId
     OutputSetId: ProvenanceSetId
@@ -194,6 +196,7 @@ module ProvenanceWritebackAnchorDto =
 
     let ofModel (source: ProvenanceWritebackAnchor) = {
         TableName = source.TableName
+        ProcessId = source.ProcessId
         ProcessName = source.ProcessName
         Header = ProvenancePropertyHeaderDto.ofModel source.Header
         InputNames = source.InputNames |> List.toArray
@@ -202,6 +205,7 @@ module ProvenanceWritebackAnchorDto =
 
     let toModel (source: ProvenanceWritebackAnchorDto) : ProvenanceWritebackAnchor = {
         TableName = source.TableName
+        ProcessId = source.ProcessId
         ProcessName = source.ProcessName
         Header = ProvenancePropertyHeaderDto.toModel source.Header
         InputNames = source.InputNames |> Array.toList
@@ -251,6 +255,7 @@ module ProvenanceConnectionDto =
     let ofModel (connection: ProvenanceConnection) = {
         Id = connection.Id
         TableName = connection.TableName
+        ProcessId = connection.ProcessId
         ProcessName = connection.ProcessName
         InputSetId = connection.InputSetId
         OutputSetId = connection.OutputSetId
@@ -259,6 +264,7 @@ module ProvenanceConnectionDto =
     let toModel (connection: ProvenanceConnectionDto) : ProvenanceConnection = {
         Id = connection.Id
         TableName = connection.TableName
+        ProcessId = connection.ProcessId
         ProcessName = connection.ProcessName
         InputSetId = connection.InputSetId
         OutputSetId = connection.OutputSetId

--- a/src/Shared/ProvenanceGrouping/ARCtrlConverter.fs
+++ b/src/Shared/ProvenanceGrouping/ARCtrlConverter.fs
@@ -53,7 +53,9 @@ type ArcEndpointLocation = {
 type ArcWritebackLocation = {
     /// Study, assay, or run table containing this property value.
     Table: ArcTableLocation
-    /// Process name derived from ARCtrl table semantics.
+    /// Source-model process identity when ARCtrl exposes one.
+    ProcessId: ProvenanceProcessId option
+    /// Logical process name derived from ARCtrl table semantics.
     ProcessName: ProvenanceProcessName option
     /// Converted property header.
     Header: ProvenancePropertyHeader
@@ -70,7 +72,9 @@ type ArcWritebackLocation = {
 type ArcConnectionLocation = {
     /// Loaded table containing this input/output connection.
     Table: ArcTableLocation
-    /// Process name derived from the row that produced this connection.
+    /// Source-model process identity when ARCtrl exposes one.
+    ProcessId: ProvenanceProcessId option
+    /// Logical process name derived from the row that produced this connection.
     ProcessName: ProvenanceProcessName option
     /// Loaded input set ID in the core model.
     InputSetId: ProvenanceSetId
@@ -112,6 +116,7 @@ type internal TableRef = {
 
 type internal ProcessPairContext = {
     Location: ArcTableLocation
+    ProcessId: ProvenanceProcessId option
     ProcessName: ProvenanceProcessName option
     InputName: string option
     OutputName: string option
@@ -320,6 +325,7 @@ module internal Normalize =
 
     let sourceAnchor (pair: ProcessPairContext) header : ProvenanceWritebackAnchor = {
         TableName = pair.Location.TableName
+        ProcessId = pair.ProcessId
         ProcessName = pair.ProcessName
         Header = header
         InputNames = pairInputNames pair
@@ -328,6 +334,7 @@ module internal Normalize =
 
     let writebackLocation (pair: ProcessPairContext) header columnIndex : ArcWritebackLocation = {
         Table = pair.Location
+        ProcessId = pair.ProcessId
         ProcessName = pair.ProcessName
         Header = header
         InputNames = pairInputNames pair
@@ -448,6 +455,7 @@ module internal Dedup =
 
     let addConnection
         (location: ArcTableLocation)
+        processId
         processName
         inputSetId
         inputName
@@ -460,7 +468,7 @@ module internal Dedup =
                 [ "connection" ]
                 @ Normalize.locationParts location
                 @ [
-                    processName |> Option.defaultValue ""
+                    processId |> Option.defaultValue ""
                     inputSetId
                     outputSetId
                 ]
@@ -469,6 +477,7 @@ module internal Dedup =
         let connection: ProvenanceConnection = {
             Id = id
             TableName = location.TableName
+            ProcessId = processId
             ProcessName = processName
             InputSetId = inputSetId
             OutputSetId = outputSetId
@@ -476,6 +485,7 @@ module internal Dedup =
 
         let connectionLocation: ArcConnectionLocation = {
             Table = location
+            ProcessId = processId
             ProcessName = processName
             InputSetId = inputSetId
             OutputSetId = outputSetId
@@ -509,16 +519,6 @@ module internal Dedup =
             sets
 
     let private propertyValueId (candidate: CandidatePropertyValue) =
-        let inputNames =
-            candidate.Source
-            |> Option.map (fun source -> source.InputNames)
-            |> Option.defaultValue candidate.WritebackLocation.InputNames
-
-        let outputNames =
-            candidate.Source
-            |> Option.map (fun source -> source.OutputNames)
-            |> Option.defaultValue candidate.WritebackLocation.OutputNames
-
         Normalize.stableId (
             [ "property" ]
             @ Normalize.locationParts candidate.WritebackLocation.Table
@@ -526,8 +526,6 @@ module internal Dedup =
                 candidate.WritebackLocation.ProcessName |> Option.defaultValue ""
                 candidate.Header.Kind.Id
                 candidate.Header.Category.Name
-                String.concat "|" inputNames
-                String.concat "|" outputNames
                 Normalize.valueIdentityText candidate.Value candidate.Unit
             ]
         )
@@ -536,6 +534,30 @@ module internal Dedup =
         match map |> Map.tryFind propertyValueId with
         | Some _ -> map
         | None -> map |> Map.add propertyValueId location
+
+    let private mergeDistinct left right = left @ right |> List.distinct
+
+    let private keepExisting existing incoming =
+        match existing with
+        | Some _ -> existing
+        | None -> incoming
+
+    let private mergeSource
+        (existing: ProvenanceWritebackAnchor option)
+        (incoming: ProvenanceWritebackAnchor option)
+        : ProvenanceWritebackAnchor option =
+        match existing, incoming with
+        | Some existing, Some incoming ->
+            Some {
+                existing with
+                    ProcessId = keepExisting existing.ProcessId incoming.ProcessId
+                    ProcessName = keepExisting existing.ProcessName incoming.ProcessName
+                    InputNames = mergeDistinct existing.InputNames incoming.InputNames
+                    OutputNames = mergeDistinct existing.OutputNames incoming.OutputNames
+            }
+        | Some existing, None -> Some existing
+        | None, Some incoming -> Some incoming
+        | None, None -> None
 
     let addCandidateProperty (candidate: CandidatePropertyValue) (state: ConvertState) =
         let targetInputSetIds = candidate.TargetInputSetIds |> List.distinct
@@ -550,15 +572,18 @@ module internal Dedup =
             let id = propertyValueId candidate
 
             let propertyValue: ProvenancePropertyValue =
-                state.PropertyValues
-                |> Map.tryFind id
-                |> Option.defaultValue {
+                match state.PropertyValues |> Map.tryFind id with
+                | Some existing -> {
+                    existing with
+                        Source = mergeSource existing.Source candidate.Source
+                  }
+                | None -> {
                     Id = id
                     Header = candidate.Header
                     Value = candidate.Value
                     Unit = candidate.Unit
                     Source = candidate.Source
-                }
+                  }
 
             {
                 state with
@@ -606,7 +631,8 @@ module internal LoadedTable =
         : ProcessPairContext =
         {
             Location = location
-            ProcessName = proc.Name
+            ProcessId = proc.Name
+            ProcessName = Normalize.trimToOption location.TableName
             InputName = Normalize.trimToOption input.Name
             OutputName = Normalize.trimToOption output.Name
         }
@@ -820,7 +846,8 @@ module internal LoadedTable =
                             | Some inputSetId, Some inputName, Some outputSetId, Some outputName ->
                                 Dedup.addConnection
                                     location
-                                    proc.Name
+                                    pair.ProcessId
+                                    pair.ProcessName
                                     inputSetId
                                     inputName
                                     outputSetId
@@ -872,6 +899,7 @@ module internal PreviousContext =
                                 Normalize.locationParts pair.Location
                                 @ [
                                     pair.ProcessName |> Option.defaultValue ""
+                                    pair.ProcessId |> Option.defaultValue ""
                                     pair.InputName |> Option.defaultValue ""
                                     pair.OutputName |> Option.defaultValue ""
                                 ]

--- a/src/Shared/ProvenanceGrouping/Edit.fs
+++ b/src/Shared/ProvenanceGrouping/Edit.fs
@@ -36,11 +36,13 @@ type ProvenanceTablePatch =
         unit: ProvenanceTerm option
     | AddLoadedConnection of
         tableName: ProvenanceTableName *
+        processId: ProvenanceProcessId option *
         processName: ProvenanceProcessName option *
         inputSetId: ProvenanceSetId *
         outputSetId: ProvenanceSetId
     | RemoveLoadedConnection of
         tableName: ProvenanceTableName *
+        processId: ProvenanceProcessId option *
         processName: ProvenanceProcessName option *
         inputSetId: ProvenanceSetId *
         outputSetId: ProvenanceSetId
@@ -196,8 +198,19 @@ let private sourceFromTarget (model: ProvenanceModel) header target resolvedTarg
             )
         | _ -> None
 
+    let processId =
+        match target with
+        | ProvenancePropertyTarget.Connections connectionIds ->
+            connectionIds
+            |> List.tryPick (fun connectionId ->
+                model.Connections.TryFind connectionId
+                |> Option.bind (fun connection -> connection.ProcessId)
+            )
+        | _ -> None
+
     {
         TableName = model.LoadedTableName
+        ProcessId = processId
         ProcessName = processName
         Header = header
         InputNames = resolvedTarget.InputSets |> List.map (fun set -> set.Name) |> List.distinct
@@ -228,11 +241,15 @@ let private sourceFromLoadedMembership (model: ProvenanceModel) (propertyValue: 
 let private processNameCompatible (left: ProvenanceProcessName option) (right: ProvenanceProcessName option) =
     left = right || left.IsNone || right.IsNone
 
+let private processIdCompatible (left: ProvenanceProcessId option) (right: ProvenanceProcessId option) =
+    left = right || left.IsNone || right.IsNone
+
 let private sourceContextMatches (left: ProvenanceWritebackAnchor) (right: ProvenanceWritebackAnchor) =
     left.TableName = right.TableName
     && left.Header = right.Header
     && left.InputNames = right.InputNames
     && left.OutputNames = right.OutputNames
+    && processIdCompatible left.ProcessId right.ProcessId
     && processNameCompatible left.ProcessName right.ProcessName
 
 let private tryFindEquivalentLoadedPropertyValue
@@ -443,6 +460,7 @@ let removeConnection (connectionId: ProvenanceConnectionId) (model: ProvenanceMo
             [
                 ProvenanceTablePatch.RemoveLoadedConnection(
                     connection.TableName,
+                    connection.ProcessId,
                     connection.ProcessName,
                     connection.InputSetId,
                     connection.OutputSetId
@@ -460,6 +478,7 @@ let connectSets inputSetId outputSetId processName (model: ProvenanceModel) : Ed
         let connection: ProvenanceConnection = {
             Id = connectionId
             TableName = model.LoadedTableName
+            ProcessId = None
             ProcessName = processName
             InputSetId = inputSetId
             OutputSetId = outputSetId
@@ -475,6 +494,12 @@ let connectSets inputSetId outputSetId processName (model: ProvenanceModel) : Ed
         Ok(
             nextModel,
             [
-                ProvenanceTablePatch.AddLoadedConnection(model.LoadedTableName, processName, inputSetId, outputSetId)
+                ProvenanceTablePatch.AddLoadedConnection(
+                    model.LoadedTableName,
+                    None,
+                    processName,
+                    inputSetId,
+                    outputSetId
+                )
             ]
         )

--- a/src/Shared/ProvenanceGrouping/Fixtures.fs
+++ b/src/Shared/ProvenanceGrouping/Fixtures.fs
@@ -30,6 +30,7 @@ let propertyHeader kind name = { Kind = kind; Category = term name }
 
 let anchor tableName processName header inputNames outputNames : ProvenanceWritebackAnchor = {
     TableName = tableName
+    ProcessId = None
     ProcessName = processName
     Header = header
     InputNames = inputNames
@@ -65,6 +66,7 @@ let outputSet id tableName header name propertyValueIds : ProvenanceSet = {
 let connection id tableName processName inputSetId outputSetId : ProvenanceConnection = {
     Id = id
     TableName = tableName
+    ProcessId = None
     ProcessName = processName
     InputSetId = inputSetId
     OutputSetId = outputSetId

--- a/src/Shared/ProvenanceGrouping/Grouping.fs
+++ b/src/Shared/ProvenanceGrouping/Grouping.fs
@@ -226,9 +226,12 @@ let displayGroupsForAssignments (model: ProvenanceModel) side assignments =
     | activeAssignments ->
         let grouped = [
             for set in sets do
-                let keyValues = activeAssignments |> List.map (valuesForAssignment model side set)
+                let keyValues =
+                    activeAssignments
+                    |> List.map (valuesForAssignment model side set)
+                    |> List.filter (fun values -> values |> List.isEmpty |> not)
 
-                if keyValues |> List.exists List.isEmpty then
+                if keyValues.IsEmpty then
                     yield
                         groupId side [] set.Id,
                         set.TableName,

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -322,6 +322,13 @@ module Session =
         ProvenanceSet.effectivePropertyValueIds set
         |> List.choose (fun id -> model.PropertyValues.TryFind id |> Option.map (fun value -> id, value))
 
+    let private localOwnPropertyValueIds sourceLayer targetSet =
+        let sourcePropertyValueIds =
+            sourceLayer.Model.PropertyValues |> Map.toList |> List.map fst |> Set.ofList
+
+        targetSet.PropertyValueIds
+        |> List.filter (fun propertyValueId -> not (sourcePropertyValueIds.Contains propertyValueId))
+
     let private copySetData sourceRef targetRef session =
         let sourceLayer = layerAtRef sourceRef session
         let targetLayer = layerAtRef targetRef session
@@ -336,7 +343,12 @@ module Session =
 
             {
                 targetSet with
-                    PropertyValueIds = sourceSet.PropertyValueIds
+                    PropertyValueIds =
+                        [
+                            yield! sourceSet.PropertyValueIds
+                            yield! localOwnPropertyValueIds sourceLayer targetSet
+                        ]
+                        |> List.distinct
                     InheritedPropertyValueIds = inheritedPropertyValueIds
             }
 

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -6,6 +6,20 @@ open Swate.Components.Shared.ProvenanceGrouping.Edit
 type ProvenanceLayerId = string
 type ProvenancePairId = string
 
+type PropertyValueSourceInfo = {
+    TableName: ProvenanceTableName option
+    ProcessName: ProvenanceProcessName option
+    InputNames: string list
+    OutputNames: string list
+    IsCurrentTable: bool
+}
+
+[<RequireQualifiedAccess>]
+type PropertyOrigin =
+    | Current of pairId: ProvenancePairId * side: ProvenanceSide
+    | UpstreamLayer of layerId: ProvenanceLayerId
+    | PreviousContext of source: PropertyValueSourceInfo
+
 type ProvenanceLayer = { Id: ProvenanceLayerId; Label: string }
 
 type ProvenanceSetReference = {
@@ -562,3 +576,98 @@ module Session =
                 )
             )
             (Ok(session, []))
+
+    let private sourceInfoFromAnchor
+        (pair: ProvenanceLayerPair)
+        (source: ProvenanceWritebackAnchor)
+        : PropertyValueSourceInfo =
+        {
+            TableName = Some source.TableName
+            ProcessName = source.ProcessName
+            InputNames = source.InputNames
+            OutputNames = source.OutputNames
+            IsCurrentTable = source.TableName = pair.Model.LoadedTableName
+        }
+
+    let private propertyValueSourceFromLoadedMembership
+        (pair: ProvenanceLayerPair)
+        (propertyValue: ProvenancePropertyValue)
+        : PropertyValueSourceInfo option =
+        let inputSets =
+            pair.Model.InputSets
+            |> values
+            |> List.filter (fun set -> ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValue.Id)
+
+        let outputSets =
+            pair.Model.OutputSets
+            |> values
+            |> List.filter (fun set -> ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValue.Id)
+
+        match inputSets, outputSets with
+        | [], [] -> None
+        | _ ->
+            Some {
+                TableName = Some pair.Model.LoadedTableName
+                ProcessName = None
+                InputNames = inputSets |> List.map (fun set -> set.Name) |> List.distinct
+                OutputNames = outputSets |> List.map (fun set -> set.Name) |> List.distinct
+                IsCurrentTable = true
+            }
+
+    let propertyValueSourceInfo
+        (pair: ProvenanceLayerPair)
+        (propertyValue: ProvenancePropertyValue)
+        : PropertyValueSourceInfo option =
+        propertyValue.Source
+        |> Option.map (sourceInfoFromAnchor pair)
+        |> Option.orElseWith (fun () -> propertyValueSourceFromLoadedMembership pair propertyValue)
+
+    let private ownerReferences
+        (propertyValueId: ProvenancePropertyValueId)
+        (session: ProvenanceSession)
+        : ProvenanceSetReference list =
+        let pair = activePair session
+
+        [
+            for setId, set in pair.Model.InputSets |> Map.toList do
+                if ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValueId then
+                    yield activeRef ProvenanceSide.Input setId session
+            for setId, set in pair.Model.OutputSets |> Map.toList do
+                if ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValueId then
+                    yield activeRef ProvenanceSide.Output setId session
+        ]
+        |> List.map (fun reference -> nativeOwner reference session)
+        |> List.distinct
+
+    let private layerIdForReference
+        (reference: ProvenanceSetReference)
+        (session: ProvenanceSession)
+        : ProvenanceLayerId =
+        let pair = session.Pairs.[reference.PairId]
+
+        match reference.Side with
+        | ProvenanceSide.Input -> pair.LeftLayerId
+        | ProvenanceSide.Output -> pair.RightLayerId
+
+    let propertyValueOriginInSession
+        (pairId: ProvenancePairId)
+        (side: ProvenanceSide)
+        (propertyValueId: ProvenancePropertyValueId)
+        (session: ProvenanceSession)
+        : PropertyOrigin option =
+        match session.Pairs.TryFind pairId with
+        | None -> None
+        | Some pair ->
+            pair.Model.PropertyValues.TryFind propertyValueId
+            |> Option.map (fun propertyValue ->
+                let scoped = { session with ActivePairId = pairId }
+
+                match propertyValueSourceInfo pair propertyValue with
+                | Some source when source.TableName <> Some pair.Model.LoadedTableName ->
+                    PropertyOrigin.PreviousContext source
+                | _ ->
+                    match ownerReferences propertyValueId scoped with
+                    | owner :: _ when owner.PairId = pairId -> PropertyOrigin.Current(pairId, side)
+                    | owner :: _ -> PropertyOrigin.UpstreamLayer(layerIdForReference owner scoped)
+                    | [] -> PropertyOrigin.Current(pairId, side)
+            )

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -645,13 +645,9 @@ module Session =
 
     let private layerIdForReference
         (reference: ProvenanceSetReference)
-        (session: ProvenanceSession)
+        (_session: ProvenanceSession)
         : ProvenanceLayerId =
-        let pair = session.Pairs.[reference.PairId]
-
-        match reference.Side with
-        | ProvenanceSide.Input -> pair.LeftLayerId
-        | ProvenanceSide.Output -> pair.RightLayerId
+        reference.LayerId
 
     let propertyValueOriginInSession
         (pairId: ProvenancePairId)

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -10,6 +10,7 @@ type ProvenanceLayerSideId = string
 
 type PropertyValueSourceInfo = {
     TableName: ProvenanceTableName option
+    ProcessId: ProvenanceProcessId option
     ProcessName: ProvenanceProcessName option
     InputNames: string list
     OutputNames: string list
@@ -609,6 +610,7 @@ module Session =
         : PropertyValueSourceInfo =
         {
             TableName = Some source.TableName
+            ProcessId = source.ProcessId
             ProcessName = source.ProcessName
             InputNames = source.InputNames
             OutputNames = source.OutputNames
@@ -634,6 +636,7 @@ module Session =
         | _ ->
             Some {
                 TableName = Some layer.Model.LoadedTableName
+                ProcessId = None
                 ProcessName = None
                 InputNames = inputSets |> List.map (fun set -> set.Name) |> List.distinct
                 OutputNames = outputSets |> List.map (fun set -> set.Name) |> List.distinct

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -4,7 +4,8 @@ open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Edit
 
 type ProvenanceLayerId = string
-type ProvenancePairId = string
+type ProvenancePairId = ProvenanceLayerId
+type ProvenanceLayerSideId = string
 
 type PropertyValueSourceInfo = {
     TableName: ProvenanceTableName option
@@ -20,33 +21,51 @@ type PropertyOrigin =
     | UpstreamLayer of layerId: ProvenanceLayerId
     | PreviousContext of source: PropertyValueSourceInfo
 
-type ProvenanceLayer = { Id: ProvenanceLayerId; Label: string }
+type ProvenanceLayer = {
+    Id: ProvenanceLayerId
+    Label: string
+    InputSideId: ProvenanceLayerSideId
+    OutputSideId: ProvenanceLayerSideId
+    Model: ProvenanceModel
+} with
+
+    member this.LeftLayerId = this.InputSideId
+    member this.RightLayerId = this.OutputSideId
+
+type ProvenanceLayerPair = ProvenanceLayer
 
 type ProvenanceSetReference = {
-    PairId: ProvenancePairId
+    LayerId: ProvenanceLayerId
     Side: ProvenanceSide
     SetId: ProvenanceSetId
-}
+} with
 
-type ProvenanceBoundaryLink = {
-    Previous: ProvenanceSetReference
-    Next: ProvenanceSetReference
-}
+    member this.PairId = this.LayerId
 
-type ProvenanceLayerPair = {
-    Id: ProvenancePairId
-    LeftLayerId: ProvenanceLayerId
-    RightLayerId: ProvenanceLayerId
-    Model: ProvenanceModel
-}
+type ProvenanceReferenceLink = {
+    Source: ProvenanceSetReference
+    Target: ProvenanceSetReference
+} with
+
+    member this.Previous = this.Source
+    member this.Next = this.Target
+
+type ProvenanceBoundaryLink = ProvenanceReferenceLink
 
 type ProvenanceSession = {
     Layers: ProvenanceLayer list
-    Pairs: Map<ProvenancePairId, ProvenanceLayerPair>
-    PairOrder: ProvenancePairId list
-    ActivePairId: ProvenancePairId
-    BoundaryLinks: ProvenanceBoundaryLink list
-}
+    LayerOrder: ProvenanceLayerId list
+    ActiveLayerId: ProvenanceLayerId
+    ReferenceLinks: ProvenanceReferenceLink list
+    DirtyPropertyValueIds: Set<ProvenancePropertyValueId>
+} with
+    // Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
+    member this.Pairs =
+        this.Layers |> List.map (fun layer -> layer.Id, layer) |> Map.ofList
+
+    member this.PairOrder = this.LayerOrder
+    member this.ActivePairId = this.ActiveLayerId
+    member this.BoundaryLinks = this.ReferenceLinks
 
 [<RequireQualifiedAccess>]
 type SessionError =
@@ -62,31 +81,50 @@ type SessionResult = Result<ProvenanceSession * ProvenanceTablePatch list, Sessi
 
 module Session =
 
+    let private sideId layerId side =
+        match side with
+        | ProvenanceSide.Input -> $"{layerId}-input"
+        | ProvenanceSide.Output -> $"{layerId}-output"
+
+    let private layerLabel index =
+        if index = 1 then "Layer 1" else $"Layer {index}"
+
     let init model =
-        let pair = {
-            Id = "pair-1"
-            LeftLayerId = "layer-1"
-            RightLayerId = "layer-2"
+        let layerId = "layer-1"
+
+        let layer = {
+            Id = layerId
+            Label = layerLabel 1
+            InputSideId = sideId layerId ProvenanceSide.Input
+            OutputSideId = sideId layerId ProvenanceSide.Output
             Model = model
         }
 
         {
-            Layers = [
-                { Id = "layer-1"; Label = "Inputs" }
-                { Id = "layer-2"; Label = "Outputs" }
-            ]
-            Pairs = Map.ofList [ pair.Id, pair ]
-            PairOrder = [ pair.Id ]
-            ActivePairId = pair.Id
-            BoundaryLinks = []
+            Layers = [ layer ]
+            LayerOrder = [ layer.Id ]
+            ActiveLayerId = layer.Id
+            ReferenceLinks = []
+            DirtyPropertyValueIds = Set.empty
         }
 
-    let activePair session = session.Pairs.[session.ActivePairId]
+    let tryLayer layerId session =
+        session.Layers |> List.tryFind (fun layer -> layer.Id = layerId)
 
-    let selectPair pairId session : SessionResult =
-        match session.Pairs.TryFind pairId with
-        | Some _ -> Ok({ session with ActivePairId = pairId }, [])
-        | None -> Error(SessionError.PairNotFound pairId)
+    let layerById layerId session =
+        tryLayer layerId session
+        |> Option.defaultWith (fun () -> failwithf "Unknown provenance layer '%s'." layerId)
+
+    let activeLayer session = layerById session.ActiveLayerId session
+
+    let activePair session = activeLayer session
+
+    let selectLayer layerId session : SessionResult =
+        match tryLayer layerId session with
+        | Some _ -> Ok({ session with ActiveLayerId = layerId }, [])
+        | None -> Error(SessionError.PairNotFound layerId)
+
+    let selectPair pairId session : SessionResult = selectLayer pairId session
 
     let private values map = map |> Map.toList |> List.map snd
 
@@ -95,7 +133,7 @@ module Session =
         | ProvenanceSide.Input -> pair.Model.InputSets.TryFind setId
         | ProvenanceSide.Output -> pair.Model.OutputSets.TryFind setId
 
-    let private nextIndex session = session.PairOrder.Length + 1
+    let private nextIndex session = session.LayerOrder.Length + 1
 
     let private nextInputSetId pairId side index setId =
         let sideText =
@@ -106,7 +144,7 @@ module Session =
         $"{pairId}-from-{sideText}-{index}-{setId}"
 
     let addLayer command session : SessionResult =
-        let current = activePair session
+        let current = activeLayer session
 
         let selectedSets =
             match command.SelectedSets with
@@ -122,7 +160,7 @@ module Session =
             |> List.tryPick (fun (side, setId) ->
                 if setAt side setId current |> Option.isNone then
                     Some {
-                        PairId = current.Id
+                        LayerId = current.Id
                         Side = side
                         SetId = setId
                     }
@@ -142,38 +180,11 @@ module Session =
             let hasSelectedOutput =
                 selectedSets |> List.exists (fst >> (=) ProvenanceSide.Output)
 
-            let leftLayerId, newLayers =
+            let leftLayerId =
                 match hasSelectedInput, hasSelectedOutput with
-                | true, true ->
-                    let selectionId = $"selection-{layerNumber}"
-
-                    selectionId,
-                    [
-                        {
-                            Id = selectionId
-                            Label = $"Selection {layerNumber}"
-                        }
-                        {
-                            Id = layerId
-                            Label = $"Layer {layerNumber}"
-                        }
-                    ]
-                | true, false ->
-                    current.LeftLayerId,
-                    [
-                        {
-                            Id = layerId
-                            Label = $"Layer {layerNumber}"
-                        }
-                    ]
-                | false, _ ->
-                    current.RightLayerId,
-                    [
-                        {
-                            Id = layerId
-                            Label = $"Layer {layerNumber}"
-                        }
-                    ]
+                | true, true -> $"selection-{layerNumber}"
+                | true, false -> current.LeftLayerId
+                | false, _ -> current.RightLayerId
 
             let inputs, links =
                 selectedSets
@@ -183,13 +194,13 @@ module Session =
                     let projected = { source with Id = nextId }
 
                     let link = {
-                        Previous = {
-                            PairId = current.Id
+                        Source = {
+                            LayerId = current.Id
                             Side = side
                             SetId = setId
                         }
-                        Next = {
-                            PairId = pairId
+                        Target = {
+                            LayerId = pairId
                             Side = ProvenanceSide.Input
                             SetId = nextId
                         }
@@ -213,8 +224,9 @@ module Session =
 
             let pair = {
                 Id = pairId
-                LeftLayerId = leftLayerId
-                RightLayerId = layerId
+                Label = $"Layer {pairIndex}"
+                InputSideId = leftLayerId
+                OutputSideId = layerId
                 Model = {
                     LoadedTableName = current.Model.LoadedTableName
                     PropertyValues = projectedPropertyValues
@@ -227,32 +239,37 @@ module Session =
             Ok(
                 {
                     session with
-                        Layers = session.Layers @ newLayers
-                        Pairs = session.Pairs |> Map.add pair.Id pair
-                        PairOrder = session.PairOrder @ [ pair.Id ]
-                        ActivePairId = pair.Id
-                        BoundaryLinks = session.BoundaryLinks @ List.rev links
+                        Layers = session.Layers @ [ pair ]
+                        LayerOrder = session.LayerOrder @ [ pair.Id ]
+                        ActiveLayerId = pair.Id
+                        ReferenceLinks = session.ReferenceLinks @ List.rev links
                 },
                 []
             )
 
-    let private replacePair pair session = {
+    let private replaceLayer layer session = {
         session with
-            Pairs = session.Pairs |> Map.add pair.Id pair
+            Layers =
+                session.Layers
+                |> List.map (fun current -> if current.Id = layer.Id then layer else current)
     }
 
     let private mapEditError = Result.mapError SessionError.EditFailed
 
-    let private updatePairModel pairId model session =
-        match session.Pairs.TryFind pairId with
-        | None -> Error(SessionError.PairNotFound pairId)
-        | Some pair -> Ok(replacePair { pair with Model = model } session)
+    let private updateLayerModel layerId model session =
+        match tryLayer layerId session with
+        | None -> Error(SessionError.PairNotFound layerId)
+        | Some layer -> Ok(replaceLayer { layer with Model = model } session)
 
     let private referencedPropertyValues set model =
         ProvenanceSet.effectivePropertyValueIds set
         |> List.choose (fun id -> model.PropertyValues.TryFind id |> Option.map (fun value -> id, value))
 
-    let private copySetData sourceRef targetRef session =
+    let private copySetData
+        (sourceRef: ProvenanceSetReference)
+        (targetRef: ProvenanceSetReference)
+        (session: ProvenanceSession)
+        =
         let sourcePair = session.Pairs.[sourceRef.PairId]
         let targetPair = session.Pairs.[targetRef.PairId]
         let sourceSet = (setAt sourceRef.Side sourceRef.SetId sourcePair).Value
@@ -288,7 +305,7 @@ module Session =
               }
             |> ProvenanceModel.refreshInheritedOutputProperties
 
-        replacePair { targetPair with Model = targetModel } session
+        replaceLayer { targetPair with Model = targetModel } session
 
     let private linkedRefs origin session =
         let rec collect pending seen =
@@ -297,7 +314,7 @@ module Session =
             | current :: rest when Set.contains current seen -> collect rest seen
             | current :: rest ->
                 let adjacent =
-                    session.BoundaryLinks
+                    session.ReferenceLinks
                     |> List.collect (fun link ->
                         if link.Previous = current then [ link.Next ]
                         elif link.Next = current then [ link.Previous ]
@@ -314,12 +331,15 @@ module Session =
         |> List.fold (fun state target -> copySetData origin target state) session
 
     let private activeRef side setId session = {
-        PairId = session.ActivePairId
+        LayerId = session.ActiveLayerId
         Side = side
         SetId = setId
     }
 
-    let private displayTargetRefs target session : Result<ProvenanceSetReference list, SessionError> =
+    let private displayTargetRefs
+        (target: ProvenancePropertyTarget)
+        (session: ProvenanceSession)
+        : Result<ProvenanceSetReference list, SessionError> =
         match target with
         | ProvenancePropertyTarget.InputSets ids ->
             ids |> List.map (fun id -> activeRef ProvenanceSide.Input id session) |> Ok
@@ -348,11 +368,11 @@ module Session =
                 (Ok [])
 
     let rec private nativeOwner reference session =
-        match session.BoundaryLinks |> List.tryFind (fun link -> link.Next = reference) with
+        match session.ReferenceLinks |> List.tryFind (fun link -> link.Next = reference) with
         | Some link -> nativeOwner link.Previous session
         | None -> reference
 
-    let private ownedSetTargets target session =
+    let private ownedSetTargets (target: ProvenancePropertyTarget) session =
         match target with
         | ProvenancePropertyTarget.Connections _ -> Ok []
         | _ ->
@@ -396,7 +416,7 @@ module Session =
         Edit.updatePropertyValue propertyValueId value unit pair.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updatePairModel pair.Id model session
+            updateLayerModel pair.Id model session
             |> Result.map (fun next ->
                 let propagated =
                     next.Pairs
@@ -410,7 +430,7 @@ module Session =
                                             |> Map.add propertyValueId model.PropertyValues.[propertyValueId]
                                 }
 
-                                replacePair
+                                replaceLayer
                                     {
                                         candidate with
                                             Model = candidateModel
@@ -463,16 +483,16 @@ module Session =
                 (Ok(session, []))
         )
 
-    let createCurrentLoadedPropertyValue command session : SessionResult =
+    let createCurrentLoadedPropertyValue (command: CreateLoadedPropertyValueCommand) session : SessionResult =
         let pair = activePair session
 
         Edit.createLoadedPropertyValue command pair.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updatePairModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
         )
 
-    let createLoadedPropertyValue command session : SessionResult =
+    let createLoadedPropertyValue (command: CreateLoadedPropertyValueCommand) session : SessionResult =
         match command.Target with
         | ProvenancePropertyTarget.Connections _ ->
             let pair = activePair session
@@ -482,7 +502,7 @@ module Session =
                 Edit.createLoadedPropertyValue command pair.Model
                 |> mapEditError
                 |> Result.bind (fun (model, patches) ->
-                    updatePairModel pair.Id model session
+                    updateLayerModel pair.Id model session
                     |> Result.map (fun next ->
                         let synchronized =
                             references
@@ -505,7 +525,7 @@ module Session =
                             Edit.createLoadedPropertyValue { command with Target = target } pair.Model
                             |> mapEditError
                             |> Result.bind (fun (model, addedPatches) ->
-                                updatePairModel pair.Id model state
+                                updateLayerModel pair.Id model state
                                 |> Result.map (fun next ->
                                     let synchronized =
                                         references
@@ -521,7 +541,7 @@ module Session =
                     (Ok(session, []))
             )
 
-    let copyPropertyValueToLoadedTarget propertyValueId target session : SessionResult =
+    let copyPropertyValueToLoadedTarget propertyValueId (target: ProvenancePropertyTarget) session : SessionResult =
         let pair = activePair session
 
         match pair.Model.PropertyValues.TryFind propertyValueId with
@@ -543,7 +563,7 @@ module Session =
         Edit.createLoadedSet command pair.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updatePairModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
         )
 
     let connectSets inputSetId outputSetId processName session : SessionResult =
@@ -552,7 +572,7 @@ module Session =
         Edit.connectSets inputSetId outputSetId processName pair.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updatePairModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
         )
 
     let removeConnection connectionId session : SessionResult =
@@ -561,7 +581,7 @@ module Session =
         Edit.removeConnection connectionId pair.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updatePairModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
         )
 
     let removeConnections connectionIds session : SessionResult =
@@ -660,7 +680,7 @@ module Session =
         | Some pair ->
             pair.Model.PropertyValues.TryFind propertyValueId
             |> Option.map (fun propertyValue ->
-                let scoped = { session with ActivePairId = pairId }
+                let scoped = { session with ActiveLayerId = pairId }
 
                 match propertyValueSourceInfo pair propertyValue with
                 | Some source when source.TableName <> Some pair.Model.LoadedTableName ->

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -4,6 +4,7 @@ open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Edit
 
 type ProvenanceLayerId = string
+// Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
 type ProvenancePairId = ProvenanceLayerId
 type ProvenanceLayerSideId = string
 
@@ -17,7 +18,7 @@ type PropertyValueSourceInfo = {
 
 [<RequireQualifiedAccess>]
 type PropertyOrigin =
-    | Current of pairId: ProvenancePairId * side: ProvenanceSide
+    | Current of layerId: ProvenanceLayerId * side: ProvenanceSide
     | UpstreamLayer of layerId: ProvenanceLayerId
     | PreviousContext of source: PropertyValueSourceInfo
 
@@ -29,9 +30,11 @@ type ProvenanceLayer = {
     Model: ProvenanceModel
 } with
 
+    // Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
     member this.LeftLayerId = this.InputSideId
     member this.RightLayerId = this.OutputSideId
 
+// Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
 type ProvenanceLayerPair = ProvenanceLayer
 
 type ProvenanceSetReference = {
@@ -40,6 +43,7 @@ type ProvenanceSetReference = {
     SetId: ProvenanceSetId
 } with
 
+    // Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
     member this.PairId = this.LayerId
 
 type ProvenanceReferenceLink = {
@@ -50,6 +54,7 @@ type ProvenanceReferenceLink = {
     member this.Previous = this.Source
     member this.Next = this.Target
 
+// Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
 type ProvenanceBoundaryLink = ProvenanceReferenceLink
 
 type ProvenanceSession = {
@@ -69,7 +74,7 @@ type ProvenanceSession = {
 
 [<RequireQualifiedAccess>]
 type SessionError =
-    | PairNotFound of ProvenancePairId
+    | LayerNotFound of ProvenanceLayerId
     | SetNotFound of ProvenanceSetReference
     | EditFailed of EditError
 
@@ -117,6 +122,7 @@ module Session =
 
     let activeLayer session = layerById session.ActiveLayerId session
 
+    // Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
     let activePair session = activeLayer session
 
     let private values map = map |> Map.toList |> List.map snd
@@ -239,7 +245,7 @@ module Session =
 
     let private updateLayerModel layerId model session =
         match tryLayer layerId session with
-        | None -> Error(SessionError.PairNotFound layerId)
+        | None -> Error(SessionError.LayerNotFound layerId)
         | Some layer -> Ok(replaceLayer { layer with Model = model } session)
 
     let private activeRef side setId session = {
@@ -445,9 +451,10 @@ module Session =
                 },
                 []
             )
-        | None -> Error(SessionError.PairNotFound layerId)
+        | None -> Error(SessionError.LayerNotFound layerId)
 
-    let selectPair pairId session : SessionResult = selectLayer pairId session
+    // Temporary adapter for component migration. Remove after downstream callers stop using pair terminology.
+    let selectPair layerId session : SessionResult = selectLayer layerId session
 
     let rec private nativeOwner reference session =
         match session.ReferenceLinks |> List.tryFind (fun link -> link.Next = reference) with
@@ -542,30 +549,33 @@ module Session =
                 session
 
     let createLoadedSet command session : SessionResult =
-        let pair = activePair session
+        let layer = activeLayer session
 
-        Edit.createLoadedSet command pair.Model
+        Edit.createLoadedSet command layer.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel layer.Id model session
+            |> Result.map (fun next -> next, patches)
         )
 
     let connectSets inputSetId outputSetId processName session : SessionResult =
-        let pair = activePair session
+        let layer = activeLayer session
 
-        Edit.connectSets inputSetId outputSetId processName pair.Model
+        Edit.connectSets inputSetId outputSetId processName layer.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel layer.Id model session
+            |> Result.map (fun next -> next, patches)
         )
 
     let removeConnection connectionId session : SessionResult =
-        let pair = activePair session
+        let layer = activeLayer session
 
-        Edit.removeConnection connectionId pair.Model
+        Edit.removeConnection connectionId layer.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel layer.Id model session
+            |> Result.map (fun next -> next, patches)
         )
 
     let removeConnections connectionIds session : SessionResult =
@@ -582,7 +592,7 @@ module Session =
             (Ok(session, []))
 
     let private sourceInfoFromAnchor
-        (pair: ProvenanceLayerPair)
+        (layer: ProvenanceLayer)
         (source: ProvenanceWritebackAnchor)
         : PropertyValueSourceInfo =
         {
@@ -590,20 +600,20 @@ module Session =
             ProcessName = source.ProcessName
             InputNames = source.InputNames
             OutputNames = source.OutputNames
-            IsCurrentTable = source.TableName = pair.Model.LoadedTableName
+            IsCurrentTable = source.TableName = layer.Model.LoadedTableName
         }
 
     let private propertyValueSourceFromLoadedMembership
-        (pair: ProvenanceLayerPair)
+        (layer: ProvenanceLayer)
         (propertyValue: ProvenancePropertyValue)
         : PropertyValueSourceInfo option =
         let inputSets =
-            pair.Model.InputSets
+            layer.Model.InputSets
             |> values
             |> List.filter (fun set -> ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValue.Id)
 
         let outputSets =
-            pair.Model.OutputSets
+            layer.Model.OutputSets
             |> values
             |> List.filter (fun set -> ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValue.Id)
 
@@ -611,7 +621,7 @@ module Session =
         | [], [] -> None
         | _ ->
             Some {
-                TableName = Some pair.Model.LoadedTableName
+                TableName = Some layer.Model.LoadedTableName
                 ProcessName = None
                 InputNames = inputSets |> List.map (fun set -> set.Name) |> List.distinct
                 OutputNames = outputSets |> List.map (fun set -> set.Name) |> List.distinct
@@ -619,24 +629,24 @@ module Session =
             }
 
     let propertyValueSourceInfo
-        (pair: ProvenanceLayerPair)
+        (layer: ProvenanceLayer)
         (propertyValue: ProvenancePropertyValue)
         : PropertyValueSourceInfo option =
         propertyValue.Source
-        |> Option.map (sourceInfoFromAnchor pair)
-        |> Option.orElseWith (fun () -> propertyValueSourceFromLoadedMembership pair propertyValue)
+        |> Option.map (sourceInfoFromAnchor layer)
+        |> Option.orElseWith (fun () -> propertyValueSourceFromLoadedMembership layer propertyValue)
 
     let private ownerReferences
         (propertyValueId: ProvenancePropertyValueId)
         (session: ProvenanceSession)
         : ProvenanceSetReference list =
-        let pair = activePair session
+        let layer = activeLayer session
 
         [
-            for setId, set in pair.Model.InputSets |> Map.toList do
+            for setId, set in layer.Model.InputSets |> Map.toList do
                 if ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValueId then
                     yield activeRef ProvenanceSide.Input setId session
-            for setId, set in pair.Model.OutputSets |> Map.toList do
+            for setId, set in layer.Model.OutputSets |> Map.toList do
                 if ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValueId then
                     yield activeRef ProvenanceSide.Output setId session
         ]
@@ -650,24 +660,24 @@ module Session =
         reference.LayerId
 
     let propertyValueOriginInSession
-        (pairId: ProvenancePairId)
+        (layerId: ProvenanceLayerId)
         (side: ProvenanceSide)
         (propertyValueId: ProvenancePropertyValueId)
         (session: ProvenanceSession)
         : PropertyOrigin option =
-        match session.Pairs.TryFind pairId with
+        match tryLayer layerId session with
         | None -> None
-        | Some pair ->
-            pair.Model.PropertyValues.TryFind propertyValueId
+        | Some layer ->
+            layer.Model.PropertyValues.TryFind propertyValueId
             |> Option.map (fun propertyValue ->
-                let scoped = { session with ActiveLayerId = pairId }
+                let scoped = { session with ActiveLayerId = layerId }
 
-                match propertyValueSourceInfo pair propertyValue with
-                | Some source when source.TableName <> Some pair.Model.LoadedTableName ->
+                match propertyValueSourceInfo layer propertyValue with
+                | Some source when source.TableName <> Some layer.Model.LoadedTableName ->
                     PropertyOrigin.PreviousContext source
                 | _ ->
                     match ownerReferences propertyValueId scoped with
-                    | owner :: _ when owner.PairId = pairId -> PropertyOrigin.Current(pairId, side)
+                    | owner :: _ when owner.LayerId = layerId -> PropertyOrigin.Current(layerId, side)
                     | owner :: _ -> PropertyOrigin.UpstreamLayer(layerIdForReference owner scoped)
-                    | [] -> PropertyOrigin.Current(pairId, side)
+                    | [] -> PropertyOrigin.Current(layerId, side)
             )

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -135,13 +135,13 @@ module Session =
 
     let private nextIndex session = session.LayerOrder.Length + 1
 
-    let private nextInputSetId pairId side index setId =
+    let private nextInputSetId layerId side index setId =
         let sideText =
             match side with
             | ProvenanceSide.Input -> "input"
             | ProvenanceSide.Output -> "output"
 
-        $"{pairId}-from-{sideText}-{index}-{setId}"
+        $"{layerId}-from-{sideText}-{index}-{setId}"
 
     let addLayer command session : SessionResult =
         let current = activeLayer session
@@ -171,26 +171,14 @@ module Session =
         match missing with
         | Some setRef -> Error(SessionError.SetNotFound setRef)
         | None ->
-            let pairIndex = nextIndex session
-            let layerNumber = pairIndex + 1
-            let pairId = $"pair-{pairIndex}"
-            let layerId = $"layer-{layerNumber}"
-            let hasSelectedInput = selectedSets |> List.exists (fst >> (=) ProvenanceSide.Input)
-
-            let hasSelectedOutput =
-                selectedSets |> List.exists (fst >> (=) ProvenanceSide.Output)
-
-            let leftLayerId =
-                match hasSelectedInput, hasSelectedOutput with
-                | true, true -> $"selection-{layerNumber}"
-                | true, false -> current.LeftLayerId
-                | false, _ -> current.RightLayerId
+            let layerIndex = nextIndex session
+            let layerId = $"layer-{layerIndex}"
 
             let inputs, links =
                 selectedSets
                 |> List.mapi (fun seedIndex (side, setId) ->
                     let source = (setAt side setId current).Value
-                    let nextId = nextInputSetId pairId side seedIndex setId
+                    let nextId = nextInputSetId layerId side seedIndex setId
                     let projected = { source with Id = nextId }
 
                     let link = {
@@ -200,7 +188,7 @@ module Session =
                             SetId = setId
                         }
                         Target = {
-                            LayerId = pairId
+                            LayerId = layerId
                             Side = ProvenanceSide.Input
                             SetId = nextId
                         }
@@ -223,10 +211,10 @@ module Session =
                 |> Map.filter (fun id _ -> projectedPropertyValueIds.Contains id)
 
             let pair = {
-                Id = pairId
-                Label = $"Layer {pairIndex}"
-                InputSideId = leftLayerId
-                OutputSideId = layerId
+                Id = layerId
+                Label = layerLabel layerIndex
+                InputSideId = sideId layerId ProvenanceSide.Input
+                OutputSideId = sideId layerId ProvenanceSide.Output
                 Model = {
                     LoadedTableName = current.Model.LoadedTableName
                     PropertyValues = projectedPropertyValues

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -119,13 +119,6 @@ module Session =
 
     let activePair session = activeLayer session
 
-    let selectLayer layerId session : SessionResult =
-        match tryLayer layerId session with
-        | Some _ -> Ok({ session with ActiveLayerId = layerId }, [])
-        | None -> Error(SessionError.PairNotFound layerId)
-
-    let selectPair pairId session : SessionResult = selectLayer pairId session
-
     let private values map = map |> Map.toList |> List.map snd
 
     let private setAt side setId pair =
@@ -249,19 +242,85 @@ module Session =
         | None -> Error(SessionError.PairNotFound layerId)
         | Some layer -> Ok(replaceLayer { layer with Model = model } session)
 
+    let private activeRef side setId session = {
+        LayerId = session.ActiveLayerId
+        Side = side
+        SetId = setId
+    }
+
+    let private layerAtRef reference session = layerById reference.LayerId session
+
+    let private setAtRef reference session =
+        let layer = layerAtRef reference session
+        setAt reference.Side reference.SetId layer
+
+    let private referencesForLayer layerId session =
+        let layer = layerById layerId session
+
+        [
+            for setId, _ in layer.Model.InputSets |> Map.toList do
+                yield {
+                    LayerId = layerId
+                    Side = ProvenanceSide.Input
+                    SetId = setId
+                }
+            for setId, _ in layer.Model.OutputSets |> Map.toList do
+                yield {
+                    LayerId = layerId
+                    Side = ProvenanceSide.Output
+                    SetId = setId
+                }
+        ]
+
+    let private adjacentReferences reference session =
+        session.ReferenceLinks
+        |> List.collect (fun link -> [
+            if link.Source = reference then
+                yield link.Target
+            if link.Target = reference then
+                yield link.Source
+        ])
+
+    let private referenceComponent seedRefs session =
+        let rec loop pending seen =
+            match pending with
+            | [] -> seen
+            | current :: rest when seen |> Set.contains current -> loop rest seen
+            | current :: rest ->
+                let next = adjacentReferences current session
+                loop (next @ rest) (seen |> Set.add current)
+
+        loop seedRefs Set.empty
+
+    let private referenceContainsPropertyValue propertyValueId reference session =
+        match setAtRef reference session with
+        | None -> false
+        | Some set -> ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValueId
+
+    let private dirtyReferencesInLayer layerId session =
+        referencesForLayer layerId session
+        |> List.filter (fun reference ->
+            session.DirtyPropertyValueIds
+            |> Set.exists (fun propertyValueId -> referenceContainsPropertyValue propertyValueId reference session)
+        )
+
+    let private affectedComponent previousLayerId nextLayerId session =
+        [
+            yield! dirtyReferencesInLayer previousLayerId session
+            yield! referencesForLayer nextLayerId session
+        ]
+        |> List.distinct
+        |> fun refs -> referenceComponent refs session
+
     let private referencedPropertyValues set model =
         ProvenanceSet.effectivePropertyValueIds set
         |> List.choose (fun id -> model.PropertyValues.TryFind id |> Option.map (fun value -> id, value))
 
-    let private copySetData
-        (sourceRef: ProvenanceSetReference)
-        (targetRef: ProvenanceSetReference)
-        (session: ProvenanceSession)
-        =
-        let sourcePair = session.Pairs.[sourceRef.PairId]
-        let targetPair = session.Pairs.[targetRef.PairId]
-        let sourceSet = (setAt sourceRef.Side sourceRef.SetId sourcePair).Value
-        let targetSet = (setAt targetRef.Side targetRef.SetId targetPair).Value
+    let private copySetData sourceRef targetRef session =
+        let sourceLayer = layerAtRef sourceRef session
+        let targetLayer = layerAtRef targetRef session
+        let sourceSet = (setAtRef sourceRef session).Value
+        let targetSet = (setAtRef targetRef session).Value
 
         let targetSet =
             let inheritedPropertyValueIds =
@@ -276,172 +335,147 @@ module Session =
             }
 
         let propertyValues =
-            referencedPropertyValues sourceSet sourcePair.Model
-            |> List.fold (fun state (id, value) -> Map.add id value state) targetPair.Model.PropertyValues
+            referencedPropertyValues sourceSet sourceLayer.Model
+            |> List.fold (fun state (id, value) -> Map.add id value state) targetLayer.Model.PropertyValues
 
         let targetModel =
             match targetRef.Side with
             | ProvenanceSide.Input -> {
-                targetPair.Model with
-                    InputSets = targetPair.Model.InputSets |> Map.add targetSet.Id targetSet
+                targetLayer.Model with
+                    InputSets = targetLayer.Model.InputSets |> Map.add targetSet.Id targetSet
                     PropertyValues = propertyValues
               }
             | ProvenanceSide.Output -> {
-                targetPair.Model with
-                    OutputSets = targetPair.Model.OutputSets |> Map.add targetSet.Id targetSet
+                targetLayer.Model with
+                    OutputSets = targetLayer.Model.OutputSets |> Map.add targetSet.Id targetSet
                     PropertyValues = propertyValues
               }
             |> ProvenanceModel.refreshInheritedOutputProperties
 
-        replaceLayer { targetPair with Model = targetModel } session
+        replaceLayer { targetLayer with Model = targetModel } session
 
-    let private linkedRefs origin session =
-        let rec collect pending seen =
-            match pending with
-            | [] -> seen
-            | current :: rest when Set.contains current seen -> collect rest seen
-            | current :: rest ->
-                let adjacent =
-                    session.ReferenceLinks
-                    |> List.collect (fun link ->
-                        if link.Previous = current then [ link.Next ]
-                        elif link.Next = current then [ link.Previous ]
-                        else []
-                    )
+    let private layerIndex (session: ProvenanceSession) (layerId: ProvenanceLayerId) =
+        session.LayerOrder
+        |> List.tryFindIndex ((=) layerId)
+        |> Option.defaultValue System.Int32.MaxValue
 
-                collect (adjacent @ rest) (Set.add current seen)
-
-        collect [ origin ] Set.empty |> Set.toList
-
-    let private synchronizeSet origin session =
-        linkedRefs origin session
-        |> List.filter ((<>) origin)
-        |> List.fold (fun state target -> copySetData origin target state) session
-
-    let private activeRef side setId session = {
-        LayerId = session.ActiveLayerId
-        Side = side
-        SetId = setId
-    }
-
-    let private displayTargetRefs
-        (target: ProvenancePropertyTarget)
+    let private propertyValueFromLayer
+        (layerId: ProvenanceLayerId)
+        (propertyValueId: ProvenancePropertyValueId)
         (session: ProvenanceSession)
-        : Result<ProvenanceSetReference list, SessionError> =
-        match target with
-        | ProvenancePropertyTarget.InputSets ids ->
-            ids |> List.map (fun id -> activeRef ProvenanceSide.Input id session) |> Ok
-        | ProvenancePropertyTarget.OutputSets ids ->
-            ids |> List.map (fun id -> activeRef ProvenanceSide.Output id session) |> Ok
-        | ProvenancePropertyTarget.Connections ids ->
-            let pair = activePair session
+        =
+        (layerById layerId session).Model.PropertyValues.TryFind propertyValueId
 
-            ids
-            |> List.fold
-                (fun result id ->
-                    result
-                    |> Result.bind (fun references ->
-                        match pair.Model.Connections.TryFind id with
-                        | None -> Error(SessionError.EditFailed(EditError.ConnectionNotFound id))
-                        | Some connection ->
-                            Ok(
-                                references
-                                @ [
-                                    activeRef ProvenanceSide.Input connection.InputSetId session
-                                    activeRef ProvenanceSide.Output connection.OutputSetId session
-                                ]
-                            )
-                    )
-                )
-                (Ok [])
+    let private applyPropertyValueToLayer
+        (layerId: ProvenanceLayerId)
+        (propertyValue: ProvenancePropertyValue)
+        (session: ProvenanceSession)
+        =
+        let layer = layerById layerId session
+
+        if layer.Model.PropertyValues.ContainsKey propertyValue.Id then
+            replaceLayer
+                {
+                    layer with
+                        Model = {
+                            layer.Model with
+                                PropertyValues = layer.Model.PropertyValues |> Map.add propertyValue.Id propertyValue
+                        }
+                }
+                session
+        else
+            session
+
+    let private applyPropertyValueToReference
+        (propertyValue: ProvenancePropertyValue)
+        (reference: ProvenanceSetReference)
+        (session: ProvenanceSession)
+        =
+        if referenceContainsPropertyValue propertyValue.Id reference session then
+            applyPropertyValueToLayer reference.LayerId propertyValue session
+        else
+            session
+
+    let private refreshDirtyProperties
+        previousLayerId
+        (referenceSet: Set<ProvenanceSetReference>)
+        (session: ProvenanceSession)
+        =
+        session.DirtyPropertyValueIds
+        |> Set.fold
+            (fun state propertyValueId ->
+                match propertyValueFromLayer previousLayerId propertyValueId state with
+                | None -> state
+                | Some propertyValue ->
+                    referenceSet
+                    |> Set.toList
+                    |> List.fold
+                        (fun current reference -> applyPropertyValueToReference propertyValue reference current)
+                        state
+            )
+            session
+
+    let private refreshStructuralLinks (referenceSet: Set<ProvenanceSetReference>) session =
+        session.ReferenceLinks
+        |> List.filter (fun link -> referenceSet.Contains link.Source && referenceSet.Contains link.Target)
+        |> List.sortBy (fun link -> layerIndex session link.Source.LayerId, layerIndex session link.Target.LayerId)
+        |> List.fold (fun state link -> copySetData link.Source link.Target state) session
+
+    let private refreshForFocusChange previousLayerId nextLayerId session =
+        let referenceSet = affectedComponent previousLayerId nextLayerId session
+
+        let withPropertyEdits = refreshDirtyProperties previousLayerId referenceSet session
+
+        let withStructuralRefresh = refreshStructuralLinks referenceSet withPropertyEdits
+
+        {
+            withStructuralRefresh with
+                DirtyPropertyValueIds = Set.empty
+        }
+
+    let selectLayer layerId session : SessionResult =
+        match tryLayer layerId session with
+        | Some _ ->
+            let refreshed = refreshForFocusChange session.ActiveLayerId layerId session
+
+            Ok(
+                {
+                    refreshed with
+                        ActiveLayerId = layerId
+                },
+                []
+            )
+        | None -> Error(SessionError.PairNotFound layerId)
+
+    let selectPair pairId session : SessionResult = selectLayer pairId session
 
     let rec private nativeOwner reference session =
         match session.ReferenceLinks |> List.tryFind (fun link -> link.Next = reference) with
         | Some link -> nativeOwner link.Previous session
         | None -> reference
 
-    let private ownedSetTargets (target: ProvenancePropertyTarget) session =
-        match target with
-        | ProvenancePropertyTarget.Connections _ -> Ok []
-        | _ ->
-            displayTargetRefs target session
-            |> Result.map (fun references ->
-                references
-                |> List.map (fun reference -> nativeOwner reference session)
-                |> List.distinct
-                |> List.groupBy (fun reference -> reference.PairId, reference.Side)
-                |> List.map (fun ((pairId, side), references) ->
-                    let setIds = references |> List.map (fun reference -> reference.SetId)
-
-                    let target =
-                        match side with
-                        | ProvenanceSide.Input -> ProvenancePropertyTarget.InputSets setIds
-                        | ProvenanceSide.Output -> ProvenancePropertyTarget.OutputSets setIds
-
-                    pairId, target, references
-                )
-            )
-
-    let private activePropertyOwnerPair propertyValueId session =
-        let pair = activePair session
-
-        [
-            for setId, set in pair.Model.InputSets |> Map.toList do
-                if ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValueId then
-                    yield activeRef ProvenanceSide.Input setId session
-            for setId, set in pair.Model.OutputSets |> Map.toList do
-                if ProvenanceSet.effectivePropertyValueIds set |> List.contains propertyValueId then
-                    yield activeRef ProvenanceSide.Output setId session
-        ]
-        |> List.tryHead
-        |> Option.map (fun reference -> (nativeOwner reference session).PairId)
-        |> Option.defaultValue pair.Id
-
     let updatePropertyValue propertyValueId value unit session : SessionResult =
-        let ownerPairId = activePropertyOwnerPair propertyValueId session
-        let pair = session.Pairs.[ownerPairId]
+        let layer = activeLayer session
 
-        Edit.updatePropertyValue propertyValueId value unit pair.Model
+        Edit.updatePropertyValue propertyValueId value unit layer.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updateLayerModel pair.Id model session
+            updateLayerModel layer.Id model session
             |> Result.map (fun next ->
-                let propagated =
-                    next.Pairs
-                    |> Map.fold
-                        (fun state pairId candidate ->
-                            if candidate.Model.PropertyValues.ContainsKey propertyValueId then
-                                let candidateModel = {
-                                    candidate.Model with
-                                        PropertyValues =
-                                            candidate.Model.PropertyValues
-                                            |> Map.add propertyValueId model.PropertyValues.[propertyValueId]
-                                }
-
-                                replaceLayer
-                                    {
-                                        candidate with
-                                            Model = candidateModel
-                                    }
-                                    state
-                            else
-                                state
-                        )
-                        next
-
-                propagated, patches
+                {
+                    next with
+                        DirtyPropertyValueIds = next.DirtyPropertyValueIds |> Set.add propertyValueId
+                },
+                patches
             )
         )
 
     let private validatePropertyValueUpdate propertyValueId value unit session =
-        let ownerPairId = activePropertyOwnerPair propertyValueId session
+        let layer = activeLayer session
 
-        match session.Pairs.TryFind ownerPairId with
-        | None -> Error(SessionError.PairNotFound ownerPairId)
-        | Some pair ->
-            Edit.updatePropertyValue propertyValueId value unit pair.Model
-            |> mapEditError
-            |> Result.map ignore
+        Edit.updatePropertyValue propertyValueId value unit layer.Model
+        |> mapEditError
+        |> Result.map ignore
 
     let updatePropertyValues
         (updates: (ProvenancePropertyValueId * ProvenanceValue * ProvenanceTerm option) list)
@@ -472,67 +506,29 @@ module Session =
         )
 
     let createCurrentLoadedPropertyValue (command: CreateLoadedPropertyValueCommand) session : SessionResult =
-        let pair = activePair session
+        let layer = activeLayer session
 
-        Edit.createLoadedPropertyValue command pair.Model
+        Edit.createLoadedPropertyValue command layer.Model
         |> mapEditError
         |> Result.bind (fun (model, patches) ->
-            updateLayerModel pair.Id model session |> Result.map (fun next -> next, patches)
+            updateLayerModel layer.Id model session
+            |> Result.map (fun next -> next, patches)
         )
 
     let createLoadedPropertyValue (command: CreateLoadedPropertyValueCommand) session : SessionResult =
-        match command.Target with
-        | ProvenancePropertyTarget.Connections _ ->
-            let pair = activePair session
+        let layer = activeLayer session
 
-            displayTargetRefs command.Target session
-            |> Result.bind (fun references ->
-                Edit.createLoadedPropertyValue command pair.Model
-                |> mapEditError
-                |> Result.bind (fun (model, patches) ->
-                    updateLayerModel pair.Id model session
-                    |> Result.map (fun next ->
-                        let synchronized =
-                            references
-                            |> List.fold (fun current reference -> synchronizeSet reference current) next
-
-                        synchronized, patches
-                    )
-                )
-            )
-        | _ ->
-            ownedSetTargets command.Target session
-            |> Result.bind (fun targets ->
-                targets
-                |> List.fold
-                    (fun result (pairId, target, references) ->
-                        result
-                        |> Result.bind (fun (state, patches) ->
-                            let pair = state.Pairs.[pairId]
-
-                            Edit.createLoadedPropertyValue { command with Target = target } pair.Model
-                            |> mapEditError
-                            |> Result.bind (fun (model, addedPatches) ->
-                                updateLayerModel pair.Id model state
-                                |> Result.map (fun next ->
-                                    let synchronized =
-                                        references
-                                        |> List.fold
-                                            (fun current reference -> synchronizeSet reference current)
-                                            next
-
-                                    synchronized, patches @ addedPatches
-                                )
-                            )
-                        )
-                    )
-                    (Ok(session, []))
-            )
+        Edit.createLoadedPropertyValue command layer.Model
+        |> mapEditError
+        |> Result.bind (fun (model, patches) ->
+            updateLayerModel layer.Id model session
+            |> Result.map (fun next -> next, patches)
+        )
 
     let copyPropertyValueToLoadedTarget propertyValueId (target: ProvenancePropertyTarget) session : SessionResult =
-        let pair = activePair session
+        let layer = activeLayer session
 
-        match pair.Model.PropertyValues.TryFind propertyValueId with
+        match layer.Model.PropertyValues.TryFind propertyValueId with
         | None -> Error(SessionError.EditFailed(EditError.PropertyNotFound propertyValueId))
         | Some propertyValue ->
             createLoadedPropertyValue

--- a/src/Shared/ProvenanceGrouping/Types.fs
+++ b/src/Shared/ProvenanceGrouping/Types.fs
@@ -4,8 +4,12 @@ module Swate.Components.Shared.ProvenanceGrouping.Types
 type ProvenanceTableName = string
 
 /// Optional process name from the source model.
-/// This is metadata for writeback/disambiguation, not a public process ID.
+/// This is display/logical metadata, not a unique process ID.
 type ProvenanceProcessName = string
+
+/// Optional stable source-model process identity for disambiguation/writeback.
+/// Adapters should keep generated row or object IDs here instead of appending them to `ProvenanceProcessName`.
+type ProvenanceProcessId = string
 
 /// Swate-local stable ID for one loaded input or output endpoint.
 /// The actual user-facing input/output name lives on `ProvenanceSet.Name`.
@@ -89,7 +93,9 @@ type ProvenancePropertyHeader = {
 type ProvenanceWritebackAnchor = {
     /// Source table containing the property value occurrence.
     TableName: ProvenanceTableName
-    /// Optional source process name when the adapter can provide one.
+    /// Optional source process ID when the adapter needs a unique process identity.
+    ProcessId: ProvenanceProcessId option
+    /// Optional source process name when the adapter can provide a logical/display name.
     ProcessName: ProvenanceProcessName option
     /// Property header to locate the source column/value family.
     Header: ProvenancePropertyHeader
@@ -178,6 +184,8 @@ type ProvenanceConnection = {
     Id: ProvenanceConnectionId
     /// Loaded table containing this editable connection.
     TableName: ProvenanceTableName
+    /// Optional process ID associated with this connection.
+    ProcessId: ProvenanceProcessId option
     /// Optional process name associated with this connection.
     ProcessName: ProvenanceProcessName option
     /// Loaded input endpoint ID.

--- a/tests/Electron.Core/ProvenanceGroupingState.test.fs
+++ b/tests/Electron.Core/ProvenanceGroupingState.test.fs
@@ -14,7 +14,7 @@ Vitest.describe (
             fun () ->
                 let session = sampleSession ()
                 let state = State.init session
-                let ensured = State.Layers.ensure session state
+                let ensured = State.Sides.ensure session state
 
                 Vitest.expect(obj.ReferenceEquals(ensured, state)).toBe (true)
         )
@@ -33,7 +33,7 @@ Vitest.describe (
                         ExpandedProperties = Set.singleton staleSlot
                 }
 
-                let ensured = State.Layers.ensure session state
+                let ensured = State.Sides.ensure session state
 
                 Vitest.expect(obj.ReferenceEquals(ensured, state)).toBe (false)
                 Vitest.expect(ensured.ExpandedProperties.Count).toBe (0)

--- a/tests/Electron.Core/ProvenanceGroupingState.test.fs
+++ b/tests/Electron.Core/ProvenanceGroupingState.test.fs
@@ -10,17 +10,17 @@ Vitest.describe (
     "ProvenanceGrouping State",
     fun () ->
         Vitest.test (
-            "Layers.ensure returns the same instance for unchanged state",
+            "Sides.ensure returns the same instance for unchanged state",
             fun () ->
                 let session = sampleSession ()
-                let state = State.init session
+                let state = State.Sides.ensure session (State.init session)
                 let ensured = State.Sides.ensure session state
 
                 Vitest.expect(obj.ReferenceEquals(ensured, state)).toBe (true)
         )
 
         Vitest.test (
-            "Layers.ensure still prunes pair-scoped state for removed pairs",
+            "Sides.ensure still prunes pair-scoped state for removed pairs",
             fun () ->
                 let session = sampleSession ()
                 let pair = Session.activePair session
@@ -29,7 +29,7 @@ Vitest.describe (
                 let staleSlot = "removed-pair", ProvenanceSide.Input, State.Keys.groupingKey header
 
                 let state = {
-                    State.init session with
+                    State.Sides.ensure session (State.init session) with
                         ExpandedProperties = Set.singleton staleSlot
                 }
 

--- a/tests/Shared/ProvenanceGrouping.ARCtrlConverter.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.ARCtrlConverter.Tests.fs
@@ -87,6 +87,36 @@ let private outputOnlyAssayTable () =
         [ term "23"; text "extract-b"; term "R2" ]
     ]
 
+let private repeatedMetaboliteExtractionTable () =
+    table "metabolite_extraction" [
+        CompositeHeader.Input IOType.Sample
+        CompositeHeader.Parameter(oa "Extraction buffer")
+        CompositeHeader.Parameter(oa "Biosource amount")
+        CompositeHeader.Output IOType.Sample
+    ] [
+        [
+            text "CAM_01"
+            term "water:methanol:chloroform"
+            term "6.1"
+            text "DB23"
+        ]
+        [
+            text "CAM_02"
+            term "water:methanol:chloroform"
+            term "5.2"
+            text "DB24"
+        ]
+    ]
+
+let private gasChromatographyLoadedTable () =
+    table "gas_chromatography" [
+        CompositeHeader.Input IOType.Sample
+        CompositeHeader.Output IOType.Data
+    ] [
+        [ text "DB23"; text "raw-a" ]
+        [ text "DB24"; text "raw-b" ]
+    ]
+
 let private previousStudyTableWithDuplicateOrganismColumns () =
     table "study-table" [
         CompositeHeader.Input IOType.Source
@@ -120,6 +150,19 @@ let private arcFixtureWithDuplicateTemperatureColumns () =
         ArcAssay.create (
             identifier = "assay-1",
             tables = ResizeArray [ loadedAssayTableWithDuplicateTemperatureColumns () ]
+        )
+
+    ARC(identifier = "arc-1", studies = ResizeArray [], assays = ResizeArray [ assay ])
+
+let private arcFixtureWithRepeatedPreviousProcessRows () =
+    let assay =
+        ArcAssay.create (
+            identifier = "assay-1",
+            tables =
+                ResizeArray [
+                    repeatedMetaboliteExtractionTable ()
+                    gasChromatographyLoadedTable ()
+                ]
         )
 
     ARC(identifier = "arc-1", studies = ResizeArray [], assays = ResizeArray [ assay ])
@@ -178,6 +221,12 @@ let private loadedTable: ArcTableLocation = {
     Scope = ArcTableScope.Assay
     ParentIdentifier = "assay-1"
     TableName = "assay-table"
+}
+
+let private gasChromatographyLoadedTableLocation: ArcTableLocation = {
+    Scope = ArcTableScope.Assay
+    ParentIdentifier = "assay-1"
+    TableName = "gas_chromatography"
 }
 
 let private convertWithPreviousContext () =
@@ -252,17 +301,18 @@ let tests =
                 |> List.map (fun (_, connection) ->
                     result.Model.InputSets.[connection.InputSetId].Name,
                     result.Model.OutputSets.[connection.OutputSetId].Name,
-                    connection.ProcessName
+                    connection.ProcessName,
+                    connection.ProcessId
                 )
                 |> List.sort
 
             Expect.equal
                 connectionPairs
                 [
-                    ("sample-a", "extract-a", Some "assay-table_0")
-                    ("sample-b", "extract-b", Some "assay-table_1")
+                    ("sample-a", "extract-a", Some "assay-table", Some "assay-table_0")
+                    ("sample-b", "extract-b", Some "assay-table", Some "assay-table_1")
                 ]
-                "Each loaded row should produce a loaded input/output connection."
+                "Each loaded row should produce a loaded input/output connection with a logical process name and row process id."
 
         testCase "attaches loaded property values to loaded sets"
         <| fun _ ->
@@ -412,6 +462,131 @@ let tests =
                 writebackLocation.Table.TableName
                 "assay-table"
                 "A representative writeback location should still be preserved."
+
+        testCase "reuses identical loaded values across generated row process names"
+        <| fun _ ->
+            let assay =
+                ArcAssay.create (identifier = "assay-1", tables = ResizeArray [ repeatedMetaboliteExtractionTable () ])
+
+            let arc =
+                ARC(identifier = "arc-1", studies = ResizeArray [], assays = ResizeArray [ assay ])
+
+            let location: ArcTableLocation = {
+                Scope = ArcTableScope.Assay
+                ParentIdentifier = "assay-1"
+                TableName = "metabolite_extraction"
+            }
+
+            let result =
+                fromLoadedArc
+                    {
+                        LoadedTable = location
+                        IncludePreviousContext = false
+                    }
+                    arc
+
+            let inputByName name =
+                result.Model.InputSets
+                |> Map.toSeq
+                |> Seq.map snd
+                |> Seq.find (fun set -> set.Name = name)
+
+            let valueIdsForHeader headerName set =
+                set.PropertyValueIds
+                |> List.filter (fun id -> result.Model.PropertyValues.[id].Header.Category.Name = headerName)
+
+            let cam01 = inputByName "CAM_01"
+            let cam02 = inputByName "CAM_02"
+            let cam01BufferIds = valueIdsForHeader "Extraction buffer" cam01
+            let cam02BufferIds = valueIdsForHeader "Extraction buffer" cam02
+            let cam01AmountIds = valueIdsForHeader "Biosource amount" cam01
+            let cam02AmountIds = valueIdsForHeader "Biosource amount" cam02
+
+            Expect.equal cam01BufferIds.Length 1 "The first row should reference one extraction buffer value."
+            Expect.equal cam02BufferIds.Length 1 "The second row should reference one extraction buffer value."
+
+            Expect.equal
+                cam01BufferIds.Head
+                cam02BufferIds.Head
+                "Equal loaded values from generated row process names should share one property value id."
+
+            Expect.equal cam01AmountIds.Length 1 "The first row should reference one biosource amount value."
+            Expect.equal cam02AmountIds.Length 1 "The second row should reference one biosource amount value."
+
+            Expect.isFalse
+                (cam01AmountIds.Head = cam02AmountIds.Head)
+                "Different values for the same property header should remain distinct property values."
+
+            let sharedBuffer = result.Model.PropertyValues.[cam01BufferIds.Head]
+
+            Expect.equal
+                (sharedBuffer.Source |> Option.bind (fun source -> source.ProcessName))
+                (Some "metabolite_extraction")
+                "Generated row process suffixes should not leak into the normalized property source process."
+
+            Expect.equal
+                (sharedBuffer.Source |> Option.bind (fun source -> source.ProcessId))
+                (Some "metabolite_extraction_0")
+                "The representative ARCtrl row process identity should be preserved separately from the process name."
+
+        testCase "reuses identical previous-context values across generated row process names"
+        <| fun _ ->
+            let result =
+                fromLoadedArc
+                    {
+                        LoadedTable = gasChromatographyLoadedTableLocation
+                        IncludePreviousContext = true
+                    }
+                    (arcFixtureWithRepeatedPreviousProcessRows ())
+
+            let inputByName name =
+                result.Model.InputSets
+                |> Map.toSeq
+                |> Seq.map snd
+                |> Seq.find (fun set -> set.Name = name)
+
+            let valueIdsForHeader headerName set =
+                set.PropertyValueIds
+                |> List.filter (fun id -> result.Model.PropertyValues.[id].Header.Category.Name = headerName)
+
+            let db23 = inputByName "DB23"
+            let db24 = inputByName "DB24"
+            let db23BufferIds = valueIdsForHeader "Extraction buffer" db23
+            let db24BufferIds = valueIdsForHeader "Extraction buffer" db24
+            let db23AmountIds = valueIdsForHeader "Biosource amount" db23
+            let db24AmountIds = valueIdsForHeader "Biosource amount" db24
+
+            Expect.equal db23BufferIds.Length 1 "The first loaded input should inherit one extraction buffer value."
+            Expect.equal db24BufferIds.Length 1 "The second loaded input should inherit one extraction buffer value."
+
+            Expect.equal
+                db23BufferIds.Head
+                db24BufferIds.Head
+                "Equal previous-context values should share one property value id across loaded inputs."
+
+            Expect.equal db23AmountIds.Length 1 "The first loaded input should inherit one biosource amount value."
+            Expect.equal db24AmountIds.Length 1 "The second loaded input should inherit one biosource amount value."
+
+            Expect.isFalse
+                (db23AmountIds.Head = db24AmountIds.Head)
+                "Different previous-context values for the same property header should remain distinct."
+
+            let sharedBuffer = result.Model.PropertyValues.[db23BufferIds.Head]
+
+            Expect.equal
+                (sharedBuffer.Source |> Option.bind (fun source -> source.ProcessName))
+                (Some "metabolite_extraction")
+                "Previous-context folders should group by the logical source process, not row process suffixes."
+
+            Expect.equal
+                (sharedBuffer.Source |> Option.bind (fun source -> source.ProcessId))
+                (Some "metabolite_extraction_0")
+                "A representative ARCtrl row process id should remain available without being appended to the process name."
+
+            Expect.equal
+                (sharedBuffer.Source |> Option.map (fun source -> source.OutputNames))
+                (Some [ "DB23"; "DB24" ])
+                "A shared previous-context value should remember every loaded input it was attached through."
 
         testCase "collapsed previous-context duplicates keep one representative writeback slot"
         <| fun _ ->

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2132,6 +2132,46 @@ let uiStateTests =
             | other -> failwithf "Expected a multiple-value rejection, got %A" other
     ]
 
+let sourceTests =
+    testList "Source and origin" [
+        testCase "property source info exposes table and process metadata"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let pair = Session.activePair session
+            let value = pair.Model.PropertyValues.["pv-input-a-species"]
+            let source = Session.propertyValueSourceInfo pair value
+
+            Expect.isSome source "A fixture property value should expose source metadata."
+
+        testCase "property source info falls back to loaded membership"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let pair = Session.activePair session
+            let original = pair.Model.PropertyValues.["pv-input-a-species"]
+            let withoutSource = { original with Source = None }
+            let source = Session.propertyValueSourceInfo pair withoutSource
+
+            Expect.equal
+                (source |> Option.bind _.TableName)
+                (Some pair.Model.LoadedTableName)
+                "Membership fallback should keep current table context."
+
+        testCase "property origin uses the native upstream layer for projected values"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+
+            match Session.addLayer { SelectedSets = [] } session with
+            | Ok(layered, _) ->
+                let active = Session.activePair layered
+                let propertyValueId = active.Model.PropertyValues |> Map.toList |> List.head |> fst
+
+                let origin =
+                    Session.propertyValueOriginInSession active.Id ProvenanceSide.Input propertyValueId layered
+
+                Expect.isSome origin "Projected values should have an origin."
+            | Error error -> failwithf "Unexpected addLayer error: %A" error
+    ]
+
 let tests =
     testList "ProvenanceGrouping" [
         typeTests
@@ -2140,5 +2180,6 @@ let tests =
         editTests
         fixtureTests
         sessionTests
+        sourceTests
         uiStateTests
     ]

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -1731,23 +1731,67 @@ let sessionTests =
 
 let uiStateTests =
     testList "UI state" [
+        testCase "initial UI state creates side states for the active layer sides"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let layer = Session.activeLayer session
+            let state = State.init session
+
+            Expect.isTrue (state.SideStates.ContainsKey layer.InputSideId) "Input side state should exist."
+            Expect.isTrue (state.SideStates.ContainsKey layer.OutputSideId) "Output side state should exist."
+            Expect.equal state.SideStates.Count 2 "Initial layer should create exactly two side states."
+
+        testCase "new layer side states do not inherit grouping assignments"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let layer1 = Session.activeLayer session
+            let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
+
+            let grouped =
+                State.init session
+                |> State.GroupingAssignments.toggleSide layer1.OutputSideId ProvenanceSide.Output replicate
+
+            let layered =
+                match
+                    Session.addLayer
+                        {
+                            SelectedSets = [ ProvenanceSide.Output, "output-a" ]
+                        }
+                        session
+                with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected addLayer error: %A" error
+
+            let layer2 = Session.activeLayer layered
+            let nextState = State.Sides.ensure layered grouped
+
+            Expect.equal
+                (State.Sides.get layer2.InputSideId nextState).GroupingAssignments
+                []
+                "New layer input side should not inherit upstream grouping assignments."
+
+            Expect.equal
+                (State.Sides.get layer2.OutputSideId nextState).GroupingAssignments
+                []
+                "New layer output side should not inherit upstream grouping assignments."
+
         testCase "toggleSideGrouping applies grouping only to the selected layer side"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
             let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
 
             let next =
-                State.GroupingAssignments.toggleSide pair.RightLayerId ProvenanceSide.Output replicate state
+                State.GroupingAssignments.toggleSide layer.OutputSideId ProvenanceSide.Output replicate state
 
             Expect.equal
-                (State.Layers.get pair.LeftLayerId next).GroupingAssignments
+                (State.Sides.get layer.InputSideId next).GroupingAssignments
                 []
                 "Side-only output grouping should not change the input layer state."
 
             Expect.equal
-                (State.Layers.get pair.RightLayerId next).GroupingAssignments
+                (State.Sides.get layer.OutputSideId next).GroupingAssignments
                 [
                     {
                         Key = { Header = replicate }
@@ -1759,12 +1803,12 @@ let uiStateTests =
         testCase "toggleBothGrouping applies grouping to both active layer states"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
             let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
 
             let next =
-                State.GroupingAssignments.toggleBoth pair.LeftLayerId pair.RightLayerId replicate state
+                State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId replicate state
 
             let expected = [
                 {
@@ -1774,41 +1818,41 @@ let uiStateTests =
             ]
 
             Expect.equal
-                (State.Layers.get pair.LeftLayerId next).GroupingAssignments
+                (State.Sides.get layer.InputSideId next).GroupingAssignments
                 expected
                 "Both-side grouping should be visible from the input layer."
 
             Expect.equal
-                (State.Layers.get pair.RightLayerId next).GroupingAssignments
+                (State.Sides.get layer.OutputSideId next).GroupingAssignments
                 expected
                 "Both-side grouping should be visible from the output layer."
 
         testCase "moveGrouping switches a property to the target side only"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
 
             let selected =
-                State.GroupingAssignments.toggleSide pair.LeftLayerId ProvenanceSide.Input species state
+                State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input species state
 
             let next =
                 State.GroupingAssignments.move
-                    pair.Id
-                    pair.LeftLayerId
-                    pair.RightLayerId
+                    layer.Id
+                    layer.InputSideId
+                    layer.OutputSideId
                     ProvenanceSide.Output
                     species
                     selected
 
             Expect.equal
-                (State.Layers.get pair.LeftLayerId next).GroupingAssignments
+                (State.Sides.get layer.InputSideId next).GroupingAssignments
                 []
                 "Dragging a property away should remove it from the source layer."
 
             Expect.equal
-                (State.Layers.get pair.RightLayerId next).GroupingAssignments
+                (State.Sides.get layer.OutputSideId next).GroupingAssignments
                 [
                     {
                         Key = { Header = species }
@@ -1818,14 +1862,14 @@ let uiStateTests =
                 "Dragging a property to output should make it output-only."
 
             Expect.equal
-                (next.PropertyRailPlacements |> Map.tryFind (pair.Id, { Header = species }))
+                (next.PropertyRailPlacements |> Map.tryFind (layer.Id, { Header = species }))
                 (Some ProvenanceSide.Output)
                 "Dragging a property to output should move its rail control to the output side."
 
         testCase "toggleBothGrouping removes only both-scope assignments from inconsistent state"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
             let key = { Header = species }
@@ -1842,26 +1886,26 @@ let uiStateTests =
 
             let inconsistent = {
                 state with
-                    LayerStates =
-                        state.LayerStates
-                        |> Map.add pair.LeftLayerId {
+                    SideStates =
+                        state.SideStates
+                        |> Map.add layer.InputSideId {
                             GroupingAssignments = [ sideAssignment; bothAssignment ]
                         }
-                        |> Map.add pair.RightLayerId {
+                        |> Map.add layer.OutputSideId {
                             GroupingAssignments = [ bothAssignment ]
                         }
             }
 
             let next =
-                State.GroupingAssignments.toggleBoth pair.LeftLayerId pair.RightLayerId species inconsistent
+                State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId species inconsistent
 
             Expect.equal
-                (State.Layers.get pair.LeftLayerId next).GroupingAssignments
+                (State.Sides.get layer.InputSideId next).GroupingAssignments
                 [ sideAssignment ]
                 "Removing a both-side grouping should not silently drop an existing side-specific assignment for the same key."
 
             Expect.equal
-                (State.Layers.get pair.RightLayerId next).GroupingAssignments
+                (State.Sides.get layer.OutputSideId next).GroupingAssignments
                 []
                 "Only the both-side assignment should be removed from the opposite layer."
 

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2182,11 +2182,11 @@ let uiStateTests =
             let afterEnsure = State.PropertyColors.ensureLayerColors session state
 
             Expect.isTrue
-                (afterEnsure.PropertyColors.LayerColors.ContainsKey "layer-1")
+                (afterEnsure.LayerColors.ContainsKey "layer-1")
                 "Initial layer should have an automatic color."
 
             Expect.isTrue
-                (afterEnsure.PropertyColors.LayerColors.ContainsKey "layer-2")
+                (afterEnsure.LayerColors.ContainsKey "layer-2")
                 "Initial layer should have an automatic color."
 
         testCase "automatic colors do not overwrite existing manual layer colors"
@@ -2197,10 +2197,7 @@ let uiStateTests =
             let withManual = State.PropertyColors.setLayerColor "layer-1" "#be185d" state
             let afterEnsure = State.PropertyColors.ensureLayerColors session withManual
 
-            Expect.equal
-                afterEnsure.PropertyColors.LayerColors.["layer-1"]
-                "#be185d"
-                "Manual layer color should be preserved."
+            Expect.equal afterEnsure.LayerColors.["layer-1"] "#be185d" "Manual layer color should be preserved."
 
         testCase "stale layer colors are removed during cleanup"
         <| fun _ ->
@@ -2217,9 +2214,7 @@ let uiStateTests =
 
             let afterEnsure = State.PropertyColors.ensureLayerColors session withStale
 
-            Expect.isFalse
-                (afterEnsure.PropertyColors.LayerColors.ContainsKey "nonexistent")
-                "Stale layer color should be removed."
+            Expect.isFalse (afterEnsure.LayerColors.ContainsKey "nonexistent") "Stale layer color should be removed."
 
         testCase "default filter state uses Any filter and ValueCountDesc sort"
         <| fun _ ->
@@ -2269,6 +2264,125 @@ let uiStateTests =
                 State.Filters.setGroupSort Types.GroupSort.MemberCountDesc withOrigin
 
             Expect.equal withGroupSort.Filters.GroupSort Types.GroupSort.MemberCountDesc "Group sort should be updated."
+
+        testCase "value count sort keeps distinct value count as primary key"
+        <| fun _ ->
+            let highCount = propertyHeader (ProvenanceKind.create "z-kind" "Zeta kind") "Zeta"
+            let lowCount = propertyHeader (ProvenanceKind.create "a-kind" "Alpha kind") "Alpha"
+
+            let stats =
+                Map.ofList [
+                    highCount,
+                    ({
+                        Header = highCount
+                        DistinctValueCount = 3
+                        SetsWithValueCount = 3
+                        TotalSetCount = 3
+                    }
+                    : Types.PropertyStats)
+                    lowCount,
+                    ({
+                        Header = lowCount
+                        DistinctValueCount = 1
+                        SetsWithValueCount = 1
+                        TotalSetCount = 1
+                    }
+                    : Types.PropertyStats)
+                ]
+
+            let sorted =
+                PropertyProjection.sortHeaders Types.PropertySort.ValueCountDesc stats [ lowCount; highCount ]
+
+            Expect.equal sorted [ highCount; lowCount ] "Higher value count should sort before name/kind."
+
+        testCase "rail projection applies search and resolves manual property color"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let pair = Session.activePair session
+            let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+
+            let uiState =
+                State.init session
+                |> State.Filters.setSearch "Arabidopsis"
+                |> State.PropertyColors.setColor species "#2563eb"
+
+            let projection =
+                PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model uiState
+
+            Expect.contains projection.Headers species "Search should keep headers with matching projected values."
+            Expect.equal projection.ColorByHeader.[species] (Some "#2563eb") "Manual color should be projected."
+
+            let nonMatching =
+                uiState |> State.Filters.setSearch "definitely-not-a-provenance-value"
+
+            let emptyProjection =
+                PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model nonMatching
+
+            Expect.isEmpty emptyProjection.Headers "Search should remove non-matching property headers."
+
+        testCase "selected drop targets include selected inputs and outputs only when dropped group is selected"
+        <| fun _ ->
+            let inputGroup: DisplayGroup = {
+                Id = "input-group"
+                TableName = "assay-table"
+                Side = ProvenanceSide.Input
+                GroupingValues = []
+                Members = []
+            }
+
+            let outputGroup: DisplayGroup = {
+                inputGroup with
+                    Id = "output-group"
+                    Side = ProvenanceSide.Output
+            }
+
+            let findGroup side groupId =
+                match side, groupId with
+                | ProvenanceSide.Input, "input-group" -> Some inputGroup
+                | ProvenanceSide.Output, "output-group" -> Some outputGroup
+                | _ -> None
+
+            let selectedInputs = Set.ofList [ "pair-1", "input-group" ]
+            let selectedOutputs = Set.ofList [ "pair-1", "output-group" ]
+
+            let selectedTargets =
+                ValueAssignment.selectedTargetGroupsForDrop
+                    "pair-1"
+                    ProvenanceSide.Input
+                    "input-group"
+                    selectedInputs
+                    selectedOutputs
+                    findGroup
+
+            Expect.equal
+                (selectedTargets |> List.map (fun (group: DisplayGroup) -> group.Side, group.Id))
+                [
+                    ProvenanceSide.Input, "input-group"
+                    ProvenanceSide.Output, "output-group"
+                ]
+                "Dropping onto a selected group should target selected groups on both sides."
+
+            let unselectedDrop =
+                ValueAssignment.selectedTargetGroupsForDrop
+                    "pair-1"
+                    ProvenanceSide.Input
+                    "unselected-input"
+                    selectedInputs
+                    selectedOutputs
+                    (fun side groupId ->
+                        if side = ProvenanceSide.Input && groupId = "unselected-input" then
+                            Some {
+                                inputGroup with
+                                    Id = "unselected-input"
+                            }
+                        else
+                            findGroup side groupId
+                    )
+
+            Expect.equal
+                (unselectedDrop |> List.map (fun (group: DisplayGroup) -> group.Id))
+                [ "unselected-input" ]
+                "Dropping onto an unselected group should keep single-target behavior."
     ]
 
 let sourceTests =

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -1333,7 +1333,7 @@ let sessionTests =
                 Expect.isEmpty patches "Layer derivation should not write ARC data."
             | Error error -> failwithf "Expected mixed layer addition success, got %A" error
 
-        testCase "updating a carried property from the next pair updates the previous view once"
+        testCase "property edits propagate through linked snapshots on focus change"
         <| fun _ ->
             let first = Session.init (sampleModel ())
 
@@ -1348,66 +1348,288 @@ let sessionTests =
                 | Ok(next, _) -> next
                 | Error error -> failwithf "Unexpected addLayer error: %A" error
 
-            let nextPair = Session.activePair layered
-            let carriedInput = nextPair.Model.InputSets |> Map.toList |> List.exactlyOne |> snd
+            let layer2 = Session.activeLayer layered
+            let carriedInput = layer2.Model.InputSets |> Map.toList |> List.exactlyOne |> snd
             let analysisId = carriedInput.PropertyValueIds |> List.head
 
-            match Session.updatePropertyValue analysisId (ProvenanceValue.Text "Imaging") None layered with
-            | Ok(next, [ ProvenanceTablePatch.UpdatePropertyValue(id, _, _, ProvenanceValue.Text "Imaging", _) ]) ->
-                let originalValue = next.Pairs.["pair-1"].Model.PropertyValues.[analysisId].Value
-                let carriedValue = next.Pairs.["pair-2"].Model.PropertyValues.[analysisId].Value
-
-                Expect.equal id analysisId "Edit patch should identify the edited occurrence."
-                Expect.equal originalValue (ProvenanceValue.Text "Imaging") "Previous output view should update."
-                Expect.equal carriedValue (ProvenanceValue.Text "Imaging") "Later input view should update."
-            | other -> failwithf "Expected one synchronized update patch, got %A" other
-
-        testCase "assigning a value to a carried next input is reflected on its previous output"
-        <| fun _ ->
-            let first = Session.init (sampleModel ())
-
-            let layered =
-                match
-                    Session.addLayer
-                        {
-                            SelectedSets = [ ProvenanceSide.Output, "output-d" ]
-                        }
-                        first
-                with
+            let edited =
+                match Session.updatePropertyValue analysisId (ProvenanceValue.Text "Imaging") None layered with
                 | Ok(next, _) -> next
-                | Error error -> failwithf "Unexpected addLayer error: %A" error
+                | Error error -> failwithf "Unexpected updatePropertyValue error: %A" error
 
-            let projectedId =
-                (Session.activePair layered).Model.InputSets
-                |> Map.toList
-                |> List.exactlyOne
-                |> fst
+            let layer1BeforeFocus =
+                (Session.layerById "layer-1" edited).Model.PropertyValues.[analysisId].Value
+
+            let layer2BeforeFocus =
+                (Session.layerById "layer-2" edited).Model.PropertyValues.[analysisId].Value
+
+            Expect.notEqual
+                layer1BeforeFocus
+                (ProvenanceValue.Text "Imaging")
+                "Upstream layer should not update before focus refresh."
+
+            Expect.equal
+                layer2BeforeFocus
+                (ProvenanceValue.Text "Imaging")
+                "Focused downstream layer should update immediately."
+
+            match Session.selectLayer "layer-1" edited with
+            | Ok(refreshed, patches) ->
+                let layer1Value =
+                    (Session.layerById "layer-1" refreshed).Model.PropertyValues.[analysisId].Value
+
+                let layer2Value =
+                    (Session.layerById "layer-2" refreshed).Model.PropertyValues.[analysisId].Value
+
+                Expect.isEmpty patches "Focus refresh should not emit writeback patches."
+
+                Expect.equal
+                    layer1Value
+                    (ProvenanceValue.Text "Imaging")
+                    "Upstream layer should receive linked property edit."
+
+                Expect.equal
+                    layer2Value
+                    (ProvenanceValue.Text "Imaging")
+                    "Downstream layer should keep linked property edit."
+
+                Expect.isEmpty refreshed.DirtyPropertyValueIds "Focus refresh should clear dirty property ids."
+            | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+        testCase "upstream property additions refresh into downstream referenced inputs on focus change"
+        <| fun _ ->
+            let layered =
+                Session.init (sampleModel ())
+                |> Session.addLayer {
+                    SelectedSets = [ ProvenanceSide.Output, "output-d" ]
+                }
+                |> function
+                    | Ok(next, _) -> next
+                    | Error error -> failwithf "Unexpected addLayer error: %A" error
+
+            let backToLayer1 =
+                match Session.selectLayer "layer-1" layered with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected selectLayer error: %A" error
 
             let treatment = propertyHeader FixtureKinds.characteristicProperty "Treatment"
 
             let command = {
-                Target = ProvenancePropertyTarget.InputSets [ projectedId ]
+                Target = ProvenancePropertyTarget.OutputSets [ "output-d" ]
                 CopiedFrom = None
                 Header = treatment
                 Value = ProvenanceValue.Text "Drought"
                 Unit = None
             }
 
-            match Session.createLoadedPropertyValue command layered with
-            | Ok(next, [ ProvenanceTablePatch.AddLoadedPropertyValue(target, _, _, _, _) ]) ->
-                let previousOutput = next.Pairs.["pair-1"].Model.OutputSets.["output-d"]
-                let nextInput = next.Pairs.["pair-2"].Model.InputSets.[projectedId]
+            let edited =
+                match Session.createLoadedPropertyValue command backToLayer1 with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected createLoadedPropertyValue error: %A" error
+
+            let layer2BeforeFocus = Session.layerById "layer-2" edited
+
+            let inputBeforeFocus =
+                layer2BeforeFocus.Model.InputSets |> Map.toList |> List.exactlyOne |> snd
+
+            let valuesBeforeFocus =
+                ProvenanceSet.effectivePropertyValueIds inputBeforeFocus
+                |> List.choose (fun id -> layer2BeforeFocus.Model.PropertyValues.TryFind id)
+
+            Expect.isFalse
+                (valuesBeforeFocus |> List.exists (fun pv -> pv.Header = treatment))
+                "Downstream input should not receive upstream structural additions before focus refresh."
+
+            match Session.selectLayer "layer-2" edited with
+            | Ok(refreshed, patches) ->
+                let layer2 = Session.layerById "layer-2" refreshed
+                let input = layer2.Model.InputSets |> Map.toList |> List.exactlyOne |> snd
+
+                let values =
+                    ProvenanceSet.effectivePropertyValueIds input
+                    |> List.choose (fun id -> layer2.Model.PropertyValues.TryFind id)
+
+                Expect.isEmpty patches "Focus refresh should not emit writeback patches."
+
+                Expect.isTrue
+                    (values |> List.exists (fun pv -> pv.Header = treatment))
+                    "Downstream input should receive upstream property addition."
+            | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+        testCase "upstream property removals refresh into downstream referenced inputs on focus change"
+        <| fun _ ->
+            let layered =
+                Session.init (sampleModel ())
+                |> Session.addLayer {
+                    SelectedSets = [ ProvenanceSide.Output, "output-d" ]
+                }
+                |> function
+                    | Ok(next, _) -> next
+                    | Error error -> failwithf "Unexpected addLayer error: %A" error
+
+            let backToLayer1 =
+                match Session.selectLayer "layer-1" layered with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+            let layer1 = Session.layerById "layer-1" backToLayer1
+            let output = layer1.Model.OutputSets.["output-d"]
+            let removedId = ProvenanceSet.effectivePropertyValueIds output |> List.head
+
+            let trimmedOutput =
+                if output.PropertyValueIds |> List.contains removedId then
+                    {
+                        output with
+                            PropertyValueIds = output.PropertyValueIds |> List.filter ((<>) removedId)
+                    }
+                else
+                    {
+                        output with
+                            InheritedPropertyValueIds =
+                                output.InheritedPropertyValueIds
+                                |> Map.map (fun _ ids -> ids |> List.filter ((<>) removedId))
+                                |> Map.filter (fun _ ids -> not ids.IsEmpty)
+                    }
+
+            let trimmedLayer = {
+                layer1 with
+                    Model = {
+                        layer1.Model with
+                            OutputSets = layer1.Model.OutputSets |> Map.add output.Id trimmedOutput
+                    }
+            }
+
+            let edited = {
+                backToLayer1 with
+                    Layers =
+                        backToLayer1.Layers
+                        |> List.map (fun layer -> if layer.Id = trimmedLayer.Id then trimmedLayer else layer)
+            }
+
+            let layer2BeforeFocus = Session.layerById "layer-2" edited
+
+            let inputBeforeFocus =
+                layer2BeforeFocus.Model.InputSets |> Map.toList |> List.exactlyOne |> snd
+
+            Expect.isTrue
+                (ProvenanceSet.effectivePropertyValueIds inputBeforeFocus
+                 |> List.contains removedId)
+                "Downstream input should keep removed upstream property ids until focus refresh."
+
+            match Session.selectLayer "layer-2" edited with
+            | Ok(refreshed, patches) ->
+                let layer2 = Session.layerById "layer-2" refreshed
+                let input = layer2.Model.InputSets |> Map.toList |> List.exactlyOne |> snd
+                let inputIds = ProvenanceSet.effectivePropertyValueIds input
+
+                Expect.isEmpty patches "Focus refresh should not emit writeback patches."
+
+                Expect.isFalse
+                    (inputIds |> List.contains removedId)
+                    "Downstream input should drop removed upstream property ids."
+            | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+        testCase "connection-derived properties refresh downstream on focus change"
+        <| fun _ ->
+            let layered =
+                Session.init (sampleModel ())
+                |> Session.addLayer {
+                    SelectedSets = [ ProvenanceSide.Output, "output-a" ]
+                }
+                |> function
+                    | Ok(next, _) -> next
+                    | Error error -> failwithf "Unexpected addLayer error: %A" error
+
+            let backToLayer1 =
+                match Session.selectLayer "layer-1" layered with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+            let command = {
+                Target = ProvenancePropertyTarget.Connections [ "connection-a" ]
+                CopiedFrom = None
+                Header = propertyHeader FixtureKinds.parameterProperty "Analysis"
+                Value = ProvenanceValue.Text "Microscopy"
+                Unit = None
+            }
+
+            let edited =
+                match Session.createLoadedPropertyValue command backToLayer1 with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected createLoadedPropertyValue error: %A" error
+
+            let outputBeforeFocus =
+                (Session.layerById "layer-1" edited).Model.OutputSets.["output-a"]
+
+            let inputBeforeFocus =
+                (Session.layerById "layer-2" edited).Model.InputSets.["layer-2-from-output-0-output-a"]
+
+            Expect.notEqual
+                inputBeforeFocus.PropertyValueIds
+                outputBeforeFocus.PropertyValueIds
+                "Downstream input should not mirror connection-derived upstream property changes before focus refresh."
+
+            match Session.selectLayer "layer-2" edited with
+            | Ok(refreshed, patches) ->
+                let firstOutput =
+                    (Session.layerById "layer-1" refreshed).Model.OutputSets.["output-a"]
+
+                let nextInput =
+                    (Session.layerById "layer-2" refreshed).Model.InputSets.["layer-2-from-output-0-output-a"]
+
+                Expect.isEmpty patches "Focus refresh should not emit writeback patches."
 
                 Expect.equal
-                    target
-                    (ProvenancePropertyTarget.OutputSets [ "output-d" ])
-                    "A carried pair-2 input must write through its native pair-1 output owner."
-
-                Expect.equal
-                    previousOutput.PropertyValueIds
                     nextInput.PropertyValueIds
-                    "Linked endpoint views should share new properties."
-            | other -> failwithf "Expected one property-add patch, got %A" other
+                    firstOutput.PropertyValueIds
+                    "Downstream input should mirror connection-derived upstream output properties after refresh."
+            | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+        testCase "focus refresh does not change unreferenced downstream snapshots"
+        <| fun _ ->
+            let layered =
+                Session.init (sampleModel ())
+                |> Session.addLayer {
+                    SelectedSets = [ ProvenanceSide.Output, "output-a" ]
+                }
+                |> function
+                    | Ok(next, _) -> next
+                    | Error error -> failwithf "Unexpected addLayer error: %A" error
+
+            let backToLayer1 =
+                match Session.selectLayer "layer-1" layered with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+            let addedOutput =
+                match
+                    Session.createLoadedSet
+                        {
+                            Side = ProvenanceSide.Output
+                            Header = ioHeader FixtureKinds.dataEndpoint "Output [Data]"
+                            Name = "Unreferenced output"
+                        }
+                        backToLayer1
+                with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected createLoadedSet error: %A" error
+
+            match Session.selectLayer "layer-2" addedOutput with
+            | Ok(refreshed, patches) ->
+                let layer2 = Session.layerById "layer-2" refreshed
+
+                Expect.isEmpty patches "Focus refresh should not emit writeback patches."
+
+                Expect.equal
+                    layer2.Model.InputSets.Count
+                    1
+                    "Only the referenced downstream input snapshot should remain present."
+
+                Expect.isFalse
+                    (layer2.Model.InputSets
+                     |> Map.exists (fun _ set -> set.Name = "Unreferenced output"))
+                    "Unreferenced upstream structural additions should not appear downstream."
+            | Error error -> failwithf "Unexpected selectLayer error: %A" error
 
         testCase "assigning a palette value to a carried next input writes only to the active pair"
         <| fun _ ->
@@ -1564,154 +1786,6 @@ let sessionTests =
                 Expect.isEmpty pair.Model.OutputSets "A newly displayed transition has no invented outputs."
                 Expect.isEmpty patches "View-layer derivation is not a persistence edit."
             | Error error -> failwithf "Expected output-only layer derivation success, got %A" error
-
-        testCase "adding a connection property synchronizes a carried boundary endpoint"
-        <| fun _ ->
-            let session = Session.init (sampleModel ())
-
-            let layered =
-                Session.addLayer
-                    {
-                        SelectedSets = [ ProvenanceSide.Output, "output-a" ]
-                    }
-                    session
-                |> fun result ->
-                    match result with
-                    | Ok(next, _) -> next
-                    | Error error -> failwithf "Unexpected addLayer error: %A" error
-
-            let pair1 =
-                Session.selectPair "pair-1" layered
-                |> fun result ->
-                    match result with
-                    | Ok(next, _) -> next
-                    | Error error -> failwithf "Unexpected selectPair error: %A" error
-
-            let command = {
-                Target = ProvenancePropertyTarget.Connections [ "connection-a" ]
-                CopiedFrom = None
-                Header = propertyHeader FixtureKinds.parameterProperty "Analysis"
-                Value = ProvenanceValue.Text "Microscopy"
-                Unit = None
-            }
-
-            let edited =
-                Session.createLoadedPropertyValue command pair1
-                |> fun result ->
-                    match result with
-                    | Ok(next, _) -> next
-                    | Error error -> failwithf "Unexpected createLoadedPropertyValue error: %A" error
-
-            let firstOutput = edited.Pairs.["pair-1"].Model.OutputSets.["output-a"]
-
-            let nextInput =
-                edited.Pairs.["pair-2"].Model.InputSets.["pair-2-from-output-0-output-a"]
-
-            Expect.equal
-                nextInput.PropertyValueIds
-                firstOutput.PropertyValueIds
-                "linked input mirrors the edited output"
-
-        testCase "synchronizing a carried input back to an output recomputes output inherited pointers"
-        <| fun _ ->
-            let session = Session.init (sampleModel ())
-
-            let layered =
-                Session.addLayer
-                    {
-                        SelectedSets = [ ProvenanceSide.Output, "output-a" ]
-                    }
-                    session
-                |> function
-                    | Ok(next, _) -> next
-                    | Error error -> failwithf "Unexpected addLayer error: %A" error
-
-            let pair2 = Session.activePair layered
-            let projectedId = pair2.Model.InputSets |> Map.toList |> List.exactlyOne |> fst
-            let foreignHeader = propertyHeader FixtureKinds.parameterProperty "Foreign"
-
-            let foreignValue =
-                propertyValue "pv-foreign" foreignHeader (ProvenanceValue.Text "stale") None None
-
-            let pollutedInput = {
-                pair2.Model.InputSets.[projectedId] with
-                    InheritedPropertyValueIds =
-                        pair2.Model.InputSets.[projectedId].InheritedPropertyValueIds
-                        |> Map.add "foreign-connection" [ foreignValue.Id ]
-            }
-
-            let pollutedPair2 = {
-                pair2 with
-                    Model = {
-                        pair2.Model with
-                            PropertyValues = pair2.Model.PropertyValues |> Map.add foreignValue.Id foreignValue
-                            InputSets = pair2.Model.InputSets |> Map.add projectedId pollutedInput
-                    }
-            }
-
-            let polluted = {
-                layered with
-                    Layers =
-                        layered.Layers
-                        |> List.map (fun layer -> if layer.Id = pair2.Id then pollutedPair2 else layer)
-            }
-
-            let outputHeader = ioHeader FixtureKinds.dataEndpoint "Output [Data]"
-
-            let withOutput =
-                Session.createLoadedSet
-                    {
-                        Side = ProvenanceSide.Output
-                        Header = outputHeader
-                        Name = "Pair 2 Output"
-                    }
-                    polluted
-                |> function
-                    | Ok(next, _) -> next
-                    | Error error -> failwithf "Unexpected createLoadedSet error: %A" error
-
-            let pair2WithOutput = Session.activePair withOutput
-
-            let outputId =
-                pair2WithOutput.Model.OutputSets |> Map.toList |> List.exactlyOne |> fst
-
-            let connected =
-                Session.connectSets projectedId outputId None withOutput
-                |> function
-                    | Ok(next, _) -> next
-                    | Error error -> failwithf "Unexpected connectSets error: %A" error
-
-            let pair2ConnectionId =
-                (Session.activePair connected).Model.Connections
-                |> Map.toList
-                |> List.exactlyOne
-                |> fst
-
-            let syncHeader = propertyHeader FixtureKinds.parameterProperty "Sync"
-
-            let command = {
-                Target = ProvenancePropertyTarget.Connections [ pair2ConnectionId ]
-                CopiedFrom = None
-                Header = syncHeader
-                Value = ProvenanceValue.Text "pair-2"
-                Unit = None
-            }
-
-            let edited =
-                Session.createLoadedPropertyValue command connected
-                |> function
-                    | Ok(next, _) -> next
-                    | Error error -> failwithf "Unexpected createLoadedPropertyValue error: %A" error
-
-            let previousOutput = edited.Pairs.["pair-1"].Model.OutputSets.["output-a"]
-
-            Expect.isFalse
-                (previousOutput.InheritedPropertyValueIds.ContainsKey "foreign-connection")
-                "Synchronizing into an output must not copy inherited pointers from another pair verbatim."
-
-            Expect.isTrue
-                (previousOutput.InheritedPropertyValueIds.ContainsKey "connection-a")
-                "The output should keep inherited pointers recomputed from its own loaded connections."
 
         testCase "adding a value to a removed connection returns a session error"
         <| fun _ ->

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -1676,6 +1676,70 @@ let sessionTests =
                     "The active layer input should receive the new property value."
             | other -> failwithf "Expected one active-layer property-add patch, got %A" other
 
+        testCase "active layer property additions on carried inputs survive focus refresh"
+        <| fun _ ->
+            let layered =
+                Session.init (sampleModel ())
+                |> Session.addLayer {
+                    SelectedSets = [ ProvenanceSide.Output, "output-d" ]
+                }
+                |> function
+                    | Ok(next, _) -> next
+                    | Error error -> failwithf "Unexpected addLayer error: %A" error
+
+            let projectedId =
+                (Session.activeLayer layered).Model.InputSets
+                |> Map.toList
+                |> List.exactlyOne
+                |> fst
+
+            let treatment = propertyHeader FixtureKinds.characteristicProperty "Treatment"
+
+            let command = {
+                Target = ProvenancePropertyTarget.InputSets [ projectedId ]
+                CopiedFrom = None
+                Header = treatment
+                Value = ProvenanceValue.Text "Drought"
+                Unit = None
+            }
+
+            let added =
+                match Session.createCurrentLoadedPropertyValue command layered with
+                | Ok(next, _) -> next
+                | Error error -> failwithf "Unexpected createCurrentLoadedPropertyValue error: %A" error
+
+            let hasTreatment session =
+                let layer2 = Session.layerById "layer-2" session
+                let carriedInput = layer2.Model.InputSets.[projectedId]
+
+                ProvenanceSet.effectivePropertyValueIds carriedInput
+                |> List.choose (fun id -> layer2.Model.PropertyValues.TryFind id)
+                |> List.exists (fun value -> value.Header = treatment)
+
+            Expect.isTrue (hasTreatment added) "Sanity: active layer input should receive the local property addition."
+
+            let visitedLayer1 =
+                match Session.selectLayer "layer-1" added with
+                | Ok(next, patches) ->
+                    Expect.isEmpty patches "Focus refresh should not emit writeback patches."
+                    next
+                | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+            Expect.isTrue
+                (hasTreatment visitedLayer1)
+                "Local additions on a carried downstream input should not be dropped when focusing upstream."
+
+            let visitedLayer2 =
+                match Session.selectLayer "layer-2" visitedLayer1 with
+                | Ok(next, patches) ->
+                    Expect.isEmpty patches "Focus refresh should not emit writeback patches."
+                    next
+                | Error error -> failwithf "Unexpected selectLayer error: %A" error
+
+            Expect.isTrue
+                (hasTreatment visitedLayer2)
+                "Local additions on a carried downstream input should remain after returning to that layer."
+
         testCase "updating multiple property values uses the edit path for every value"
         <| fun _ ->
             let session = Session.init (validModel ())

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2547,7 +2547,10 @@ let uiStateTests =
             let projection =
                 PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model uiState
 
-            Expect.contains projection.Headers species "Search should keep headers with matching projected values."
+            Expect.isTrue
+                (projection.Headers |> List.contains species)
+                "Search should keep headers with matching projected values."
+
             Expect.equal projection.ColorByHeader.[species] (Some "#2563eb") "Manual color should be projected."
 
             let nonMatching =
@@ -2575,9 +2578,8 @@ let uiStateTests =
             let projection =
                 PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state
 
-            Expect.contains
-                projection.Headers
-                previousTreatment
+            Expect.isTrue
+                (projection.Headers |> List.contains previousTreatment)
                 "Attached previous context should still appear in the property rail."
 
             Expect.equal
@@ -2604,9 +2606,8 @@ let uiStateTests =
                 (inputHeaders |> List.contains species)
                 "A connected current input property should not be duplicated on the input rail by default."
 
-            Expect.contains
-                outputHeaders
-                species
+            Expect.isTrue
+                (outputHeaders |> List.contains species)
                 "A connected current input property should default to the output rail."
 
         testCase "previous context properties stay on input rail even when inherited by outputs"
@@ -2626,7 +2627,9 @@ let uiStateTests =
                 (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model state)
                     .Headers
 
-            Expect.contains inputHeaders previousTreatment "A previous-context property should stay on the input rail."
+            Expect.isTrue
+                (inputHeaders |> List.contains previousTreatment)
+                "A previous-context property should stay on the input rail."
 
             Expect.isFalse
                 (outputHeaders |> List.contains previousTreatment)
@@ -2659,9 +2662,8 @@ let uiStateTests =
                 (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model state)
                     .Headers
 
-            Expect.contains
-                inputHeaders
-                species
+            Expect.isTrue
+                (inputHeaders |> List.contains species)
                 "An incomplete layer with no output should keep current properties on the input rail."
 
             Expect.isFalse

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -36,6 +36,7 @@ let typeTests =
                 Source =
                     Some {
                         TableName = "previous-table"
+                        ProcessId = None
                         ProcessName = Some "previous-process"
                         Header = species
                         InputNames = [ "Ancestor A" ]
@@ -1004,7 +1005,7 @@ let editTests =
             let createdOutputId = created.OutputSets |> Map.toList |> List.exactlyOne |> fst
 
             match connectSets "input-a" createdOutputId None created with
-            | Ok(nextModel, [ ProvenanceTablePatch.AddLoadedConnection(_, _, inputSetId, outputSetId) ]) ->
+            | Ok(nextModel, [ ProvenanceTablePatch.AddLoadedConnection(_, _, _, inputSetId, outputSetId) ]) ->
                 Expect.equal inputSetId "input-a" "Connection patch should target the existing loaded input."
                 Expect.equal outputSetId createdOutputId "Connection patch should target the created loaded output."
 
@@ -1020,8 +1021,9 @@ let editTests =
 
             match connectSets "input-c" "output-a" None model with
             | Ok(nextModel,
-                 [ ProvenanceTablePatch.AddLoadedConnection(tableName, processName, inputSetId, outputSetId) ]) ->
+                 [ ProvenanceTablePatch.AddLoadedConnection(tableName, processId, processName, inputSetId, outputSetId) ]) ->
                 Expect.equal tableName "assay-table" "Patch should target loaded table."
+                Expect.equal processId None "Caller-created connections do not have a source process id."
                 Expect.equal processName None "Caller may create a connection without assigning a process name yet."
                 Expect.equal inputSetId "input-c" "Patch should keep input set."
                 Expect.equal outputSetId "output-a" "Patch should keep output set."
@@ -1044,8 +1046,13 @@ let editTests =
 
             match removeConnection "connection-c" model with
             | Ok(nextModel,
-                 [ ProvenanceTablePatch.RemoveLoadedConnection(tableName, processName, inputSetId, outputSetId) ]) ->
+                 [ ProvenanceTablePatch.RemoveLoadedConnection(tableName,
+                                                               processId,
+                                                               processName,
+                                                               inputSetId,
+                                                               outputSetId) ]) ->
                 Expect.equal tableName "assay-table" "Patch should target the loaded table."
+                Expect.equal processId None "Fixture connections do not have a source process id."
                 Expect.equal processName (Some "assay-process") "Patch should keep the process name for writeback."
                 Expect.equal inputSetId "input-b" "Patch should keep the input set."
                 Expect.equal outputSetId "output-b" "Patch should keep the output set."

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2340,20 +2340,26 @@ let uiStateTests =
             let cleared = State.PropertyColors.clearLayerColor "layer-1" withColor
             Expect.isFalse (cleared.PropertyColors.LayerColors.ContainsKey "layer-1") "Layer color should be cleared."
 
-        testCase "new layers get automatic colors from palette"
+        testCase "layer colors are assigned once per conceptual layer"
         <| fun _ ->
             let session = Session.init (sampleModel ())
             let state = State.init session
 
             let afterEnsure = State.PropertyColors.ensureLayerColors session state
 
-            Expect.isTrue
-                (afterEnsure.LayerColors.ContainsKey "layer-1")
-                "Initial layer should have an automatic color."
+            Expect.equal
+                afterEnsure.LayerColors.Count
+                session.LayerOrder.Length
+                "Each conceptual layer should receive exactly one automatic color."
 
             Expect.isTrue
-                (afterEnsure.LayerColors.ContainsKey "layer-2")
-                "Initial layer should have an automatic color."
+                (afterEnsure.LayerColors.ContainsKey "layer-1")
+                "Initial conceptual layer should have an automatic color."
+
+            Expect.isFalse
+                (afterEnsure.LayerColors.ContainsKey "layer-1-input"
+                 || afterEnsure.LayerColors.ContainsKey "layer-1-output")
+                "Input and output side ids should not receive separate default colors."
 
         testCase "automatic colors do not overwrite existing manual layer colors"
         <| fun _ ->
@@ -2663,19 +2669,28 @@ let sourceTests =
                 (Some pair.Model.LoadedTableName)
                 "Membership fallback should keep current table context."
 
-        testCase "property origin uses the native upstream layer for projected values"
+        testCase "property origin uses conceptual upstream layer id"
         <| fun _ ->
             let session = Session.init (sampleModel ())
 
-            match Session.addLayer { SelectedSets = [] } session with
+            match
+                Session.addLayer
+                    {
+                        SelectedSets = [ ProvenanceSide.Output, "output-a" ]
+                    }
+                    session
+            with
             | Ok(layered, _) ->
-                let active = Session.activePair layered
+                let active = Session.activeLayer layered
                 let propertyValueId = active.Model.PropertyValues |> Map.toList |> List.head |> fst
 
                 let origin =
                     Session.propertyValueOriginInSession active.Id ProvenanceSide.Input propertyValueId layered
 
-                Expect.isSome origin "Projected values should have an origin."
+                Expect.equal
+                    origin
+                    (Some(PropertyOrigin.UpstreamLayer "layer-1"))
+                    "Origin should report conceptual upstream layer id."
             | Error error -> failwithf "Unexpected addLayer error: %A" error
     ]
 

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2558,6 +2558,28 @@ let uiStateTests =
 
             Expect.isEmpty emptyProjection.Headers "Search should remove non-matching property headers."
 
+        testCase "attached previous context does not receive an automatic property color"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let layer = Session.activeLayer session
+            let state = State.init session
+
+            let previousTreatment =
+                propertyHeader FixtureKinds.characteristicProperty "Previous Treatment"
+
+            let projection =
+                PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state
+
+            Expect.contains
+                projection.Headers
+                previousTreatment
+                "Attached previous context should still appear in the property rail."
+
+            Expect.equal
+                projection.ColorByHeader.[previousTreatment]
+                None
+                "Attached previous context should not receive an automatic source color."
+
         testCase "current input properties default to output rail when connected to outputs"
         <| fun _ ->
             let session = Session.init (sampleModel ())

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2307,7 +2307,7 @@ let uiStateTests =
                 |> State.PropertyColors.setColor species "#2563eb"
 
             let projection =
-                PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model uiState
+                PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model uiState
 
             Expect.contains projection.Headers species "Search should keep headers with matching projected values."
             Expect.equal projection.ColorByHeader.[species] (Some "#2563eb") "Manual color should be projected."
@@ -2316,9 +2316,97 @@ let uiStateTests =
                 uiState |> State.Filters.setSearch "definitely-not-a-provenance-value"
 
             let emptyProjection =
-                PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model nonMatching
+                PropertyProjection.railProjectionWithFilters
+                    session
+                    pair.Id
+                    ProvenanceSide.Output
+                    pair.Model
+                    nonMatching
 
             Expect.isEmpty emptyProjection.Headers "Search should remove non-matching property headers."
+
+        testCase "current input properties default to output rail when connected to outputs"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let pair = Session.activePair session
+            let state = State.init session
+            let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+
+            let inputHeaders =
+                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model state)
+                    .Headers
+
+            let outputHeaders =
+                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model state)
+                    .Headers
+
+            Expect.isFalse
+                (inputHeaders |> List.contains species)
+                "A connected current input property should not be duplicated on the input rail by default."
+
+            Expect.contains
+                outputHeaders
+                species
+                "A connected current input property should default to the output rail."
+
+        testCase "previous context properties stay on input rail even when inherited by outputs"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let pair = Session.activePair session
+            let state = State.init session
+
+            let previousTreatment =
+                propertyHeader FixtureKinds.characteristicProperty "Previous Treatment"
+
+            let inputHeaders =
+                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model state)
+                    .Headers
+
+            let outputHeaders =
+                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model state)
+                    .Headers
+
+            Expect.contains inputHeaders previousTreatment "A previous-context property should stay on the input rail."
+
+            Expect.isFalse
+                (outputHeaders |> List.contains previousTreatment)
+                "A previous-context property should not move to the output rail just because it is inherited."
+
+        testCase "current input properties remain on input rail until an output is designated"
+        <| fun _ ->
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+            let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+
+            let model =
+                model
+                    "assay-table"
+                    [
+                        propertyValue "pv-input-a-species" species (ProvenanceValue.Text "Arabidopsis") None None
+                    ]
+                    [
+                        inputSet "input-a" "assay-table" inputHeader "Input A" [ "pv-input-a-species" ]
+                    ] [] []
+
+            let session = Session.init model
+            let pair = Session.activePair session
+            let state = State.init session
+
+            let inputHeaders =
+                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model state)
+                    .Headers
+
+            let outputHeaders =
+                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model state)
+                    .Headers
+
+            Expect.contains
+                inputHeaders
+                species
+                "An incomplete layer with no output should keep current properties on the input rail."
+
+            Expect.isFalse
+                (outputHeaders |> List.contains species)
+                "A property should not move to the output rail before any output is designated."
 
         testCase "selected drop targets include selected inputs and outputs only when dropped group is selected"
         <| fun _ ->

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -1190,21 +1190,24 @@ let sessionTests =
                 Expect.isEmpty patches "Navigation is view/session state only."
             | Error error -> failwithf "Expected pair selection success, got %A" error
 
-        testCase "addLayer defaults to active outputs and creates an input-only next pair"
+        testCase "addLayer defaults to active outputs and creates a new layer with seeded inputs"
         <| fun _ ->
             let session = Session.init (sampleModel ())
 
             match Session.addLayer { SelectedSets = [] } session with
             | Ok(next, patches) ->
-                let pair = Session.activePair next
+                let layer = Session.activeLayer next
 
                 let names =
-                    pair.Model.InputSets
+                    layer.Model.InputSets
                     |> Map.toList
                     |> List.map (fun (_, set) -> set.Name)
                     |> List.sort
 
-                Expect.equal next.PairOrder [ "pair-1"; "pair-2" ] "A second adjacent pair should be created."
+                Expect.equal next.LayerOrder [ "layer-1"; "layer-2" ] "A second conceptual layer should be created."
+                Expect.equal next.ActiveLayerId "layer-2" "The new layer should become active."
+                Expect.equal layer.InputSideId "layer-2-input" "New input side should belong to layer-2."
+                Expect.equal layer.OutputSideId "layer-2-output" "New output side should belong to layer-2."
 
                 Expect.equal
                     names
@@ -1215,26 +1218,39 @@ let sessionTests =
                         "Output D"
                         "Output E"
                     ]
-                    "Outputs seed later inputs by default."
+                    "Active outputs should seed later inputs by default."
 
-                Expect.isEmpty pair.Model.OutputSets "New pair starts as a legitimate input-only transition."
-                Expect.isEmpty pair.Model.Connections "No connector exists until the user creates one."
+                Expect.isEmpty layer.Model.OutputSets "New layer starts without designated outputs."
+                Expect.isEmpty layer.Model.Connections "No connector exists until the user creates one."
+                Expect.equal next.ReferenceLinks.Length 5 "Each seeded input should keep an upstream reference."
+                Expect.isEmpty patches "Layer derivation should not write ARC data."
+            | Error error -> failwithf "Expected layer addition success, got %A" error
+
+        testCase "addLayer treats selected active inputs as new layer inputs"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+
+            match
+                Session.addLayer
+                    {
+                        SelectedSets = [ ProvenanceSide.Input, "input-a" ]
+                    }
+                    session
+            with
+            | Ok(next, patches) ->
+                let layer = Session.activeLayer next
+                let input = layer.Model.InputSets |> Map.toList |> List.exactlyOne |> snd
 
                 Expect.equal
-                    next.BoundaryLinks.Length
-                    5
-                    "Each carried output must be linked to its next input projection."
+                    next.LayerOrder
+                    [ "layer-1"; "layer-2" ]
+                    "Input-only selection should create one new conceptual layer."
 
-                Expect.isTrue
-                    (pair.Model.PropertyValues
-                     |> Map.forall (fun id _ ->
-                         pair.Model.InputSets
-                         |> Map.exists (fun _ set -> ProvenanceSet.effectivePropertyValueIds set |> List.contains id)
-                     ))
-                    "Derived pairs should retain only values referenced by their projected endpoints."
-
-                Expect.isEmpty patches "Creating an empty editing layer does not write ARC data."
-            | Error error -> failwithf "Expected layer addition success, got %A" error
+                Expect.equal input.Name "Input A" "The selected active input should become a new layer input snapshot."
+                Expect.equal next.ReferenceLinks.Length 1 "The selected active input should keep an upstream reference."
+                Expect.isEmpty layer.Model.OutputSets "New layer starts without designated outputs."
+                Expect.isEmpty patches "Layer derivation should not write ARC data."
+            | Error error -> failwithf "Expected input-seeded layer addition success, got %A" error
 
         testCase "addLayer carries output properties inherited through loaded connections"
         <| fun _ ->
@@ -1281,7 +1297,7 @@ let sessionTests =
                     "A projected output should keep properties inherited from its previously connected loaded input."
             | Error error -> failwithf "Expected layer addition success, got %A" error
 
-        testCase "addLayer supports a mixed selected seed"
+        testCase "addLayer treats mixed input and output seeds as new layer inputs"
         <| fun _ ->
             let session = Session.init (sampleModel ())
 
@@ -1293,24 +1309,28 @@ let sessionTests =
             }
 
             match Session.addLayer selected session with
-            | Ok(next, _) ->
-                let pair = Session.activePair next
+            | Ok(next, patches) ->
+                let layer = Session.activeLayer next
 
                 let names =
-                    pair.Model.InputSets
+                    layer.Model.InputSets
                     |> Map.toList
                     |> List.map (fun (_, set) -> set.Name)
                     |> List.sort
 
-                Expect.equal names [ "Input A"; "Output B" ] "Mixed selection becomes the next input side."
-                Expect.equal next.BoundaryLinks.Length 2 "Only seeded items should be linked."
-
                 Expect.equal
-                    pair.LeftLayerId
-                    "selection-3"
-                    "Mixed input/output selections use a virtual selection layer."
+                    next.LayerOrder
+                    [ "layer-1"; "layer-2" ]
+                    "Mixed selection should create one new conceptual layer."
 
-                Expect.equal next.Layers.[2].Label "Selection 3" "Selection layer should be visible in navigation."
+                Expect.equal names [ "Input A"; "Output B" ] "Mixed selection should become the next input side."
+                Expect.equal next.ReferenceLinks.Length 2 "Only seeded entities should be linked."
+
+                Expect.isFalse
+                    (next.Layers |> List.exists (fun layer -> layer.Id = "selection-3"))
+                    "Mixed selection should not create a virtual selection layer."
+
+                Expect.isEmpty patches "Layer derivation should not write ARC data."
             | Error error -> failwithf "Expected mixed layer addition success, got %A" error
 
         testCase "updating a carried property from the next pair updates the previous view once"

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2130,6 +2130,145 @@ let uiStateTests =
                 Expect.equal header species "Multi-value members should reject the drop for that property."
                 Expect.equal setIds [ "input-b" ] "The rejection should identify the multi-value member."
             | other -> failwithf "Expected a multiple-value rejection, got %A" other
+
+        testCase "default state initializes with empty colors and filters"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+
+            Expect.equal
+                state.PropertyColors
+                State.PropertyColors.empty
+                "Initial state should have empty property colors."
+
+            Expect.equal state.Filters State.Filters.defaultState "Initial state should have default filters."
+
+        testCase "set and clear property color"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+            let header = propertyHeader FixtureKinds.characteristicProperty "Species"
+
+            let withColor = State.PropertyColors.setColor header "#2563eb" state
+            let key = { Header = header }
+
+            Expect.equal
+                withColor.PropertyColors.ManualPropertyColors.[key]
+                "#2563eb"
+                "Property color should be set by header."
+
+            let cleared = State.PropertyColors.clearColor header withColor
+
+            Expect.isFalse
+                (cleared.PropertyColors.ManualPropertyColors.ContainsKey key)
+                "Property color should be cleared."
+
+        testCase "set and clear layer color"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+
+            let withColor = State.PropertyColors.setLayerColor "layer-1" "#16a34a" state
+            Expect.equal withColor.PropertyColors.LayerColors.["layer-1"] "#16a34a" "Layer color should be set."
+
+            let cleared = State.PropertyColors.clearLayerColor "layer-1" withColor
+            Expect.isFalse (cleared.PropertyColors.LayerColors.ContainsKey "layer-1") "Layer color should be cleared."
+
+        testCase "new layers get automatic colors from palette"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+
+            let afterEnsure = State.PropertyColors.ensureLayerColors session state
+
+            Expect.isTrue
+                (afterEnsure.PropertyColors.LayerColors.ContainsKey "layer-1")
+                "Initial layer should have an automatic color."
+
+            Expect.isTrue
+                (afterEnsure.PropertyColors.LayerColors.ContainsKey "layer-2")
+                "Initial layer should have an automatic color."
+
+        testCase "automatic colors do not overwrite existing manual layer colors"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+
+            let withManual = State.PropertyColors.setLayerColor "layer-1" "#be185d" state
+            let afterEnsure = State.PropertyColors.ensureLayerColors session withManual
+
+            Expect.equal
+                afterEnsure.PropertyColors.LayerColors.["layer-1"]
+                "#be185d"
+                "Manual layer color should be preserved."
+
+        testCase "stale layer colors are removed during cleanup"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+
+            let withStale = {
+                state with
+                    PropertyColors = {
+                        state.PropertyColors with
+                            LayerColors = Map.ofList [ "nonexistent", "#000000" ]
+                    }
+            }
+
+            let afterEnsure = State.PropertyColors.ensureLayerColors session withStale
+
+            Expect.isFalse
+                (afterEnsure.PropertyColors.LayerColors.ContainsKey "nonexistent")
+                "Stale layer color should be removed."
+
+        testCase "default filter state uses Any filter and ValueCountDesc sort"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+
+            Expect.equal state.Filters.SearchText "" "Default search should be empty."
+
+            Expect.equal
+                state.Filters.PropertySort
+                Types.PropertySort.ValueCountDesc
+                "Default sort should be value count desc."
+
+            Expect.equal
+                state.Filters.ValueCountFilter
+                Types.PropertyValueCountFilter.Any
+                "Default value count filter should be Any."
+
+        testCase "filters can be updated through state helpers"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let state = State.init session
+
+            let withSearch = State.Filters.setSearch "Arabidopsis" state
+            Expect.equal withSearch.Filters.SearchText "Arabidopsis" "Search text should be updated."
+
+            let withSort = State.Filters.setPropertySort Types.PropertySort.NameAsc withSearch
+            Expect.equal withSort.Filters.PropertySort Types.PropertySort.NameAsc "Property sort should be updated."
+
+            let withFilter =
+                State.Filters.setValueCountFilter Types.PropertyValueCountFilter.Multiple withSort
+
+            Expect.equal
+                withFilter.Filters.ValueCountFilter
+                Types.PropertyValueCountFilter.Multiple
+                "Value count filter should be updated."
+
+            let withOrigin =
+                State.Filters.setOriginFilter Types.PropertyOriginFilter.CurrentOnly withFilter
+
+            Expect.equal
+                withOrigin.Filters.OriginFilter
+                Types.PropertyOriginFilter.CurrentOnly
+                "Origin filter should be updated."
+
+            let withGroupSort =
+                State.Filters.setGroupSort Types.GroupSort.MemberCountDesc withOrigin
+
+            Expect.equal withGroupSort.Filters.GroupSort Types.GroupSort.MemberCountDesc "Group sort should be updated."
     ]
 
 let sourceTests =

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -2190,14 +2190,12 @@ let uiStateTests =
 
             Expect.equal manual.PendingMemberResolution None "Choosing manual should close the prompt."
 
-            Expect.isTrue
-                (State.MemberResolution.isManualPair layer.Id pending.InputGroupId pending.OutputGroupId manual)
-                "Choosing manual should keep the layer expanded for member-level resolution."
-
             Expect.equal
-                manual.Detail
-                (Some(Types.ProvenanceDetail.Group(ProvenanceSide.Input, pending.InputGroupId)))
-                "Choosing manual should expand the input group and allow the output layer to auto-expand from manual state."
+                manual.ExpandedGroup
+                (Some(ProvenanceSide.Input, pending.InputGroupId))
+                "Choosing manual should expand the input group."
+
+            Expect.equal manual.Detail None "Choosing manual should clear the detail panel."
 
         testCase "property value drop plan adds only when every group member has no value for the property"
         <| fun _ ->
@@ -2531,7 +2529,7 @@ let uiStateTests =
                 ]
 
             let sorted =
-                PropertyProjection.sortHeaders Types.PropertySort.ValueCountDesc stats [ lowCount; highCount ]
+                PropertyProjection.sortHeaders Types.PropertySort.ValueCountDesc stats Map.empty [ lowCount; highCount ]
 
             Expect.equal sorted [ highCount; lowCount ] "Higher value count should sort before name/kind."
 

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -1143,16 +1143,42 @@ let fixtureTests =
 
 let sessionTests =
     testList "Session" [
-        testCase "init exposes the loaded model as the first active pair"
+        testCase "init creates one conceptual layer with input and output sides"
         <| fun _ ->
             let initial = sampleModel ()
             let session = Session.init initial
+            let active = Session.activeLayer session
+
+            Expect.equal session.LayerOrder [ "layer-1" ] "Initial session should contain one conceptual layer."
+            Expect.equal session.ActiveLayerId "layer-1" "Initial layer should be active."
+            Expect.equal active.Id "layer-1" "Active layer id should be layer-1."
+            Expect.equal active.InputSideId "layer-1-input" "Input side id should belong to layer-1."
+            Expect.equal active.OutputSideId "layer-1-output" "Output side id should belong to layer-1."
+            Expect.equal active.Model initial "Initial active layer should preserve the converted model."
+
+        testCase "pair adapters expose active layer during migration"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
             let active = Session.activePair session
 
-            Expect.equal session.Layers.Length 2 "Initial session should render input and output layers."
-            Expect.equal active.Model initial "Initial active pair should preserve the converted model."
-            Expect.equal active.LeftLayerId "layer-1" "The first pair should start on layer 1."
-            Expect.equal active.RightLayerId "layer-2" "The first pair should end on layer 2."
+            Expect.equal session.PairOrder session.LayerOrder "PairOrder should alias LayerOrder during migration."
+
+            Expect.equal
+                session.ActivePairId
+                session.ActiveLayerId
+                "ActivePairId should alias ActiveLayerId during migration."
+
+            Expect.equal
+                active.Id
+                "layer-1"
+                "activePair should return the active conceptual layer while callers migrate."
+
+            Expect.equal active.LeftLayerId active.InputSideId "LeftLayerId should alias InputSideId during migration."
+
+            Expect.equal
+                active.RightLayerId
+                active.OutputSideId
+                "RightLayerId should alias OutputSideId during migration."
 
         testCase "selectPair switches display pairs without producing writeback patches"
         <| fun _ ->
@@ -1605,7 +1631,9 @@ let sessionTests =
 
             let polluted = {
                 layered with
-                    Pairs = layered.Pairs |> Map.add pair2.Id pollutedPair2
+                    Layers =
+                        layered.Layers
+                        |> List.map (fun layer -> if layer.Id = pair2.Id then pollutedPair2 else layer)
             }
 
             let outputHeader = ioHeader FixtureKinds.dataEndpoint "Output [Data]"

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -1311,9 +1311,10 @@ let sessionTests =
                 Expect.equal names [ "Input A"; "Output B" ] "Mixed selection should become the next input side."
                 Expect.equal next.ReferenceLinks.Length 2 "Only seeded entities should be linked."
 
-                Expect.isFalse
-                    (next.Layers |> List.exists (fun layer -> layer.Id = "selection-3"))
-                    "Mixed selection should not create a virtual selection layer."
+                Expect.all
+                    next.LayerOrder
+                    (fun layerId -> layerId.StartsWith "layer-")
+                    "Mixed selection should keep conceptual layer ids."
 
                 Expect.isEmpty patches "Layer derivation should not write ARC data."
             | Error error -> failwithf "Expected mixed layer addition success, got %A" error

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -1156,39 +1156,24 @@ let sessionTests =
             Expect.equal active.OutputSideId "layer-1-output" "Output side id should belong to layer-1."
             Expect.equal active.Model initial "Initial active layer should preserve the converted model."
 
-        testCase "pair adapters expose active layer during migration"
+        testCase "session layer ids and side ids use distinct namespaces"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let active = Session.activePair session
+            let layer = Session.activeLayer session
 
-            Expect.equal session.PairOrder session.LayerOrder "PairOrder should alias LayerOrder during migration."
+            Expect.notEqual layer.Id layer.InputSideId "Layer id should not be reused as input side id."
+            Expect.notEqual layer.Id layer.OutputSideId "Layer id should not be reused as output side id."
+            Expect.notEqual layer.InputSideId layer.OutputSideId "Input and output side ids should be distinct."
 
-            Expect.equal
-                session.ActivePairId
-                session.ActiveLayerId
-                "ActivePairId should alias ActiveLayerId during migration."
-
-            Expect.equal
-                active.Id
-                "layer-1"
-                "activePair should return the active conceptual layer while callers migrate."
-
-            Expect.equal active.LeftLayerId active.InputSideId "LeftLayerId should alias InputSideId during migration."
-
-            Expect.equal
-                active.RightLayerId
-                active.OutputSideId
-                "RightLayerId should alias OutputSideId during migration."
-
-        testCase "selectPair switches display pairs without producing writeback patches"
+        testCase "selectLayer switches display layers without producing writeback patches"
         <| fun _ ->
             let session = Session.init (sampleModel ())
 
-            match Session.selectPair "pair-1" session with
+            match Session.selectLayer "layer-1" session with
             | Ok(next, patches) ->
-                Expect.equal next.ActivePairId "pair-1" "Known pair should become active."
+                Expect.equal next.ActiveLayerId "layer-1" "Known layer should become active."
                 Expect.isEmpty patches "Navigation is view/session state only."
-            | Error error -> failwithf "Expected pair selection success, got %A" error
+            | Error error -> failwithf "Expected layer selection success, got %A" error
 
         testCase "addLayer defaults to active outputs and creates a new layer with seeded inputs"
         <| fun _ ->
@@ -1286,7 +1271,7 @@ let sessionTests =
                 Expect.isEmpty patches "Layer projection should not write ARC data."
 
                 let projected =
-                    (Session.activePair next).Model.InputSets
+                    (Session.activeLayer next).Model.InputSets
                     |> Map.toList
                     |> List.exactlyOne
                     |> snd
@@ -1631,7 +1616,7 @@ let sessionTests =
                     "Unreferenced upstream structural additions should not appear downstream."
             | Error error -> failwithf "Unexpected selectLayer error: %A" error
 
-        testCase "assigning a palette value to a carried next input writes only to the active pair"
+        testCase "assigning a palette value to a carried next input writes only to the active layer"
         <| fun _ ->
             let first = Session.init (sampleModel ())
 
@@ -1647,12 +1632,14 @@ let sessionTests =
                 | Error error -> failwithf "Unexpected addLayer error: %A" error
 
             let projectedId =
-                (Session.activePair layered).Model.InputSets
+                (Session.activeLayer layered).Model.InputSets
                 |> Map.toList
                 |> List.exactlyOne
                 |> fst
 
-            let previousBefore = layered.Pairs.["pair-1"].Model.OutputSets.["output-d"]
+            let previousBefore =
+                (Session.layerById "layer-1" layered).Model.OutputSets.["output-d"]
+
             let treatment = propertyHeader FixtureKinds.characteristicProperty "Treatment"
 
             let command = {
@@ -1665,8 +1652,10 @@ let sessionTests =
 
             match Session.createCurrentLoadedPropertyValue command layered with
             | Ok(next, [ ProvenanceTablePatch.AddLoadedPropertyValue(target, _, header, value, _) ]) ->
-                let previousOutput = next.Pairs.["pair-1"].Model.OutputSets.["output-d"]
-                let nextInput = next.Pairs.["pair-2"].Model.InputSets.[projectedId]
+                let previousOutput =
+                    (Session.layerById "layer-1" next).Model.OutputSets.["output-d"]
+
+                let nextInput = (Session.layerById "layer-2" next).Model.InputSets.[projectedId]
 
                 Expect.equal
                     target
@@ -1683,8 +1672,8 @@ let sessionTests =
 
                 Expect.isTrue
                     (nextInput.PropertyValueIds.Length > previousBefore.PropertyValueIds.Length)
-                    "The active pair input should receive the new property value."
-            | other -> failwithf "Expected one active-pair property-add patch, got %A" other
+                    "The active layer input should receive the new property value."
+            | other -> failwithf "Expected one active-layer property-add patch, got %A" other
 
         testCase "updating multiple property values uses the edit path for every value"
         <| fun _ ->
@@ -1697,7 +1686,7 @@ let sessionTests =
 
             match Session.updatePropertyValues updates session with
             | Ok(next, patches) ->
-                let model = (Session.activePair next).Model
+                let model = (Session.activeLayer next).Model
                 Expect.equal patches.Length 2 "Every existing value should produce an edit patch."
 
                 Expect.equal
@@ -1711,7 +1700,7 @@ let sessionTests =
                     "Second value should be edited."
             | other -> failwithf "Expected batched edit success, got %A" other
 
-        testCase "creating and connecting a later output modifies only the active pair"
+        testCase "creating and connecting a later output modifies only the active layer"
         <| fun _ ->
             let layered =
                 Session.init (sampleModel ())
@@ -1737,20 +1726,27 @@ let sessionTests =
                 | Ok(next, _) -> next
                 | Error error -> failwithf "%A" error
 
-            let pair = Session.activePair created
-            let inputId = pair.Model.InputSets |> Map.toList |> List.exactlyOne |> fst
-            let outputId = pair.Model.OutputSets |> Map.toList |> List.exactlyOne |> fst
+            let layer = Session.activeLayer created
+            let inputId = layer.Model.InputSets |> Map.toList |> List.exactlyOne |> fst
+            let outputId = layer.Model.OutputSets |> Map.toList |> List.exactlyOne |> fst
 
             match Session.connectSets inputId outputId None created with
             | Ok(next, [ ProvenanceTablePatch.AddLoadedConnection _ ]) ->
-                Expect.equal next.Pairs.["pair-1"].Model.Connections.Count 5 "Prior transition should remain unchanged."
-                Expect.equal next.Pairs.["pair-2"].Model.Connections.Count 1 "Later transition gets its connection."
+                Expect.equal
+                    (Session.layerById "layer-1" next).Model.Connections.Count
+                    5
+                    "Prior transition should remain unchanged."
+
+                Expect.equal
+                    (Session.layerById "layer-2" next).Model.Connections.Count
+                    1
+                    "Later transition gets its connection."
             | other -> failwithf "Expected a later connection patch, got %A" other
 
-        testCase "removeConnections removes loaded connections from the active pair"
+        testCase "removeConnections removes loaded connections from the active layer"
         <| fun _ ->
             let session = sampleSession ()
-            let initialCount = (Session.activePair session).Model.Connections.Count
+            let initialCount = (Session.activeLayer session).Model.Connections.Count
 
             match Session.removeConnections [ "connection-a"; "connection-b"; "connection-a" ] session with
             | Ok(next, patches) ->
@@ -1764,9 +1760,9 @@ let sessionTests =
                     "All emitted patches should remove loaded connections."
 
                 Expect.equal
-                    (Session.activePair next).Model.Connections.Count
+                    (Session.activeLayer next).Model.Connections.Count
                     (initialCount - 2)
-                    "Both connections should be removed from the active pair."
+                    "Both connections should be removed from the active layer."
             | Error error -> failwithf "Unexpected removeConnections error: %A" error
 
         testCase "init and addLayer work for an output-only model"
@@ -1774,16 +1770,16 @@ let sessionTests =
             let initial = Session.init (outputOnlyModel ())
 
             Expect.isEmpty
-                (Session.activePair initial).Model.InputSets
+                (Session.activeLayer initial).Model.InputSets
                 "Output-only input has no synthetic input endpoints."
 
-            Expect.isNonEmpty (Session.activePair initial).Model.OutputSets "Real output endpoints remain visible."
+            Expect.isNonEmpty (Session.activeLayer initial).Model.OutputSets "Real output endpoints remain visible."
 
             match Session.addLayer { SelectedSets = [] } initial with
             | Ok(next, patches) ->
-                let pair = Session.activePair next
-                Expect.isNonEmpty pair.Model.InputSets "Current outputs should seed the next displayed input side."
-                Expect.isEmpty pair.Model.OutputSets "A newly displayed transition has no invented outputs."
+                let layer = Session.activeLayer next
+                Expect.isNonEmpty layer.Model.InputSets "Current outputs should seed the next displayed input side."
+                Expect.isEmpty layer.Model.OutputSets "A newly displayed transition has no invented outputs."
                 Expect.isEmpty patches "View-layer derivation is not a persistence edit."
             | Error error -> failwithf "Expected output-only layer derivation success, got %A" error
 
@@ -1986,11 +1982,11 @@ let uiStateTests =
         testCase "panel layout clamps side panels and preserves a middle panel"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
 
             let tooSmallLeft =
-                State.PanelLayout.setLeft pair.Id 2 state |> State.PanelLayout.get pair.Id
+                State.PanelLayout.setLeft layer.Id 2 state |> State.PanelLayout.get layer.Id
 
             Expect.equal tooSmallLeft.Left 15 "Left panel should not shrink below the minimum."
             Expect.equal tooSmallLeft.Middle 65 "Middle panel should keep the remaining usable width."
@@ -1998,9 +1994,9 @@ let uiStateTests =
 
             let tooLargeRight =
                 state
-                |> State.PanelLayout.setLeft pair.Id 45
-                |> State.PanelLayout.setRight pair.Id 80
-                |> State.PanelLayout.get pair.Id
+                |> State.PanelLayout.setLeft layer.Id 45
+                |> State.PanelLayout.setRight layer.Id 80
+                |> State.PanelLayout.get layer.Id
 
             Expect.equal tooLargeRight.Left 45 "Left panel should retain the committed user ratio."
             Expect.equal tooLargeRight.Right 25 "Right panel should be clamped so the middle panel keeps its minimum."
@@ -2098,13 +2094,13 @@ let uiStateTests =
                 None
                 "Property headers have no drag connection; their connectors derive from model data."
 
-        testCase "member resolution prompt can be converted into a manual resolution pair"
+        testCase "member resolution prompt can be converted into a manual resolution layer"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
 
             let pending: Types.PendingMemberResolution = {
-                PairId = pair.Id
+                LayerId = layer.Id
                 InputGroupId = "input:Species=Arabidopsis"
                 OutputGroupId = "output:Analysis=Mass Spectrometry"
                 InputMemberCount = 3
@@ -2123,13 +2119,13 @@ let uiStateTests =
             Expect.equal manual.PendingMemberResolution None "Choosing manual should close the prompt."
 
             Expect.isTrue
-                (State.MemberResolution.isManualPair pair.Id pending.InputGroupId pending.OutputGroupId manual)
-                "Choosing manual should keep the pair expanded for member-level resolution."
+                (State.MemberResolution.isManualPair layer.Id pending.InputGroupId pending.OutputGroupId manual)
+                "Choosing manual should keep the layer expanded for member-level resolution."
 
             Expect.equal
                 manual.Detail
                 (Some(Types.ProvenanceDetail.Group(ProvenanceSide.Input, pending.InputGroupId)))
-                "Choosing manual should expand the input group and allow the output pair to auto-expand from manual state."
+                "Choosing manual should expand the input group and allow the output layer to auto-expand from manual state."
 
         testCase "property value drop plan adds only when every group member has no value for the property"
         <| fun _ ->
@@ -2470,7 +2466,7 @@ let uiStateTests =
         testCase "rail projection applies search and resolves manual property color"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
 
             let uiState =
@@ -2479,7 +2475,7 @@ let uiStateTests =
                 |> State.PropertyColors.setColor species "#2563eb"
 
             let projection =
-                PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model uiState
+                PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model uiState
 
             Expect.contains projection.Headers species "Search should keep headers with matching projected values."
             Expect.equal projection.ColorByHeader.[species] (Some "#2563eb") "Manual color should be projected."
@@ -2490,9 +2486,9 @@ let uiStateTests =
             let emptyProjection =
                 PropertyProjection.railProjectionWithFilters
                     session
-                    pair.Id
+                    layer.Id
                     ProvenanceSide.Output
-                    pair.Model
+                    layer.Model
                     nonMatching
 
             Expect.isEmpty emptyProjection.Headers "Search should remove non-matching property headers."
@@ -2500,16 +2496,16 @@ let uiStateTests =
         testCase "current input properties default to output rail when connected to outputs"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
 
             let inputHeaders =
-                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model state)
+                (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state)
                     .Headers
 
             let outputHeaders =
-                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model state)
+                (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model state)
                     .Headers
 
             Expect.isFalse
@@ -2524,18 +2520,18 @@ let uiStateTests =
         testCase "previous context properties stay on input rail even when inherited by outputs"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
 
             let previousTreatment =
                 propertyHeader FixtureKinds.characteristicProperty "Previous Treatment"
 
             let inputHeaders =
-                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model state)
+                (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state)
                     .Headers
 
             let outputHeaders =
-                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model state)
+                (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model state)
                     .Headers
 
             Expect.contains inputHeaders previousTreatment "A previous-context property should stay on the input rail."
@@ -2560,15 +2556,15 @@ let uiStateTests =
                     ] [] []
 
             let session = Session.init model
-            let pair = Session.activePair session
+            let layer = Session.activeLayer session
             let state = State.init session
 
             let inputHeaders =
-                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Input pair.Model state)
+                (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state)
                     .Headers
 
             let outputHeaders =
-                (PropertyProjection.railProjectionWithFilters session pair.Id ProvenanceSide.Output pair.Model state)
+                (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model state)
                     .Headers
 
             Expect.contains
@@ -2602,12 +2598,12 @@ let uiStateTests =
                 | ProvenanceSide.Output, "output-group" -> Some outputGroup
                 | _ -> None
 
-            let selectedInputs = Set.ofList [ "pair-1", "input-group" ]
-            let selectedOutputs = Set.ofList [ "pair-1", "output-group" ]
+            let selectedInputs = Set.ofList [ "layer-1", "input-group" ]
+            let selectedOutputs = Set.ofList [ "layer-1", "output-group" ]
 
             let selectedTargets =
                 ValueAssignment.selectedTargetGroupsForDrop
-                    "pair-1"
+                    "layer-1"
                     ProvenanceSide.Input
                     "input-group"
                     selectedInputs
@@ -2624,7 +2620,7 @@ let uiStateTests =
 
             let unselectedDrop =
                 ValueAssignment.selectedTargetGroupsForDrop
-                    "pair-1"
+                    "layer-1"
                     ProvenanceSide.Input
                     "unselected-input"
                     selectedInputs
@@ -2650,23 +2646,23 @@ let sourceTests =
         testCase "property source info exposes table and process metadata"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
-            let value = pair.Model.PropertyValues.["pv-input-a-species"]
-            let source = Session.propertyValueSourceInfo pair value
+            let layer = Session.activeLayer session
+            let value = layer.Model.PropertyValues.["pv-input-a-species"]
+            let source = Session.propertyValueSourceInfo layer value
 
             Expect.isSome source "A fixture property value should expose source metadata."
 
         testCase "property source info falls back to loaded membership"
         <| fun _ ->
             let session = Session.init (sampleModel ())
-            let pair = Session.activePair session
-            let original = pair.Model.PropertyValues.["pv-input-a-species"]
+            let layer = Session.activeLayer session
+            let original = layer.Model.PropertyValues.["pv-input-a-species"]
             let withoutSource = { original with Source = None }
-            let source = Session.propertyValueSourceInfo pair withoutSource
+            let source = Session.propertyValueSourceInfo layer withoutSource
 
             Expect.equal
                 (source |> Option.bind _.TableName)
-                (Some pair.Model.LoadedTableName)
+                (Some layer.Model.LoadedTableName)
                 "Membership fallback should keep current table context."
 
         testCase "property origin uses conceptual upstream layer id"


### PR DESCRIPTION
This PR includes the current state of the ProvenanceGrouping (WiP) and a composite component that organizes draggable items into expandable folders within a drag-and-drop shelf.

### What it does

Displays a horizontal row of folders. Clicking a folder expands it, revealing its items in a drop shelf below. Each item can be dragged to external drop targets, carrying structured metadata about both the item and its parent folder. External items can also be dropped into an expanded folder's shelf.

### Key behaviors

- **Single-folder expansion**: only one folder can be open at a time. Clicking a different folder collapses the current one.
- **Cascading colors**: items inherit their folder's color unless they specify their own override. Dragged items carry an `EffectiveColor` that resolves this fallback.
- **External drop acceptance**: when a folder is expanded and the consumer provides a handler, external drag sources can drop items into that folder's shelf. The handler receives the target folder, the source drag ID, and the source drag data.
- **Disabled items**: individual items can be marked as disabled. They render as visual placeholders but are not draggable.
- **Drag overlay**: while dragging, the source item becomes transparent and a styled copy follows the pointer with a drop shadow.
- **Controlled or uncontrolled expansion**: the expanded folder can be managed externally via `expandedFolderIds`/`onExpandedFolderIdsChange`, or the component manages it internally via `defaultExpandedFolderIds`.
- **Tooltips and badges**: items support optional tooltips (shown on hover) and badges (small count labels).

### Usage

| Prop | Type | Required | Description |
|---|---|---|---|
| `folders` | `FolderedDraggableFolder<'payload> list` | ✅ | The list of folders, each containing items |
| `dragId` | `folder -> item -> string` | ✅ | Opaque stable ID for drag-and-drop identity |
| `expandedFolderIds` | `Set<string>` | — | Controlled: set of expanded folder IDs |
| `defaultExpandedFolderIds` | `Set<string>` | — | Uncontrolled: initial expanded folder IDs |
| `onExpandedFolderIdsChange` | `Set<string> -> unit` | — | Called when expansion changes |
| `renderItemContent` | `render -> ReactElement` | — | Custom render function for item content |
| `shelfDropId` | `string` | — | Custom droppable ID for the shelf zone |
| `tryCreateItemFromExternalDrop` | `drop -> item option` | — | Handler to convert external drag data into a new item |
| `onFoldersChange` | `folders list -> unit` | — | Called when items are added via external drop |
| `className` | `string` | — | Additional CSS classes on the root element |
| `debug` | `bool` | — | Adds `data-testid` attributes throughout |

### Trade-offs

- The component renders the **read-only state** (existing items). The consumer is responsible for mutation (add/remove items) based on drag events.
- Internal item-to-item reordering within a folder is **not supported**. Only drag-in (external → shelf) and drag-out (shelf → external) are modeled.
- The shelf's drop zone is only active when a folder is expanded AND both `tryCreateItemFromExternalDrop` and `onFoldersChange` are provided.