### PR TITLE
Fix git upload problems

### DIFF
--- a/src/Components/src/Page/GitSidebar/GitSidebar.fs
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.fs
@@ -262,9 +262,27 @@ type GitSidebar =
             ?warningNotice: string,
             ?busyTestId: string,
             ?errorTestId: string,
-            ?warningTestId: string
+            ?warningTestId: string,
+            ?onCancelOperation: unit -> unit
         ) =
         let runStatus = defaultArg runStatus GitSidebarRunStatus.Idle
+
+        let cancelButton =
+            onCancelOperation
+            |> Option.map (fun cancel ->
+                Html.button [
+                    prop.testId "GitSidebarCancelOperationButton"
+                    prop.className "swt:btn swt:btn-ghost swt:btn-xs swt:shrink-0 swt:gap-1 swt:normal-case"
+                    prop.title "Cancel"
+                    prop.onClick (fun _ -> cancel ())
+                    prop.children [
+                        Html.span [
+                            prop.className "swt:iconify swt:fluent--dismiss-circle-24-regular swt:size-4"
+                        ]
+                        Html.span [ prop.text "Cancel" ]
+                    ]
+                ]
+            )
 
         React.Fragment [
             match runStatus with
@@ -339,6 +357,9 @@ type GitSidebar =
                                         | None -> Html.none
                                     ]
                                 ]
+                                match cancelButton with
+                                | Some button -> button
+                                | None -> Html.none
                             ]
                         ]
                     ]
@@ -360,6 +381,9 @@ type GitSidebar =
                                     prop.className "swt:min-w-0 swt:wrap-anywhere"
                                     prop.text notice
                                 ]
+                                match cancelButton with
+                                | Some button -> button
+                                | None -> Html.none
                             ]
                         ]
                     ]
@@ -1606,6 +1630,7 @@ type GitSidebar =
             ?remoteActionsEnabled: bool,
             ?remoteActionsWarning: string,
             ?canOpenRemoteRepository: bool,
+            ?canCancelOperation: bool,
             ?onOpenRemoteRepository: unit -> unit,
             ?onSubmitPublishRename: string -> unit,
             ?onCancelPublishRename: unit -> unit
@@ -1619,6 +1644,7 @@ type GitSidebar =
         let remoteActionsEnabled = defaultArg remoteActionsEnabled true
         let remoteActionsWarning = remoteActionsWarning
         let canOpenRemoteRepository = defaultArg canOpenRemoteRepository false
+        let canCancelOperation = defaultArg canCancelOperation false
         let onOpenRemoteRepository = defaultArg onOpenRemoteRepository (fun () -> ())
         let onSubmitPublishRename = defaultArg onSubmitPublishRename (fun _ -> ())
         let onCancelPublishRename = defaultArg onCancelPublishRename (fun () -> ())
@@ -1640,6 +1666,7 @@ type GitSidebar =
         let onCreateBranch = callbacks.OnCreateBranch
         let onSwitchBranch = callbacks.OnSwitchBranch
         let onSelectChange = callbacks.OnSelectChange
+        let onCancelOperation = callbacks.OnCancelOperation
 
         let localError, setLocalError = React.useState (None: string option)
         let activeDialog, setActiveDialog = React.useState ActiveDialog.None
@@ -1978,7 +2005,12 @@ type GitSidebar =
                     ?errorNotice = visibleError,
                     ?warningNotice = warningNotice,
                     busyTestId = "GitSidebarProgressNotice",
-                    errorTestId = "GitSidebarErrorNotice"
+                    errorTestId = "GitSidebarErrorNotice",
+                    ?onCancelOperation =
+                        (if canCancelOperation && isBusy then
+                             Some onCancelOperation
+                         else
+                             None)
                 )
 
                 GitSidebar.BranchStatusDetails(branchHeaderProps)

--- a/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
+++ b/src/Components/src/Page/GitSidebar/GitSidebar.stories.tsx
@@ -15,6 +15,7 @@ const noopWithBranch = (_branchName: string) => {};
 const noopWithThreshold = (_thresholdMb: number) => {};
 const noopWithDownloadPreference = (_downloadLargeFiles: boolean) => {};
 const noopOpenRemoteRepository = () => {};
+const cancelOperationSpy = fn();
 const noopSelectChange = (_change: unknown) =>
   Promise.resolve(FSharpResult$2_Ok<void, string>(undefined));
 
@@ -38,6 +39,7 @@ const baseCallbacks = {
   OnSelectChange: noopSelectChange,
   OnPruneLfsCache: noop,
   OnDedupLfsStorage: noop,
+  OnCancelOperation: noop,
 };
 
 const buildCallbacks = (
@@ -601,6 +603,35 @@ export const BusyProgressState: Story = {
       canvas.getByTestId("GitSidebarProgressNotice").compareDocumentPosition(trackingInfo) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  },
+};
+
+export const CancelableUploadProgressState: Story = {
+  args: {
+    status: baseStatus,
+    changedFiles: changedFiles.slice(),
+    branchOptions: branchOptions.slice(),
+    runStatus: buildProgressRunStatus({
+      Method: "lfs",
+      Stage: "Uploading Git LFS objects",
+      Output: "Uploading LFS objects: 0% (0/6), 524 KB | 121 KB/s\n",
+    }),
+    callbacks: buildCallbacks({
+      OnCancelOperation: cancelOperationSpy,
+    }),
+    canCancelOperation: true,
+    downloadLargeFiles: true,
+    lfsAutoTrackThresholdMb: 1,
+  },
+  play: async ({ canvasElement }) => {
+    cancelOperationSpy.mockClear();
+    const canvas = within(canvasElement);
+
+    const cancelButton = canvas.getByTestId("GitSidebarCancelOperationButton");
+    await expect(cancelButton).toHaveTextContent("Cancel");
+
+    await userEvent.click(cancelButton);
+    await expect(cancelOperationSpy).toHaveBeenCalledTimes(1);
   },
 };
 

--- a/src/Components/src/Page/GitSidebar/Types.fs
+++ b/src/Components/src/Page/GitSidebar/Types.fs
@@ -82,6 +82,7 @@ type GitSidebarCallbacks = {
     OnSelectChange: GitSidebarChange -> JS.Promise<Result<unit, string>>
     OnPruneLfsCache: unit -> unit
     OnDedupLfsStorage: unit -> unit
+    OnCancelOperation: unit -> unit
 }
 
 [<RequireQualifiedAccess>]

--- a/src/Electron/src/Main/Git/GitLfsService.fs
+++ b/src/Electron/src/Main/Git/GitLfsService.fs
@@ -95,12 +95,18 @@ let createRequest
     (filePath: string option)
     (timeoutMs: int option)
     : GitLfsRequest =
+    let effectiveTimeout =
+        match command with
+        | Pull
+        | Fetch -> None
+        | _ -> Some(defaultArg timeoutMs DefaultTimeoutMs)
+
     {
         RequestId = Guid.NewGuid().ToString()
         RepoPath = repoPath
         Command = command
         FilePath = filePath
-        TimeoutMs = Some(defaultArg timeoutMs DefaultTimeoutMs)
+        TimeoutMs = effectiveTimeout
     }
 
 /// Runs a Git LFS adapter request and normalizes unsuccessful adapter results to Result.Error.
@@ -220,6 +226,7 @@ let private readLsFilesByRelativePath
                     Arguments = buildLsFilesJsonArgs ()
                     Environment = None
                     StandardInput = None
+                    CancelCheck = None
                     TimeoutMs = Some lfsLsFilesTimeoutMs
                 }
 
@@ -626,6 +633,51 @@ let private extractSpawnFailureMessage (result: GitSpawnResult) =
 
 let private spawnFailure (result: GitSpawnResult) = exn (extractSpawnFailureMessage result)
 
+let runAuthenticatedTransferWith
+    (runSpawnedGit: GitSpawnRequest -> JS.Promise<GitSpawnResult>)
+    (commandAuth: GitCommandAuthentication)
+    (repoPath: string)
+    (arguments: string[])
+    (cancelCheck: (unit -> bool) option)
+    : JS.Promise<Result<unit, exn>> =
+    promise {
+        let! result =
+            runSpawnedGit {
+                WorkingDirectory = Some repoPath
+                Arguments = [| yield! commandAuth.ConfigArgs; yield! arguments |]
+                Environment = Some commandAuth.Environment
+                StandardInput = None
+                CancelCheck = cancelCheck
+                TimeoutMs = None
+            }
+
+        return
+            if result.ExitCode = 0 && not result.TimedOut then
+                Ok()
+            else
+                Error(exn (extractSpawnFailureMessage result))
+    }
+
+let pullAll
+    (repoPath: string)
+    (commandAuth: GitCommandAuthentication)
+    (cancelCheck: (unit -> bool) option)
+    : JS.Promise<Result<unit, exn>> =
+    runAuthenticatedTransferWith runGitDiscardingStdout commandAuth repoPath [| "lfs"; "pull" |] cancelCheck
+
+let fetchRefetchForPath
+    (repoPath: string)
+    (commandAuth: GitCommandAuthentication)
+    (relativePath: string)
+    (cancelCheck: (unit -> bool) option)
+    : JS.Promise<Result<unit, exn>> =
+    runAuthenticatedTransferWith
+        runGitDiscardingStdout
+        commandAuth
+        repoPath
+        (buildFetchRefetchArgs relativePath)
+        cancelCheck
+
 let private buildPointerInput (listing: GitLfsLsFileInfo) =
     let sizeText = listing.size |> int64 |> string
 
@@ -649,7 +701,8 @@ let downloadObjectFromListing
                 |]
                 Environment = Some commandAuth.Environment
                 StandardInput = Some(buildPointerInput listing)
-                TimeoutMs = Some DefaultTimeoutMs
+                CancelCheck = None
+                TimeoutMs = None
             }
 
         return
@@ -685,6 +738,7 @@ let private filterResolvableRemoteTipIds
                     Arguments = [| "cat-file"; "--batch-check" |]
                     Environment = None
                     StandardInput = Some(String.concat "\n" [| yield! distinctRemoteTipIds; yield "" |])
+                    CancelCheck = None
                     TimeoutMs = Some DefaultTimeoutMs
                 }
 
@@ -783,6 +837,7 @@ let private tryGetOptimizedLfsObjectIds
                 |]
                 Environment = None
                 StandardInput = Some(buildRevListStandardInput refSpec remoteTipIds)
+                CancelCheck = None
                 TimeoutMs = Some DefaultTimeoutMs
             }
 
@@ -805,6 +860,7 @@ let private tryGetOptimizedLfsObjectIds
                         Arguments = [| "cat-file"; "--batch"; "--buffer" |]
                         Environment = None
                         StandardInput = Some(String.concat "\n" [| yield! candidateBlobIds; yield "" |])
+                        CancelCheck = None
                         TimeoutMs = Some DefaultTimeoutMs
                     }
 
@@ -841,6 +897,7 @@ let private getOutboundObjectIdsFromRemoteTips
                 |]
                 Environment = None
                 StandardInput = Some(buildRevListStandardInput refSpec remoteTipIds)
+                CancelCheck = None
                 TimeoutMs = Some DefaultTimeoutMs
             }
 
@@ -954,6 +1011,7 @@ let planOutboundPush
 let uploadObjects
     (runSpawnedGit: GitSpawnRequest -> JS.Promise<GitSpawnResult>)
     (commandAuth: GitCommandAuthentication)
+    (cancelCheck: unit -> bool)
     (repoPath: string)
     (remoteName: string)
     (refSpec: string)
@@ -962,6 +1020,8 @@ let uploadObjects
     promise {
         if lfsObjectIds.Length = 0 then
             return Ok()
+        elif cancelCheck () then
+            return Error(exn "Git LFS upload cancelled.")
         else
             let! exactUploadResult =
                 runSpawnedGit {
@@ -976,32 +1036,37 @@ let uploadObjects
                     |]
                     Environment = Some commandAuth.Environment
                     StandardInput = Some(String.concat "\n" [| yield! lfsObjectIds; yield "" |])
-                    TimeoutMs = Some DefaultTimeoutMs
+                    CancelCheck = Some cancelCheck
+                    TimeoutMs = None
                 }
 
             if exactUploadResult.ExitCode = 0 then
                 return Ok()
             elif isUnsupportedOptionFailure exactUploadResult then
-                let! fallbackResult =
-                    runSpawnedGit {
-                        WorkingDirectory = Some repoPath
-                        Arguments = [|
-                            yield! commandAuth.ConfigArgs
-                            "lfs"
-                            "push"
-                            remoteName
-                            refSpec
-                        |]
-                        Environment = Some commandAuth.Environment
-                        StandardInput = None
-                        TimeoutMs = Some DefaultTimeoutMs
-                    }
+                if cancelCheck () then
+                    return Error(exn "Git LFS upload cancelled.")
+                else
+                    let! fallbackResult =
+                        runSpawnedGit {
+                            WorkingDirectory = Some repoPath
+                            Arguments = [|
+                                yield! commandAuth.ConfigArgs
+                                "lfs"
+                                "push"
+                                remoteName
+                                refSpec
+                            |]
+                            Environment = Some commandAuth.Environment
+                            StandardInput = None
+                            CancelCheck = Some cancelCheck
+                            TimeoutMs = None
+                        }
 
-                return
-                    if fallbackResult.ExitCode = 0 then
-                        Ok()
-                    else
-                        Error(exn (extractSpawnFailureMessage fallbackResult))
+                    return
+                        if fallbackResult.ExitCode = 0 then
+                            Ok()
+                        else
+                            Error(exn (extractSpawnFailureMessage fallbackResult))
             else
                 return Error(exn (extractSpawnFailureMessage exactUploadResult))
     }

--- a/src/Electron/src/Main/Git/GitLfsService.fs
+++ b/src/Electron/src/Main/Git/GitLfsService.fs
@@ -633,6 +633,39 @@ let private extractSpawnFailureMessage (result: GitSpawnResult) =
 
 let private spawnFailure (result: GitSpawnResult) = exn (extractSpawnFailureMessage result)
 
+let private isHttpExtraHeaderConfigArg (configArg: string) =
+    let trimmed = configArg.Trim()
+    let equalsIndex = trimmed.IndexOf("=")
+
+    let key =
+        if equalsIndex >= 0 then
+            trimmed.Substring(0, equalsIndex)
+        else
+            trimmed
+
+    let normalizedKey = key.Trim().ToLowerInvariant()
+
+    normalizedKey.Equals("http.extraheader", StringComparison.Ordinal)
+    || (normalizedKey.StartsWith("http.", StringComparison.Ordinal)
+        && normalizedKey.EndsWith(".extraheader", StringComparison.Ordinal))
+
+let private lfsTransferConfigArgs (configArgs: string[]) =
+    let filtered = ResizeArray<string>()
+    let mutable index = 0
+
+    while index < configArgs.Length do
+        if
+            configArgs.[index] = "-c"
+            && index + 1 < configArgs.Length
+            && isHttpExtraHeaderConfigArg configArgs.[index + 1]
+        then
+            index <- index + 2
+        else
+            filtered.Add configArgs.[index]
+            index <- index + 1
+
+    filtered.ToArray()
+
 let runAuthenticatedTransferWith
     (runSpawnedGit: GitSpawnRequest -> JS.Promise<GitSpawnResult>)
     (commandAuth: GitCommandAuthentication)
@@ -644,7 +677,10 @@ let runAuthenticatedTransferWith
         let! result =
             runSpawnedGit {
                 WorkingDirectory = Some repoPath
-                Arguments = [| yield! commandAuth.ConfigArgs; yield! arguments |]
+                Arguments = [|
+                    yield! lfsTransferConfigArgs commandAuth.ConfigArgs
+                    yield! arguments
+                |]
                 Environment = Some commandAuth.Environment
                 StandardInput = None
                 CancelCheck = cancelCheck
@@ -696,7 +732,7 @@ let downloadObjectFromListing
             runGitDiscardingStdout {
                 WorkingDirectory = Some repoPath
                 Arguments = [|
-                    yield! commandAuth.ConfigArgs
+                    yield! lfsTransferConfigArgs commandAuth.ConfigArgs
                     yield! buildSmudgePointerArgs relativePath
                 |]
                 Environment = Some commandAuth.Environment
@@ -1027,7 +1063,7 @@ let uploadObjects
                 runSpawnedGit {
                     WorkingDirectory = Some repoPath
                     Arguments = [|
-                        yield! commandAuth.ConfigArgs
+                        yield! lfsTransferConfigArgs commandAuth.ConfigArgs
                         "lfs"
                         "push"
                         "--object-id"
@@ -1050,7 +1086,7 @@ let uploadObjects
                         runSpawnedGit {
                             WorkingDirectory = Some repoPath
                             Arguments = [|
-                                yield! commandAuth.ConfigArgs
+                                yield! lfsTransferConfigArgs commandAuth.ConfigArgs
                                 "lfs"
                                 "push"
                                 remoteName

--- a/src/Electron/src/Main/Git/GitProvisioningService.fs
+++ b/src/Electron/src/Main/Git/GitProvisioningService.fs
@@ -214,13 +214,26 @@ let private cloneWithGit
 // after clone via a separate `git lfs pull` step (see hydrateClonedLfsContent).
 let private applyCloneSkipSmudge (git: ISimpleGit) = git.env (GitLfsSkipSmudgeEnvKey, "1")
 
-let private hydrateClonedLfsContent (git: ISimpleGit) : JS.Promise<GitService.GitResult<unit>> =
-    runSimpleGit
-        (fun currentGit -> promise {
-            let! _ = currentGit.raw [| "lfs"; "pull" |]
-            return ()
-        })
-        git
+let private createCloneLfsCommandAuth host tokenOption remoteUrl =
+    match
+        tokenOption
+        |> Option.filter (fun token -> not (String.IsNullOrWhiteSpace token))
+    with
+    | Some token -> createCommandAuthentication host token (Some "origin") (Some remoteUrl)
+    | None -> {
+        ConfigArgs = [||]
+        Environment = createNonInteractiveEnv ()
+      }
+
+let private hydrateClonedLfsContent
+    (repoPath: string)
+    (commandAuth: GitCommandAuthentication)
+    : JS.Promise<GitService.GitResult<unit>> =
+    promise {
+        match! GitLfsService.pullAll repoPath commandAuth None with
+        | Ok() -> return Ok()
+        | Error error -> return errorResult error
+    }
 
 let private persistCloneDownloadPreference
     (repoPath: string)
@@ -396,51 +409,20 @@ let cloneRepository
                                                     | Error failure -> return Error failure
                                                     | Ok() when not downloadLargeFiles -> return cloneResult
                                                     | Ok() ->
-                                                        let repoOptions =
-                                                            createOptions normalizedTargetPath syncTimeout progress
+                                                        GitInternals.reportPhase
+                                                            progress
+                                                            "lfs"
+                                                            "Downloading Git LFS files"
 
-                                                        let hydrateGitResult =
-                                                            try
-                                                                match
-                                                                    tokenOption
-                                                                    |> Option.filter (fun token ->
-                                                                        not (String.IsNullOrWhiteSpace token)
-                                                                    )
-                                                                with
-                                                                | Some token ->
-                                                                    Ok(
-                                                                        applyAuth
-                                                                            (fun options ->
-                                                                                createGit options
-                                                                                |> withGitOutputProgress progress
-                                                                            )
-                                                                            repoOptions
-                                                                            host
-                                                                            token
-                                                                            (Some "origin")
-                                                                            (Some safeRemoteUrl)
-                                                                    )
-                                                                | None ->
-                                                                    Ok(
-                                                                        createGit repoOptions
-                                                                        |> withGitOutputProgress progress
-                                                                    )
-                                                            with authError ->
-                                                                Error authError
+                                                        let commandAuth =
+                                                            createCloneLfsCommandAuth host tokenOption safeRemoteUrl
 
-                                                        match hydrateGitResult with
-                                                        | Error authError -> return errorResult authError
-                                                        | Ok hydrateGit ->
-                                                            GitInternals.reportPhase
-                                                                progress
-                                                                "lfs"
-                                                                "Downloading Git LFS files"
+                                                        let! hydrateResult =
+                                                            hydrateClonedLfsContent normalizedTargetPath commandAuth
 
-                                                            let! hydrateResult = hydrateClonedLfsContent hydrateGit
-
-                                                            match hydrateResult with
-                                                            | Ok() -> return cloneResult
-                                                            | Error failure -> return Error failure
+                                                        match hydrateResult with
+                                                        | Ok() -> return cloneResult
+                                                        | Error failure -> return Error failure
                                             }
 
                                             match tokenResult with

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -51,11 +51,45 @@ let private gitLfsDefaultThresholdMb = 1
 let private gitLfsMaximumThresholdMb = 100
 let private gitLfsDefaultDownloadLargeFiles = false
 
+let private pushCancellationRequests =
+    System.Collections.Generic.Dictionary<string, bool>()
+
 let private normalizeOptionalGitRef (value: string option) =
     value
     |> Option.bind Option.ofObj
     |> Option.map _.Trim()
     |> Option.filter (fun item -> not (String.IsNullOrWhiteSpace item))
+
+let private pushCancellationKey (arcPath: string) =
+    let raw =
+        try
+            resolve [| arcPath |]
+        with _ ->
+            arcPath
+
+    raw.Trim().TrimEnd([| '/'; '\\' |]).ToLowerInvariant()
+
+let private startPushCancellationScope (arcPath: string) =
+    let key = pushCancellationKey arcPath
+    pushCancellationRequests.[key] <- false
+
+    let cancelCheck () =
+        match pushCancellationRequests.TryGetValue key with
+        | true, value -> value
+        | _ -> false
+
+    key, cancelCheck
+
+let private clearPushCancellationScope key =
+    pushCancellationRequests.Remove key |> ignore
+
+let cancelPush (arcPath: string) : GitResult<unit> =
+    let key = pushCancellationKey arcPath
+
+    if pushCancellationRequests.ContainsKey key then
+        pushCancellationRequests.[key] <- true
+
+    Ok()
 
 let private lfsInstallRequiredTokens = [|
     "git lfs is required for files larger than"
@@ -488,6 +522,7 @@ let private ensureBackupMatchesLfsOid (backupPath: string) (listing: GitLfsLsFil
             Arguments = [| "lfs"; "pointer"; "--file"; backupPath |]
             Environment = None
             StandardInput = None
+            CancelCheck = None
             TimeoutMs = Some 30000
         }
 
@@ -955,30 +990,21 @@ let private validateCommitLfsPolicy (git: ISimpleGit) : JS.Promise<GitResult<uni
         | None -> return Error(createCommitLfsValidationFailure thresholdMb (oversizedPaths.ToArray()))
 }
 
-// GitService keeps the pull preference application here because it changes how the authenticated pull workflow checks out the working tree.
-let private applyLfsDownloadPreference (downloadLargeFiles: bool) (git: ISimpleGit) =
-    if downloadLargeFiles then
-        git
-    else
-        git.env (GitLfsSkipSmudgeEnvKey, "1")
+// Pull always skips smudge downloads; when enabled, LFS content is hydrated afterward by a no-timeout transfer.
+let private applyPullLfsSkipSmudge (git: ISimpleGit) = git.env (GitLfsSkipSmudgeEnvKey, "1")
 
 // GitService keeps explicit post-pull hydration here because it must reuse the authenticated git instance created for the pull workflow.
 let private hydratePulledLfsContent
     (progressCallback: GitProgressCallback option)
-    (git: ISimpleGit)
+    (repoPath: string)
+    (commandAuth: GitCommandAuthentication)
     : JS.Promise<GitResult<unit>> =
     promise {
         reportPhase progressCallback "lfs" "Downloading Git LFS files"
 
-        let! result =
-            runSimpleGit
-                (fun currentGit -> promise {
-                    let! _ = currentGit.raw [| "lfs"; "pull" |]
-                    return ()
-                })
-                git
-
-        return result
+        match! GitLfsService.pullAll repoPath commandAuth None with
+        | Ok() -> return Ok()
+        | Error error -> return errorResult error
     }
 
 let private createPullHydrationFailure (failure: GitFailure) = {
@@ -1650,6 +1676,7 @@ let previewPull
                                                 |]
                                                 Environment = None
                                                 StandardInput = None
+                                                CancelCheck = None
                                                 TimeoutMs = Some 30000
                                             }
 
@@ -1702,37 +1729,41 @@ let pull
             match validateOptionalBranchName branchName with
             | Error branchError -> return errorResult branchError
             | Ok safeBranchName ->
-                let! result =
-                    withAuthenticatedGit
-                        arcPath
-                        safeRemoteName
-                        progressCallback
-                        (fun git -> promise {
-                            let! downloadLargeFiles = getConfiguredLfsDownloadLargeFiles git
-                            let effectiveGit = applyLfsDownloadPreference downloadLargeFiles git
+                let! sessionResult = createAuthenticatedGitSession arcPath safeRemoteName progressCallback
 
-                            match safeBranchName with
-                            | None ->
-                                do! ensureDefaultTrackingBranchForPull safeRemoteName effectiveGit
-                                let! _ = effectiveGit.pull (safeRemoteName)
-                                ()
-                            | Some safeBranch ->
-                                let! _ = effectiveGit.pull (safeRemoteName, safeBranch)
-                                ()
+                match sessionResult with
+                | Error failure -> return Error failure
+                | Ok session ->
+                    let! result =
+                        runSimpleGit
+                            (fun git -> promise {
+                                let! downloadLargeFiles = getConfiguredLfsDownloadLargeFiles git
+                                let effectiveGit = applyPullLfsSkipSmudge git
 
-                            if downloadLargeFiles then
-                                let! lfsPullResult = hydratePulledLfsContent progressCallback effectiveGit
+                                match safeBranchName with
+                                | None ->
+                                    do! ensureDefaultTrackingBranchForPull safeRemoteName effectiveGit
+                                    let! _ = effectiveGit.pull (safeRemoteName)
+                                    ()
+                                | Some safeBranch ->
+                                    let! _ = effectiveGit.pull (safeRemoteName, safeBranch)
+                                    ()
 
-                                match lfsPullResult with
-                                | Ok() -> return { Warning = None }
-                                | Error failure ->
-                                    let hydrationFailure = createPullHydrationFailure failure
-                                    return abortGitPromise hydrationFailure.Message
-                            else
-                                return { Warning = None }
-                        })
+                                if downloadLargeFiles then
+                                    let! lfsPullResult =
+                                        hydratePulledLfsContent progressCallback arcPath session.CommandAuth
 
-                return result
+                                    match lfsPullResult with
+                                    | Ok() -> return { Warning = None }
+                                    | Error failure ->
+                                        let hydrationFailure = createPullHydrationFailure failure
+                                        return abortGitPromise hydrationFailure.Message
+                                else
+                                    return { Warning = None }
+                            })
+                            session.Git
+
+                    return result
     }
 
 /// Coordinates LFS upload planning, optional LFS upload, and the final git push.
@@ -1791,83 +1822,94 @@ let push
                     | Ok session ->
                         let git = session.Git
                         let runGitCapturedForProgress = runGitCapturedWithOutput progressCallback
-                        let! pushStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
+                        let cancellationKey, cancelCheck = startPushCancellationScope arcPath
 
-                        match pushStatusResult with
-                        | Error failure -> return Error failure
-                        | Ok pushStatus ->
-                            let pushTarget =
-                                resolvePushTarget
-                                    safeBranchName
-                                    pushStatus.current
-                                    pushStatus.tracking
-                                    pushStatus.detached
+                        try
+                            let! pushStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
 
-                            return!
-                                executePushWorkflow
-                                    pushTarget
-                                    (fun () ->
-                                        reportPhase progressCallback "lfs" "Checking Git LFS objects"
+                            match pushStatusResult with
+                            | Error failure -> return Error failure
+                            | Ok pushStatus ->
+                                let pushTarget =
+                                    resolvePushTarget
+                                        safeBranchName
+                                        pushStatus.current
+                                        pushStatus.tracking
+                                        pushStatus.detached
 
-                                        planOutboundPush
-                                            runSimpleGit
-                                            runGitCapturedForProgress
-                                            toFailure
-                                            (fun currentGit ->
-                                                runSimpleGit (fun gitInstance -> gitInstance.status ()) currentGit
-                                            )
-                                            arcPath
-                                            safeRemoteName
-                                            (Some pushTarget.RefSpec)
-                                            git
-                                    )
-                                    (fun objectIds -> promise {
-                                        reportPhase progressCallback "lfs" "Uploading Git LFS objects"
+                                return!
+                                    executePushWorkflow
+                                        pushTarget
+                                        (fun () ->
+                                            reportPhase progressCallback "lfs" "Checking Git LFS objects"
 
-                                        let! uploadResult =
-                                            GitLfsService.uploadObjects
+                                            planOutboundPush
+                                                runSimpleGit
                                                 runGitCapturedForProgress
-                                                session.CommandAuth
+                                                toFailure
+                                                (fun currentGit ->
+                                                    runSimpleGit (fun gitInstance -> gitInstance.status ()) currentGit
+                                                )
                                                 arcPath
                                                 safeRemoteName
-                                                pushTarget.RefSpec
-                                                objectIds
+                                                (Some pushTarget.RefSpec)
+                                                git
+                                        )
+                                        (fun objectIds -> promise {
+                                            reportPhase progressCallback "lfs" "Uploading Git LFS objects"
 
-                                        return uploadResult |> Result.mapError toFailure
-                                    })
-                                    (fun skipLfsHook currentPushTarget ->
-                                        runSimpleGit
-                                            (fun currentGit -> promise {
-                                                let pushGit =
-                                                    if skipLfsHook then
-                                                        currentGit.env ("GIT_LFS_SKIP_PUSH", "1")
-                                                    else
-                                                        currentGit
+                                            let! uploadResult =
+                                                GitLfsService.uploadObjects
+                                                    runGitCapturedForProgress
+                                                    session.CommandAuth
+                                                    cancelCheck
+                                                    arcPath
+                                                    safeRemoteName
+                                                    pushTarget.RefSpec
+                                                    objectIds
 
-                                                if currentPushTarget.SetUpstream then
-                                                    let! _ =
-                                                        pushGit.push (
-                                                            safeRemoteName,
-                                                            currentPushTarget.PushBranch,
-                                                            !^[| "--set-upstream" |]
-                                                        )
+                                            return uploadResult |> Result.mapError toFailure
+                                        })
+                                        (fun skipLfsHook currentPushTarget ->
+                                            reportPhase progressCallback "push" "Pushing refs"
 
-                                                    return ()
-                                                else
-                                                    let! _ =
-                                                        pushGit.push (safeRemoteName, currentPushTarget.PushBranch)
-
-                                                    return ()
-                                            })
-                                            git
-                                    )
-                                    (fun _failure ->
-                                        collectPushDiagnostics
                                             runSimpleGit
-                                            (fun currentFailure -> Some currentFailure.Message)
-                                            safeRemoteName
-                                            git
-                                    )
+                                                (fun currentGit -> promise {
+                                                    let pushGit =
+                                                        if skipLfsHook then
+                                                            currentGit.env ("GIT_LFS_SKIP_PUSH", "1")
+                                                        else
+                                                            currentGit
+
+                                                    if currentPushTarget.SetUpstream then
+                                                        let! _ =
+                                                            pushGit.push (
+                                                                safeRemoteName,
+                                                                currentPushTarget.PushBranch,
+                                                                !^[| "--set-upstream" |]
+                                                            )
+
+                                                        return ()
+                                                    else
+                                                        let! _ =
+                                                            pushGit.push (
+                                                                safeRemoteName,
+                                                                currentPushTarget.PushBranch
+                                                            )
+
+                                                        return ()
+                                                })
+                                                git
+                                        )
+                                        (fun _failure ->
+                                            collectPushDiagnostics
+                                                runSimpleGit
+                                                (fun currentFailure -> Some currentFailure.Message)
+                                                safeRemoteName
+                                                git
+                                        )
+                        finally
+                            clearPushCancellationScope cancellationKey
     }
 
 /// Persists Git workflow LFS settings in local repository config.
@@ -2028,14 +2070,6 @@ let private requireLfsListingForPath (arcPath: string) (safePath: string) : JS.P
 let private runLfsRaw (args: string[]) git =
     runSimpleGit (fun currentGit -> currentGit.raw args) git
 
-let private withOriginLfsGitResult arcPath (operation: ISimpleGit -> JS.Promise<GitResult<'T>>) = promise {
-    let! gitResult = createOriginLfsRemoteGit arcPath None
-
-    match gitResult with
-    | Error failure -> return Error failure
-    | Ok git -> return! operation git
-}
-
 let private getCleanLfsListingForPath
     (arcPath: string)
     (safePath: string)
@@ -2137,63 +2171,60 @@ let freeLocalLfsCopy (arcPath: string) (requestedPath: string) : JS.Promise<GitR
     | Ok(safePath, _, _) when not (isTrackedByAttributes arcPath safePath) ->
         return errorResult (createMissingLfsAttributesFailure safePath "freeing the local LFS copy")
     | Ok(safePath, absolutePath, listing) ->
-        return!
-            withOriginLfsGitResult
-                arcPath
-                (fun git -> promise {
-                    let! fetchResult = runLfsRaw (GitLfsService.buildFetchRefetchArgs safePath) git
+        match! createOriginLfsRemoteSession arcPath None with
+        | Error failure -> return Error failure
+        | Ok session ->
+            match! GitLfsService.fetchRefetchForPath arcPath session.CommandAuth safePath None with
+            | Error error -> return errorResult error
+            | Ok() ->
+                let git = session.Git
+                let backupPath = createTemporaryLfsBackupPath absolutePath
 
-                    match fetchResult with
-                    | Error failure -> return Error failure
-                    | Ok _ ->
-                        let backupPath = createTemporaryLfsBackupPath absolutePath
+                try
+                    renameSync absolutePath backupPath
 
-                        try
-                            renameSync absolutePath backupPath
+                    match! ensureBackupMatchesLfsOid backupPath listing with
+                    | Error validationError ->
+                        restoreTemporaryLfsBackup backupPath absolutePath
 
-                            match! ensureBackupMatchesLfsOid backupPath listing with
-                            | Error validationError ->
-                                restoreTemporaryLfsBackup backupPath absolutePath
+                        return errorResult validationError
+                    | Ok() ->
+                        let pointerGit = git.env (GitLfsSkipSmudgeEnvKey, "1")
 
-                                return errorResult validationError
-                            | Ok() ->
-                                let pointerGit = git.env (GitLfsSkipSmudgeEnvKey, "1")
+                        let! checkoutResult =
+                            runSimpleGit
+                                (fun currentGit -> currentGit.raw [| "checkout"; "HEAD"; "--"; safePath |])
+                                pointerGit
 
-                                let! checkoutResult =
-                                    runSimpleGit
-                                        (fun currentGit -> currentGit.raw [| "checkout"; "HEAD"; "--"; safePath |])
-                                        pointerGit
-
-                                match checkoutResult with
-                                | Error failure ->
-                                    restoreTemporaryLfsBackup backupPath absolutePath
-
-                                    return Error failure
-                                | Ok _ ->
-                                    let! finalStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
-
-                                    match finalStatusResult with
-                                    | Error failure ->
-                                        restoreTemporaryLfsBackup backupPath absolutePath
-
-                                        return Error failure
-                                    | Ok finalStatus when not (isPathCleanInStatus finalStatus safePath) ->
-                                        restoreTemporaryLfsBackup backupPath absolutePath
-
-                                        return
-                                            errorResult (
-                                                exn
-                                                    $"Could not replace '{safePath}' with an LFS pointer without changing Git status."
-                                            )
-                                    | Ok _ ->
-                                        removeTemporaryLfsBackup backupPath
-
-                                        return Ok()
-                        with ex ->
+                        match checkoutResult with
+                        | Error failure ->
                             restoreTemporaryLfsBackup backupPath absolutePath
 
-                            return errorResult ex
-                })
+                            return Error failure
+                        | Ok _ ->
+                            let! finalStatusResult = runSimpleGit (fun currentGit -> currentGit.status ()) git
+
+                            match finalStatusResult with
+                            | Error failure ->
+                                restoreTemporaryLfsBackup backupPath absolutePath
+
+                                return Error failure
+                            | Ok finalStatus when not (isPathCleanInStatus finalStatus safePath) ->
+                                restoreTemporaryLfsBackup backupPath absolutePath
+
+                                return
+                                    errorResult (
+                                        exn
+                                            $"Could not replace '{safePath}' with an LFS pointer without changing Git status."
+                                    )
+                            | Ok _ ->
+                                removeTemporaryLfsBackup backupPath
+
+                                return Ok()
+                with ex ->
+                    restoreTemporaryLfsBackup backupPath absolutePath
+
+                    return errorResult ex
 }
 
 let downloadLfsFile (arcPath: string) (requestedPath: string) : JS.Promise<GitResult<unit>> = promise {

--- a/src/Electron/src/Main/Git/GitlfsAdapter.fs
+++ b/src/Electron/src/Main/Git/GitlfsAdapter.fs
@@ -16,6 +16,7 @@ type GitSpawnRequest = {
     Arguments: string[]
     Environment: obj option
     StandardInput: string option
+    CancelCheck: (unit -> bool) option
     TimeoutMs: int option
 }
 
@@ -52,10 +53,36 @@ let private runGitProcess (captureStdout: bool) (request: GitSpawnRequest) : Pro
             let stderrChunks = ResizeArray<string>()
             let mutable finished = false
             let mutable timedOut = false
+            let mutable cancelRequested = false
+            let mutable timeoutId: int option = None
+
+            let clearIdleTimer () =
+                timeoutId |> Option.iter Fable.Core.JS.clearTimeout
+                timeoutId <- None
+
+            let resetIdleTimer () =
+                clearIdleTimer ()
+
+                match request.TimeoutMs with
+                | Some timeoutMs when timeoutMs > 0 ->
+                    timeoutId <-
+                        Some(
+                            Fable.Core.JS.setTimeout
+                                (fun () ->
+                                    if not finished then
+                                        timedOut <- true
+                                        stderrChunks.Add $"Git command timed out after no output for {timeoutMs} ms."
+                                        proc?kill ("SIGTERM") |> ignore
+                                )
+                                timeoutMs
+                        )
+                | _ -> ()
 
             let finish exitCode =
                 if not finished then
                     finished <- true
+                    clearIdleTimer ()
+                    let effectiveExitCode = if cancelRequested && exitCode = 0 then -1 else exitCode
 
                     let stdoutBuffer =
                         if captureStdout then
@@ -64,7 +91,7 @@ let private runGitProcess (captureStdout: bool) (request: GitSpawnRequest) : Pro
                             bufferConcat [||]
 
                     resolve {
-                        ExitCode = exitCode
+                        ExitCode = effectiveExitCode
                         StdoutBuffer = stdoutBuffer
                         StdoutText = bufferToUtf8String stdoutBuffer
                         StderrText = String.Concat(stderrChunks.ToArray())
@@ -74,31 +101,40 @@ let private runGitProcess (captureStdout: bool) (request: GitSpawnRequest) : Pro
             proc?stdout?on (
                 "data",
                 fun d ->
+                    resetIdleTimer ()
+
                     if captureStdout then
                         stdoutChunks.Add d
             )
             |> ignore
 
-            proc?stderr?on ("data", fun d -> stderrChunks.Add(d?toString ("utf8") |> unbox<string>))
+            proc?stderr?on (
+                "data",
+                fun d ->
+                    resetIdleTimer ()
+                    stderrChunks.Add(d?toString ("utf8") |> unbox<string>)
+            )
             |> ignore
 
-            let timeoutId =
-                request.TimeoutMs
-                |> Option.map (fun timeoutMs ->
-                    Fable.Core.JS.setTimeout
+            resetIdleTimer ()
+
+            let cancelInterval =
+                request.CancelCheck
+                |> Option.map (fun cancelCheck ->
+                    Fable.Core.JS.setInterval
                         (fun () ->
-                            if not finished then
-                                timedOut <- true
-                                stderrChunks.Add $"Git command timed out after {timeoutMs} ms."
+                            if not finished && not cancelRequested && cancelCheck () then
+                                cancelRequested <- true
+                                stderrChunks.Add "Git command cancelled."
                                 proc?kill ("SIGTERM") |> ignore
                         )
-                        timeoutMs
+                        300
                 )
 
             proc?on (
                 "close",
                 fun code ->
-                    timeoutId |> Option.iter Fable.Core.JS.clearTimeout
+                    cancelInterval |> Option.iter Fable.Core.JS.clearInterval
                     finish (if isNull code then -1 else int (unbox<float> code))
             )
             |> ignore
@@ -106,7 +142,7 @@ let private runGitProcess (captureStdout: bool) (request: GitSpawnRequest) : Pro
             proc?on (
                 "error",
                 fun error ->
-                    timeoutId |> Option.iter Fable.Core.JS.clearTimeout
+                    cancelInterval |> Option.iter Fable.Core.JS.clearInterval
 
                     stderrChunks.Add(
                         error
@@ -139,35 +175,20 @@ let runGitDiscardingStdout (request: GitSpawnRequest) : Promise<GitSpawnResult> 
 /// Runs a small git command and returns stdout text, or None on command failure.
 /// Used for feature probes where failure should not surface as a user-facing Git error.
 let tryExecGitText (workingDirectory: string option) (timeoutMs: int) (args: string[]) : Promise<string option> = promise {
-    let! output =
-        Fable.Core.JS.Constructors.Promise.Create(fun resolve _reject ->
-            let options =
-                createObj [
-                    "encoding" ==> "utf8"
-                    "stdio" ==> "pipe"
-                    "shell" ==> false
-                    "timeout" ==> timeoutMs
-                    "env" ==> createNonInteractiveEnv ()
+    let! result =
+        runGitCaptured {
+            WorkingDirectory = workingDirectory
+            Arguments = args
+            Environment = None
+            StandardInput = None
+            CancelCheck = None
+            TimeoutMs = Some timeoutMs
+        }
 
-                    match workingDirectory with
-                    | Some value -> "cwd" ==> value
-                    | None -> ()
-                ]
-
-            childProcessDynamic?execFile (
-                "git",
-                args,
-                options,
-                fun (error: obj) (stdout: obj) (_stderr: obj) ->
-                    if error |> Option.ofObj |> Option.isSome then
-                        resolve None
-                    else
-                        stdout |> Option.ofObj |> Option.map string |> resolve
-            )
-            |> ignore
-        )
-
-    return output
+    if result.ExitCode = 0 && not result.TimedOut then
+        return Some result.StdoutText
+    else
+        return None
 }
 
 
@@ -271,10 +292,40 @@ type NodeGitLfsAdapter() =
                             let mutable output = ""
                             let mutable errorOut = ""
                             let mutable finished = false
+                            let mutable timedOut = false
+                            let mutable cancelRequested = false
+                            let mutable timeoutId: int option = None
+
+                            let clearIdleTimer () =
+                                timeoutId |> Option.iter Fable.Core.JS.clearTimeout
+                                timeoutId <- None
+
+                            let resetIdleTimer () =
+                                clearIdleTimer ()
+
+                                match timeoutMs with
+                                | Some ms when ms > 0 ->
+                                    timeoutId <-
+                                        Some(
+                                            Fable.Core.JS.setTimeout
+                                                (fun () ->
+                                                    if not finished then
+                                                        timedOut <- true
+
+                                                        errorOut <-
+                                                            errorOut
+                                                            + $"Git LFS command timed out after no output for {ms} ms."
+
+                                                        proc?kill ("SIGTERM") |> ignore
+                                                )
+                                                ms
+                                        )
+                                | _ -> ()
 
                             proc?stdout?on (
                                 "data",
                                 fun d ->
+                                    resetIdleTimer ()
                                     let msg = string d
                                     output <- output + msg
                                     onProgress msg
@@ -284,27 +335,21 @@ type NodeGitLfsAdapter() =
                             proc?stderr?on (
                                 "data",
                                 fun d ->
+                                    resetIdleTimer ()
                                     let msg = string d
                                     errorOut <- errorOut + msg
                                     onProgress msg
                             )
                             |> ignore
 
-                            let timeoutId =
-                                timeoutMs
-                                |> Option.map (fun ms ->
-                                    Fable.Core.JS.setTimeout
-                                        (fun () ->
-                                            if not finished then
-                                                proc?kill ("SIGTERM") |> ignore
-                                        )
-                                        ms
-                                )
+                            resetIdleTimer ()
 
                             let cancelInterval =
                                 Fable.Core.JS.setInterval
                                     (fun () ->
-                                        if not finished && cancelCheck () then
+                                        if not finished && not cancelRequested && cancelCheck () then
+                                            cancelRequested <- true
+                                            errorOut <- errorOut + "Git LFS command cancelled."
                                             proc?kill ("SIGTERM") |> ignore
                                     )
                                     300
@@ -313,10 +358,13 @@ type NodeGitLfsAdapter() =
                                 "close",
                                 fun code ->
                                     finished <- true
-                                    timeoutId |> Option.iter Fable.Core.JS.clearTimeout
+                                    clearIdleTimer ()
                                     Fable.Core.JS.clearInterval cancelInterval
 
-                                    let success = if isNull code then false else (unbox<float> code) = 0.
+                                    let success =
+                                        (not timedOut)
+                                        && (not cancelRequested)
+                                        && if isNull code then false else (unbox<float> code) = 0.
 
                                     resolve {
                                         Success = success
@@ -330,7 +378,7 @@ type NodeGitLfsAdapter() =
                                 "error",
                                 fun err ->
                                     finished <- true
-                                    timeoutId |> Option.iter Fable.Core.JS.clearTimeout
+                                    clearIdleTimer ()
                                     Fable.Core.JS.clearInterval cancelInterval
 
                                     resolve {

--- a/src/Electron/src/Main/IPC/IGitApi.fs
+++ b/src/Electron/src/Main/IPC/IGitApi.fs
@@ -264,6 +264,14 @@ let api (event: IpcMainInvokeEvent) : IGitApi = {
                 let! result = GitService.push arcPath request.Remote request.Branch (Some progressReporter)
                 return toGitOperationResult (fun () -> Some "Push completed.") None None result
         }
+    gitCancelPush =
+        fun () -> promise {
+            match tryGetVaultAndArcPath event with
+            | Error error -> return Error error
+            | Ok(_, arcPath) ->
+                let result = GitService.cancelPush arcPath
+                return toGitOperationResult (fun () -> Some "Push cancellation requested.") None None result
+        }
     gitInitRepository =
         fun (targetPath: string) -> promise {
             // Init provisioning is path-driven only; no vault/window context is required.

--- a/src/Electron/src/Renderer/Components/LeftSidebar/Git/GitSidebarPanel.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/Git/GitSidebarPanel.fs
@@ -8,6 +8,10 @@ open Swate.Components.Primitive.ErrorModal.Types
 
 let mutable private gitVersionCheckStarted = false
 
+let private isLfsUploadProgress (progress: Swate.Components.Page.GitSidebarTypes.GitSidebarProgress) =
+    progress.Method = Some "lfs"
+    && progress.Stage = Some "Uploading Git LFS objects"
+
 [<ReactComponent>]
 let Main () =
 
@@ -89,6 +93,9 @@ let Main () =
             }
         )
     | Some _ ->
+        let canCancelOperation =
+            gitStateCtx.state.CurrentProgress |> Option.exists isLfsUploadProgress
+
         Swate.Components.Page.GitSidebar.Main(
             status = gitStateCtx.state.Status,
             changedFiles = gitStateCtx.state.ChangedFiles,
@@ -124,10 +131,12 @@ let Main () =
                 OnSelectChange = gitStateCtx.selectChange
                 OnPruneLfsCache = gitStateCtx.pruneLfsCache
                 OnDedupLfsStorage = gitStateCtx.dedupLfsStorage
+                OnCancelOperation = gitStateCtx.cancelOperation
             },
             downloadLargeFiles = gitStateCtx.state.DownloadLargeFiles,
             lfsAutoTrackThresholdMb = gitStateCtx.state.LfsAutoTrackThresholdMb,
             remoteActionsEnabled = remoteActionsEnabled,
+            canCancelOperation = canCancelOperation,
             canOpenRemoteRepository = gitStateCtx.state.OriginRemoteRepositoryWebUrl.IsSome,
             onSubmitPublishRename = gitStateCtx.submitPublishRename,
             onCancelPublishRename = gitStateCtx.cancelPublishRename,

--- a/src/Electron/src/Renderer/Context/GitStateContext.fs
+++ b/src/Electron/src/Renderer/Context/GitStateContext.fs
@@ -21,6 +21,7 @@ type GitStateController = {
     fetch: unit -> unit
     pull: unit -> unit
     push: unit -> unit
+    cancelOperation: unit -> unit
     updateFromOnline: unit -> unit
     primarySaveSelection: GitSidebarCommitSelectionRequest -> unit
     primarySaveAll: string -> unit
@@ -82,6 +83,7 @@ module private Helper =
         gitFetch = Renderer.GitApiClient.gitFetch
         gitPull = Renderer.GitApiClient.gitPull
         gitPush = Renderer.GitApiClient.gitPush
+        gitCancelPush = Renderer.GitApiClient.gitCancelPush
         gitCloneRepository = Renderer.GitApiClient.gitCloneRepository
         createBranch = Renderer.GitApiClient.createBranch
         checkoutBranch = Renderer.GitApiClient.checkoutBranch
@@ -107,6 +109,7 @@ let GitStateCtx =
             fetch = fun () -> ()
             pull = fun () -> ()
             push = fun () -> ()
+            cancelOperation = fun () -> ()
             updateFromOnline = fun () -> ()
             primarySaveSelection = fun _ -> ()
             primarySaveAll = fun _ -> ()
@@ -166,6 +169,9 @@ let GitStateCtxProvider (children: ReactElement) =
     let pull () = dispatch PullRequested
 
     let push () = dispatch PushRequested
+
+    let cancelOperation () =
+        dispatch CancelCurrentOperationRequested
 
     let updateFromOnline () = dispatch UpdateFromOnlineRequested
 
@@ -230,6 +236,7 @@ let GitStateCtxProvider (children: ReactElement) =
                 fetch = fetch
                 pull = pull
                 push = push
+                cancelOperation = cancelOperation
                 updateFromOnline = updateFromOnline
                 primarySaveSelection = primarySaveSelection
                 primarySaveAll = primarySaveAll

--- a/src/Electron/src/Renderer/Context/GitWorkflow.fs
+++ b/src/Electron/src/Renderer/Context/GitWorkflow.fs
@@ -209,6 +209,8 @@ type Msg =
     | FetchRequested
     | PullRequested
     | PushRequested
+    | CancelCurrentOperationRequested
+    | CancelCurrentOperationCompleted of Result<GitOperationResult, string>
     | UpdateFromOnlineRequested
     | UpdatePreflightCompleted of sessionId: int * Result<GitPullPreflightResult, string>
     | CloneRequested of GitCloneRepositoryRequest * Reply<string>
@@ -245,6 +247,7 @@ type GitDependencies = {
     gitFetch: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
     gitPush: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, string>>
+    gitCancelPush: unit -> JS.Promise<Result<GitOperationResult, string>>
     gitCloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, string>>
     createBranch: GitCreateBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
     checkoutBranch: GitCheckoutBranchRequest -> JS.Promise<Result<GitOperationResult, string>>
@@ -1328,6 +1331,31 @@ let update
     | FetchRequested -> model, Cmd.ofMsg (WriteRequested Fetch)
     | PullRequested -> model, Cmd.ofMsg (WriteRequested Pull)
     | PushRequested -> model, Cmd.ofMsg (WriteRequested Push)
+    | CancelCurrentOperationRequested ->
+        let nextModel = {
+            model with
+                WarningNotice = Some "Canceling push..."
+        }
+
+        let cmd =
+            Cmd.OfPromise.either
+                deps.gitCancelPush
+                ()
+                CancelCurrentOperationCompleted
+                (fun err -> CancelCurrentOperationCompleted(Error(string err)))
+
+        nextModel, cmd
+    | CancelCurrentOperationCompleted(Ok operationResult) when not operationResult.Success ->
+        let message =
+            operationResult.Message |> Option.defaultValue "Could not cancel push."
+
+        {
+            model with
+                ErrorNotice = Some message
+                WarningNotice = None
+        },
+        reportErrorCmd deps "Could not cancel push" message
+    | CancelCurrentOperationCompleted _ -> model, Cmd.none
     | UpdateFromOnlineRequested when model.CurrentArcPath.IsNone -> model, Cmd.none
     | UpdateFromOnlineRequested ->
         let nextModel =

--- a/src/Electron/src/Renderer/GitApiClient.fs
+++ b/src/Electron/src/Renderer/GitApiClient.fs
@@ -50,6 +50,9 @@ let previewGitPull (request: GitRemoteOperationRequest) =
 
 let gitPush (request: GitRemoteOperationRequest) = callIpcWith request (gitApi.gitPush)
 
+let gitCancelPush () =
+    callIpc (fun () -> gitApi.gitCancelPush ())
+
 let gitInitRepository (targetPath: string) = promise {
     let! result = gitApi.gitInitRepository targetPath
 

--- a/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
+++ b/src/Electron/src/Swate.Electron.Shared/IPCTypes.fs
@@ -88,6 +88,7 @@ type IGitApi = {
     gitFetch: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitPull: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitPush: GitRemoteOperationRequest -> JS.Promise<Result<GitOperationResult, exn>>
+    gitCancelPush: unit -> JS.Promise<Result<GitOperationResult, exn>>
     gitInitRepository: string -> JS.Promise<Result<GitOperationResult, exn>>
     gitAddRemote: GitRemoteConfigRequest -> JS.Promise<Result<GitOperationResult, exn>>
     gitCloneRepository: GitCloneRepositoryRequest -> JS.Promise<Result<GitOperationResult, exn>>

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -1513,9 +1513,14 @@ Vitest.describe (
                     }
 
                 let! result =
-                    GitLfsService.uploadObjects fakeSpawnedGit commandAuth "C:/repo" "origin" "refs/heads/main" [|
-                        lfsObjectId
-                    |]
+                    GitLfsService.uploadObjects
+                        fakeSpawnedGit
+                        commandAuth
+                        (fun () -> false)
+                        "C:/repo"
+                        "origin"
+                        "refs/heads/main"
+                        [| lfsObjectId |]
 
                 expectOkResult "upload exact object ids" result |> ignore
 
@@ -1530,6 +1535,137 @@ Vitest.describe (
 
                 Vitest.expect(recordedArgs).toEqual (expectedArgs)
                 Vitest.expect(recordedStdin).toEqual (Some $"{lfsObjectId}\n")
+            }
+        )
+
+        Vitest.test (
+            "uploadObjects does not set a timeout for LFS transfers",
+            fun () -> promise {
+                let lfsObjectId = "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+
+                let commandAuth: GitAuthAdapter.GitCommandAuthentication = {
+                    ConfigArgs = [||]
+                    Environment = createObj []
+                }
+
+                let mutable recordedTimeout = Some 0
+
+                let fakeSpawnedGit: GitLfsAdapter.GitSpawnRequest -> JS.Promise<GitLfsAdapter.GitSpawnResult> =
+                    fun (request: GitLfsAdapter.GitSpawnRequest) -> promise {
+                        recordedTimeout <- request.TimeoutMs
+
+                        return {
+                            ExitCode = 0
+                            StdoutBuffer = utf8Buffer ""
+                            StdoutText = ""
+                            StderrText = ""
+                            TimedOut = false
+                        }
+                    }
+
+                let! result =
+                    GitLfsService.uploadObjects
+                        fakeSpawnedGit
+                        commandAuth
+                        (fun () -> false)
+                        "C:/repo"
+                        "origin"
+                        "refs/heads/main"
+                        [| lfsObjectId |]
+
+                expectOkResult "upload without timeout" result |> ignore
+                Vitest.expect(recordedTimeout).toEqual (None)
+            }
+        )
+
+        Vitest.test (
+            "runAuthenticatedTransferWith does not set a timeout for LFS downloads",
+            fun () -> promise {
+                let commandAuth: GitAuthAdapter.GitCommandAuthentication = {
+                    ConfigArgs = [| "-c"; "lfs.url=https://example.test/info/lfs" |]
+                    Environment = createObj []
+                }
+
+                let mutable recordedArgs = [||]
+                let mutable recordedTimeout = Some 0
+
+                let fakeSpawnedGit: GitLfsAdapter.GitSpawnRequest -> JS.Promise<GitLfsAdapter.GitSpawnResult> =
+                    fun (request: GitLfsAdapter.GitSpawnRequest) -> promise {
+                        recordedArgs <- request.Arguments
+                        recordedTimeout <- request.TimeoutMs
+
+                        return {
+                            ExitCode = 0
+                            StdoutBuffer = utf8Buffer ""
+                            StdoutText = ""
+                            StderrText = ""
+                            TimedOut = false
+                        }
+                    }
+
+                let! result =
+                    GitLfsService.runAuthenticatedTransferWith
+                        fakeSpawnedGit
+                        commandAuth
+                        "C:/repo"
+                        [| "lfs"; "pull" |]
+                        None
+
+                expectOkResult "download without timeout" result |> ignore
+
+                Vitest
+                    .expect(recordedArgs)
+                    .toEqual (
+                        [|
+                            "-c"
+                            "lfs.url=https://example.test/info/lfs"
+                            "lfs"
+                            "pull"
+                        |]
+                    )
+
+                Vitest.expect(recordedTimeout).toEqual (None)
+            }
+        )
+
+        Vitest.test (
+            "uploadObjects stops before spawning when cancellation is already requested",
+            fun () -> promise {
+                let commandAuth: GitAuthAdapter.GitCommandAuthentication = {
+                    ConfigArgs = [||]
+                    Environment = createObj []
+                }
+
+                let mutable spawnCount = 0
+
+                let fakeSpawnedGit: GitLfsAdapter.GitSpawnRequest -> JS.Promise<GitLfsAdapter.GitSpawnResult> =
+                    fun _ -> promise {
+                        spawnCount <- spawnCount + 1
+
+                        return {
+                            ExitCode = 0
+                            StdoutBuffer = utf8Buffer ""
+                            StdoutText = ""
+                            StderrText = ""
+                            TimedOut = false
+                        }
+                    }
+
+                let! result =
+                    GitLfsService.uploadObjects
+                        fakeSpawnedGit
+                        commandAuth
+                        (fun () -> true)
+                        "C:/repo"
+                        "origin"
+                        "refs/heads/main"
+                        [|
+                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        |]
+
+                let failure = expectErrorResult result
+                Vitest.expect(spawnCount).toEqual (0)
+                Vitest.expect(failure.Message.ToLowerInvariant().Contains("cancel")).toBe (true)
             }
         )
 
@@ -1808,9 +1944,14 @@ Vitest.describe (
                     }
 
                 let! result =
-                    GitLfsService.uploadObjects fakeSpawnedGit commandAuth "C:/repo" "origin" "refs/heads/main" [|
-                        lfsObjectId
-                    |]
+                    GitLfsService.uploadObjects
+                        fakeSpawnedGit
+                        commandAuth
+                        (fun () -> false)
+                        "C:/repo"
+                        "origin"
+                        "refs/heads/main"
+                        [| lfsObjectId |]
 
                 expectOkResult "upload fallback" result |> ignore
 
@@ -2001,9 +2142,16 @@ Vitest.describe (
                     }
 
                 let! result =
-                    GitLfsService.uploadObjects fakeSpawnedGit commandAuth "C:/repo" "origin" "refs/heads/main" [|
-                        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                    |]
+                    GitLfsService.uploadObjects
+                        fakeSpawnedGit
+                        commandAuth
+                        (fun () -> false)
+                        "C:/repo"
+                        "origin"
+                        "refs/heads/main"
+                        [|
+                            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                        |]
 
                 let failure = expectErrorResult result
                 Vitest.expect(failure.Message.Contains("timed out")).toBe (true)

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -1525,7 +1525,7 @@ Vitest.describe (
                 expectOkResult "upload exact object ids" result |> ignore
 
                 let expectedArgs = [|
-                    yield! commandAuth.ConfigArgs
+                    yield! (commandAuth.ConfigArgs |> Array.skip 2)
                     yield "lfs"
                     yield "push"
                     yield "--object-id"
@@ -1579,10 +1579,77 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "uploadObjects omits HTTP extraHeader config from LFS transfer commands",
+            fun () -> promise {
+                let lfsObjectId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+                let commandAuth: GitAuthAdapter.GitCommandAuthentication = {
+                    ConfigArgs = [|
+                        "-c"
+                        "http.https://git.nfdi4plants.org/.extraHeader=Authorization: Basic TEST"
+                        "-c"
+                        "remote.origin.url=https://oauth2:TOKEN@git.nfdi4plants.org/caroott/TestARCGit.git"
+                        "-c"
+                        "lfs.url=https://oauth2:TOKEN@git.nfdi4plants.org/caroott/TestARCGit.git/info/lfs"
+                    |]
+                    Environment = createObj []
+                }
+
+                let mutable recordedArgs = [||]
+
+                let fakeSpawnedGit: GitLfsAdapter.GitSpawnRequest -> JS.Promise<GitLfsAdapter.GitSpawnResult> =
+                    fun (request: GitLfsAdapter.GitSpawnRequest) -> promise {
+                        recordedArgs <- request.Arguments
+
+                        return {
+                            ExitCode = 0
+                            StdoutBuffer = utf8Buffer ""
+                            StdoutText = ""
+                            StderrText = ""
+                            TimedOut = false
+                        }
+                    }
+
+                let! result =
+                    GitLfsService.uploadObjects
+                        fakeSpawnedGit
+                        commandAuth
+                        (fun () -> false)
+                        "C:/repo"
+                        "origin"
+                        "refs/heads/main"
+                        [| lfsObjectId |]
+
+                expectOkResult "upload without HTTP extraHeader" result |> ignore
+
+                Vitest
+                    .expect(recordedArgs)
+                    .toEqual (
+                        [|
+                            "-c"
+                            "remote.origin.url=https://oauth2:TOKEN@git.nfdi4plants.org/caroott/TestARCGit.git"
+                            "-c"
+                            "lfs.url=https://oauth2:TOKEN@git.nfdi4plants.org/caroott/TestARCGit.git/info/lfs"
+                            "lfs"
+                            "push"
+                            "--object-id"
+                            "origin"
+                            "--stdin"
+                        |]
+                    )
+            }
+        )
+
+        Vitest.test (
             "runAuthenticatedTransferWith does not set a timeout for LFS downloads",
             fun () -> promise {
                 let commandAuth: GitAuthAdapter.GitCommandAuthentication = {
-                    ConfigArgs = [| "-c"; "lfs.url=https://example.test/info/lfs" |]
+                    ConfigArgs = [|
+                        "-c"
+                        "http.extraHeader=Authorization: Basic TEST"
+                        "-c"
+                        "lfs.url=https://example.test/info/lfs"
+                    |]
                     Environment = createObj []
                 }
 
@@ -1893,7 +1960,12 @@ Vitest.describe (
                 let lfsObjectId = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 
                 let commandAuth: GitAuthAdapter.GitCommandAuthentication = {
-                    ConfigArgs = [| "-c"; "http.extraHeader=Authorization: Basic TEST" |]
+                    ConfigArgs = [|
+                        "-c"
+                        "http.extraHeader=Authorization: Basic TEST"
+                        "-c"
+                        "lfs.url=https://example.test/info/lfs"
+                    |]
                     Environment = createObj []
                 }
 
@@ -1901,7 +1973,7 @@ Vitest.describe (
 
                 let objectIdUploadArgs = [|
                     "-c"
-                    "http.extraHeader=Authorization: Basic TEST"
+                    "lfs.url=https://example.test/info/lfs"
                     "lfs"
                     "push"
                     "--object-id"
@@ -1911,7 +1983,7 @@ Vitest.describe (
 
                 let refSpecUploadArgs = [|
                     "-c"
-                    "http.extraHeader=Authorization: Basic TEST"
+                    "lfs.url=https://example.test/info/lfs"
                     "lfs"
                     "push"
                     "origin"
@@ -1959,8 +2031,8 @@ Vitest.describe (
                     .expect(calls.ToArray())
                     .toEqual (
                         [|
-                            "-c http.extraHeader=Authorization: Basic TEST lfs push --object-id origin --stdin"
-                            "-c http.extraHeader=Authorization: Basic TEST lfs push origin refs/heads/main"
+                            "-c lfs.url=https://example.test/info/lfs lfs push --object-id origin --stdin"
+                            "-c lfs.url=https://example.test/info/lfs lfs push origin refs/heads/main"
                         |]
                     )
             }

--- a/tests/Electron.Renderer/GitWorkflow.test.fs
+++ b/tests/Electron.Renderer/GitWorkflow.test.fs
@@ -281,6 +281,7 @@ let private defaultDependencies: GitDependencies = {
     gitFetch = fun _ -> unexpectedPromise "gitFetch"
     gitPull = fun _ -> unexpectedPromise "gitPull"
     gitPush = fun _ -> unexpectedPromise "gitPush"
+    gitCancelPush = fun () -> unexpectedPromise "gitCancelPush"
     gitCloneRepository = fun _ -> unexpectedPromise "gitCloneRepository"
     createBranch = fun _ -> unexpectedPromise "createBranch"
     checkoutBranch = fun _ -> unexpectedPromise "checkoutBranch"
@@ -340,6 +341,7 @@ let private noopCallbacks: GitSidebarCallbacks = {
     OnSelectChange = fun _ -> promise { return Ok() }
     OnPruneLfsCache = fun () -> ()
     OnDedupLfsStorage = fun () -> ()
+    OnCancelOperation = fun () -> ()
 }
 
 Vitest.afterEach (fun () -> document.body.innerHTML <- "")
@@ -972,6 +974,68 @@ Vitest.describe (
                 Vitest.expect(reportedErrors.Count).toBe (1)
                 Vitest.expect(reportedErrors[0].Title).toBe ("Could not push changes")
                 Vitest.expect(reportedErrors[0].Message).toBe ("remote rejected the push")
+            }
+        )
+
+        Vitest.test (
+            "CancelCurrentOperationRequested requests push cancellation while pushing",
+            fun () -> promise {
+                let mutable cancelCalls = 0
+
+                let deps = {
+                    defaultDependencies with
+                        gitCancelPush =
+                            fun () -> promise {
+                                cancelCalls <- cancelCalls + 1
+                                return Ok okOperationResult
+                            }
+                }
+
+                let state = {
+                    GitState.Empty with
+                        BusyOperation = Some GitBusyOperation.PushingToRemote
+                        BusyNotice = Some "Pushing to remote"
+                }
+
+                let nextState, cmd = update deps ignore CancelCurrentOperationRequested state
+
+                Vitest.expect(nextState.WarningNotice).toEqual (Some "Canceling push...")
+
+                let! messages = collectMessages cmd
+
+                Vitest.expect(cancelCalls).toBe (1)
+
+                match messages with
+                | [| CancelCurrentOperationCompleted(Ok result) |] -> Vitest.expect(result.Success).toBe (true)
+                | _ -> failwith "Expected push cancellation completion message."
+            }
+        )
+
+        Vitest.test (
+            "CancelCurrentOperationRequested always forwards cancel to the backend",
+            fun () -> promise {
+                let mutable cancelCalls = 0
+
+                let deps = {
+                    defaultDependencies with
+                        gitCancelPush =
+                            fun () -> promise {
+                                cancelCalls <- cancelCalls + 1
+                                return Ok okOperationResult
+                            }
+                }
+
+                let nextState, cmd =
+                    update deps ignore CancelCurrentOperationRequested GitState.Empty
+
+                let! messages = collectMessages cmd
+
+                Vitest.expect(nextState.WarningNotice).toEqual (Some "Canceling push...")
+                Vitest.expect(cancelCalls).toBe (1)
+
+                match messages with
+                | [| CancelCurrentOperationCompleted(Ok result) |] -> Vitest.expect(result.Success).toBe (true)
+                | _ -> failwith "Expected push cancellation completion message."
             }
         )
 
@@ -2356,6 +2420,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2436,6 +2501,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5,
@@ -2490,6 +2556,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2542,6 +2609,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2594,6 +2662,7 @@ Vitest.describe (
                                         OnSelectChange = fun _ -> promise { return Ok() }
                                         OnPruneLfsCache = fun () -> ()
                                         OnDedupLfsStorage = fun () -> ()
+                                        OnCancelOperation = fun () -> ()
                                     },
                                     downloadLargeFiles = true,
                                     lfsAutoTrackThresholdMb = 5
@@ -2685,6 +2754,7 @@ Vitest.describe (
                                         OnSelectChange = fun _ -> promise { return Ok() }
                                         OnPruneLfsCache = fun () -> ()
                                         OnDedupLfsStorage = fun () -> ()
+                                        OnCancelOperation = fun () -> ()
                                     },
                                     downloadLargeFiles = true,
                                     lfsAutoTrackThresholdMb = 5
@@ -2772,6 +2842,7 @@ Vitest.describe (
                                                         OnSelectChange = fun _ -> promise { return Ok() }
                                                         OnPruneLfsCache = fun () -> ()
                                                         OnDedupLfsStorage = fun () -> ()
+                                                        OnCancelOperation = fun () -> ()
                                                     },
                                                     downloadLargeFiles = true,
                                                     lfsAutoTrackThresholdMb = 5
@@ -2841,6 +2912,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -2900,6 +2972,7 @@ Vitest.describe (
                                         OnSelectChange = fun _ -> promise { return Ok() }
                                         OnPruneLfsCache = fun () -> ()
                                         OnDedupLfsStorage = fun () -> ()
+                                        OnCancelOperation = fun () -> ()
                                     },
                                     downloadLargeFiles = true,
                                     lfsAutoTrackThresholdMb = 5
@@ -2954,6 +3027,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -3083,6 +3157,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -3169,6 +3244,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -3263,6 +3339,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Error "Diff failed to load." }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5
@@ -3373,6 +3450,7 @@ Vitest.describe (
                                 OnSelectChange = fun _ -> promise { return Ok() }
                                 OnPruneLfsCache = fun () -> ()
                                 OnDedupLfsStorage = fun () -> ()
+                                OnCancelOperation = fun () -> ()
                             },
                             downloadLargeFiles = true,
                             lfsAutoTrackThresholdMb = 5


### PR DESCRIPTION
Two improvements to Git push/pull reliability: cancelable LFS uploads with idle-based timeouts, and a fix for LFS authentication failures caused by `http.extraHeader` appendede to LFS transfer commands.

## Changes

### Cancel button for LFS uploads

- Added a **Cancel** button in the Git sidebar, shown during LFS upload (`Uploading Git LFS objects` phase).
- Replaced **flat timeouts** on spawned Git processes with **idle timeouts**. The timer resets on every stdout/stderr event, so  transfers with progress output won't time out prematurely. Processes that go silent for the timeout duration are still killed.
  - Push/Pull don't have timeouts

### Fix: LFS auth header stripping

- Git LFS uses its own HTTP authentication separate from regular Git HTTP auth. When `http.extraHeader` (set by the credential helper) was passed to `git lfs push/pull/smudge`, some LFS servers rejected the conflicting header.
- Added a filter (`lfsTransferConfigArgs`) that strips `http.extraheader` and `http.<url>.extraheader` config args before spawning LFS transfer commands.
- The filter is applied at all 4 LFS transfer call sites: `pullAll`, `fetchRefetchForPath`, `downloadObjectFromListing`, and `uploadObjects`.