### PR TITLE
Follow-up LFS reliability fix

### DIFF
--- a/src/Electron/src/Main/Git/GitLfsService.fs
+++ b/src/Electron/src/Main/Git/GitLfsService.fs
@@ -965,7 +965,9 @@ let planOutboundPush
         let! dryRunResult =
             runSimpleGitRaw
                 (fun currentGit ->
-                    currentGit.raw [|
+                    let dryRunGit = currentGit.env ("GIT_LFS_SKIP_PUSH", "1")
+
+                    dryRunGit.raw [|
                         "push"
                         "--porcelain"
                         "--dry-run"

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -990,8 +990,8 @@ let private validateCommitLfsPolicy (git: ISimpleGit) : JS.Promise<GitResult<uni
         | None -> return Error(createCommitLfsValidationFailure thresholdMb (oversizedPaths.ToArray()))
 }
 
-// Pull always skips smudge downloads; when enabled, LFS content is hydrated afterward by a no-timeout transfer.
-let private applyPullLfsSkipSmudge (git: ISimpleGit) = git.env (GitLfsSkipSmudgeEnvKey, "1")
+// Worktree-populating commands skip implicit LFS downloads; explicit LFS hydration uses authenticated transfers.
+let private applyLfsSkipSmudge (git: ISimpleGit) = git.env (GitLfsSkipSmudgeEnvKey, "1")
 
 // GitService keeps explicit post-pull hydration here because it must reuse the authenticated git instance created for the pull workflow.
 let private hydratePulledLfsContent
@@ -1738,7 +1738,7 @@ let pull
                         runSimpleGit
                             (fun git -> promise {
                                 let! downloadLargeFiles = getConfiguredLfsDownloadLargeFiles git
-                                let effectiveGit = applyPullLfsSkipSmudge git
+                                let effectiveGit = applyLfsSkipSmudge git
 
                                 match safeBranchName with
                                 | None ->
@@ -2189,7 +2189,7 @@ let freeLocalLfsCopy (arcPath: string) (requestedPath: string) : JS.Promise<GitR
 
                         return errorResult validationError
                     | Ok() ->
-                        let pointerGit = git.env (GitLfsSkipSmudgeEnvKey, "1")
+                        let pointerGit = applyLfsSkipSmudge git
 
                         let! checkoutResult =
                             runSimpleGit
@@ -2267,12 +2267,14 @@ let discardPaths (arcPath: string) (pathSpecs: string[]) : JS.Promise<GitResult<
                             let! headPaths = headPathsForPathspecs git discardPathSpecs
 
                             if headPaths.Length > 0 then
+                                let restoreGit = applyLfsSkipSmudge git
+
                                 let! restoreResult =
                                     runSimpleGit
                                         (fun currentGit ->
                                             currentGit.raw (withGitPathspecs [| "restore"; "--worktree" |] headPaths)
                                         )
-                                        git
+                                        restoreGit
 
                                 match restoreResult with
                                 | Error failure -> return abortGitPromise failure.Message
@@ -2439,7 +2441,9 @@ let createBranch (arcPath: string) (branchName: string) (startPoint: string opti
                 withLocalGit
                     arcPath
                     (fun git -> promise {
-                        let! _ = git.checkoutLocalBranch (safeBranchName)
+                        let checkoutGit = applyLfsSkipSmudge git
+
+                        let! _ = checkoutGit.checkoutLocalBranch (safeBranchName)
                         do! reconcileTrackingBranchForCheckout "origin" safeBranchName git
                         return ()
                     })
@@ -2451,7 +2455,9 @@ let createBranch (arcPath: string) (branchName: string) (startPoint: string opti
                     withLocalGit
                         arcPath
                         (fun git -> promise {
-                            let! _ = git.checkoutBranch (safeBranchName, safeStartPoint)
+                            let checkoutGit = applyLfsSkipSmudge git
+
+                            let! _ = checkoutGit.checkoutBranch (safeBranchName, safeStartPoint)
                             do! reconcileTrackingBranchForCheckout "origin" safeBranchName git
                             return ()
                         })
@@ -2579,7 +2585,9 @@ let checkoutBranch (arcPath: string) (request: GitCheckoutBranchRequest) : JS.Pr
                     withLocalGit
                         arcPath
                         (fun git -> promise {
-                            let! _ = git.checkoutBranch (safeBranchName, safeStartPoint)
+                            let checkoutGit = applyLfsSkipSmudge git
+
+                            let! _ = checkoutGit.checkoutBranch (safeBranchName, safeStartPoint)
                             do! reconcileTrackingBranchForCheckout "origin" safeBranchName git
                             return ()
                         })
@@ -2588,6 +2596,8 @@ let checkoutBranch (arcPath: string) (request: GitCheckoutBranchRequest) : JS.Pr
                 withLocalGit
                     arcPath
                     (fun git -> promise {
+                        let checkoutGit = applyLfsSkipSmudge git
+
                         let! localBranches = git.branchLocal ()
                         let branches = valueOrEmptyArray localBranches.all
 
@@ -2600,7 +2610,7 @@ let checkoutBranch (arcPath: string) (request: GitCheckoutBranchRequest) : JS.Pr
                         if not exists then
                             return abortGitPromise $"Branch '{safeBranchName}' does not exist in the local repository."
 
-                        let! _ = git.checkout (safeBranchName)
+                        let! _ = checkoutGit.checkout (safeBranchName)
                         do! reconcileTrackingBranchForCheckout "origin" safeBranchName git
                         return ()
                     })

--- a/tests/Electron.Core/GitService.test.fs
+++ b/tests/Electron.Core/GitService.test.fs
@@ -239,6 +239,9 @@ let private writeUtf8FileAsync (path: string) (content: string) : JS.Promise<uni
     return ()
 }
 
+let private readUtf8FileAsync (path: string) : JS.Promise<string> =
+    fsPromisesDynamic?readFile (path, "utf8") |> unbox<JS.Promise<string>>
+
 let private expectOk<'T> (operationName: string) (result: GitService.GitResult<'T>) : 'T =
     match result with
     | Ok value -> value
@@ -295,16 +298,44 @@ let private runSimpleGitResult
     }
 
 let private createRawOnlyGit (rawHandler: string[] -> JS.Promise<string>) : ISimpleGit =
-    createObj [
-        "raw"
-        ==> (fun (command: obj) ->
-            match command with
-            | :? (string array) as commands -> rawHandler commands
-            | :? string as singleCommand -> rawHandler [| singleCommand |]
-            | _ -> failwith "Unexpected raw command payload."
-        )
-    ]
-    |> unbox<ISimpleGit>
+    let mutable fakeGit = Unchecked.defaultof<ISimpleGit>
+
+    fakeGit <-
+        createObj [
+            "raw"
+            ==> (fun (command: obj) ->
+                match command with
+                | :? (string array) as commands -> rawHandler commands
+                | :? string as singleCommand -> rawHandler [| singleCommand |]
+                | _ -> failwith "Unexpected raw command payload."
+            )
+            "env" ==> (fun (_name: string) (_value: string) -> fakeGit)
+        ]
+        |> unbox<ISimpleGit>
+
+    fakeGit
+
+let private createEnvAwareRawOnlyGit (rawHandler: string option -> string[] -> JS.Promise<string>) : ISimpleGit =
+    let rec createGit (gitLfsSkipPush: string option) : ISimpleGit =
+        createObj [
+            "raw"
+            ==> (fun (command: obj) ->
+                match command with
+                | :? (string array) as commands -> rawHandler gitLfsSkipPush commands
+                | :? string as singleCommand -> rawHandler gitLfsSkipPush [| singleCommand |]
+                | _ -> failwith "Unexpected raw command payload."
+            )
+            "env"
+            ==> (fun (name: string) (value: string) ->
+                if name = "GIT_LFS_SKIP_PUSH" then
+                    createGit (Some value)
+                else
+                    createGit gitLfsSkipPush
+            )
+        ]
+        |> unbox<ISimpleGit>
+
+    createGit None
 
 let private runSimpleGitRawWithFakeGit
     (fakeGit: ISimpleGit)
@@ -733,6 +764,43 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "discardPaths keeps restored LFS files as pointers instead of smudging",
+            gitLfsIntegrationTestOptions,
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let artifactPath = join [| context.RepoPath; "artifact.bin" |]
+
+                        let! _ = context.Git.raw [| "lfs"; "install"; "--local" |]
+                        let! _ = context.Git.raw [| "lfs"; "track"; "*.bin" |]
+
+                        do! writeUtf8FileAsync artifactPath "original binary-ish content\n"
+
+                        let! stageResult =
+                            GitService.stagePaths context.RepoPath [| ".gitattributes"; "artifact.bin" |]
+
+                        expectOk "stage lfs artifact" stageResult |> ignore
+
+                        let! commitResult = GitService.commit context.RepoPath "test: add lfs artifact"
+                        expectOk "commit lfs artifact" commitResult |> ignore
+
+                        do! writeUtf8FileAsync artifactPath "modified local content\n"
+
+                        let! discardResult = GitService.discardPaths context.RepoPath [| "artifact.bin" |]
+                        expectOk "discard lfs artifact" discardResult |> ignore
+
+                        let! restoredContent = readUtf8FileAsync artifactPath
+
+                        Vitest
+                            .expect(restoredContent.StartsWith("version https://git-lfs.github.com/spec/v1"))
+                            .toBe (true)
+
+                        Vitest.expect(restoredContent.Contains("oid sha256:")).toBe (true)
+                    })
+            }
+        )
+
+        Vitest.test (
             "addRemote stores the requested origin URL in the local repository config",
             fun () -> promise {
                 do!
@@ -1140,6 +1208,89 @@ Vitest.describe (
 
                         Vitest.expect(trackedFileStatus.WorkingDir).toBe ("M")
                     })
+            }
+        )
+
+        Vitest.test (
+            "planOutboundPush skips Git LFS pre-push hook during dry-run planning",
+            fun () -> promise {
+                let candidateBlobId = "1111111111111111111111111111111111111111"
+                let lfsObjectId = "abababababababababababababababababababababababababababababababab"
+
+                let pointerContent =
+                    $"version https://git-lfs.github.com/spec/v1\noid sha256:{lfsObjectId}\nsize 18\n"
+
+                let pointerSize = utf8ByteLength pointerContent
+                let mutable dryRunLfsSkipPush = None
+
+                let optimizedRevListArgs = [|
+                    "rev-list"
+                    "--objects"
+                    "--no-object-names"
+                    "--stdin"
+                    "--ignore-missing"
+                    "--filter=blob:limit=1024"
+                    "--filter=object:type=blob"
+                    "--filter-provided-objects"
+                |]
+
+                let catFileBatchArgs = [| "cat-file"; "--batch"; "--buffer" |]
+
+                let fakeGit =
+                    createEnvAwareRawOnlyGit (fun gitLfsSkipPush command -> promise {
+                        let commandText = String.concat " " command
+
+                        match command with
+                        | [| "push"; "--porcelain"; "--dry-run"; "origin"; "refs/heads/main" |] ->
+                            dryRunLfsSkipPush <- gitLfsSkipPush
+                            return "To origin\n* [new branch] refs/heads/main -> refs/heads/main\nDone\n"
+                        | [| "ls-remote"; "--refs"; "origin" |] ->
+                            Vitest.expect(gitLfsSkipPush).toEqual (None)
+                            return ""
+                        | _ -> return failwith $"Unexpected raw command: {commandText}"
+                    })
+
+                let fakeSpawnedGit: GitLfsAdapter.GitSpawnRequest -> JS.Promise<GitLfsAdapter.GitSpawnResult> =
+                    fun request -> promise {
+                        let commandText = String.concat " " request.Arguments
+
+                        match request.Arguments with
+                        | args when args = optimizedRevListArgs ->
+                            return {
+                                ExitCode = 0
+                                StdoutBuffer = utf8Buffer $"{candidateBlobId}\n"
+                                StdoutText = $"{candidateBlobId}\n"
+                                StderrText = ""
+                                TimedOut = false
+                            }
+                        | args when args = catFileBatchArgs ->
+                            let stdoutText = $"{candidateBlobId} blob {pointerSize}\n{pointerContent}"
+
+                            return {
+                                ExitCode = 0
+                                StdoutBuffer = utf8Buffer stdoutText
+                                StdoutText = stdoutText
+                                StderrText = ""
+                                TimedOut = false
+                            }
+                        | _ -> return failwith $"Unexpected spawned command: {commandText}"
+                    }
+
+                let! plan =
+                    GitLfsService.planOutboundPush
+                        (runSimpleGitRawWithFakeGit fakeGit)
+                        fakeSpawnedGit
+                        id
+                        (fun _ -> promise { return Error(exn "status should not be called") })
+                        "C:/repo"
+                        "origin"
+                        (Some "refs/heads/main")
+                        fakeGit
+
+                let actualPlan = expectOkResult "plan outbound push with skipped LFS dry-run" plan
+
+                Vitest.expect(dryRunLfsSkipPush).toEqual (Some "1")
+                Vitest.expect(actualPlan).toEqual (GitLfsService.OutboundPushPlan.UploadLfsObjects [| lfsObjectId |])
             }
         )
 
@@ -2305,6 +2456,74 @@ Vitest.describe (
                                 expectError
 
                         Vitest.expect(failure.Message.Contains("does not exist in the local repository")).toBe (true)
+                    })
+            }
+        )
+
+        Vitest.test (
+            "checkoutBranch keeps LFS files as pointers instead of smudging during branch switch",
+            gitLfsIntegrationTestOptions,
+            fun () -> promise {
+                do!
+                    withTempRepository (fun context -> promise {
+                        let baseFilePath = join [| context.RepoPath; "base.txt" |]
+                        let artifactPath = join [| context.RepoPath; "artifact.bin" |]
+                        let featureBranch = "feature/lfs-checkout"
+
+                        do! writeUtf8FileAsync baseFilePath "base\n"
+
+                        let! stageBaseResult = GitService.stagePaths context.RepoPath [| "base.txt" |]
+                        expectOk "stage base file" stageBaseResult |> ignore
+
+                        let! commitBaseResult = GitService.commit context.RepoPath "test: base commit"
+                        expectOk "commit base file" commitBaseResult |> ignore
+
+                        let! baseStatus =
+                            unwrapResultAsync
+                                (GitService.getStatus context.RepoPath)
+                                (expectOk "git status after base commit")
+
+                        let baseBranch =
+                            baseStatus.Current
+                            |> Option.defaultWith (fun () -> failwith "Expected current branch after base commit.")
+
+                        let! createFeatureResult = GitService.createBranch context.RepoPath featureBranch None
+                        expectOk "create lfs feature branch" createFeatureResult |> ignore
+
+                        let! _ = context.Git.raw [| "lfs"; "install"; "--local" |]
+                        let! _ = context.Git.raw [| "lfs"; "track"; "*.bin" |]
+
+                        do! writeUtf8FileAsync artifactPath "binary-ish content\n"
+
+                        let! stageArtifactResult =
+                            GitService.stagePaths context.RepoPath [| ".gitattributes"; "artifact.bin" |]
+
+                        expectOk "stage lfs artifact" stageArtifactResult |> ignore
+
+                        let! commitArtifactResult = GitService.commit context.RepoPath "test: add lfs artifact"
+
+                        expectOk "commit lfs artifact" commitArtifactResult |> ignore
+
+                        let! checkoutBaseResult =
+                            GitService.checkoutBranch context.RepoPath { Name = baseBranch; StartPoint = None }
+
+                        expectOk "checkout base branch" checkoutBaseResult |> ignore
+
+                        let! checkoutFeatureResult =
+                            GitService.checkoutBranch context.RepoPath {
+                                Name = featureBranch
+                                StartPoint = None
+                            }
+
+                        expectOk "checkout lfs feature branch" checkoutFeatureResult |> ignore
+
+                        let! checkedOutContent = readUtf8FileAsync artifactPath
+
+                        Vitest
+                            .expect(checkedOutContent.StartsWith("version https://git-lfs.github.com/spec/v1"))
+                            .toBe (true)
+
+                        Vitest.expect(checkedOutContent.Contains("oid sha256:")).toBe (true)
                     })
             }
         )


### PR DESCRIPTION
Follow-up LFS reliability fix for #1215 : prevent Git workflows from invoking LFS implicitly outside Swate’s authenticated transfer path.

## Changes

- Skip Git LFS pre-push hooks during `git push --dry-run` planning with `GIT_LFS_SKIP_PUSH=1`.
  - This prevents dry-run push planning from attempting an unauthenticated LFS upload before Swate reaches its explicit LFS upload step.

- Skip implicit LFS smudge during worktree-changing Git operations with `GIT_LFS_SKIP_SMUDGE=1`.
  - Applied to branch creation, branch checkout, and discard/restore paths.
  - Keeps LFS files as pointer files unless Swate explicitly downloads them through the authenticated LFS flow.