### PR TITLE
Make parent of branch sticky in filetree

### DIFF
--- a/src/Components/src/JsBindings/ResizeObserver.fs
+++ b/src/Components/src/JsBindings/ResizeObserver.fs
@@ -1,0 +1,11 @@
+namespace Swate.Components.JsBindings
+
+open Browser.Types
+open Fable.Core
+
+[<AllowNullLiteral; Global>]
+type ResizeObserver(callback: unit -> unit) =
+
+    member _.observe(_target: HTMLElement) : unit = jsNative
+
+    member _.disconnect() : unit = jsNative

--- a/src/Components/src/Page/FileExplorer/FileExplorer.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorer.fs
@@ -158,6 +158,17 @@ type FileExplorer =
         let model, dispatch = React.useReducer (reducer, initialModel)
         let containerRef = React.useElementRef ()
 
+        let stickyRowHeights, setStickyRowHeights =
+            React.useStateWithUpdater (Map.empty<string, int>)
+
+        let handleStickyRowHeightChange (itemId: string) (height: int) =
+            setStickyRowHeights (fun heights ->
+                match heights |> Map.tryFind itemId with
+                | Some currentHeight when currentHeight = height -> heights
+                | _ -> heights |> Map.add itemId height
+            )
+            |> ignore
+
         let onDirectoryExpansionChange =
             onDirectoryExpansionChange
             |> Option.orElse onExpansionChange
@@ -271,7 +282,7 @@ type FileExplorer =
 
         let selectedPathIds = model.SelectedPath |> List.map _.Id |> Set.ofList
 
-        let rec renderItem depth item =
+        let rec renderItem depth stickyTopOffset item =
             let isSelected = model.SelectedId = Some item.Id
             let isInSelectedPath = selectedPathIds.Contains item.Id
             let isHighlighted = isSelected || isInSelectedPath
@@ -303,10 +314,17 @@ type FileExplorer =
                     if isExpanded then
                         match item.Children with
                         | Some children ->
+                            let childStickyTopOffset =
+                                if delegateHorizontalScrollToParent then
+                                    stickyTopOffset
+                                    + (stickyRowHeights |> Map.tryFind item.Id |> Option.defaultValue 0)
+                                else
+                                    stickyTopOffset
+
                             Some(
                                 Html.ul [
                                     prop.className "swt:ml-4"
-                                    prop.children (children |> List.map (renderItem (depth + 1)))
+                                    prop.children (children |> List.map (renderItem (depth + 1) childStickyTopOffset))
                                 ]
                             )
                         | None -> None
@@ -316,6 +334,18 @@ type FileExplorer =
                 let stickyDepth =
                     if delegateHorizontalScrollToParent then
                         Some depth
+                    else
+                        None
+
+                let rowStickyTopOffset =
+                    if delegateHorizontalScrollToParent then
+                        Some stickyTopOffset
+                    else
+                        None
+
+                let onStickyRowHeightChange =
+                    if delegateHorizontalScrollToParent then
+                        Some handleStickyRowHeightChange
                     else
                         None
 
@@ -340,6 +370,8 @@ type FileExplorer =
                     canDeleteItem = canDeleteItem,
                     ?statusAction = statusAction,
                     ?stickyDepth = stickyDepth,
+                    ?stickyTopOffset = rowStickyTopOffset,
+                    ?onStickyRowHeightChange = onStickyRowHeightChange,
                     ?children = childrenTree
                 )
             else
@@ -366,7 +398,7 @@ type FileExplorer =
                         Html.ul [
                             prop.testId "file-explorer-container"
                             prop.className listClassName
-                            prop.children (model.Items |> List.map (renderItem 0))
+                            prop.children (model.Items |> List.map (renderItem 0 0))
                         ]
                     ]
                 ]

--- a/src/Components/src/Page/FileExplorer/FileExplorer.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorer.fs
@@ -165,7 +165,10 @@ type FileExplorer =
 
         let scrollContainerClassName =
             if truncateOverflowingItemNames then
-                "swt:w-full swt:min-w-0 swt:overflow-x-hidden"
+                if delegateHorizontalScrollToParent then
+                    "swt:w-full swt:min-w-0 swt:overflow-x-clip"
+                else
+                    "swt:w-full swt:min-w-0 swt:overflow-x-hidden"
             elif delegateHorizontalScrollToParent then
                 "swt:w-max swt:min-w-full"
             else
@@ -267,8 +270,9 @@ type FileExplorer =
             )
 
         let selectedPathIds = model.SelectedPath |> List.map _.Id |> Set.ofList
+        let stickyParentRowHeightPx = 32
 
-        let rec renderItem item =
+        let rec renderItem depth item =
             let isSelected = model.SelectedId = Some item.Id
             let isInSelectedPath = selectedPathIds.Contains item.Id
             let isHighlighted = isSelected || isInSelectedPath
@@ -303,10 +307,16 @@ type FileExplorer =
                             Some(
                                 Html.ul [
                                     prop.className "swt:ml-4"
-                                    prop.children (children |> List.map renderItem)
+                                    prop.children (children |> List.map (renderItem (depth + 1)))
                                 ]
                             )
                         | None -> None
+                    else
+                        None
+
+                let stickyTopOffset =
+                    if delegateHorizontalScrollToParent && childrenTree.IsSome then
+                        Some(depth * stickyParentRowHeightPx)
                     else
                         None
 
@@ -330,6 +340,7 @@ type FileExplorer =
                     ?onDeleteItem = onDeleteItem,
                     canDeleteItem = canDeleteItem,
                     ?statusAction = statusAction,
+                    ?stickyTopOffset = stickyTopOffset,
                     ?children = childrenTree
                 )
             else
@@ -356,7 +367,7 @@ type FileExplorer =
                         Html.ul [
                             prop.testId "file-explorer-container"
                             prop.className listClassName
-                            prop.children (model.Items |> List.map renderItem)
+                            prop.children (model.Items |> List.map (renderItem 0))
                         ]
                     ]
                 ]

--- a/src/Components/src/Page/FileExplorer/FileExplorer.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorer.fs
@@ -270,7 +270,6 @@ type FileExplorer =
             )
 
         let selectedPathIds = model.SelectedPath |> List.map _.Id |> Set.ofList
-        let stickyParentRowHeightPx = 32
 
         let rec renderItem depth item =
             let isSelected = model.SelectedId = Some item.Id
@@ -314,9 +313,9 @@ type FileExplorer =
                     else
                         None
 
-                let stickyTopOffset =
-                    if delegateHorizontalScrollToParent && childrenTree.IsSome then
-                        Some(depth * stickyParentRowHeightPx)
+                let stickyDepth =
+                    if delegateHorizontalScrollToParent then
+                        Some depth
                     else
                         None
 
@@ -340,7 +339,7 @@ type FileExplorer =
                     ?onDeleteItem = onDeleteItem,
                     canDeleteItem = canDeleteItem,
                     ?statusAction = statusAction,
-                    ?stickyTopOffset = stickyTopOffset,
+                    ?stickyDepth = stickyDepth,
                     ?children = childrenTree
                 )
             else

--- a/src/Components/src/Page/FileExplorer/FileExplorer.stories.tsx
+++ b/src/Components/src/Page/FileExplorer/FileExplorer.stories.tsx
@@ -362,6 +362,46 @@ const TruncatedOverflowFileExplorer = () => {
   );
 };
 
+const StickyParentsFileExplorer = () => {
+  const items = React.useMemo(() => {
+    const measurements = Array.from({ length: 36 }, (_, index) =>
+      createStableFile(
+        `measurement-${String(index + 1).padStart(2, "0")}.tsv`,
+        `studies/Study A/assays/Assay A/data/measurement-${index + 1}.tsv`,
+        `sticky-measurement-${index + 1}`,
+      ),
+    );
+
+    const dataFolder = Object.assign(
+      createStableFolder("data", "studies/Study A/assays/Assay A/data", "sticky-data", measurements),
+      { IsExpanded: true },
+    );
+    const assayFolder = Object.assign(
+      createStableFolder("Assay A", "studies/Study A/assays/Assay A", "sticky-assay", [dataFolder]),
+      { IsExpanded: true },
+    );
+    const studyFolder = Object.assign(
+      createStableFolder("Study A", "studies/Study A", "sticky-study", [assayFolder]),
+      { IsExpanded: true },
+    );
+
+    return ofArray([studyFolder]);
+  }, []);
+
+  return (
+    <div
+      data-testid="sticky-file-explorer-viewport"
+      className="swt:h-40 swt:overflow-y-auto swt:overflow-x-auto"
+    >
+      <FileExplorer
+        initialItems={items}
+        delegateHorizontalScrollToParent={true}
+        truncateOverflowingItemNames={true}
+      />
+    </div>
+  );
+};
+
 const installClipboardMock = () => {
   const writeText = fn(async () => undefined);
   Object.defineProperty(navigator, "clipboard", {
@@ -371,6 +411,30 @@ const installClipboardMock = () => {
   });
 
   return writeText;
+};
+
+const expectStickyParentRowsToStayVisible = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const viewport = await canvas.findByTestId("sticky-file-explorer-viewport");
+  const parentToggles = await Promise.all(
+    ["Collapse Study A", "Collapse Assay A", "Collapse data"].map((name) =>
+      canvas.findByRole("button", { name }),
+    ),
+  );
+
+  viewport.scrollTop = 360;
+  fireEvent.scroll(viewport);
+
+  await waitFor(() => {
+    const viewportRect = viewport.getBoundingClientRect();
+
+    for (const toggle of parentToggles) {
+      const rect = toggle.getBoundingClientRect();
+
+      expect(rect.top).toBeGreaterThanOrEqual(viewportRect.top - 1);
+      expect(rect.bottom).toBeLessThanOrEqual(viewportRect.bottom + 1);
+    }
+  });
 };
 
 const expectContextMenuCopy = async (
@@ -729,5 +793,13 @@ export const LongNamesKeepInlineControlsVisible: StoryObj<typeof TruncatedOverfl
   play: async ({ canvasElement }) => {
     await expectLongNameControlsToStayVisible(canvasElement, veryLongFolderName);
     await expectLongNameControlsToStayVisible(canvasElement, veryLongFileName);
+  },
+};
+
+export const ExpandedDirectoryParentsStayVisibleWhileScrolling: StoryObj<typeof StickyParentsFileExplorer> = {
+  render: () => <StickyParentsFileExplorer />,
+
+  play: async ({ canvasElement }) => {
+    await expectStickyParentRowsToStayVisible(canvasElement);
   },
 };

--- a/src/Components/src/Page/FileExplorer/FileExplorer.stories.tsx
+++ b/src/Components/src/Page/FileExplorer/FileExplorer.stories.tsx
@@ -422,13 +422,17 @@ const expectStickyParentRowsToStayVisible = async (canvasElement: HTMLElement) =
     ),
   );
 
-  for (const toggle of parentToggles) {
+  const parentRows = parentToggles.map((toggle) => {
     const parentRow = toggle.closest("[data-file-item-id]");
 
     if (!parentRow) {
       throw new Error(`Expected sticky parent row for ${toggle.getAttribute("aria-label")}.`);
     }
 
+    return parentRow;
+  });
+
+  for (const parentRow of parentRows) {
     await expect(parentRow).toHaveClass(/swt:bg-base-100/);
     await expect(parentRow).toHaveClass(/swt:border-b/);
     await expect(parentRow).toHaveClass(/swt:shadow-sm/);
@@ -439,12 +443,15 @@ const expectStickyParentRowsToStayVisible = async (canvasElement: HTMLElement) =
 
   await waitFor(() => {
     const viewportRect = viewport.getBoundingClientRect();
+    let expectedTop = viewportRect.top;
 
-    for (const toggle of parentToggles) {
-      const rect = toggle.getBoundingClientRect();
+    for (const parentRow of parentRows) {
+      const rect = parentRow.getBoundingClientRect();
 
-      expect(rect.top).toBeGreaterThanOrEqual(viewportRect.top - 1);
+      expect(rect.top).toBeGreaterThanOrEqual(expectedTop - 1);
+      expect(rect.top).toBeLessThanOrEqual(expectedTop + 1);
       expect(rect.bottom).toBeLessThanOrEqual(viewportRect.bottom + 1);
+      expectedTop = rect.bottom;
     }
   });
 };

--- a/src/Components/src/Page/FileExplorer/FileExplorer.stories.tsx
+++ b/src/Components/src/Page/FileExplorer/FileExplorer.stories.tsx
@@ -422,6 +422,18 @@ const expectStickyParentRowsToStayVisible = async (canvasElement: HTMLElement) =
     ),
   );
 
+  for (const toggle of parentToggles) {
+    const parentRow = toggle.closest("[data-file-item-id]");
+
+    if (!parentRow) {
+      throw new Error(`Expected sticky parent row for ${toggle.getAttribute("aria-label")}.`);
+    }
+
+    await expect(parentRow).toHaveClass(/swt:bg-base-100/);
+    await expect(parentRow).toHaveClass(/swt:border-b/);
+    await expect(parentRow).toHaveClass(/swt:shadow-sm/);
+  }
+
   viewport.scrollTop = 360;
   fireEvent.scroll(viewport);
 
@@ -435,6 +447,23 @@ const expectStickyParentRowsToStayVisible = async (canvasElement: HTMLElement) =
       expect(rect.bottom).toBeLessThanOrEqual(viewportRect.bottom + 1);
     }
   });
+};
+
+const expectExpandedNonStickyDirectoryRowsToStayUnframed = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const folderLabel = await canvas.findByText("Initially Expanded");
+  const folderRow = folderLabel.closest("[data-file-item-id]");
+
+  await waitFor(() => expect(folderRow).toBeTruthy());
+
+  if (!folderRow) {
+    throw new Error("Expected expanded directory row.");
+  }
+
+  await expect(folderRow).not.toHaveClass(/swt:bg-base-100/);
+  await expect(folderRow).not.toHaveClass(/swt:border-b/);
+  await expect(folderRow).not.toHaveClass(/swt:shadow-sm/);
+  expect(window.getComputedStyle(folderRow).position).not.toBe("sticky");
 };
 
 const expectContextMenuCopy = async (
@@ -576,6 +605,7 @@ export const InitialExpandedHintIsApplied: StoryObj<typeof InitiallyExpandedFile
 
     await expect(await canvas.findByText("Initially Visible.txt")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Collapse Initially Expanded" })).toBeInTheDocument();
+    await expectExpandedNonStickyDirectoryRowsToStayUnframed(canvasElement);
   },
 };
 

--- a/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
@@ -314,7 +314,7 @@ type FileExplorerItem =
                         |> Option.map (fun depth -> [
                             style.position.sticky
                             style.top (depth * stickyParentRowHeightPx)
-                            // Parent rows need to layer above nested sticky rows; raise the base for very deep trees.
+                            // Parent rows need to layer above nested sticky rows. Very deep trees can exhaust this z-index base.
                             style.zIndex (100 - depth)
                         ])
                         |> Option.defaultValue []

--- a/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
@@ -2,6 +2,7 @@ namespace Swate.Components.Page.FileExplorer
 
 open Fable.Core
 open Feliz
+open Swate.Components.JsBindings
 open Swate.Components.Page.FileExplorer.Types
 
 [<Mangle(false); Erase>]
@@ -276,6 +277,8 @@ type FileExplorerItem =
             ?canDeleteItem: FileItem -> bool,
             ?statusAction: ContextMenuItem,
             ?stickyDepth: int,
+            ?stickyTopOffset: int,
+            ?onStickyRowHeightChange: string -> int -> unit,
             ?children: ReactElement
         ) =
         let canCreateItem = defaultArg canCreateItem (fun (_: FileItem) -> false)
@@ -287,9 +290,27 @@ type FileExplorerItem =
         let hasStatusControl = Helper.isLfs item || statusAction.IsSome
 
         let effectiveStickyDepth = if isExpanded then stickyDepth else None
-        let hasStickyTreatment = effectiveStickyDepth.IsSome
+        let effectiveStickyTopOffset = if isExpanded then stickyTopOffset else None
+        let hasStickyTreatment = effectiveStickyTopOffset.IsSome
 
-        let stickyParentRowHeightPx = 32
+        let rowObserverRef = React.useRef<ResizeObserver option> None
+
+        let setRowRef (element: Browser.Types.Element) =
+            rowObserverRef.current |> Option.iter (fun observer -> observer.disconnect ())
+            rowObserverRef.current <- None
+
+            match hasStickyTreatment, isNull element, onStickyRowHeightChange with
+            | true, false, Some onHeightChange ->
+                let row = unbox<Browser.Types.HTMLElement> element
+
+                let reportHeight () =
+                    onHeightChange item.Id (int row.offsetHeight)
+
+                reportHeight ()
+                let observer = ResizeObserver(reportHeight)
+                observer.observe row
+                rowObserverRef.current <- Some observer
+            | _ -> ()
 
         let directoryToggleIconClass =
             if isExpanded then
@@ -299,6 +320,7 @@ type FileExplorerItem =
 
         let rowChildren = [
             Html.div [
+                prop.ref setRowRef
                 prop.custom ("data-file-item-id", item.Id)
                 prop.className [
                     "swt:group swt:w-full swt:px-2 swt:py-1 swt:cursor-default"
@@ -311,12 +333,12 @@ type FileExplorerItem =
                     style.display.flex
                     style.width (length.percent 100)
                     yield!
-                        effectiveStickyDepth
-                        |> Option.map (fun depth -> [
+                        effectiveStickyTopOffset
+                        |> Option.map (fun topOffset -> [
                             style.position.sticky
-                            style.top (depth * stickyParentRowHeightPx)
+                            style.top topOffset
                             // Parent rows need to layer above nested sticky rows. Very deep trees can exhaust this z-index base.
-                            style.zIndex (100 - depth)
+                            style.zIndex (100 - defaultArg effectiveStickyDepth 0)
                         ])
                         |> Option.defaultValue []
                 ]

--- a/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
@@ -287,6 +287,7 @@ type FileExplorerItem =
         let hasStatusControl = Helper.isLfs item || statusAction.IsSome
 
         let effectiveStickyDepth = if isExpanded then stickyDepth else None
+        let hasStickyTreatment = effectiveStickyDepth.IsSome
 
         let stickyParentRowHeightPx = 32
 
@@ -301,7 +302,7 @@ type FileExplorerItem =
                 prop.custom ("data-file-item-id", item.Id)
                 prop.className [
                     "swt:group swt:w-full swt:px-2 swt:py-1 swt:cursor-default"
-                    if isExpanded then
+                    if hasStickyTreatment then
                         "swt:bg-base-100 swt:border-b swt:border-base-content/10 swt:shadow-sm"
 
                     rowHighlightClass

--- a/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
@@ -287,8 +287,8 @@ type FileExplorerItem =
         let hasStatusControl = Helper.isLfs item || statusAction.IsSome
 
         let stickyRowClasses =
-            if stickyTopOffset.IsSome then
-                "swt:sticky swt:bg-base-100 swt:border-b swt:border-base-content/10 swt:shadow-sm"
+            if isExpanded then
+                "swt:bg-base-100 swt:border-b swt:border-base-content/10 swt:shadow-sm"
             else
                 ""
 

--- a/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
@@ -275,6 +275,7 @@ type FileExplorerItem =
             ?onDeleteItem: FileItem -> unit,
             ?canDeleteItem: FileItem -> bool,
             ?statusAction: ContextMenuItem,
+            ?stickyTopOffset: int,
             ?children: ReactElement
         ) =
         let canCreateItem = defaultArg canCreateItem (fun (_: FileItem) -> false)
@@ -284,6 +285,12 @@ type FileExplorerItem =
         let hasItemActions = itemActions |> List.isEmpty |> not
         let canDeleteFromDirectory = canDeleteItem item && onDeleteItem.IsSome
         let hasStatusControl = Helper.isLfs item || statusAction.IsSome
+
+        let stickyRowClasses =
+            if stickyTopOffset.IsSome then
+                "swt:sticky swt:bg-base-100 swt:border-b swt:border-base-content/10 swt:shadow-sm"
+            else
+                ""
 
         let directoryToggleIconClass =
             if isExpanded then
@@ -296,9 +303,21 @@ type FileExplorerItem =
                 prop.custom ("data-file-item-id", item.Id)
                 prop.className [
                     "swt:group swt:w-full swt:px-2 swt:py-1 swt:cursor-default"
+                    stickyRowClasses
                     rowHighlightClass
                 ]
-                prop.style [ style.display.flex; style.width (length.percent 100) ]
+                prop.style [
+                    style.display.flex
+                    style.width (length.percent 100)
+                    yield!
+                        stickyTopOffset
+                        |> Option.map (fun offset -> [
+                            style.position.sticky
+                            style.top offset
+                            style.zIndex (100 - (offset / 32))
+                        ])
+                        |> Option.defaultValue []
+                ]
 
                 if not directoryChevronToggleOnly then
                     prop.onClick onDirectorySelect

--- a/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorerItem.fs
@@ -275,7 +275,7 @@ type FileExplorerItem =
             ?onDeleteItem: FileItem -> unit,
             ?canDeleteItem: FileItem -> bool,
             ?statusAction: ContextMenuItem,
-            ?stickyTopOffset: int,
+            ?stickyDepth: int,
             ?children: ReactElement
         ) =
         let canCreateItem = defaultArg canCreateItem (fun (_: FileItem) -> false)
@@ -286,11 +286,9 @@ type FileExplorerItem =
         let canDeleteFromDirectory = canDeleteItem item && onDeleteItem.IsSome
         let hasStatusControl = Helper.isLfs item || statusAction.IsSome
 
-        let stickyRowClasses =
-            if isExpanded then
-                "swt:bg-base-100 swt:border-b swt:border-base-content/10 swt:shadow-sm"
-            else
-                ""
+        let effectiveStickyDepth = if isExpanded then stickyDepth else None
+
+        let stickyParentRowHeightPx = 32
 
         let directoryToggleIconClass =
             if isExpanded then
@@ -303,18 +301,21 @@ type FileExplorerItem =
                 prop.custom ("data-file-item-id", item.Id)
                 prop.className [
                     "swt:group swt:w-full swt:px-2 swt:py-1 swt:cursor-default"
-                    stickyRowClasses
+                    if isExpanded then
+                        "swt:bg-base-100 swt:border-b swt:border-base-content/10 swt:shadow-sm"
+
                     rowHighlightClass
                 ]
                 prop.style [
                     style.display.flex
                     style.width (length.percent 100)
                     yield!
-                        stickyTopOffset
-                        |> Option.map (fun offset -> [
+                        effectiveStickyDepth
+                        |> Option.map (fun depth -> [
                             style.position.sticky
-                            style.top offset
-                            style.zIndex (100 - (offset / 32))
+                            style.top (depth * stickyParentRowHeightPx)
+                            // Parent rows need to layer above nested sticky rows; raise the base for very deep trees.
+                            style.zIndex (100 - depth)
                         ])
                         |> Option.defaultValue []
                 ]

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -73,6 +73,7 @@
     <Compile Include="JsBindings\Virtual.fs" />
     <Compile Include="JsBindings\FloatingUI.fs" />
     <Compile Include="JsBindings\DndKit.fs" />
+    <Compile Include="JsBindings\ResizeObserver.fs" />
     <Compile Include="ARCtrl\TermCollection.fs" />
     <Compile Include="ARCtrl\Helper.fs" />
     <Compile Include="ARCtrl\ArcIO.fs" />


### PR DESCRIPTION
* Track each rendered item’s tree depth
* Use that depth to calculate a stacked sticky top offset for expanded parent branches
* Keep expanded parent branches sticky so their collapse controls remain visible while scrolling