### PR TITLE
Enable copying of multiple unit rows without header into not unit rows

### DIFF
--- a/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
+++ b/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
@@ -62,7 +62,12 @@ type CompositeCell with
                 && not (System.String.IsNullOrWhiteSpace unit)
                 ->
                 CompositeCell.createUnitized (value, OntologyAnnotation.create unit)
-            | arr when arr.Length > 0 && arr.Length < 4 && header.IsTermColumn && CompositeCell.isNumber arr.[0] ->
+            | arr when
+                arr.Length > 0
+                && arr.Length < 4
+                && header.IsTermColumn
+                && CompositeCell.isNumber arr.[0]
+                ->
                 CompositeCell.createUnitizedFromString (arr.[0]) |> _.ConvertToValidCell(header)
             | [| value; _ |] when header.IsTermColumn ->
                 CompositeCell.createFreeText value |> _.ConvertToValidCell(header)

--- a/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
+++ b/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
@@ -56,6 +56,10 @@ type CompositeCell with
             let header = header.Value
 
             match content with
+            // Clipboard fitting treats term/unit columns as variable-width cells, so a pasted
+            // value + unit can arrive here as one cell with two fields.
+            // Unitized columns are represented by term headers; missing unit metadata is restored
+            // later from a matching unit annotation when available.
             | [| value; unit |] when
                 header.IsTermColumn
                 && CompositeCell.isNumber value

--- a/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
+++ b/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
@@ -2,6 +2,7 @@
 module ARCtrl.CompositeCellExtensions
 
 open ARCtrl
+open ARCtrl.Helper
 
 type CompositeCell with
 
@@ -42,10 +43,6 @@ type CompositeCell with
         | CompositeCell.Unitized _ -> CompositeCell.Unitized("", OntologyAnnotation())
         | CompositeCell.Data _ -> CompositeCell.Data(Data())
 
-    static member isNumber(input: string) =
-        let success, _ = System.Double.TryParse(input)
-        success
-
     /// <summary>
     ///
     /// </summary>
@@ -62,16 +59,11 @@ type CompositeCell with
             // later from a matching unit annotation when available.
             | [| value; unit |] when
                 header.IsTermColumn
-                && CompositeCell.isNumber value
+                && isNumber value
                 && not (System.String.IsNullOrWhiteSpace unit)
                 ->
                 CompositeCell.createUnitized (value, OntologyAnnotation.create unit)
-            | arr when
-                arr.Length > 0
-                && arr.Length < 4
-                && header.IsTermColumn
-                && CompositeCell.isNumber arr.[0]
-                ->
+            | arr when arr.Length > 0 && arr.Length < 4 && header.IsTermColumn && isNumber arr.[0] ->
                 CompositeCell.createUnitizedFromString (arr.[0]) |> _.ConvertToValidCell(header)
             | [| value; _ |] when header.IsTermColumn ->
                 CompositeCell.createFreeText value |> _.ConvertToValidCell(header)

--- a/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
+++ b/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
@@ -42,6 +42,10 @@ type CompositeCell with
         | CompositeCell.Unitized _ -> CompositeCell.Unitized("", OntologyAnnotation())
         | CompositeCell.Data _ -> CompositeCell.Data(Data())
 
+    static member isNumber(input: string) =
+        let success, _ = System.Double.TryParse(input)
+        success
+
     /// <summary>
     ///
     /// </summary>
@@ -51,13 +55,17 @@ type CompositeCell with
         if header.IsSome then
             let header = header.Value
 
-            let isNumber (input: string) =
-                let success, _ = System.Double.TryParse(input)
-                success
-
             match content with
-            | arr when arr.Length > 0 && arr.Length < 4 && header.IsTermColumn && isNumber arr.[0] ->
+            | [| value; unit |] when
+                header.IsTermColumn
+                && CompositeCell.isNumber value
+                && not (System.String.IsNullOrWhiteSpace unit)
+                ->
+                CompositeCell.createUnitized (value, OntologyAnnotation.create unit)
+            | arr when arr.Length > 0 && arr.Length < 4 && header.IsTermColumn && CompositeCell.isNumber arr.[0] ->
                 CompositeCell.createUnitizedFromString (arr.[0]) |> _.ConvertToValidCell(header)
+            | [| value; _ |] when header.IsTermColumn ->
+                CompositeCell.createFreeText value |> _.ConvertToValidCell(header)
             | [| freetext |] when header.IsSingleColumn -> CompositeCell.createFreeText freetext
             | [| freetext |] -> CompositeCell.createFreeText freetext |> _.ConvertToValidCell(header)
             | [| name; tsr; tan |] when header.IsTermColumn -> CompositeCell.createTermFromString (name, tsr, tan)

--- a/src/Components/src/ARCtrl/Extensions/OntologyAnnotation.fs
+++ b/src/Components/src/ARCtrl/Extensions/OntologyAnnotation.fs
@@ -15,6 +15,17 @@ module OntologyAnnotationHelper =
 type OntologyAnnotation with
     static member empty() = OntologyAnnotation.create ()
 
+    member this.hasName = not (System.String.IsNullOrWhiteSpace this.NameText)
+
+    member this.hasTermMetadata =
+        Option.exists (System.String.IsNullOrWhiteSpace >> not) this.TermSourceREF
+        && Option.exists (System.String.IsNullOrWhiteSpace >> not) this.TermAccessionNumber
+
+    member this.NameEquals(other: OntologyAnnotation) =
+        this.hasName
+        && other.hasName
+        && System.String.Equals(this.NameText, other.NameText, System.StringComparison.OrdinalIgnoreCase)
+
     static member from(term: Shared.Database.Term) =
         let comments =
             ResizeArray [

--- a/src/Components/src/ARCtrl/Helper.fs
+++ b/src/Components/src/ARCtrl/Helper.fs
@@ -1,3 +1,7 @@
 module ARCtrl.Helper
 
 let doptstr (o: string option) = Option.defaultValue "" o
+
+let isNumber (input: string) =
+    let success, _ = System.Double.TryParse(input)
+    success

--- a/src/Components/src/Composite/AnnotationTable/AnnotationTable.fs
+++ b/src/Components/src/Composite/AnnotationTable/AnnotationTable.fs
@@ -676,7 +676,7 @@ type AnnotationTable =
                                 arcTable.ClearSelectedCells(tableRef.current.SelectHandle)
                                 arcTable.Copy() |> setArcTable
                             | AnnotationTableHelper.KbdShortcutTrigger kbd_CtrlV ->
-                                AnnotationTableContextMenuUtil.tryPasteCopiedCells (
+                                AnnotationTableClipboard.tryPasteCopiedCells (
                                     selectedCells.selectedCellsReducedSet.MinimumElement,
                                     arcTable,
                                     tableRef.current.SelectHandle,
@@ -685,14 +685,14 @@ type AnnotationTable =
                                 )
                                 |> Promise.start
                             | AnnotationTableHelper.KbdShortcutTrigger kbd_CtrlC ->
-                                AnnotationTableContextMenuUtil.copy (
+                                AnnotationTableClipboard.copy (
                                     selectedCells.selectedCellsReducedSet.MinimumElement,
                                     arcTable,
                                     tableRef.current.SelectHandle
                                 )
                                 |> Promise.start
                             | AnnotationTableHelper.KbdShortcutTrigger kbd_CtrlX ->
-                                AnnotationTableContextMenuUtil.cut (
+                                AnnotationTableClipboard.cut (
                                     selectedCells.selectedCellsReducedSet.MinimumElement,
                                     arcTable,
                                     setArcTable,

--- a/src/Components/src/Composite/AnnotationTable/AnnotationTableClipboard.fs
+++ b/src/Components/src/Composite/AnnotationTable/AnnotationTableClipboard.fs
@@ -335,6 +335,31 @@ type AnnotationTableClipboard =
             setTable
         ) =
 
+        let tryFindMatchingUnitMetadata
+            (unit: OntologyAnnotation)
+            (table: ArcTable)
+            (targetUnit: OntologyAnnotation option)
+            =
+
+            if not unit.hasName then
+                None
+            else
+                table.Columns
+                |> Seq.choose _.TryGetColumnUnits()
+                |> Seq.collect id
+                |> Seq.filter (fun candidate ->
+                    targetUnit
+                    |> Option.exists (fun target -> System.Object.ReferenceEquals(candidate, target))
+                    |> not
+                    && candidate.hasTermMetadata
+                    && unit.NameEquals candidate
+                )
+                |> Seq.distinctBy (fun unit -> unit.TermSourceREF, unit.TermAccessionNumber)
+                |> Seq.toList
+                |> function
+                    | [ candidate ] -> Some candidate
+                    | _ -> None
+
         let getCorrectTargetForCell
             (currentCell: CompositeCell)
             (table: ArcTable)
@@ -342,35 +367,25 @@ type AnnotationTableClipboard =
             adaption
             =
 
-            if currentCell.isUnitized then
-                let targetCell =
-                    table.GetCellAt(targetCoordinate.x - adaption, targetCoordinate.y - adaption)
-
-                let value, unit = currentCell.AsUnitized
-
-                let unitNeedsMetadata =
-                    unit.isEmpty ()
-                    || Option.forall String.IsNullOrWhiteSpace unit.TermSourceREF
-                    || Option.forall String.IsNullOrWhiteSpace unit.TermAccessionNumber
-
-                let hasSameUnitName (targetTerm: OntologyAnnotation) =
-                    unit.isEmpty ()
-                    || String.Equals(unit.NameText, targetTerm.NameText, StringComparison.OrdinalIgnoreCase)
-
+            match currentCell with
+            | CompositeCell.Unitized(_, unit) when unit.hasTermMetadata -> currentCell
+            | CompositeCell.Unitized(value, unit) ->
                 let targetUnit =
-                    if targetCell.isUnitized then
-                        targetCell.AsUnitized |> snd |> Some
-                    elif targetCell.isTerm then
-                        targetCell.AsTerm |> Some
-                    else
-                        None
+                    match table.GetCellAt(targetCoordinate.x - adaption, targetCoordinate.y - adaption) with
+                    | CompositeCell.Unitized(_, unit)
+                    | CompositeCell.Term unit -> Some unit
+                    | _ -> None
 
-                match targetUnit with
-                | Some targetUnit when unitNeedsMetadata && hasSameUnitName targetUnit ->
-                    CompositeCell.createUnitized (value, targetUnit)
-                | _ -> currentCell
-            else
-                currentCell
+                let restoredUnit =
+                    if unit.hasName then
+                        tryFindMatchingUnitMetadata unit table targetUnit
+                    else
+                        targetUnit |> Option.filter _.hasTermMetadata
+
+                restoredUnit
+                |> Option.map (fun unit -> CompositeCell.createUnitized (value, unit))
+                |> Option.defaultValue currentCell
+            | _ -> currentCell
 
         let getCorrectTargetForHeader
             (currentHeader: CompositeHeader)

--- a/src/Components/src/Composite/AnnotationTable/AnnotationTableClipboard.fs
+++ b/src/Components/src/Composite/AnnotationTable/AnnotationTableClipboard.fs
@@ -85,8 +85,7 @@ type AnnotationTableClipboard =
     static member cut(cellIndex: CellCoordinate, table: ArcTable, setTable, selectHandle: SelectHandle) = promise {
         do! AnnotationTableClipboard.copy (cellIndex, table, selectHandle)
 
-        let nextTable =
-            AnnotationTableClipboard.clear (cellIndex, table, selectHandle)
+        let nextTable = AnnotationTableClipboard.clear (cellIndex, table, selectHandle)
 
         nextTable |> setTable
     }
@@ -249,10 +248,7 @@ type AnnotationTableClipboard =
 
             let areHeaders =
                 headers
-                |> Array.collect (fun _ ->
-                    row
-                    |> Array.map (fun cell -> AnnotationTableClipboard.checkForHeader cell)
-                )
+                |> Array.collect (fun _ -> row |> Array.map (fun cell -> AnnotationTableClipboard.checkForHeader cell))
 
             Array.contains true areHeaders
 
@@ -353,12 +349,12 @@ type AnnotationTableClipboard =
                 let value, unit = currentCell.AsUnitized
 
                 let unitNeedsMetadata =
-                    unit.isEmpty()
+                    unit.isEmpty ()
                     || Option.forall String.IsNullOrWhiteSpace unit.TermSourceREF
                     || Option.forall String.IsNullOrWhiteSpace unit.TermAccessionNumber
 
                 let hasSameUnitName (targetTerm: OntologyAnnotation) =
-                    unit.isEmpty()
+                    unit.isEmpty ()
                     || String.Equals(unit.NameText, targetTerm.NameText, StringComparison.OrdinalIgnoreCase)
 
                 let targetUnit =
@@ -501,14 +497,7 @@ type AnnotationTableClipboard =
                 let prediction =
                     AnnotationTableClipboard.predictPasteBehaviour (cellIndex, arcTable, selectHandle, data)
 
-                AnnotationTableClipboard.paste (
-                    prediction,
-                    cellIndex,
-                    arcTable,
-                    selectHandle,
-                    setModal,
-                    setArcTable
-                )
+                AnnotationTableClipboard.paste (prediction, cellIndex, arcTable, selectHandle, setModal, setArcTable)
             with exn ->
                 setModal (AnnotationTable.ModalTypes.Error(exn.Message) |> Some)
         }

--- a/src/Components/src/Composite/AnnotationTable/AnnotationTableClipboard.fs
+++ b/src/Components/src/Composite/AnnotationTable/AnnotationTableClipboard.fs
@@ -1,0 +1,514 @@
+namespace Swate.Components.Composite.AnnotationTable
+
+open System
+open System.Text.RegularExpressions
+open ARCtrl
+
+open Swate.Components
+open Types.AnnotationTableContextMenu
+open Swate.Components.Composite.Table
+open Swate.Components.Composite.Table.Types
+open Swate.Components.Composite.AnnotationTable.Types
+
+type AnnotationTableClipboard =
+
+    static member clear(cellIndex: CellCoordinate, table: ArcTable, selectHandle: SelectHandle) : ArcTable =
+        let nextTable = table.Copy()
+
+        if selectHandle.contains cellIndex then
+            nextTable.ClearSelectedCells(selectHandle)
+        else
+            nextTable.ClearCell(cellIndex)
+
+        nextTable
+
+    static member copy(cellIndex: CellCoordinate, table: ArcTable, selectHandle: SelectHandle) =
+        let result =
+            if selectHandle.getCount () > 1 then
+
+                let cellCoordinates =
+                    selectHandle.getSelectedCells ()
+                    |> Array.ofSeq
+                    |> Array.groupBy (fun item -> item.y)
+
+                let headers, cells =
+                    cellCoordinates
+                    |> Array.map (fun (_, row) ->
+                        row
+                        |> Array.partition (fun coordinate -> (coordinate.y - 1) < 0)
+                        |> fun (headerCoordinates, bodyCoordinates) ->
+                            headerCoordinates
+                            |> Array.map (fun coordinate -> table.GetColumn(coordinate.x - 1).Header),
+                            bodyCoordinates
+                            |> Array.map (fun coordinate -> table.GetCellAt(coordinate.x - 1, coordinate.y - 1))
+                    )
+                    |> Array.unzip
+
+                let headers = headers |> Array.concat
+
+                if headers.Length > 0 then
+                    let columns =
+                        let body = cells.[1..] |> Array.transpose
+
+                        headers
+                        |> Array.mapi (fun index header ->
+                            if body.Length - 1 >= index then
+                                CompositeColumn.create (header, body.[index] |> ResizeArray)
+                            else
+                                CompositeColumn.create (header, Array.empty |> ResizeArray)
+                        )
+
+                    let tableString =
+                        let table = ArcTable.init ("placeholder")
+                        table.AddColumns(columns)
+                        table.ToStringSeqs()
+
+                    tableString
+                    |> Array.map (fun row -> row |> String.concat "\t")
+                    |> String.concat Environment.NewLine
+                else
+                    CompositeCell.ToTableTxt(cells)
+            else if cellIndex.y - 1 < 0 then
+                let column = table.GetColumn(cellIndex.x - 1)
+                let table = ArcTable.init ("placeholder")
+                table.AddColumn(column.Header)
+
+                table.ToStringSeqs()
+                |> Array.map (fun row -> row |> String.concat "\t")
+                |> String.concat Environment.NewLine
+            else
+                let cell = table.GetCellAt((cellIndex.x - 1, cellIndex.y - 1))
+                cell.ToTabStr()
+
+        navigator.clipboard.writeText result
+
+    static member cut(cellIndex: CellCoordinate, table: ArcTable, setTable, selectHandle: SelectHandle) = promise {
+        do! AnnotationTableClipboard.copy (cellIndex, table, selectHandle)
+
+        let nextTable =
+            AnnotationTableClipboard.clear (cellIndex, table, selectHandle)
+
+        nextTable |> setTable
+    }
+
+    static member private getIndex(startIndex, length) =
+        let rec loop index length =
+            if index < length then
+                index
+            else
+                loop (index - length) length
+
+        loop startIndex length
+
+    static member getCopiedCells() = promise {
+        let! copiedValue = navigator.clipboard.readText ()
+
+        let rows =
+            copiedValue.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.map (fun item -> item.Split('\t') |> Array.map _.Trim())
+
+        return rows
+    }
+
+    static member getFittedCells(data: string[][], headers: CompositeHeader[]) =
+
+        let fitColumnsToTarget (row: string[][]) (headers: CompositeHeader[]) =
+            let rec loop index result =
+                if index >= headers.Length then
+                    result |> List.rev |> Array.ofList
+                else
+                    let header = headers.[index]
+
+                    let newIndex =
+                        if index >= row.Length then
+                            AnnotationTableClipboard.getIndex (index, row.Length)
+                        else
+                            index
+
+                    match header with
+                    | x when x.IsSingleColumn || x.IsDataColumn || x.IsTermColumn ->
+                        let cell = CompositeCell.fromContentValid (row.[newIndex], header)
+                        loop (index + 1) (cell :: result)
+                    | anyElse -> failwith $"Error-fitColumnsToTarget: Encountered unsupported case: {anyElse}"
+
+            loop 0 []
+
+        let getHeadersExpectedLengths (headers: CompositeHeader[]) =
+            headers
+            |> Array.map (fun header ->
+                match header with
+                | x when x.IsSingleColumn -> x.ToString(), [ 1 ]
+                | x when x.IsDataColumn -> x.ToString(), [ 4 ]
+                | x when x.IsTermColumn -> x.ToString(), [ 1; 2; 3; 4 ]
+                | anyElse -> failwith $"Error-getHeadersWithLength: Encountered unsupported case: {anyElse}"
+            )
+
+        let fitHeaders (strings: string[]) (headersSizes: (string * int list)[]) (maxColumns: int) =
+            let rec tryFit (cell: string[]) index (remaining: (string * int list) list) (columnsLeft: int) =
+
+                let index =
+                    if index >= strings.Length && columnsLeft > 0 then
+                        0
+                    else
+                        index
+
+                match remaining, columnsLeft with
+                | _, 0 -> Some []
+                | [], _ -> Some []
+                | (name, sizes) :: rest, _ ->
+                    sizes
+                    |> List.sortDescending
+                    |> List.choose (fun size ->
+
+                        let maxSize =
+                            let cellsLeft = cell.Length - index
+
+                            if cellsLeft > columnsLeft - 1 then
+                                cellsLeft - (columnsLeft - 1)
+                            else
+                                cellsLeft
+
+                        let adjustedSize = min size maxSize
+
+                        let actualSize =
+                            if index + adjustedSize <= cell.Length then adjustedSize
+                            elif index < cell.Length then cell.Length - index
+                            else 0
+
+                        if actualSize > 0 then
+                            let segment = cell.[index .. index + actualSize - 1]
+
+                            match tryFit cell (index + actualSize) rest (columnsLeft - 1) with
+                            | Some restResult -> Some((name, segment) :: restResult)
+                            | None -> None
+                        else
+                            None
+                    )
+                    |> List.tryHead
+
+            tryFit strings 0 (Array.toList headersSizes) maxColumns
+
+        let fittingHeaders = getHeadersExpectedLengths headers
+
+        let fittedRows =
+            data |> Array.map (fun row -> fitHeaders row fittingHeaders headers.Length)
+
+        let result =
+            fittedRows
+            |> Array.choose id
+            |> Array.map (fun row -> row |> List.map (fun (_, cells) -> cells) |> Array.ofList)
+
+        result |> Array.map (fun row -> fitColumnsToTarget row headers)
+
+    static member checkForHeader(value: string) =
+
+        let splitCamelCase (input: string) =
+            Regex.Matches(input, @"([A-Z][a-z]+|[A-Z]+(?![a-z]))")
+            |> Seq.cast<Match>
+            |> Seq.map (fun m -> m.Value)
+            |> String.concat " "
+
+        let headerNames =
+            CompositeHeader.Cases |> Array.map (fun (_, item) -> splitCamelCase item)
+
+        match value with
+        | header when ARCtrl.Helper.Regex.tryParseCharacteristicColumnHeader(header).IsSome -> true
+        | header when ARCtrl.Helper.Regex.tryParseComponentColumnHeader(header).IsSome -> true
+        | header when ARCtrl.Helper.Regex.tryParseFactorColumnHeader(header).IsSome -> true
+        | header when ARCtrl.Helper.Regex.tryParseInputColumnHeader(header).IsSome -> true
+        | header when ARCtrl.Helper.Regex.tryParseOutputColumnHeader(header).IsSome -> true
+        | header when ARCtrl.Helper.Regex.tryParseParameterColumnHeader(header).IsSome -> true
+        | header when
+            // Header with a short length can lead to a problem here, so it must be at least as long as an expected header.
+            let shortestHeaderLength = headerNames |> Array.minBy String.length |> String.length
+
+            headerNames
+            |> Array.exists (fun case ->
+                not (String.IsNullOrEmpty header)
+                && case.StartsWith(header)
+                && header.Length >= shortestHeaderLength
+            )
+            ->
+            true
+        | _ -> false
+
+    static member predictPasteBehaviour
+        (cellIndex: CellCoordinate, targetTable: ArcTable, selectHandle: SelectHandle, data: string[][])
+        =
+
+        let cellCoordinates = selectHandle.getSelectedCells () |> Array.ofSeq
+
+        let headers =
+            let columnIndices = cellCoordinates |> Array.distinctBy (fun item -> item.x)
+
+            columnIndices
+            |> Array.map (fun index -> targetTable.GetColumn(index.x - 1).Header)
+
+        let checkForHeaders (row: string[]) =
+            let headers = CompositeHeader.Cases |> Array.map (fun (_, header) -> header)
+
+            let areHeaders =
+                headers
+                |> Array.collect (fun _ ->
+                    row
+                    |> Array.map (fun cell -> AnnotationTableClipboard.checkForHeader cell)
+                )
+
+            Array.contains true areHeaders
+
+        let groupedCellCoordinates =
+            cellCoordinates
+            |> Array.ofSeq
+            |> Array.groupBy (fun item -> item.y)
+            |> Array.map (fun (_, row) -> row)
+
+        if checkForHeaders data.[0] || cellCoordinates.[0].y <= 0 || cellIndex.y <= 0 then
+
+            let headers, body =
+                if data.Length > 1 then
+                    data.[0], data.[1..]
+                else
+                    data.[0], [||]
+
+            let columns = Array.append [| headers |] body |> Array.transpose
+            let columnsArrays = columns |> Seq.toArray |> Array.map Seq.toArray
+
+            let compositeColumns =
+                ARCtrl.Spreadsheet.ArcTable.composeColumns columnsArrays |> ResizeArray
+
+            PasteCases.AddColumns {|
+                data = compositeColumns
+                coordinate = cellIndex
+                coordinates = groupedCellCoordinates
+            |}
+        else
+            let fittedCells =
+                AnnotationTableClipboard.getFittedCells (data, headers)
+                |> Array.transpose
+                |> Array.map ResizeArray
+
+            let columns =
+                Array.map2 (fun header cells -> CompositeColumn.create (header, cells)) headers fittedCells
+                |> ResizeArray
+
+            let isEmpty =
+                Array.isEmpty fittedCells
+                || fittedCells
+                   |> Array.map (fun row ->
+                       Seq.isEmpty row
+                       || Seq.forall (fun (cell: CompositeCell) -> String.IsNullOrWhiteSpace(cell.ToTabStr())) row
+                   )
+                   |> Array.contains true
+
+            if isEmpty then
+                PasteCases.Unknown {| data = data; headers = headers |}
+            else
+                PasteCases.PasteCells {|
+                    data = columns
+                    coordinates = groupedCellCoordinates
+                |}
+
+    static member private getValueOfCompositeHeader(compositeHeader: CompositeHeader) =
+        match compositeHeader with
+        | CompositeHeader.Component oa -> defaultArg oa.Name (compositeHeader.ToString())
+        | CompositeHeader.Characteristic oa -> defaultArg oa.Name (compositeHeader.ToString())
+        | CompositeHeader.Factor oa -> defaultArg oa.Name (compositeHeader.ToString())
+        | CompositeHeader.Parameter oa -> defaultArg oa.Name (compositeHeader.ToString())
+        | CompositeHeader.ProtocolType -> CompositeHeaderDiscriminate.ProtocolType.ToString()
+        | CompositeHeader.ProtocolDescription -> CompositeHeaderDiscriminate.ProtocolDescription.ToString()
+        | CompositeHeader.ProtocolUri -> CompositeHeaderDiscriminate.ProtocolUri.ToString()
+        | CompositeHeader.ProtocolVersion -> CompositeHeaderDiscriminate.ProtocolVersion.ToString()
+        | CompositeHeader.ProtocolREF -> CompositeHeaderDiscriminate.ProtocolREF.ToString()
+        | CompositeHeader.Performer -> CompositeHeaderDiscriminate.Performer.ToString()
+        | CompositeHeader.Date -> CompositeHeaderDiscriminate.Date.ToString()
+        | CompositeHeader.Input io -> io.ToString()
+        | CompositeHeader.Output io -> io.ToString()
+        | CompositeHeader.Comment s -> s
+        | CompositeHeader.FreeText s -> s
+
+    static member pasteCells
+        (
+            pasteColumns:
+                {|
+                    data: ResizeArray<CompositeColumn>
+                    coordinates: CellCoordinate[][]
+                |},
+            coordinate: CellCoordinate,
+            selectHandle: SelectHandle,
+            table: ArcTable,
+            setTable
+        ) =
+
+        let getCorrectTargetForCell
+            (currentCell: CompositeCell)
+            (table: ArcTable)
+            (targetCoordinate: CellCoordinate)
+            adaption
+            =
+
+            if currentCell.isUnitized then
+                let targetCell =
+                    table.GetCellAt(targetCoordinate.x - adaption, targetCoordinate.y - adaption)
+
+                let value, unit = currentCell.AsUnitized
+
+                let unitNeedsMetadata =
+                    unit.isEmpty()
+                    || Option.forall String.IsNullOrWhiteSpace unit.TermSourceREF
+                    || Option.forall String.IsNullOrWhiteSpace unit.TermAccessionNumber
+
+                let hasSameUnitName (targetTerm: OntologyAnnotation) =
+                    unit.isEmpty()
+                    || String.Equals(unit.NameText, targetTerm.NameText, StringComparison.OrdinalIgnoreCase)
+
+                let targetUnit =
+                    if targetCell.isUnitized then
+                        targetCell.AsUnitized |> snd |> Some
+                    elif targetCell.isTerm then
+                        targetCell.AsTerm |> Some
+                    else
+                        None
+
+                match targetUnit with
+                | Some targetUnit when unitNeedsMetadata && hasSameUnitName targetUnit ->
+                    CompositeCell.createUnitized (value, targetUnit)
+                | _ -> currentCell
+            else
+                currentCell
+
+        let getCorrectTargetForHeader
+            (currentHeader: CompositeHeader)
+            (table: ArcTable)
+            (targetCoordinate: CellCoordinate)
+            adaption
+            =
+
+            let targetCell =
+                table.GetCellAt(targetCoordinate.x - adaption, targetCoordinate.y - adaption)
+
+            if targetCell.isUnitized then
+                let _, targetUnit = targetCell.AsUnitized
+                let value = AnnotationTableClipboard.getValueOfCompositeHeader currentHeader
+                CompositeCell.createUnitized (value, targetUnit)
+            elif targetCell.isTerm then
+                let targetTerm = defaultArg (currentHeader.TryGetTerm()) targetCell.AsTerm
+                CompositeCell.createTerm targetTerm
+            elif targetCell.isData then
+                let targetInfo = targetCell.AsData
+                let targetData = AnnotationTableClipboard.getValueOfCompositeHeader currentHeader
+
+                CompositeCell.createDataFromString (
+                    targetData,
+                    ?format = targetInfo.Format,
+                    ?selectorFormat = targetInfo.SelectorFormat
+                )
+            else
+                let value = AnnotationTableClipboard.getValueOfCompositeHeader currentHeader
+                CompositeCell.createFreeText value
+
+        let headerCoordinates, bodyCoordinates =
+            if pasteColumns.coordinates.[0].[0].y - 1 < 0 then
+                pasteColumns.coordinates.[0], pasteColumns.coordinates.[1..]
+            else
+                [||], pasteColumns.coordinates
+
+        let pasteWithCoordiantes (coordinates: CellCoordinate[][]) =
+            if selectHandle.getCount () > 1 then
+                coordinates
+                |> Array.iteri (fun yi row ->
+                    let yIndex =
+                        if (pasteColumns.data.Item 0).Cells.Count = 0 then
+                            1
+                        else
+                            AnnotationTableClipboard.getIndex (yi, (pasteColumns.data.Item 0).Cells.Count)
+
+                    row
+                    |> Array.iteri (fun xi coordinate ->
+                        let xIndex = AnnotationTableClipboard.getIndex (xi, pasteColumns.data.Count)
+
+                        if coordinate.y - 1 < 0 then
+                            table.UpdateHeader(coordinate.x - 1, pasteColumns.data.[xIndex].Header, true)
+                        else
+                            let newTarget =
+                                if pasteColumns.data.[0].Cells.Count = 0 then
+                                    let currentHeader = pasteColumns.data.[xIndex].Header
+                                    getCorrectTargetForHeader currentHeader table coordinate 1
+                                else
+                                    let cells = (pasteColumns.data.Item xIndex).Cells
+                                    let currentCell = cells.[yIndex]
+                                    getCorrectTargetForCell currentCell table coordinate 1
+
+                            table.SetCellAt(coordinate.x - 1, coordinate.y - 1, newTarget)
+                    )
+                )
+            else if coordinate.y - 1 < 0 then
+                table.UpdateHeader(coordinate.x - 1, pasteColumns.data.[0].Header, true)
+            else
+                let newTarget =
+                    if pasteColumns.data.[0].Cells.Count = 0 then
+                        let currentHeader = pasteColumns.data.[0].Header
+                        getCorrectTargetForHeader currentHeader table coordinate 1
+                    else
+                        let currentCell = pasteColumns.data.[0].Cells.[0]
+                        getCorrectTargetForCell currentCell table coordinate 1
+
+                table.SetCellAt(coordinate.x - 1, coordinate.y - 1, newTarget)
+
+        if headerCoordinates.Length > 0 then
+            pasteWithCoordiantes [| headerCoordinates |]
+
+        if bodyCoordinates.Length > 0 then
+            pasteWithCoordiantes bodyCoordinates
+
+        table.Copy() |> setTable
+
+    static member paste
+        (
+            pasteCases: PasteCases,
+            coordinate: CellCoordinate,
+            table: ArcTable,
+            selectHandle: SelectHandle,
+            setModal: Types.AnnotationTable.ModalTypes option -> unit,
+            setTable: ArcTable -> unit
+        ) =
+
+        match pasteCases with
+        | AddColumns addColumns ->
+            setModal (
+                AnnotationTable.ModalTypes.PasteCaseUserInput(PasteCases.AddColumns addColumns, selectHandle)
+                |> Some
+            )
+        | PasteCells pasteColumns ->
+            AnnotationTableClipboard.pasteCells (pasteColumns, coordinate, selectHandle, table, setTable)
+        | Unknown unknownPasteCase ->
+            setModal (
+                AnnotationTable.ModalTypes.UnknownPasteCase(PasteCases.Unknown unknownPasteCase)
+                |> Some
+            )
+
+    static member tryPasteCopiedCells
+        (
+            cellIndex: CellCoordinate,
+            arcTable: ArcTable,
+            selectHandle: SelectHandle,
+            setModal: AnnotationTable.ModalTypes option -> unit,
+            setArcTable: ArcTable -> unit
+        ) =
+        promise {
+            let! data = AnnotationTableClipboard.getCopiedCells ()
+
+            try
+                let prediction =
+                    AnnotationTableClipboard.predictPasteBehaviour (cellIndex, arcTable, selectHandle, data)
+
+                AnnotationTableClipboard.paste (
+                    prediction,
+                    cellIndex,
+                    arcTable,
+                    selectHandle,
+                    setModal,
+                    setArcTable
+                )
+            with exn ->
+                setModal (AnnotationTable.ModalTypes.Error(exn.Message) |> Some)
+        }

--- a/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
+++ b/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
@@ -1,13 +1,11 @@
 namespace Swate.Components.Composite.AnnotationTable
 
 open System
-open System.Text.RegularExpressions
 open Fable.Core
 open ARCtrl
 open Feliz
 
 open Swate.Components
-open Types.AnnotationTableContextMenu
 open Swate.Components.Primitive
 open Swate.Components.Primitive.ContextMenu.Types
 open Swate.Components.Composite.AnnotationTable.Types
@@ -42,19 +40,6 @@ type AnnotationTableContextMenuUtil =
 
         nextTable
 
-    static member clear(cellIndex: CellCoordinate, table: ArcTable, selectHandle: SelectHandle) : ArcTable =
-        let nextTable = table.Copy()
-
-
-        if selectHandle.contains cellIndex then
-            nextTable.ClearSelectedCells(selectHandle)
-        else
-            nextTable.ClearCell(cellIndex)
-
-
-        nextTable
-
-
     static member deleteRow
         (tableIndex: CellCoordinate, rowIndex, table: ArcTable, selectHandle: SelectHandle)
         : ArcTable =
@@ -71,38 +56,6 @@ type AnnotationTableContextMenuUtil =
 
         table.Copy()
 
-    static member checkForHeader(value: string) =
-
-        let splitCamelCase (input: string) =
-            Regex.Matches(input, @"([A-Z][a-z]+|[A-Z]+(?![a-z]))")
-            |> Seq.cast<Match>
-            |> Seq.map (fun m -> m.Value)
-            |> String.concat " "
-
-        let headerNames =
-            CompositeHeader.Cases |> Array.map (fun (_, item) -> splitCamelCase item)
-
-        match value with
-        | header when ARCtrl.Helper.Regex.tryParseCharacteristicColumnHeader(header).IsSome -> true
-        | header when ARCtrl.Helper.Regex.tryParseComponentColumnHeader(header).IsSome -> true
-        | header when ARCtrl.Helper.Regex.tryParseFactorColumnHeader(header).IsSome -> true
-        | header when ARCtrl.Helper.Regex.tryParseInputColumnHeader(header).IsSome -> true
-        | header when ARCtrl.Helper.Regex.tryParseOutputColumnHeader(header).IsSome -> true
-        | header when ARCtrl.Helper.Regex.tryParseParameterColumnHeader(header).IsSome -> true
-        | header when
-            //header with a short length can lead to a problem here, so they must be at least as long as an expected header
-            let shortestHeaderLength = headerNames |> Array.minBy String.length |> String.length
-
-            headerNames
-            |> Array.exists (fun case ->
-                not (System.String.IsNullOrEmpty header)
-                && case.StartsWith(header)
-                && header.Length >= shortestHeaderLength
-            )
-            ->
-            true
-        | _ -> false
-
     static member deleteColumn
         (tableIndex: CellCoordinate, colIndex: int, table: ArcTable, selectHandle: SelectHandle)
         : ArcTable =
@@ -118,480 +71,6 @@ type AnnotationTableContextMenuUtil =
             table.RemoveColumn(colIndex - 1)
 
         table.Copy()
-
-    static member copy(cellIndex: CellCoordinate, table: ArcTable, selectHandle: SelectHandle) =
-        let result =
-            if selectHandle.getCount () > 1 then
-
-                let cellCoordinates =
-                    selectHandle.getSelectedCells ()
-                    |> Array.ofSeq
-                    |> Array.groupBy (fun item -> item.y)
-
-                let headers, cells =
-                    cellCoordinates
-                    |> Array.map (fun (_, row) ->
-                        row
-                        |> Array.partition (fun coordinate -> (coordinate.y - 1) < 0)
-                        |> fun (headerCoordinates, bodyCoordinates) ->
-                            headerCoordinates
-                            |> Array.map (fun coordinate -> table.GetColumn(coordinate.x - 1).Header),
-                            bodyCoordinates
-                            |> Array.map (fun coordinate -> table.GetCellAt(coordinate.x - 1, coordinate.y - 1))
-                    )
-                    |> Array.unzip
-
-                let headers = headers |> Array.concat
-
-                if headers.Length > 0 then
-                    let columns =
-                        let body = cells.[1..] |> Array.transpose
-
-                        headers
-                        |> Array.mapi (fun index header ->
-                            if body.Length - 1 >= index then
-                                CompositeColumn.create (header, body.[index] |> ResizeArray)
-                            else
-                                CompositeColumn.create (header, Array.empty |> ResizeArray)
-                        )
-
-                    let tableString =
-                        let table = ArcTable.init ("placeholder")
-                        table.AddColumns(columns)
-                        table.ToStringSeqs()
-
-                    tableString
-                    |> Array.map (fun row -> row |> String.concat "\t")
-                    |> String.concat System.Environment.NewLine
-                else
-                    CompositeCell.ToTableTxt(cells)
-            else if cellIndex.y - 1 < 0 then
-                let column = table.GetColumn(cellIndex.x - 1)
-                let table = ArcTable.init ("placeholder")
-                table.AddColumn(column.Header)
-
-                table.ToStringSeqs()
-                |> Array.map (fun row -> row |> String.concat "\t")
-                |> String.concat System.Environment.NewLine
-            else
-                let cell = table.GetCellAt((cellIndex.x - 1, cellIndex.y - 1))
-                cell.ToTabStr()
-
-        navigator.clipboard.writeText result
-
-    static member cut(cellIndex: CellCoordinate, table: ArcTable, setTable, selectHandle: SelectHandle) = promise {
-        do! AnnotationTableContextMenuUtil.copy (cellIndex, table, selectHandle)
-
-        let nextTable =
-            AnnotationTableContextMenuUtil.clear (cellIndex, table, selectHandle)
-
-        nextTable |> setTable
-    }
-
-    //Recalculates the index, then the amount of selected cells is bigger than the amount of copied cells
-    static member getIndex(startIndex, length) =
-        let rec loop index length =
-            if index < length then
-                index
-            else
-                loop (index - length) length
-
-        loop startIndex length
-
-    static member getCopiedCells() = promise {
-        let! copiedValue = navigator.clipboard.readText ()
-
-        let rows =
-            copiedValue.Split([| System.Environment.NewLine |], System.StringSplitOptions.RemoveEmptyEntries)
-            |> Array.map (fun item -> item.Split('\t') |> Array.map _.Trim())
-
-        return rows
-    }
-
-    static member getFittedCells(data: string[][], headers: CompositeHeader[]) =
-
-        let fitColumnsToTarget (row: string[][]) (headers: CompositeHeader[]) =
-            let rec loop index result =
-                if index >= headers.Length then
-                    result |> List.rev |> Array.ofList
-                else
-                    let header = headers.[index]
-
-                    let newIndex =
-                        if index >= row.Length then
-                            AnnotationTableContextMenuUtil.getIndex (index, row.Length)
-                        else
-                            index
-
-                    match header with
-                    | x when x.IsSingleColumn || x.IsDataColumn || x.IsTermColumn ->
-                        let cell = CompositeCell.fromContentValid (row.[newIndex], header)
-                        loop (index + 1) (cell :: result)
-                    | anyElse -> failwith $"Error-fitColumnsToTarget: Encountered unsupported case: {anyElse}"
-
-            loop 0 []
-
-        let getHeadersExpectedLengths (headers: CompositeHeader[]) =
-            headers
-            |> Array.map (fun header ->
-                match header with
-                | x when x.IsSingleColumn -> x.ToString(), [ 1 ]
-                | x when x.IsDataColumn -> x.ToString(), [ 4 ]
-                | x when x.IsTermColumn -> x.ToString(), [ 1; 2; 3; 4 ]
-                | anyElse -> failwith $"Error-getHeadersWithLength: Encountered unsupported case: {anyElse}"
-            )
-
-        let fitHeaders (strings: string[]) (headersSizes: (string * int list)[]) (maxColumns: int) =
-            let rec tryFit (cell: string[]) index (remaining: (string * int list) list) (columnsLeft: int) =
-
-                let index =
-                    if index >= strings.Length && columnsLeft > 0 then
-                        0
-                    else
-                        index
-
-                match remaining, columnsLeft with
-                | _, 0 -> Some []
-                | [], _ -> Some []
-                | (name, sizes) :: rest, _ ->
-                    sizes
-                    |> List.sortDescending
-                    |> List.choose (fun size ->
-
-                        let maxSize =
-                            let cellsLeft = (cell.Length - index)
-
-                            if cellsLeft > columnsLeft - 1 then
-                                cellsLeft - (columnsLeft - 1)
-                            else
-                                cellsLeft
-
-                        let adjustedSize = min size maxSize
-
-                        let actualSize =
-                            if index + adjustedSize <= cell.Length then adjustedSize
-                            elif index < cell.Length then cell.Length - index
-                            else 0
-
-                        if actualSize > 0 then
-                            let segment = cell.[index .. index + actualSize - 1]
-
-                            match tryFit cell (index + actualSize) rest (columnsLeft - 1) with
-                            | Some restResult -> Some((name, segment) :: restResult)
-                            | None -> None
-                        else
-                            None
-                    )
-                    |> List.tryHead
-
-            tryFit strings 0 (Array.toList headersSizes) maxColumns
-
-        let fittingHeaders = getHeadersExpectedLengths headers
-
-        let fittedRows =
-            data |> Array.map (fun row -> fitHeaders row fittingHeaders headers.Length)
-
-        let result =
-            fittedRows
-            |> Array.choose (fun row -> row)
-            |> Array.map (fun row -> row |> List.map (fun (_, cells) -> cells) |> Array.ofList)
-
-        result |> Array.map (fun row -> fitColumnsToTarget row headers)
-
-    static member predictPasteBehaviour
-        (cellIndex: CellCoordinate, targetTable: ArcTable, selectHandle: SelectHandle, data: string[][])
-        =
-
-        //Convert cell coordinates to array
-        let cellCoordinates = selectHandle.getSelectedCells () |> Array.ofSeq
-
-        //Get all required headers for cells
-        let headers =
-            let columnIndices = cellCoordinates |> Array.distinctBy (fun item -> item.x)
-
-            columnIndices
-            |> Array.map (fun index -> targetTable.GetColumn(index.x - 1).Header)
-
-        let checkForHeaders (row: string[]) =
-            let headers = ARCtrl.CompositeHeader.Cases |> Array.map (fun (_, header) -> header)
-
-            let areHeaders =
-                headers
-                |> Array.collect (fun _ ->
-                    row
-                    |> Array.map (fun cell -> AnnotationTableContextMenuUtil.checkForHeader (cell))
-                )
-
-            Array.contains true areHeaders
-
-        //Group all cells based on their row
-        let groupedCellCoordinates =
-            cellCoordinates
-            |> Array.ofSeq
-            |> Array.groupBy (fun item -> item.y)
-            |> Array.map (fun (_, row) -> row)
-
-        if checkForHeaders data.[0] || cellCoordinates.[0].y <= 0 || cellIndex.y <= 0 then
-
-            let headers, body =
-                if data.Length > 1 then
-                    data.[0], data.[1..]
-                else
-                    data.[0], [||]
-
-            let columns = Array.append [| headers |] body |> Array.transpose
-            let columnsArrays = columns |> Seq.toArray |> Array.map (Seq.toArray)
-
-            let compositeColumns =
-                ARCtrl.Spreadsheet.ArcTable.composeColumns columnsArrays |> ResizeArray
-
-            PasteCases.AddColumns {|
-                data = compositeColumns
-                coordinate = cellIndex
-                coordinates = groupedCellCoordinates
-            |}
-        else
-            let fittedCells =
-                AnnotationTableContextMenuUtil.getFittedCells (data, headers)
-                |> Array.transpose
-                |> Array.map (fun column -> column |> ResizeArray)
-
-            let columns =
-                Array.map2 (fun header cells -> CompositeColumn.create (header, cells)) headers fittedCells
-                |> ResizeArray
-
-            let isEmpty =
-                Array.isEmpty fittedCells
-                || fittedCells
-                   |> Array.map (fun row ->
-                       Seq.isEmpty row
-                       || Seq.forall (fun (cell: CompositeCell) -> String.IsNullOrWhiteSpace(cell.ToTabStr())) row
-                   )
-                   |> Array.contains true
-
-            if isEmpty then
-                PasteCases.Unknown {| data = data; headers = headers |}
-            else
-                PasteCases.PasteCells {|
-                    data = columns
-                    coordinates = groupedCellCoordinates
-                |}
-
-    static member getValueOfCompositeHeader(compositeHeader: CompositeHeader) =
-        match compositeHeader with
-        | CompositeHeader.Component oa -> defaultArg oa.Name (compositeHeader.ToString())
-        | CompositeHeader.Characteristic oa -> defaultArg oa.Name (compositeHeader.ToString())
-        | CompositeHeader.Factor oa -> defaultArg oa.Name (compositeHeader.ToString())
-        | CompositeHeader.Parameter oa -> defaultArg oa.Name (compositeHeader.ToString())
-        | CompositeHeader.ProtocolType -> CompositeHeaderDiscriminate.ProtocolType.ToString()
-        | CompositeHeader.ProtocolDescription -> CompositeHeaderDiscriminate.ProtocolDescription.ToString()
-        | CompositeHeader.ProtocolUri -> CompositeHeaderDiscriminate.ProtocolUri.ToString()
-        | CompositeHeader.ProtocolVersion -> CompositeHeaderDiscriminate.ProtocolVersion.ToString()
-        | CompositeHeader.ProtocolREF -> CompositeHeaderDiscriminate.ProtocolREF.ToString()
-        | CompositeHeader.Performer -> CompositeHeaderDiscriminate.Performer.ToString()
-        | CompositeHeader.Date -> CompositeHeaderDiscriminate.Date.ToString()
-        | CompositeHeader.Input io -> io.ToString()
-        | CompositeHeader.Output io -> io.ToString()
-        | CompositeHeader.Comment s -> s
-        | CompositeHeader.FreeText s -> s
-
-    static member pasteCells
-        (
-            pasteColumns:
-                {|
-                    data: ResizeArray<CompositeColumn>
-                    coordinates: CellCoordinate[][]
-                |},
-            coordinate: CellCoordinate,
-            selectHandle: SelectHandle,
-            table: ArcTable,
-            setTable
-        ) =
-
-        let getCorrectTargetForCell
-            (currentCell: CompositeCell)
-            (table: ArcTable)
-            (targetCoordinate: CellCoordinate)
-            adaption
-            =
-
-            if currentCell.isUnitized then
-                let targetCell =
-                    table.GetCellAt(targetCoordinate.x - adaption, targetCoordinate.y - adaption)
-
-                let value, unit = currentCell.AsUnitized
-
-                let unitNeedsMetadata =
-                    unit.isEmpty()
-                    || Option.forall String.IsNullOrWhiteSpace unit.TermSourceREF
-                    || Option.forall String.IsNullOrWhiteSpace unit.TermAccessionNumber
-
-                let hasSameUnitName (targetTerm: OntologyAnnotation) =
-                    unit.isEmpty()
-                    || String.Equals(unit.NameText, targetTerm.NameText, StringComparison.OrdinalIgnoreCase)
-
-                let targetUnit =
-                    if targetCell.isUnitized then
-                        targetCell.AsUnitized |> snd |> Some
-                    elif targetCell.isTerm then
-                        targetCell.AsTerm |> Some
-                    else
-                        None
-
-                match targetUnit with
-                | Some targetUnit when unitNeedsMetadata && hasSameUnitName targetUnit ->
-                    CompositeCell.createUnitized (value, targetUnit)
-                | _ -> currentCell
-            else
-                currentCell
-
-        let getCorrectTargetForHeader
-            (currentHeader: CompositeHeader)
-            (table: ArcTable)
-            (targetCoordinate: CellCoordinate)
-            adaption
-            =
-
-            let targetCell =
-                table.GetCellAt(targetCoordinate.x - adaption, targetCoordinate.y - adaption)
-
-            if targetCell.isUnitized then
-                let _, targetUnit = targetCell.AsUnitized
-                let value = AnnotationTableContextMenuUtil.getValueOfCompositeHeader (currentHeader)
-                let newTarget = CompositeCell.createUnitized (value, targetUnit)
-                newTarget
-            elif targetCell.isTerm then
-                let targetTerm = defaultArg (currentHeader.TryGetTerm()) targetCell.AsTerm
-                let newTarget = CompositeCell.createTerm (targetTerm)
-                newTarget
-            elif targetCell.isData then
-                let targetInfo = targetCell.AsData
-
-                let targetData =
-                    AnnotationTableContextMenuUtil.getValueOfCompositeHeader (currentHeader)
-
-                let newTarget =
-                    CompositeCell.createDataFromString (
-                        targetData,
-                        ?format = targetInfo.Format,
-                        ?selectorFormat = targetInfo.SelectorFormat
-                    )
-
-                newTarget
-            else
-                let value = AnnotationTableContextMenuUtil.getValueOfCompositeHeader (currentHeader)
-                CompositeCell.createFreeText (value)
-
-        //Check amount of selected cells
-        //When multiple cells are selected a different handling is required
-        let headerCoordinates, bodyCoordinates =
-            if pasteColumns.coordinates.[0].[0].y - 1 < 0 then
-                pasteColumns.coordinates.[0], pasteColumns.coordinates.[1..]
-            else
-                [||], pasteColumns.coordinates
-
-        let pasteWithCoordiantes (coordinates: CellCoordinate[][]) =
-            if selectHandle.getCount () > 1 then
-                //Map over all selected cells
-                coordinates
-                |> Array.iteri (fun yi row ->
-                    //Restart row index, when the amount of selected rows is bigger than copied rows
-                    let yIndex =
-                        if (pasteColumns.data.Item 0).Cells.Count = 0 then
-                            1
-                        else
-                            AnnotationTableContextMenuUtil.getIndex (yi, (pasteColumns.data.Item 0).Cells.Count)
-
-                    row
-                    |> Array.iteri (fun xi coordinate ->
-                        let xIndex = AnnotationTableContextMenuUtil.getIndex (xi, pasteColumns.data.Count)
-
-                        if coordinate.y - 1 < 0 then
-                            table.UpdateHeader(coordinate.x - 1, pasteColumns.data.[xIndex].Header, true)
-                        else
-                            let newTarget =
-                                if pasteColumns.data.[0].Cells.Count = 0 then
-                                    let currentHeader = pasteColumns.data.[xIndex].Header
-                                    getCorrectTargetForHeader currentHeader table coordinate 1
-                                else
-                                    let cells = (pasteColumns.data.Item xIndex).Cells
-                                    let currentCell = cells.[yIndex]
-                                    getCorrectTargetForCell currentCell table coordinate 1
-
-                            table.SetCellAt(coordinate.x - 1, coordinate.y - 1, newTarget)
-                    )
-                )
-            else if coordinate.y - 1 < 0 then
-                table.UpdateHeader(coordinate.x - 1, pasteColumns.data.[0].Header, true)
-            else
-                let newTarget =
-                    if pasteColumns.data.[0].Cells.Count = 0 then
-                        let currentHeader = pasteColumns.data.[0].Header
-                        getCorrectTargetForHeader currentHeader table coordinate 1
-                    else
-                        let currentCell = pasteColumns.data.[0].Cells.[0]
-                        getCorrectTargetForCell currentCell table coordinate 1
-
-                table.SetCellAt(coordinate.x - 1, coordinate.y - 1, newTarget)
-
-        if headerCoordinates.Length > 0 then
-            pasteWithCoordiantes [| headerCoordinates |]
-
-        if bodyCoordinates.Length > 0 then
-            pasteWithCoordiantes bodyCoordinates
-
-        table.Copy() |> setTable
-
-    static member paste
-        (
-            pasteCases: PasteCases,
-            coordinate: CellCoordinate,
-            table: ArcTable,
-            selectHandle: SelectHandle,
-            setModal: Types.AnnotationTable.ModalTypes option -> unit,
-            setTable: ArcTable -> unit
-        ) =
-
-        match pasteCases with
-        | AddColumns addColumns ->
-            setModal (
-                AnnotationTable.ModalTypes.PasteCaseUserInput(PasteCases.AddColumns addColumns, selectHandle)
-                |> Some
-            )
-        | PasteCells pasteColumns ->
-            AnnotationTableContextMenuUtil.pasteCells (pasteColumns, coordinate, selectHandle, table, setTable)
-        | Unknown unknownPasteCase ->
-            setModal (
-                AnnotationTable.ModalTypes.UnknownPasteCase(PasteCases.Unknown unknownPasteCase)
-                |> Some
-            )
-
-    static member tryPasteCopiedCells
-        (
-            cellIndex: CellCoordinate,
-            arcTable: ArcTable,
-            selectHandle: SelectHandle,
-            setModal: AnnotationTable.ModalTypes option -> unit,
-            setArcTable: ArcTable -> unit
-        ) =
-        promise {
-            let! data = AnnotationTableContextMenuUtil.getCopiedCells ()
-
-            try
-                let prediction =
-                    AnnotationTableContextMenuUtil.predictPasteBehaviour (cellIndex, arcTable, selectHandle, data)
-
-                AnnotationTableContextMenuUtil.paste (
-                    prediction,
-                    cellIndex,
-                    arcTable,
-                    selectHandle,
-                    setModal,
-                    setArcTable
-                )
-            with exn ->
-                setModal (AnnotationTable.ModalTypes.Error(exn.Message) |> Some)
-        }
 
 [<Erase>]
 type AnnotationTableContextMenu =
@@ -650,7 +129,7 @@ type AnnotationTableContextMenu =
                 kbdbutton = ATCMC.KbdHint("Del"),
                 onClick =
                     fun _ ->
-                        AnnotationTableContextMenuUtil.clear (cellIndex, arcTable, selectHandle)
+                        AnnotationTableClipboard.clear (cellIndex, arcTable, selectHandle)
                         |> setArcTable
             )
             ContextMenuItem(isDivider = true)
@@ -660,7 +139,7 @@ type AnnotationTableContextMenu =
                 kbdbutton = ATCMC.KbdHint("C"),
                 onClick =
                     fun _ ->
-                        AnnotationTableContextMenuUtil.copy (cellIndex, arcTable, selectHandle)
+                        AnnotationTableClipboard.copy (cellIndex, arcTable, selectHandle)
                         |> Promise.start
 
             )
@@ -671,7 +150,7 @@ type AnnotationTableContextMenu =
                     kbdbutton = ATCMC.KbdHint("X"),
                     onClick =
                         fun _ ->
-                            AnnotationTableContextMenuUtil.cut (cellIndex, arcTable, setArcTable, selectHandle)
+                            AnnotationTableClipboard.cut (cellIndex, arcTable, setArcTable, selectHandle)
                             |> Promise.start
                 )
             ContextMenuItem(
@@ -680,7 +159,7 @@ type AnnotationTableContextMenu =
                 kbdbutton = ATCMC.KbdHint("V"),
                 onClick =
                     fun _ ->
-                        AnnotationTableContextMenuUtil.tryPasteCopiedCells (
+                        AnnotationTableClipboard.tryPasteCopiedCells (
                             cellIndex,
                             arcTable,
                             selectHandle,
@@ -753,7 +232,7 @@ type AnnotationTableContextMenu =
                 kbdbutton = ATCMC.KbdHint("C"),
                 onClick =
                     fun _ ->
-                        AnnotationTableContextMenuUtil.copy (cellCoordinate, arcTable, selectHandle)
+                        AnnotationTableClipboard.copy (cellCoordinate, arcTable, selectHandle)
                         |> Promise.start
 
             )
@@ -763,7 +242,7 @@ type AnnotationTableContextMenu =
                 kbdbutton = ATCMC.KbdHint("V"),
                 onClick =
                     fun _ ->
-                        AnnotationTableContextMenuUtil.tryPasteCopiedCells (
+                        AnnotationTableClipboard.tryPasteCopiedCells (
                             cellCoordinate,
                             arcTable,
                             selectHandle,

--- a/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
+++ b/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
@@ -224,20 +224,8 @@ type AnnotationTableContextMenuUtil =
                             index
 
                     match header with
-                    | x when x.IsSingleColumn ->
+                    | x when x.IsSingleColumn || x.IsDataColumn || x.IsTermColumn ->
                         let cell = CompositeCell.fromContentValid (row.[newIndex], header)
-                        loop (index + 1) (cell :: result)
-                    | x when x.IsDataColumn ->
-                        let cell = CompositeCell.fromContentValid (row.[newIndex], header)
-                        loop (index + 1) (cell :: result)
-                    | x when x.IsTermColumn ->
-                        let value =
-                            if row.[newIndex].Length = 2 then
-                                [| row.[newIndex].[0] |]
-                            else
-                                row.[newIndex]
-
-                        let cell = CompositeCell.fromContentValid (value, header)
                         loop (index + 1) (cell :: result)
                     | anyElse -> failwith $"Error-fitColumnsToTarget: Encountered unsupported case: {anyElse}"
 
@@ -433,16 +421,27 @@ type AnnotationTableContextMenuUtil =
 
                 let value, unit = currentCell.AsUnitized
 
-                if targetCell.isUnitized && unit.isEmpty () then
-                    let _, targetUnit = targetCell.AsUnitized
-                    let newTarget = CompositeCell.createUnitized (value, targetUnit)
-                    newTarget
-                elif targetCell.isTerm && unit.isEmpty () then
-                    let targetTerm = targetCell.AsTerm
-                    let newTarget = CompositeCell.createUnitized (value, targetTerm)
-                    newTarget
-                else
-                    currentCell
+                let unitNeedsMetadata =
+                    unit.isEmpty()
+                    || Option.forall String.IsNullOrWhiteSpace unit.TermSourceREF
+                    || Option.forall String.IsNullOrWhiteSpace unit.TermAccessionNumber
+
+                let hasSameUnitName (targetTerm: OntologyAnnotation) =
+                    unit.isEmpty()
+                    || String.Equals(unit.NameText, targetTerm.NameText, StringComparison.OrdinalIgnoreCase)
+
+                let targetUnit =
+                    if targetCell.isUnitized then
+                        targetCell.AsUnitized |> snd |> Some
+                    elif targetCell.isTerm then
+                        targetCell.AsTerm |> Some
+                    else
+                        None
+
+                match targetUnit with
+                | Some targetUnit when unitNeedsMetadata && hasSameUnitName targetUnit ->
+                    CompositeCell.createUnitized (value, targetUnit)
+                | _ -> currentCell
             else
                 currentCell
 

--- a/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
+++ b/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
@@ -8,10 +8,9 @@ open Feliz
 open Swate.Components
 open Swate.Components.Primitive
 open Swate.Components.Primitive.ContextMenu.Types
-open Swate.Components.Composite.AnnotationTable.Types
 open Swate.Components.Composite.Table
 open Swate.Components.Composite.Table.Types
-
+open Swate.Components.Composite.AnnotationTable.Types
 
 /// AnnotationTableContextMenu Components
 type ATCMC =

--- a/src/Components/src/Composite/AnnotationTable/Modals.fs
+++ b/src/Components/src/Composite/AnnotationTable/Modals.fs
@@ -598,13 +598,7 @@ type ContextMenuModals =
                         coordinates = coordinates
                     |}
 
-                    AnnotationTableClipboard.pasteCells (
-                        pasteColumns,
-                        coordinate,
-                        selectHandle,
-                        arcTable,
-                        setArcTable
-                    )
+                    AnnotationTableClipboard.pasteCells (pasteColumns, coordinate, selectHandle, arcTable, setArcTable)
 
                     arcTable.Copy() |> setArcTable
                     rmv ()

--- a/src/Components/src/Composite/AnnotationTable/Modals.fs
+++ b/src/Components/src/Composite/AnnotationTable/Modals.fs
@@ -598,7 +598,7 @@ type ContextMenuModals =
                         coordinates = coordinates
                     |}
 
-                    AnnotationTableContextMenuUtil.pasteCells (
+                    AnnotationTableClipboard.pasteCells (
                         pasteColumns,
                         coordinate,
                         selectHandle,

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -63,7 +63,6 @@
 
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
-    <None Include="swateBundleStyle.css" Pack="true" PackagePath="fable/" />
     <Compile Include="Types\StateContext.fs" />
     <Compile Include="Types\CellCoordinate.fs" />
     <Compile Include="Util\Download.fs" />

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -144,6 +144,7 @@
     <Compile Include="Composite\AnnotationTable\Types.fs" />
     <Compile Include="Composite\AnnotationTable\Context.fs" />
     <Compile Include="Composite\AnnotationTable\ContextProvider.fs" />
+    <Compile Include="Composite\AnnotationTable\AnnotationTableClipboard.fs" />
     <Compile Include="Composite\AnnotationTable\ContextMenu.fs" />
     <Compile Include="Composite\AnnotationTable\Modals.fs" />
     <Compile Include="Composite\AnnotationTable\AnnotationTable.fs" />

--- a/tests/Client/Components/Table/ContextMenu.tests.fs
+++ b/tests/Client/Components/Table/ContextMenu.tests.fs
@@ -216,6 +216,48 @@ type TestCases =
             Expect.equal arcTableIndex.y 0 "Move column target should stay on header row"
         | _ -> failwith "Move column menu entry should open move-column modal"
 
+    static member PasteCompactUnitsIntoParameterColumn() =
+        let table = Fixture.mkTable ()
+        let selectHandle = Fixture.mkSelectHandle (1, 2, 4, 4)
+        let clickedCell: CellCoordinate = {| x = 4; y = 1 |}
+
+        let pasteData = [|
+            [| "4"; "Degree Celsius" |]
+            [| "5"; "Degree Celsius" |]
+        |]
+
+        let pasteBehavior =
+            AnnotationTableContextMenuUtil.predictPasteBehaviour (clickedCell, table, selectHandle, pasteData)
+
+        match pasteBehavior with
+        | PasteCases.PasteCells pasteColumns ->
+            let firstCell = pasteColumns.data.[0].Cells.[0]
+            let firstValue, firstUnit = firstCell.AsUnitized
+
+            Expect.equal firstValue "4" "Compact unit paste should preserve the numeric value"
+            Expect.equal firstUnit.NameText "Degree Celsius" "Compact unit paste should preserve the unit name"
+
+            let mutable updatedTable = table
+
+            AnnotationTableContextMenuUtil.pasteCells (
+                pasteColumns,
+                clickedCell,
+                selectHandle,
+                table,
+                (fun nextTable -> updatedTable <- nextTable)
+            )
+
+            Expect.equal
+                (updatedTable.GetCellAt(3, 0).ToTabStr())
+                "4\tDegree Celsius\tUO\tUO:000000001"
+                "Pasting into an existing unitized column should enrich the compact unit with target metadata"
+
+            Expect.equal
+                (updatedTable.GetCellAt(3, 1).ToTabStr())
+                "5\tDegree Celsius\tUO\tUO:000000001"
+                "Pasting multiple compact unit rows should preserve units for each row"
+        | _ -> failwith "Compact unit paste should be predicted as PasteCells"
+
 let Main =
 
     testList "Context Menu" [
@@ -312,5 +354,7 @@ let Main =
             <| fun _ -> TestCases.IndexDeleteFirstRow()
             testCase "Header move column keeps 1-based header index"
             <| fun _ -> TestCases.HeaderMoveColumnUsesSelectedHeaderIndex()
+            testCase "Compact value-unit TSV paste preserves units"
+            <| fun _ -> TestCases.PasteCompactUnitsIntoParameterColumn()
         ]
     ]

--- a/tests/Client/Components/Table/ContextMenu.tests.fs
+++ b/tests/Client/Components/Table/ContextMenu.tests.fs
@@ -216,27 +216,30 @@ type TestCases =
             Expect.equal arcTableIndex.y 0 "Move column target should stay on header row"
         | _ -> failwith "Move column menu entry should open move-column modal"
 
-    static member PasteCompactUnitsIntoParameterColumn() =
-        let table = Fixture.mkTable ()
-        let selectHandle = Fixture.mkSelectHandle (1, 2, 4, 4)
-        let clickedCell: CellCoordinate = {| x = 4; y = 1 |}
+    static member private MkUnitPasteTable(targetUnit: OntologyAnnotation, ?sourceUnit: OntologyAnnotation) =
+        let table = ARCtrl.ArcTable("UnitPasteTable", ResizeArray())
 
-        let pasteData = [|
-            [| "4"; "Degree Celsius" |]
-            [| "5"; "Degree Celsius" |]
-        |]
+        let cells =
+            [|
+                yield CompositeCell.createUnitized ("1", targetUnit)
+                match sourceUnit with
+                | Some sourceUnit -> yield CompositeCell.createUnitized ("2", sourceUnit)
+                | None -> ()
+            |]
+            |> ResizeArray
+
+        table.AddColumn(CompositeHeader.Parameter(OntologyAnnotation("Temperature", "TEMP", "TEMP:0001")), cells)
+        table
+
+    static member private PasteCellsInto(table: ArcTable, pasteData: string[][]) =
+        let selectHandle = Fixture.mkSelectHandle (1, 1, 1, 1)
+        let clickedCell: CellCoordinate = {| x = 1; y = 1 |}
 
         let pasteBehavior =
             AnnotationTableClipboard.predictPasteBehaviour (clickedCell, table, selectHandle, pasteData)
 
         match pasteBehavior with
         | PasteCases.PasteCells pasteColumns ->
-            let firstCell = pasteColumns.data.[0].Cells.[0]
-            let firstValue, firstUnit = firstCell.AsUnitized
-
-            Expect.equal firstValue "4" "Compact unit paste should preserve the numeric value"
-            Expect.equal firstUnit.NameText "Degree Celsius" "Compact unit paste should preserve the unit name"
-
             let mutable updatedTable = table
 
             AnnotationTableClipboard.pasteCells (
@@ -247,16 +250,77 @@ type TestCases =
                 (fun nextTable -> updatedTable <- nextTable)
             )
 
-            Expect.equal
-                (updatedTable.GetCellAt(3, 0).ToTabStr())
-                "4\tDegree Celsius\tUO\tUO:000000001"
-                "Pasting into an existing unitized column should enrich the compact unit with target metadata"
+            updatedTable, pasteColumns
+        | _ -> failwith "Unit paste should be predicted as PasteCells"
 
-            Expect.equal
-                (updatedTable.GetCellAt(3, 1).ToTabStr())
-                "5\tDegree Celsius\tUO\tUO:000000001"
-                "Pasting multiple compact unit rows should preserve units for each row"
-        | _ -> failwith "Compact unit paste should be predicted as PasteCells"
+    static member CompactUnitPasteRestoresMetadataFromMatchingUnit() =
+        let targetUnit = OntologyAnnotation("degree Celsius", "TARGET", "TARGET:0001")
+        let sourceUnit = OntologyAnnotation("degree Celsius", "ALTUNIT", "ALTUNIT:0001")
+        let table = TestCases.MkUnitPasteTable(targetUnit, sourceUnit = sourceUnit)
+        let pasteData = [| [| "4"; "degree Celsius" |] |]
+
+        let updatedTable, pasteColumns = TestCases.PasteCellsInto(table, pasteData)
+
+        let firstValue, firstUnit = pasteColumns.data.[0].Cells.[0].AsUnitized
+
+        Expect.equal firstValue "4" "Compact value-unit paste should preserve the numeric value"
+        Expect.equal firstUnit.NameText "degree Celsius" "Compact value-unit paste should preserve the unit name"
+        Expect.equal firstUnit.TermSourceREF None "Compact value-unit paste initially only contains the unit name"
+
+        Expect.equal
+            (updatedTable.GetCellAt(0, 0).ToTabStr())
+            "4\tdegree Celsius\tALTUNIT\tALTUNIT:0001"
+            "Compact value-unit paste should restore metadata from a matching unit, not from the target cell"
+
+    static member CompactUnitPasteDoesNotUseOnlyTargetMetadata() =
+        let targetUnit = OntologyAnnotation("degree Celsius", "TARGET", "TARGET:0001")
+        let table = TestCases.MkUnitPasteTable(targetUnit)
+        let pasteData = [| [| "4"; "degree Celsius" |] |]
+
+        let updatedTable, _ = TestCases.PasteCellsInto(table, pasteData)
+
+        Expect.equal
+            (updatedTable.GetCellAt(0, 0).ToTabStr())
+            "4\tdegree Celsius\t\t"
+            "Compact value-unit paste should not inherit metadata from the target cell alone"
+
+    static member ValueOnlyUnitPasteUsesTargetUnit() =
+        let targetUnit = OntologyAnnotation("degree Celsius", "TARGET", "TARGET:0001")
+        let table = TestCases.MkUnitPasteTable(targetUnit)
+        let pasteData = [| [| "4" |] |]
+
+        let updatedTable, _ = TestCases.PasteCellsInto(table, pasteData)
+
+        Expect.equal
+            (updatedTable.GetCellAt(0, 0).ToTabStr())
+            "4\tdegree Celsius\tTARGET\tTARGET:0001"
+            "Value-only unit paste should keep using the target unit"
+
+    static member FullUnitPasteKeepsGivenMetadata() =
+        let targetUnit = OntologyAnnotation("degree Celsius", "TARGET", "TARGET:0001")
+        let sourceUnit = OntologyAnnotation("degree Celsius", "ALTUNIT", "ALTUNIT:0001")
+        let table = TestCases.MkUnitPasteTable(targetUnit, sourceUnit = sourceUnit)
+        let pasteData = [| [| "4"; "degree Celsius"; "GIVEN"; "GIVEN:0001" |] |]
+
+        let updatedTable, _ = TestCases.PasteCellsInto(table, pasteData)
+
+        Expect.equal
+            (updatedTable.GetCellAt(0, 0).ToTabStr())
+            "4\tdegree Celsius\tGIVEN\tGIVEN:0001"
+            "Full value-unit-metadata paste should keep the given unit metadata"
+
+    static member CompactUnitPasteKeepsUnmatchedUnitNameOnly() =
+        let targetUnit = OntologyAnnotation("degree Celsius", "TARGET", "TARGET:0001")
+        let sourceUnit = OntologyAnnotation("kelvin", "ALTUNIT", "ALTUNIT:0002")
+        let table = TestCases.MkUnitPasteTable(targetUnit, sourceUnit = sourceUnit)
+        let pasteData = [| [| "4"; "meter" |] |]
+
+        let updatedTable, _ = TestCases.PasteCellsInto(table, pasteData)
+
+        Expect.equal
+            (updatedTable.GetCellAt(0, 0).ToTabStr())
+            "4\tmeter\t\t"
+            "Compact value-unit paste should keep an unmatched unit name without borrowing other metadata"
 
 let Main =
 
@@ -354,7 +418,15 @@ let Main =
             <| fun _ -> TestCases.IndexDeleteFirstRow()
             testCase "Header move column keeps 1-based header index"
             <| fun _ -> TestCases.HeaderMoveColumnUsesSelectedHeaderIndex()
-            testCase "Compact value-unit TSV paste preserves units"
-            <| fun _ -> TestCases.PasteCompactUnitsIntoParameterColumn()
+            testCase "Compact value-unit TSV paste restores metadata from matching unit"
+            <| fun _ -> TestCases.CompactUnitPasteRestoresMetadataFromMatchingUnit()
+            testCase "Compact value-unit TSV paste does not use target metadata alone"
+            <| fun _ -> TestCases.CompactUnitPasteDoesNotUseOnlyTargetMetadata()
+            testCase "Value-only TSV paste into unitized cell uses target unit"
+            <| fun _ -> TestCases.ValueOnlyUnitPasteUsesTargetUnit()
+            testCase "Full unit TSV paste keeps given metadata"
+            <| fun _ -> TestCases.FullUnitPasteKeepsGivenMetadata()
+            testCase "Compact value-unit TSV paste keeps unmatched unit without metadata"
+            <| fun _ -> TestCases.CompactUnitPasteKeepsUnmatchedUnitNameOnly()
         ]
     ]

--- a/tests/Client/Components/Table/ContextMenu.tests.fs
+++ b/tests/Client/Components/Table/ContextMenu.tests.fs
@@ -48,7 +48,7 @@ type TestCases =
             |> Array.map (fun (_, row) -> row)
 
         let pasteBehavior =
-            AnnotationTableContextMenuUtil.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
+            AnnotationTableClipboard.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
 
         Expect.equal
             pasteBehavior
@@ -67,7 +67,7 @@ type TestCases =
         let selectHandle: SelectHandle = Fixture.mkSelectHandle (1, 1, 1, 1)
 
         let pasteBehavior =
-            AnnotationTableContextMenuUtil.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
+            AnnotationTableClipboard.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
 
         Expect.equal
             pasteBehavior
@@ -86,7 +86,7 @@ type TestCases =
         let clickedCell: CellCoordinate = {| x = 1; y = 1 |}
 
         let pasteBehavior =
-            AnnotationTableContextMenuUtil.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
+            AnnotationTableClipboard.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
 
         Expect.equal
             pasteBehavior
@@ -105,7 +105,7 @@ type TestCases =
         let clickedCell: CellCoordinate = {| x = 3; y = 1 |}
 
         let pasteBehavior =
-            AnnotationTableContextMenuUtil.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
+            AnnotationTableClipboard.predictPasteBehaviour (clickedCell, currentTable, selectHandle, pasteData)
 
         Expect.equal
             pasteBehavior
@@ -133,7 +133,7 @@ type TestCases =
         let adaptedData = pasteData |> Array.map (fun item -> item)
 
         let pasteBehavior =
-            AnnotationTableContextMenuUtil.predictPasteBehaviour (clickedCell, currentTable, selectHandle, adaptedData)
+            AnnotationTableClipboard.predictPasteBehaviour (clickedCell, currentTable, selectHandle, adaptedData)
 
         Expect.equal
             pasteBehavior
@@ -227,7 +227,7 @@ type TestCases =
         |]
 
         let pasteBehavior =
-            AnnotationTableContextMenuUtil.predictPasteBehaviour (clickedCell, table, selectHandle, pasteData)
+            AnnotationTableClipboard.predictPasteBehaviour (clickedCell, table, selectHandle, pasteData)
 
         match pasteBehavior with
         | PasteCases.PasteCells pasteColumns ->
@@ -239,7 +239,7 @@ type TestCases =
 
             let mutable updatedTable = table
 
-            AnnotationTableContextMenuUtil.pasteCells (
+            AnnotationTableClipboard.pasteCells (
                 pasteColumns,
                 clickedCell,
                 selectHandle,


### PR DESCRIPTION
* Add check for unit existence and target column
* Move code that is called outside of the ContextMenu into the AnnotationTableClipboard
* Pasting a compact value-unit cells (no metadata) no longer inherits the metadata from the overwritten target cell