### PR TITLE
Provenance editor: sankey connectors, guided tutorial, side hiding & shelf redesign

### DIFF
--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -345,6 +345,21 @@ type FolderedDraggableList =
         // a card's search into another card.
         let searchByFolder, setSearchByFolder = React.useState Map.empty<string, string>
 
+        // Folders can disappear when the host swaps the folder set; drop their
+        // drafts so the map does not accumulate entries for dead folders.
+        React.useEffect (
+            (fun () ->
+                let folderIds = folders |> List.map (fun folder -> folder.Id) |> Set.ofList
+
+                let pruned =
+                    searchByFolder |> Map.filter (fun folderId _ -> folderIds.Contains folderId)
+
+                if pruned.Count <> searchByFolder.Count then
+                    setSearchByFolder pruned
+            ),
+            [| box folders |]
+        )
+
         let activeDrag, setActiveDrag =
             React.useState (None: FolderedDraggableItemRender<'payload> option)
 

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -17,21 +17,8 @@ module private FolderedDraggableListHelper =
         | Some c when c <> "" -> c
         | _ -> fallbackColor
 
-    [<Emit("$0.target && $0.target.closest && $0.target.closest('[data-folder-color-control]') !== null")>]
-    let isFolderColorControlEvent (_event: Browser.Types.Event) : bool = jsNative
-
     let effectiveColor (folder: FolderedDraggableFolder<'payload>) (item: FolderedDraggableItem<'payload>) =
         item.Color |> Option.orElse folder.Color
-
-    let expandedFolderId folders (expanded: Set<string>) =
-        folders
-        |> List.tryFind (fun folder -> expanded.Contains folder.Id)
-        |> Option.map (fun folder -> folder.Id)
-
-    let toggleExpanded folderId expandedFolderId =
-        match expandedFolderId with
-        | Some expandedFolderId when expandedFolderId = folderId -> Set.empty
-        | _ -> Set.singleton folderId
 
     let appendItemToFolder targetFolderId item folders =
         folders
@@ -45,12 +32,17 @@ module private FolderedDraggableListHelper =
                 folder
         )
 
+    let matchesSearch (query: string) (item: FolderedDraggableItem<'payload>) =
+        let query = query.Trim()
+
+        query = "" || item.Label.ToLowerInvariant().Contains(query.ToLowerInvariant())
+
     let canAcceptExternalDrop
-        (expandedFolder: FolderedDraggableFolder<'payload> option)
+        (activeFolder: FolderedDraggableFolder<'payload> option)
         (tryCreateItemFromExternalDrop: FolderedDraggableExternalDropHandler<'payload> option)
         (onFoldersChange: (FolderedDraggableFolder<'payload> list -> unit) option)
         =
-        expandedFolder.IsSome
+        activeFolder.IsSome
         && tryCreateItemFromExternalDrop.IsSome
         && onFoldersChange.IsSome
 
@@ -272,112 +264,55 @@ type FolderedDraggableList =
                 ]
         )
 
-    [<ReactComponent>]
-    static member private Folder<'payload>
-        (
-            folder: FolderedDraggableFolder<'payload>,
-            isExpanded: bool,
-            onToggle: unit -> unit,
-            ?onSetColor: string option -> unit,
-            ?debug: bool,
-            ?key: string
-        ) =
-        Html.div [
+    /// One index-card tab in the strip above the card body. The active tab
+    /// stays selected until another one is clicked - there is no toggle.
+    static member private FolderTab<'payload>
+        (folder: FolderedDraggableFolder<'payload>, isActive: bool, onSelect: unit -> unit, ?debug: bool, ?key: string)
+        =
+        Html.button [
             match key with
             | Some key -> prop.key key
             | None -> ()
-            prop.className "swt:relative swt:h-32 swt:w-36 swt:min-w-36 swt:flex-none"
+            prop.type'.button
+            prop.custom ("role", "tab")
+            prop.custom ("aria-selected", isActive)
+            prop.title folder.Name
+            prop.ariaLabel $"Show {folder.Name}"
             match folder.Color with
             | Some color when color <> "" -> prop.custom ("data-foldered-folder-color", color)
             | _ -> ()
-            prop.custom ("aria-expanded", isExpanded)
             if defaultArg debug false then
                 prop.testId $"foldered-draggable-folder-{folder.Id}"
+            prop.className [
+                "swt:flex swt:cursor-pointer swt:items-center swt:gap-2 swt:rounded-t-lg swt:border swt:border-b-0 swt:px-3 swt:py-1.5 swt:text-sm swt:transition-colors"
+                if isActive then
+                    // Sits on the card: same background, shared border, and the
+                    // strip's -mb-px pulls it over the card's top border. The
+                    // active tab claims the room for its full name first - it
+                    // only truncates once it alone exceeds the strip - while
+                    // the inactive tabs give way down to a slim remnant.
+                    "swt:min-w-0 swt:shrink swt:border-base-300 swt:bg-base-100 swt:font-semibold swt:text-primary"
+                else
+                    "swt:min-w-14 swt:max-w-48 swt:shrink-[9] swt:border-transparent swt:bg-base-200 swt:text-base-content/70 swt:hover:bg-base-300"
+            ]
+            prop.onClick (fun _ -> onSelect ())
             prop.children [
-                Html.button [
-                    prop.type'.button
-                    prop.className [
-                        "swt:btn swt:h-full swt:w-full swt:flex-col swt:items-stretch swt:justify-between swt:gap-2 swt:overflow-hidden swt:rounded-lg swt:border swt:p-3 swt:text-left swt:normal-case swt:shadow-sm swt:transition-all"
-                        if isExpanded then
-                            "swt:border-primary swt:bg-primary/10 swt:text-primary swt:ring-2 swt:ring-primary/20"
-                        else
-                            "swt:border-base-300 swt:bg-base-100 hover:swt:border-primary/60 hover:swt:bg-base-200"
+                match folder.Color with
+                | Some color when color <> "" ->
+                    Html.span [
+                        prop.className "swt:size-2.5 swt:shrink-0 swt:rounded-full swt:border swt:border-base-300"
+                        prop.custom ("data-foldered-color-swatch", "true")
+                        prop.style [ style.backgroundColor color ]
                     ]
-                    match folder.Color with
-                    | Some color when color <> "" && not isExpanded -> prop.style [ style.borderColor color ]
-                    | _ -> ()
-                    prop.custom ("aria-expanded", isExpanded)
-                    prop.title folder.Name
-                    prop.ariaLabel (
-                        if isExpanded then
-                            $"Collapse {folder.Name}"
-                        else
-                            $"Expand {folder.Name}"
-                    )
-                    prop.onClick (fun _ -> onToggle ())
-                    prop.children [
-                        Html.div [
-                            prop.className "swt:flex swt:items-start swt:justify-between swt:gap-2"
-                            prop.children [
-                                Html.i [
-                                    prop.className [
-                                        "swt:iconify swt:size-14 swt:shrink-0"
-                                        if isExpanded then
-                                            "swt:fluent--folder-open-24-regular"
-                                        else
-                                            "swt:fluent--folder-24-regular"
-                                    ]
-                                    match folder.Color with
-                                    | Some color when color <> "" -> prop.style [ style.color color ]
-                                    | _ -> ()
-                                ]
-                                Html.span [
-                                    prop.className "swt:badge swt:badge-sm swt:shrink-0"
-                                    prop.text (string folder.Items.Length)
-                                ]
-                            ]
-                        ]
-                        Html.div [
-                            prop.className "swt:flex swt:min-w-0 swt:flex-col swt:gap-2"
-                            prop.children [
-                                Html.span [
-                                    prop.className "swt:w-full swt:truncate swt:text-sm swt:font-semibold"
-                                    prop.text folder.Name
-                                ]
-                                Html.div [
-                                    prop.className "swt:flex swt:items-center swt:gap-2"
-                                    prop.children [
-                                        match onSetColor with
-                                        | Some _ ->
-                                            Html.span [
-                                                prop.className "swt:size-3 swt:shrink-0"
-                                                prop.custom ("aria-hidden", true)
-                                            ]
-                                        | None -> FolderedDraggableListHelper.colorSwatch folder.Color
-                                        Html.span [
-                                            prop.className "swt:text-xs swt:font-normal swt:text-base-content/70"
-                                            prop.text (
-                                                if folder.Items.Length = 1 then
-                                                    "1 item"
-                                                else
-                                                    $"{folder.Items.Length} items"
-                                            )
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
+                | _ -> Html.none
+                Html.span [
+                    prop.className "swt:min-w-0 swt:truncate"
+                    prop.text folder.Name
                 ]
-                match onSetColor with
-                | Some setColor ->
-                    Html.div [
-                        prop.className "swt:absolute swt:bottom-3 swt:left-3 swt:z-10 swt:flex swt:items-center"
-                        prop.children [
-                            FolderedDraggableList.FolderColorButton(folder, setColor, key = $"{folder.Id}:color")
-                        ]
-                    ]
-                | None -> Html.none
+                Html.span [
+                    prop.className "swt:badge swt:badge-sm swt:shrink-0"
+                    prop.text (string folder.Items.Length)
+                ]
             ]
         ]
 
@@ -386,9 +321,9 @@ type FolderedDraggableList =
         (
             folders: FolderedDraggableFolder<'payload> list,
             dragId: FolderedDraggableFolder<'payload> -> FolderedDraggableItem<'payload> -> string,
-            ?expandedFolderIds: Set<string>,
-            ?defaultExpandedFolderIds: Set<string>,
-            ?onExpandedFolderIdsChange: Set<string> -> unit,
+            ?activeFolderId: string,
+            ?defaultActiveFolderId: string,
+            ?onActiveFolderIdChange: string -> unit,
             ?renderItemContent: FolderedDraggableItemRenderFn<'payload>,
             ?shelfDropId: string,
             ?tryCreateItemFromExternalDrop: FolderedDraggableExternalDropHandler<'payload>,
@@ -403,23 +338,27 @@ type FolderedDraggableList =
         let shelfDropId =
             defaultArg shelfDropId $"foldered-draggable-list-shelf-{generatedShelfDropId}"
 
-        let localExpanded, setLocalExpanded =
-            React.useState (defaultArg defaultExpandedFolderIds Set.empty)
+        let localActive, setLocalActive =
+            React.useState (defaultActiveFolderId: string option)
+
+        // One search draft per folder, so switching tabs never loses or leaks
+        // a card's search into another card.
+        let searchByFolder, setSearchByFolder = React.useState Map.empty<string, string>
 
         let activeDrag, setActiveDrag =
             React.useState (None: FolderedDraggableItemRender<'payload> option)
 
-        let expanded = expandedFolderIds |> Option.defaultValue localExpanded
-        let expandedFolderId = FolderedDraggableListHelper.expandedFolderId folders expanded
+        let requestedActiveId = activeFolderId |> Option.orElse localActive
 
-        let expandedFolder =
-            folders |> List.tryFind (fun folder -> Some folder.Id = expandedFolderId)
+        // A stale id (e.g. after the host swaps the folder set) falls back to
+        // the first tab instead of leaving the card empty.
+        let activeFolder =
+            folders
+            |> List.tryFind (fun folder -> Some folder.Id = requestedActiveId)
+            |> Option.orElse (List.tryHead folders)
 
         let canAcceptExternalDrop =
-            FolderedDraggableListHelper.canAcceptExternalDrop
-                expandedFolder
-                tryCreateItemFromExternalDrop
-                onFoldersChange
+            FolderedDraggableListHelper.canAcceptExternalDrop activeFolder tryCreateItemFromExternalDrop onFoldersChange
 
         let shelfDroppable =
             DndKit.useDroppable (
@@ -429,11 +368,11 @@ type FolderedDraggableList =
                 |}
             )
 
-        let setExpanded next =
-            onExpandedFolderIdsChange |> Option.iter (fun fn -> fn next)
+        let setActive folderId =
+            onActiveFolderIdChange |> Option.iter (fun fn -> fn folderId)
 
-            if expandedFolderIds.IsNone then
-                setLocalExpanded next
+            if activeFolderId.IsNone then
+                setLocalActive (Some folderId)
 
         let renderItemContent =
             renderItemContent
@@ -446,7 +385,7 @@ type FolderedDraggableList =
                     fun (event: DndKit.IDndKitEvent) ->
                         setActiveDrag None
 
-                        match expandedFolder, tryCreateItemFromExternalDrop, onFoldersChange with
+                        match activeFolder, tryCreateItemFromExternalDrop, onFoldersChange with
                         | Some targetFolder, Some tryCreateItemFromExternalDrop, Some onFoldersChange when
                             FolderedDraggableListHelper.isShelfDrop shelfDropId event
                             ->
@@ -469,7 +408,7 @@ type FolderedDraggableList =
 
         Html.section [
             prop.className [
-                "swt:flex swt:min-w-0 swt:flex-col swt:gap-4"
+                "swt:flex swt:min-w-0 swt:flex-col"
                 match className with
                 | Some className -> className
                 | None -> ()
@@ -477,68 +416,134 @@ type FolderedDraggableList =
             if debug then
                 prop.testId "foldered-draggable-list"
             prop.children [
+                // The tab strip overlaps the card's top border so the active
+                // tab reads as part of the card, index-card style.
                 Html.div [
+                    prop.custom ("role", "tablist")
                     prop.className
-                        "swt:flex swt:min-w-0 swt:flex-row swt:flex-nowrap swt:gap-3 swt:overflow-x-auto swt:overflow-y-hidden swt:pb-2"
+                        "swt:-mb-px swt:flex swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-end swt:gap-1 swt:overflow-x-auto swt:px-2"
+                    prop.style [ style.scrollbarGutter.stable ]
                     if debug then
                         prop.testId "foldered-draggable-folder-row"
                     prop.children [
                         for folder in folders do
-                            let isExpanded = Some folder.Id = expandedFolderId
+                            let isActive = activeFolder |> Option.exists (fun active -> active.Id = folder.Id)
 
-                            let onSetColor =
-                                onSetFolderColor
-                                |> Option.map (fun setFolderColor -> fun color -> setFolderColor folder.Id color)
-
-                            FolderedDraggableList.Folder(
+                            FolderedDraggableList.FolderTab(
                                 folder,
-                                isExpanded,
-                                (fun () ->
-                                    expandedFolderId
-                                    |> FolderedDraggableListHelper.toggleExpanded folder.Id
-                                    |> setExpanded
-                                ),
-                                ?onSetColor = onSetColor,
+                                isActive,
+                                (fun () -> setActive folder.Id),
                                 debug = debug,
                                 key = folder.Id
                             )
                     ]
                 ]
-                Html.div [
-                    prop.ref shelfDroppable.setNodeRef
-                    prop.className [
-                        "swt:min-h-24 swt:min-w-0 swt:rounded-lg swt:border swt:border-dashed swt:p-3 swt:transition-colors"
-                        if canAcceptExternalDrop && shelfDroppable.isOver then
-                            "swt:border-primary swt:bg-primary/10"
-                        else
-                            "swt:border-base-300 swt:bg-base-200/40"
-                    ]
-                    if debug then
-                        prop.testId "foldered-draggable-item-shelf"
-                    prop.children [
-                        Html.div [
-                            prop.className
-                                "swt:relative swt:flex swt:min-h-12 swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-center swt:gap-2 swt:overflow-x-auto swt:overflow-y-hidden swt:pb-1"
-                            if debug then
-                                prop.testId "foldered-draggable-item-row"
-                            prop.children [
-                                match expandedFolder with
-                                | Some folder ->
-                                    for item in folder.Items do
-                                        FolderedDraggableList.Item(
-                                            folder,
-                                            item,
-                                            dragId,
-                                            renderItemContent,
-                                            setActiveDrag,
-                                            debug = debug,
-                                            key = $"{folder.Id}:{item.Id}"
+                match activeFolder with
+                | Some folder ->
+                    let searchQuery = searchByFolder |> Map.tryFind folder.Id |> Option.defaultValue ""
+
+                    let visibleItems =
+                        folder.Items
+                        |> List.filter (FolderedDraggableListHelper.matchesSearch searchQuery)
+
+                    Html.div [
+                        prop.className
+                            "swt:flex swt:min-w-0 swt:flex-col swt:gap-2 swt:rounded-lg swt:border swt:border-base-300 swt:bg-base-100 swt:p-3"
+                        prop.custom ("role", "tabpanel")
+                        if debug then
+                            prop.testId "foldered-draggable-card"
+                        prop.children [
+                            Html.div [
+                                prop.className "swt:flex swt:min-w-0 swt:items-center swt:gap-2"
+                                prop.children [
+                                    Html.div [
+                                        prop.className "swt:relative swt:flex swt:min-w-0 swt:items-center"
+                                        prop.children [
+                                            Html.i [
+                                                prop.className
+                                                    "swt:iconify swt:fluent--search-20-regular swt:absolute swt:left-2 swt:size-3.5 swt:text-base-content/50"
+                                            ]
+                                            Html.input [
+                                                prop.className
+                                                    "swt:input swt:input-bordered swt:input-xs swt:w-44 swt:pl-7"
+                                                prop.placeholder $"Search in {folder.Name}..."
+                                                prop.ariaLabel $"Search in {folder.Name}"
+                                                if debug then
+                                                    prop.testId "foldered-draggable-search"
+                                                prop.value searchQuery
+                                                prop.onChange (fun (query: string) ->
+                                                    setSearchByFolder (searchByFolder |> Map.add folder.Id query)
+                                                )
+                                            ]
+                                        ]
+                                    ]
+                                    Html.span [
+                                        prop.className "swt:text-xs swt:text-base-content/70"
+                                        prop.text (
+                                            if searchQuery.Trim() <> "" then
+                                                $"{visibleItems.Length} of {folder.Items.Length} items"
+                                            elif folder.Items.Length = 1 then
+                                                "1 item"
+                                            else
+                                                $"{folder.Items.Length} items"
                                         )
-                                | None -> ()
+                                    ]
+                                    match onSetFolderColor with
+                                    | Some setFolderColor ->
+                                        Html.div [
+                                            prop.className "swt:ml-auto swt:flex swt:items-center"
+                                            prop.children [
+                                                FolderedDraggableList.FolderColorButton(
+                                                    folder,
+                                                    setFolderColor folder.Id,
+                                                    key = $"{folder.Id}:color"
+                                                )
+                                            ]
+                                        ]
+                                    | None -> Html.none
+                                ]
+                            ]
+                            Html.div [
+                                prop.ref shelfDroppable.setNodeRef
+                                prop.className [
+                                    "swt:min-h-16 swt:min-w-0 swt:rounded-lg swt:border swt:border-dashed swt:p-2 swt:transition-colors"
+                                    if canAcceptExternalDrop && shelfDroppable.isOver then
+                                        "swt:border-primary swt:bg-primary/10"
+                                    else
+                                        "swt:border-base-300 swt:bg-base-200/40"
+                                ]
+                                if debug then
+                                    prop.testId "foldered-draggable-item-shelf"
+                                prop.children [
+                                    Html.div [
+                                        prop.className
+                                            "swt:relative swt:flex swt:h-16 swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-start swt:gap-2 swt:overflow-x-auto swt:overflow-y-hidden swt:pb-1"
+                                        prop.style [ style.scrollbarGutter.stable ]
+                                        if debug then
+                                            prop.testId "foldered-draggable-item-row"
+                                        prop.children [
+                                            if visibleItems.IsEmpty && searchQuery.Trim() <> "" then
+                                                Html.p [
+                                                    prop.className "swt:px-1 swt:text-xs swt:text-base-content/60"
+                                                    prop.text $"No items match \"{searchQuery.Trim()}\"."
+                                                ]
+                                            for item in visibleItems do
+                                                FolderedDraggableList.Item(
+                                                    folder,
+                                                    item,
+                                                    dragId,
+                                                    renderItemContent,
+                                                    setActiveDrag,
+                                                    debug = debug,
+                                                    key = $"{folder.Id}:{item.Id}"
+                                                )
+                                        ]
+                                    ]
+                                ]
                             ]
                         ]
                     ]
-                ]
+                | None -> Html.none
                 DndKit.DragOverlay(
                     dropAnimation = {| duration = 0; easing = "linear" |},
                     children =

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -191,6 +191,9 @@ type FolderedDraggableList =
                 | _ -> ()
             ]
             prop.ariaLabel $"Drag {item.Label}"
+            // Stable hook for hosts (e.g. tutorials) that must find an item
+            // without coupling to the aria-label copy.
+            prop.custom ("data-foldered-item-label", item.Label)
             if draggable.isDragging then
                 prop.tabIndex -1
             match item.Tooltip with

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -520,7 +520,7 @@ type FolderedDraggableList =
                                 prop.children [
                                     Html.div [
                                         prop.className
-                                            "swt:relative swt:flex swt:h-16 swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-start swt:gap-2 swt:overflow-x-auto swt:overflow-y-hidden swt:pb-1"
+                                            "swt:relative swt:flex swt:min-h-16 swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-start swt:gap-2 swt:overflow-x-auto swt:overflow-y-hidden swt:pb-1"
                                         prop.style [ style.scrollbarGutter.stable ]
                                         if debug then
                                             prop.testId "foldered-draggable-item-row"

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -417,11 +417,14 @@ type FolderedDraggableList =
                 prop.testId "foldered-draggable-list"
             prop.children [
                 // The tab strip overlaps the card's top border so the active
-                // tab reads as part of the card, index-card style.
+                // tab reads as part of the card, index-card style. It must be
+                // positioned so it paints above the card sibling - otherwise
+                // the card's top border draws over the active tab's bottom
+                // edge and visually cuts it off from the card.
                 Html.div [
                     prop.custom ("role", "tablist")
                     prop.className
-                        "swt:-mb-px swt:flex swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-end swt:gap-1 swt:overflow-x-auto swt:px-2"
+                        "swt:relative swt:z-10 swt:-mb-px swt:flex swt:min-w-0 swt:flex-row swt:flex-nowrap swt:items-end swt:gap-1 swt:overflow-x-auto swt:px-2"
                     prop.style [ style.scrollbarGutter.stable ]
                     if debug then
                         prop.testId "foldered-draggable-folder-row"

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.fs
@@ -281,6 +281,9 @@ type FolderedDraggableList =
             prop.custom ("aria-selected", isActive)
             prop.title folder.Name
             prop.ariaLabel $"Show {folder.Name}"
+            // Stable hook for hosts (e.g. tutorials) that must find a folder
+            // tab without coupling to the aria-label copy.
+            prop.custom ("data-foldered-folder-label", folder.Name)
             match folder.Color with
             | Some color when color <> "" -> prop.custom ("data-foldered-folder-color", color)
             | _ -> ()

--- a/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
+++ b/src/Components/src/Composite/FolderedDraggableList/FolderedDraggableList.stories.tsx
@@ -4,8 +4,6 @@ import { DndContext, useDraggable, useDroppable, type DragEndEvent } from '@dnd-
 import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
 import { FolderedDraggableList } from './FolderedDraggableList.fs.js';
 import { ofArray, type FSharpList } from '../../fable_modules/fable-library-ts.5.0.0-alpha.21/List.ts';
-import { ofArray as setOfArray, type FSharpSet } from '../../fable_modules/fable-library-ts.5.0.0-alpha.21/Set.ts';
-import { comparePrimitives } from '../../fable_modules/fable-library-ts.5.0.0-alpha.21/Util.ts';
 
 type PropertyPayload = {
   LayerId: string;
@@ -35,9 +33,9 @@ type StoryFolder = {
 type StoryListProps = {
   folders: FSharpList<StoryFolder>;
   dragId: (folder: StoryFolder, item: StoryItem) => string;
-  expandedFolderIds?: FSharpSet<string>;
-  defaultExpandedFolderIds?: FSharpSet<string>;
-  onExpandedFolderIdsChange?: (expandedFolderIds: FSharpSet<string>) => void;
+  activeFolderId?: string;
+  defaultActiveFolderId?: string;
+  onActiveFolderIdChange?: (activeFolderId: string) => void;
   shelfDropId?: string;
   tryCreateItemFromExternalDrop?: (drop: StoryExternalDrop) => StoryItem | undefined;
   onFoldersChange?: (folders: FSharpList<StoryFolder>) => void;
@@ -73,16 +71,8 @@ type ExternalPropertyDragData = {
 
 const StoryFolderedDraggableList = FolderedDraggableList as React.ComponentType<StoryListProps>;
 
-const stringComparer = {
-  Compare: (x: string, y: string) => comparePrimitives(x, y),
-};
-
 function fsList<T>(items: T[]): FSharpList<T> {
   return ofArray(items);
-}
-
-function fsSet(items: string[]): FSharpSet<string> {
-  return setOfArray(items, stringComparer);
 }
 
 function propertyItem(
@@ -269,6 +259,25 @@ function UpdatingHarness() {
   );
 }
 
+function OverflowToggleHarness() {
+  const [folders, setFolders] = React.useState(() => initialFolders());
+
+  return (
+    <div className="swt:w-72">
+      <button
+        type="button"
+        className="swt:btn swt:btn-xs swt:btn-outline swt:mb-2"
+        onClick={() => setFolders(overflowingFolders())}
+      >
+        Overflow properties
+      </button>
+      <DndContext>
+        <StoryFolderedDraggableList folders={folders} dragId={dragId} debug />
+      </DndContext>
+    </div>
+  );
+}
+
 function FolderColorHarness() {
   const [folders, setFolders] = React.useState(() => initialFolders());
 
@@ -324,7 +333,7 @@ function OutsideDropHarness() {
         <StoryFolderedDraggableList
           folders={folders}
           dragId={dragId}
-          defaultExpandedFolderIds={fsSet(['layer-b'])}
+          defaultActiveFolderId="layer-b"
           shelfDropId="story-foldered-shelf"
           tryCreateItemFromExternalDrop={tryCreateItemFromExternalDrop}
           onFoldersChange={setFolders}
@@ -336,14 +345,8 @@ function OutsideDropHarness() {
   );
 }
 
-function ControlledExpansionHarness() {
-  const [expandedFolderIds, setExpandedFolderIds] = React.useState(() => fsSet(['layer-a']));
-  const [lastExpanded, setLastExpanded] = React.useState('layer-a');
-
-  const handleExpandedChange = (nextExpandedFolderIds: FSharpSet<string>) => {
-    setExpandedFolderIds(nextExpandedFolderIds);
-    setLastExpanded(Array.from(nextExpandedFolderIds).join(',') || 'none');
-  };
+function ControlledActiveTabHarness() {
+  const [activeFolderId, setActiveFolderId] = React.useState('layer-a');
 
   return (
     <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
@@ -351,12 +354,12 @@ function ControlledExpansionHarness() {
         <StoryFolderedDraggableList
           folders={initialFolders()}
           dragId={dragId}
-          expandedFolderIds={expandedFolderIds}
-          onExpandedFolderIdsChange={handleExpandedChange}
+          activeFolderId={activeFolderId}
+          onActiveFolderIdChange={setActiveFolderId}
           debug
         />
       </DndContext>
-      <pre data-testid="last-expanded">{lastExpanded}</pre>
+      <pre data-testid="last-active">{activeFolderId}</pre>
     </div>
   );
 }
@@ -386,12 +389,7 @@ function DragHarness() {
   return (
     <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
       <DndContext onDragEnd={onDragEnd}>
-        <StoryFolderedDraggableList
-          folders={initialFolders()}
-          dragId={dragId}
-          defaultExpandedFolderIds={fsSet(['layer-a', 'layer-b'])}
-          debug
-        />
+        <StoryFolderedDraggableList folders={initialFolders()} dragId={dragId} debug />
         <DropZone />
       </DndContext>
       <pre data-testid="last-drag">{lastDrag}</pre>
@@ -430,12 +428,7 @@ function ParentRemovalHarness() {
   return (
     <div className="swt:flex swt:flex-col swt:gap-3 swt:w-96">
       <DndContext onDragEnd={onDragEnd}>
-        <StoryFolderedDraggableList
-          folders={folders}
-          dragId={dragId}
-          defaultExpandedFolderIds={fsSet(['layer-a'])}
-          debug
-        />
+        <StoryFolderedDraggableList folders={folders} dragId={dragId} debug />
         <DropZone />
       </DndContext>
       <pre data-testid="last-drop">{lastDrop}</pre>
@@ -523,7 +516,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const TogglesFolders: Story = {
+export const SwitchesTabs: Story = {
   render: () => (
     <DndContext>
       <div className="swt:w-96">
@@ -535,40 +528,34 @@ export const TogglesFolders: Story = {
     const canvas = within(canvasElement);
     const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
 
-    expect(shelf).toBeVisible();
-    expect(within(shelf).queryByRole('button', { name: /Drag/i })).not.toBeInTheDocument();
-
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
-
+    // The first tab is active from the start; its items are visible.
+    expect(canvas.getByRole('tab', { name: 'Show Layer A' })).toHaveAttribute('aria-selected', 'true');
     expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
     expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
     expect(within(shelf).queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
-    expect(canvas.getByText('Species')).toBeVisible();
     expect(within(canvas.getByTestId('foldered-draggable-item-layer-a-species')).getByText('2')).toBeVisible();
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
+    await userEvent.click(canvas.getByRole('tab', { name: 'Show Layer B' }));
 
     await waitFor(() => {
       expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
       expect(within(shelf).getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
     });
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Collapse Layer B' }));
-
-    await waitFor(() => {
-      expect(within(shelf).queryByRole('button', { name: /Drag/i })).not.toBeInTheDocument();
-    });
+    // Clicking the active tab keeps it open - there is no collapse.
+    await userEvent.click(canvas.getByRole('tab', { name: 'Show Layer B' }));
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
   },
 };
 
-export const DefaultExpansionOpensInitialFolders: Story = {
+export const DefaultActiveTabShowsItsItems: Story = {
   render: () => (
     <DndContext>
       <div className="swt:w-96">
         <StoryFolderedDraggableList
           folders={initialFolders()}
           dragId={dragId}
-          defaultExpandedFolderIds={fsSet(['layer-a'])}
+          defaultActiveFolderId="layer-b"
           debug
         />
       </div>
@@ -578,13 +565,13 @@ export const DefaultExpansionOpensInitialFolders: Story = {
     const canvas = within(canvasElement);
     const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
 
-    expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
-    expect(within(shelf).queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
+    expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
   },
 };
 
-export const ControlledExpansionFollowsProps: Story = {
-  render: () => <ControlledExpansionHarness />,
+export const ControlledActiveTabFollowsProps: Story = {
+  render: () => <ControlledActiveTabHarness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
@@ -592,13 +579,47 @@ export const ControlledExpansionFollowsProps: Story = {
     expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
     expect(within(shelf).queryByTestId('foldered-draggable-item-layer-b-instrument')).not.toBeInTheDocument();
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
+    await userEvent.click(canvas.getByRole('tab', { name: 'Show Layer B' }));
 
     await waitFor(() => {
       expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
       expect(within(shelf).getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
-      expect(canvas.getByTestId('last-expanded')).toHaveTextContent('layer-b');
+      expect(canvas.getByTestId('last-active')).toHaveTextContent('layer-b');
     });
+  },
+};
+
+export const PerTabSearchFiltersOnlyItsCard: Story = {
+  render: () => (
+    <DndContext>
+      <div className="swt:w-96">
+        <StoryFolderedDraggableList folders={initialFolders()} dragId={dragId} debug />
+      </div>
+    </DndContext>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
+
+    await userEvent.type(canvas.getByLabelText('Search in Layer A'), 'spec');
+    await waitFor(() => {
+      expect(within(shelf).queryByTestId('foldered-draggable-item-layer-a-mass')).not.toBeInTheDocument();
+      expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
+    });
+    expect(canvas.getByText('1 of 2 items')).toBeVisible();
+
+    // A query without matches says so instead of showing an empty shelf.
+    await userEvent.type(canvas.getByLabelText('Search in Layer A'), 'xyz');
+    await waitFor(() => expect(canvas.getByText('No items match "specxyz".')).toBeVisible());
+
+    // The other card keeps its own (empty) search.
+    await userEvent.click(canvas.getByRole('tab', { name: 'Show Layer B' }));
+    expect(canvas.getByLabelText('Search in Layer B')).toHaveValue('');
+    expect(within(shelf).getByTestId('foldered-draggable-item-layer-b-instrument')).toBeVisible();
+
+    // Switching back restores the first card's search untouched.
+    await userEvent.click(canvas.getByRole('tab', { name: 'Show Layer A' }));
+    expect(canvas.getByLabelText('Search in Layer A')).toHaveValue('specxyz');
   },
 };
 
@@ -617,17 +638,38 @@ export const HorizontalRowsScrollWhenOverflowing: Story = {
 
     expect(folderRow).toHaveClass('swt:flex-row');
     expect(folderRow).toHaveClass('swt:flex-nowrap');
-    expect(folderRow).toHaveClass('swt:overflow-x-auto');
+    expect(getComputedStyle(folderRow).overflowX).toBe('auto');
+    expect(getComputedStyle(folderRow).scrollbarGutter).toContain('stable');
     expect(shelf).toBeVisible();
-    expect(canvas.getAllByRole('button', { name: /Wide Layer/i })).toHaveLength(8);
+    expect(canvas.getAllByRole('tab', { name: /Wide Layer/i })).toHaveLength(8);
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Wide Layer 1' }));
+    await userEvent.click(canvas.getByRole('tab', { name: 'Show Wide Layer 1' }));
 
     const itemRow = canvas.getByTestId('foldered-draggable-item-row');
     expect(itemRow).toHaveClass('swt:flex-row');
     expect(itemRow).toHaveClass('swt:flex-nowrap');
-    expect(itemRow).toHaveClass('swt:overflow-x-auto');
+    expect(getComputedStyle(itemRow).overflowX).toBe('auto');
+    expect(getComputedStyle(itemRow).scrollbarGutter).toContain('stable');
+    expect(Math.round(itemRow.getBoundingClientRect().height)).toBeGreaterThanOrEqual(64);
     expect(within(itemRow).getAllByRole('button', { name: /Drag Property/i })).toHaveLength(8);
+  },
+};
+
+export const PropertyRowKeepsHeightWhenScrollbarAppears: Story = {
+  render: () => <OverflowToggleHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const before = Math.round(canvas.getByTestId('foldered-draggable-item-row').getBoundingClientRect().height);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Overflow properties' }));
+
+    await waitFor(() => {
+      expect(within(canvas.getByTestId('foldered-draggable-item-row')).getAllByRole('button', { name: /Drag Property/i }))
+        .toHaveLength(8);
+    });
+
+    const after = Math.round(canvas.getByTestId('foldered-draggable-item-row').getBoundingClientRect().height);
+    expect(after).toBe(before);
   },
 };
 
@@ -637,7 +679,6 @@ export const UpdatesWhenFoldersPropChanges: Story = {
     const canvas = within(canvasElement);
     const shelf = canvas.getByTestId('foldered-draggable-item-shelf');
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer A' }));
     expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-species')).toBeVisible();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Add replicate' }));
@@ -655,7 +696,7 @@ export const UpdatesWhenFoldersPropChanges: Story = {
     expect(within(shelf).getByTestId('foldered-draggable-item-layer-a-mass')).toBeVisible();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Rename and recolor Layer A' }));
-    expect(canvas.getByRole('button', { name: 'Collapse Layer Alpha' })).toBeVisible();
+    expect(canvas.getByRole('tab', { name: 'Show Layer Alpha' })).toBeVisible();
     const folderSwatch = canvas
       .getByTestId('foldered-draggable-folder-layer-a')
       .querySelector<HTMLElement>('[data-foldered-color-swatch="true"]');
@@ -668,19 +709,14 @@ export const SetsFolderColorFromPreview: Story = {
   render: () => <FolderColorHarness />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    // The color control lives in the active card's header, so picking a color
+    // never switches or re-focuses tabs.
     const trigger = canvas.getByRole('button', { name: 'Set color for folder Layer A' });
-    const triggerTarget = trigger.parentElement!;
-    const folderCard = canvas.getByTestId('foldered-draggable-folder-layer-a');
-    const folderToggle = canvas.getByRole('button', { name: 'Expand Layer A' });
+    const activeTab = canvas.getByRole('tab', { name: 'Show Layer A' });
 
-    expect(folderCard).not.toHaveAttribute('role', 'button');
-    expect(folderCard).not.toHaveAttribute('tabindex');
-    expect(folderCard).toHaveAttribute('aria-expanded', 'false');
-
-    await userEvent.click(triggerTarget);
-    expect(folderCard).toHaveAttribute('aria-expanded', 'false');
-    expect(folderCard).not.toHaveFocus();
-    expect(folderToggle).not.toHaveFocus();
+    await userEvent.click(trigger.parentElement!);
+    expect(activeTab).toHaveAttribute('aria-selected', 'true');
+    expect(activeTab).not.toHaveFocus();
 
     const body = within(document.body);
     const colorInput = await waitFor(() => body.getByLabelText('Choose color for folder Layer A'));
@@ -697,8 +733,7 @@ export const SetsFolderColorFromPreview: Story = {
       'data-foldered-folder-color',
       '#be185d',
     );
-    expect(canvas.getByTestId('foldered-draggable-folder-layer-a')).not.toHaveFocus();
-    expect(folderToggle).not.toHaveFocus();
+    expect(activeTab).toHaveAttribute('aria-selected', 'true');
   },
 };
 
@@ -875,7 +910,7 @@ export const DisabledItemsDoNotDrag: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand Layer B' }));
+    await userEvent.click(canvas.getByRole('tab', { name: 'Show Layer B' }));
 
     const disabledItem = canvas.getByTestId('foldered-draggable-item-layer-b-archived');
     expect(disabledItem).toBeDisabled();

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
@@ -69,9 +69,6 @@ module private TutorialSupport =
 
     let holePadding = 6.
 
-    /// Matches the card's `swt:w-80` class.
-    let cardWidth = 320.
-
     /// Minimum distance between the card and the host edges / the spotlight.
     let cardMargin = 12.
 
@@ -365,17 +362,19 @@ type TutorialOverlay =
               ]
 
         // The card is measured after every commit so placement can use its real
-        // height (its content changes with the step and completion state).
+        // size: the height changes with the step and completion state, and the
+        // width falls below its swt:w-80 default when its max-width clamps in.
         let cardRef = React.useElementRef ()
-        let cardHeight, setCardHeight = React.useState 220.
+        let cardSize, setCardSize = React.useState ((320., 220.))
+        let cardWidth, cardHeight = cardSize
 
         React.useLayoutEffect (fun () ->
             match cardRef.current with
             | Some card ->
-                let measured = card.getBoundingClientRect().height
+                let rect = card.getBoundingClientRect ()
 
-                if abs (measured - cardHeight) > 0.5 then
-                    setCardHeight measured
+                if abs (rect.width - cardWidth) > 0.5 || abs (rect.height - cardHeight) > 0.5 then
+                    setCardSize (rect.width, rect.height)
             | None -> ()
         )
 
@@ -406,7 +405,7 @@ type TutorialOverlay =
 
                 let left =
                     event.clientX - hostRect.left - offsetX
-                    |> min (hostRect.width - TutorialSupport.cardWidth)
+                    |> min (hostRect.width - cardWidth)
                     |> max 0.
 
                 let top =
@@ -443,7 +442,7 @@ type TutorialOverlay =
                         // highlight; if the layout leaves no clear spot, take
                         // the one covering the least of it.
                         let highlighted = if step.Task.IsSome then rects else [ first ]
-                        let cardW = TutorialSupport.cardWidth
+                        let cardW = cardWidth
                         let margin = TutorialSupport.cardMargin
                         let gap = TutorialSupport.holePadding + TutorialSupport.cardGap
 

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
@@ -1,0 +1,566 @@
+namespace Swate.Components.Composite.TutorialOverlay
+
+open Fable.Core
+open Feliz
+open Browser.Types
+open Swate.Components.Composite.TutorialOverlay.Types
+
+/// Spotlight geometry, relative to the tutorial content wrapper.
+type private SpotlightRect = {
+    Top: float
+    Left: float
+    Width: float
+    Height: float
+}
+
+type private SpotlightState = {
+    Rects: SpotlightRect list
+    HostWidth: float
+    HostHeight: float
+}
+
+module private TutorialSupport =
+
+    [<Emit("$0.closest ? $0.closest($1) : null")>]
+    let closest (_element: obj) (_selector: string) : Element = jsNative
+
+    [<Emit("Array.from($0.querySelectorAll($1))")>]
+    let queryAll (_container: HTMLElement) (_selector: string) : Element[] = jsNative
+
+    [<Emit("$0.scrollIntoView({ block: 'nearest', inline: 'nearest' })")>]
+    let scrollIntoView (_element: Element) : unit = jsNative
+
+    let measure (container: HTMLElement) (selector: string option) : SpotlightState =
+        let host = container.getBoundingClientRect ()
+
+        let rects =
+            selector
+            |> Option.map (fun selector ->
+                queryAll container selector
+                |> Array.truncate 12
+                |> Array.map (fun target ->
+                    let rect = target.getBoundingClientRect ()
+
+                    {
+                        Top = rect.top - host.top
+                        Left = rect.left - host.left
+                        Width = rect.width
+                        Height = rect.height
+                    }
+                )
+                |> Array.toList
+            )
+            |> Option.defaultValue []
+
+        {
+            Rects = rects
+            HostWidth = host.width
+            HostHeight = host.height
+        }
+
+    let holePadding = 6.
+
+[<Erase; Mangle(false)>]
+type TutorialOverlay =
+
+    /// Interactive tutorial chrome around arbitrary content: a spotlight that
+    /// follows the current step's target elements, an explanation card with
+    /// Back/Skip/Close controls, and a feature list to jump between steps or
+    /// restart from the beginning. Explanation steps block interactions outside
+    /// the spotlight; hands-on task steps highlight every selector match (e.g.
+    /// a drag source and its dropzone) and keep the whole UI interactive.
+    [<ReactComponent(true)>]
+    static member Main
+        (steps: TutorialStep[], onClose: unit -> unit, children: ReactElement, ?title: string, ?debug: bool)
+        =
+        let title = defaultArg title "Interactive tutorial"
+        let debug = defaultArg debug false
+        let contentRef = React.useElementRef ()
+        let activeIndex, setActiveIndex = React.useState 0
+        let completed, setCompleted = React.useState Set.empty<string>
+        let latestCompleted = React.useRef completed
+        let spotlight, setSpotlight = React.useState<SpotlightState option> None
+        let lastSpotlight = React.useRef (None: SpotlightState option)
+
+        let currentStep =
+            if steps.Length = 0 then
+                None
+            else
+                Some steps.[min activeIndex (steps.Length - 1)]
+
+        let markCompleted stepId =
+            let next = Set.add stepId latestCompleted.current
+            latestCompleted.current <- next
+            setCompleted next
+
+        let goToNext () =
+            // Explanation steps count as explored once read past; a task step
+            // only earns its checkmark from the interaction itself, so
+            // skipping it leaves the step open in the feature list.
+            currentStep
+            |> Option.iter (fun step ->
+                if step.Task.IsNone then
+                    markCompleted step.Id
+            )
+
+            if activeIndex < steps.Length - 1 then
+                setActiveIndex (activeIndex + 1)
+            else
+                onClose ()
+
+        // Spotlight tracking: scroll the first target into view once per step,
+        // then poll the rects - the host UI moves elements around as the user
+        // follows task instructions, and a step's target may only appear after
+        // an earlier task (polling picks it up without any host cooperation).
+        React.useEffect (
+            (fun () ->
+                let measureNow () =
+                    match contentRef.current, currentStep with
+                    | Some container, Some step ->
+                        let next = Some(TutorialSupport.measure container step.TargetSelector)
+
+                        if next <> lastSpotlight.current then
+                            lastSpotlight.current <- next
+                            setSpotlight next
+                    | _ ->
+                        if lastSpotlight.current.IsSome then
+                            lastSpotlight.current <- None
+                            setSpotlight None
+
+                match contentRef.current, currentStep with
+                | Some container, Some { TargetSelector = Some selector } ->
+                    let target = container.querySelector selector
+
+                    if not (isNull target) then
+                        TutorialSupport.scrollIntoView target
+                | _ -> ()
+
+                measureNow ()
+                let interval = JS.setInterval measureNow 250
+                FsReact.createDisposable (fun () -> JS.clearInterval interval)
+            ),
+            [| box activeIndex |]
+        )
+
+        // Hands-on steps watch for their interaction and mark the step
+        // completed when it happens - the card then shows the success state
+        // and Skip turns into Next; the user always moves on themselves.
+        React.useEffect (
+            (fun () ->
+                match currentStep with
+                | None -> FsReact.createDisposable ignore
+                | Some step ->
+                    let isPending () =
+                        not (latestCompleted.current.Contains step.Id)
+
+                    match step.Advance with
+                    | TutorialAdvance.Manual -> FsReact.createDisposable ignore
+                    | TutorialAdvance.OnEvent(eventType, selector) ->
+                        let handler =
+                            fun (event: Event) ->
+                                if
+                                    isPending ()
+                                    && not (isNull event.target)
+                                    && not (isNull (TutorialSupport.closest event.target selector))
+                                then
+                                    markCompleted step.Id
+
+                        // Capture phase, so a host handler stopping propagation
+                        // cannot swallow the completion signal.
+                        Browser.Dom.document.addEventListener (eventType, handler, true)
+
+                        FsReact.createDisposable (fun () ->
+                            Browser.Dom.document.removeEventListener (eventType, handler, true)
+                        )
+                    | TutorialAdvance.OnCondition check ->
+                        let interval =
+                            JS.setInterval
+                                (fun () ->
+                                    match contentRef.current with
+                                    | Some container when isPending () && check container -> markCompleted step.Id
+                                    | _ -> ()
+                                )
+                                400
+
+                        FsReact.createDisposable (fun () -> JS.clearInterval interval)
+            ),
+            [| box activeIndex |]
+        )
+
+        let restart () =
+            latestCompleted.current <- Set.empty
+            setCompleted Set.empty
+            setActiveIndex 0
+
+        let closeButton testId =
+            Html.button [
+                prop.type'.button
+                prop.className "swt:btn swt:btn-ghost swt:btn-xs swt:size-7 swt:p-0"
+                prop.title "Close tutorial"
+                prop.ariaLabel "Close tutorial"
+                if debug then
+                    prop.testId testId
+                prop.onClick (fun _ -> onClose ())
+                prop.children [
+                    Html.i [
+                        prop.className "swt:iconify swt:fluent--dismiss-circle-24-regular swt:size-4"
+                    ]
+                ]
+            ]
+
+        let spotlightRing (index: int) (rect: SpotlightRect) =
+            let pad = TutorialSupport.holePadding
+
+            Html.div [
+                prop.key $"tutorial-spotlight-ring-{index}"
+                prop.className
+                    "swt:absolute swt:pointer-events-none swt:rounded-lg swt:ring-2 swt:ring-primary swt:transition-all swt:duration-200"
+                // Tests and users only need one canonical spotlight handle.
+                if debug && index = 0 then
+                    prop.testId "tutorial-spotlight"
+                prop.style [
+                    style.top (length.px (rect.Top - pad))
+                    style.left (length.px (rect.Left - pad))
+                    style.width (length.px (rect.Width + 2. * pad))
+                    style.height (length.px (rect.Height + 2. * pad))
+                ]
+            ]
+
+        let spotlightPanels =
+            match currentStep, spotlight with
+            | Some step,
+              Some {
+                       Rects = (_ :: _) as rects
+                       HostWidth = hostWidth
+                       HostHeight = hostHeight
+                   } when step.Task.IsSome ->
+                // Task steps must leave the whole UI usable (a drag can travel
+                // across regions no spotlight covers), so the dim is a single
+                // click-through SVG with a cutout per highlighted target.
+                let pad = TutorialSupport.holePadding
+
+                let holePath (rect: SpotlightRect) =
+                    let x = max 0. (rect.Left - pad)
+                    let y = max 0. (rect.Top - pad)
+                    let width = rect.Width + 2. * pad
+                    let height = rect.Height + 2. * pad
+                    $"M{x} {y}h{width}v{height}h{-width}Z"
+
+                let path =
+                    $"M0 0H{hostWidth}V{hostHeight}H0Z"
+                    + (rects |> List.map holePath |> String.concat "")
+
+                [
+                    Html.div [
+                        prop.key "tutorial-dim-cutouts"
+                        prop.className "swt:absolute swt:inset-0 swt:pointer-events-none swt:text-neutral/50"
+                        prop.children [
+                            Svg.svg [
+                                svg.className "swt:h-full swt:w-full"
+                                svg.children [
+                                    Svg.path [
+                                        svg.d path
+                                        svg.custom ("fill", "currentColor")
+                                        svg.custom ("fillRule", "evenodd")
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                    yield! rects |> List.mapi spotlightRing
+                ]
+            | _,
+              Some {
+                       Rects = firstRect :: _
+                       HostWidth = hostWidth
+                       HostHeight = hostHeight
+                   } ->
+                // Explanation steps: spotlight the first match and block
+                // interactions everywhere else so the tour stays on rails.
+                // Everything in the overlay carries a stable key: the children
+                // list changes shape between step kinds, and index-based
+                // reconciliation would morph the step card's DOM node into a
+                // dim panel (breaking element identity mid-tour).
+                let pad = TutorialSupport.holePadding
+                let holeTop = max 0. (firstRect.Top - pad)
+                let holeLeft = max 0. (firstRect.Left - pad)
+                let holeRight = min hostWidth (firstRect.Left + firstRect.Width + pad)
+                let holeBottom = min hostHeight (firstRect.Top + firstRect.Height + pad)
+
+                let dim (key: string) (top: float) (left: float) (width: float) (height: float) =
+                    Html.div [
+                        prop.key key
+                        prop.className
+                            "swt:absolute swt:pointer-events-auto swt:bg-neutral/60 swt:transition-all swt:duration-200"
+                        prop.style [
+                            style.top (length.px top)
+                            style.left (length.px left)
+                            style.width (length.px (max 0. width))
+                            style.height (length.px (max 0. height))
+                        ]
+                    ]
+
+                [
+                    dim "tutorial-dim-top" 0. 0. hostWidth holeTop
+                    dim "tutorial-dim-bottom" holeBottom 0. hostWidth (hostHeight - holeBottom)
+                    dim "tutorial-dim-left" holeTop 0. holeLeft (holeBottom - holeTop)
+                    dim "tutorial-dim-right" holeTop holeRight (hostWidth - holeRight) (holeBottom - holeTop)
+                    spotlightRing 0 firstRect
+                ]
+            | _ -> [
+                // No target found (or none configured): keep the dim purely
+                // visual so a task's target can still be created by the user.
+                Html.div [
+                    prop.key "tutorial-dim-full"
+                    prop.className "swt:absolute swt:inset-0 swt:pointer-events-none swt:bg-neutral/30"
+                ]
+              ]
+
+        let stepCard =
+            match currentStep with
+            | None -> Html.none
+            | Some step ->
+                let isStepDone = completed.Contains step.Id
+
+                let positionProps =
+                    match spotlight with
+                    | Some {
+                               Rects = rect :: _
+                               HostWidth = hostWidth
+                               HostHeight = hostHeight
+                           } ->
+                        let cardWidth = 320.
+
+                        let left =
+                            rect.Left + rect.Width / 2. - cardWidth / 2.
+                            |> min (hostWidth - cardWidth - 12.)
+                            |> max 12.
+
+                        if rect.Top + rect.Height <= hostHeight * 0.55 then
+                            [
+                                style.top (length.px (rect.Top + rect.Height + 14.))
+                                style.left (length.px left)
+                            ]
+                        else
+                            [
+                                style.bottom (length.px (hostHeight - rect.Top + 14.))
+                                style.left (length.px left)
+                            ]
+                    | _ -> [
+                        style.top (length.percent 50)
+                        style.left (length.percent 50)
+                        style.custom ("transform", "translate(-50%, -50%)")
+                      ]
+
+                Html.div [
+                    prop.key "tutorial-step-card"
+                    prop.className
+                        "swt:absolute swt:z-50 swt:pointer-events-auto swt:flex swt:w-80 swt:max-w-[calc(100%-1.5rem)] swt:flex-col swt:gap-2 swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100 swt:p-4 swt:shadow-xl swt:motion-pop-in"
+                    prop.style positionProps
+                    if debug then
+                        prop.testId "tutorial-step-card"
+                    prop.children [
+                        Html.div [
+                            prop.className "swt:flex swt:items-center swt:justify-between swt:gap-2"
+                            prop.children [
+                                Html.span [
+                                    prop.className "swt:badge swt:badge-primary swt:badge-sm"
+                                    prop.text $"Step {activeIndex + 1} of {steps.Length}"
+                                ]
+                                closeButton "tutorial-card-close"
+                            ]
+                        ]
+                        Html.h3 [
+                            prop.className "swt:text-sm swt:font-semibold swt:text-primary"
+                            prop.text step.Title
+                        ]
+                        Html.p [ prop.className "swt:text-sm"; prop.text step.Description ]
+                        match step.Task with
+                        | Some task ->
+                            Html.div [
+                                prop.className [
+                                    "swt:flex swt:items-start swt:gap-2 swt:rounded-md swt:border swt:p-2 swt:text-sm"
+                                    if isStepDone then
+                                        "swt:border-success/60 swt:bg-success/10"
+                                    else
+                                        "swt:border-primary/40 swt:bg-primary/10"
+                                ]
+                                if debug then
+                                    prop.testId "tutorial-task"
+                                prop.children [
+                                    Html.i [
+                                        prop.className [
+                                            "swt:iconify swt:mt-0.5 swt:size-4 swt:shrink-0"
+                                            if isStepDone then
+                                                "swt:fluent--checkmark-circle-20-regular swt:text-success"
+                                            else
+                                                "swt:fluent--lightbulb-20-regular swt:text-primary"
+                                        ]
+                                    ]
+                                    Html.span [
+                                        prop.children [
+                                            Html.span [
+                                                prop.className "swt:font-medium"
+                                                prop.text (if isStepDone then "Completed: " else "Try it: ")
+                                            ]
+                                            Html.span task
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        | None -> Html.none
+                        Html.div [
+                            prop.className "swt:flex swt:items-center swt:justify-between swt:gap-2 swt:pt-1"
+                            prop.children [
+                                Html.button [
+                                    prop.type'.button
+                                    prop.className "swt:btn swt:btn-ghost swt:btn-xs"
+                                    prop.disabled ((activeIndex = 0))
+                                    if debug then
+                                        prop.testId "tutorial-back"
+                                    prop.onClick (fun _ -> setActiveIndex (max 0 (activeIndex - 1)))
+                                    prop.text "Back"
+                                ]
+                                Html.button [
+                                    prop.type'.button
+                                    prop.className "swt:btn swt:btn-primary swt:btn-xs"
+                                    if debug then
+                                        prop.testId "tutorial-next"
+                                    prop.onClick (fun _ -> goToNext ())
+                                    prop.children [
+                                        Html.span (
+                                            if activeIndex = steps.Length - 1 then "Finish"
+                                            elif step.Task.IsSome && not isStepDone then "Skip"
+                                            else "Next"
+                                        )
+                                        Html.i [
+                                            prop.className "swt:iconify swt:fluent--arrow-right-20-regular swt:size-4"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+
+        let sidebarStep index (step: TutorialStep) =
+            let isCurrent = index = activeIndex
+            let isCompleted = completed.Contains step.Id
+
+            Html.li [
+                prop.key step.Id
+                prop.children [
+                    Html.button [
+                        prop.type'.button
+                        prop.className [
+                            "swt:flex swt:w-full swt:items-center swt:gap-2 swt:rounded-md swt:border swt:p-2 swt:text-left swt:text-sm swt:transition-colors"
+                            if isCurrent then
+                                "swt:border-primary swt:bg-primary/10"
+                            else
+                                "swt:border-transparent swt:hover:bg-base-200"
+                        ]
+                        if debug then
+                            prop.testId $"tutorial-sidebar-step-{step.Id}"
+                        prop.onClick (fun _ -> setActiveIndex index)
+                        prop.children [
+                            if isCompleted then
+                                Html.i [
+                                    prop.className
+                                        "swt:iconify swt:fluent--checkmark-circle-20-regular swt:size-5 swt:shrink-0 swt:text-success"
+                                ]
+                            else
+                                Html.span [
+                                    prop.className [
+                                        "swt:flex swt:size-5 swt:shrink-0 swt:items-center swt:justify-center swt:rounded-full swt:text-xs swt:font-semibold"
+                                        if isCurrent then
+                                            "swt:bg-primary swt:text-primary-content"
+                                        else
+                                            "swt:bg-base-300"
+                                    ]
+                                    prop.text (string (index + 1))
+                                ]
+                            Html.span [
+                                prop.className "swt:min-w-0 swt:truncate"
+                                prop.text step.Title
+                            ]
+                            if step.Task.IsSome then
+                                Html.i [
+                                    prop.className
+                                        "swt:iconify swt:fluent--lightbulb-20-regular swt:ml-auto swt:size-4 swt:shrink-0 swt:text-base-content/50"
+                                    prop.title "Hands-on step"
+                                ]
+                        ]
+                    ]
+                ]
+            ]
+
+        let sidebar =
+            Html.aside [
+                prop.className
+                    "swt:flex swt:w-72 swt:shrink-0 swt:flex-col swt:gap-3 swt:overflow-y-auto swt:border-l swt:border-base-300 swt:bg-base-100 swt:p-3"
+                if debug then
+                    prop.testId "tutorial-sidebar"
+                prop.children [
+                    Html.div [
+                        prop.className "swt:flex swt:items-center swt:justify-between swt:gap-2"
+                        prop.children [
+                            Html.div [
+                                prop.className
+                                    "swt:flex swt:min-w-0 swt:items-center swt:gap-2 swt:text-sm swt:font-semibold"
+                                prop.children [
+                                    Html.i [
+                                        prop.className
+                                            "swt:iconify swt:fluent--book-open-24-regular swt:size-5 swt:shrink-0 swt:text-primary"
+                                    ]
+                                    Html.span [
+                                        prop.className "swt:min-w-0 swt:truncate"
+                                        prop.text title
+                                    ]
+                                ]
+                            ]
+                            closeButton "tutorial-close"
+                        ]
+                    ]
+                    Html.button [
+                        prop.type'.button
+                        prop.className "swt:btn swt:btn-primary swt:btn-sm"
+                        if debug then
+                            prop.testId "tutorial-play"
+                        prop.onClick (fun _ -> restart ())
+                        prop.children [
+                            Html.i [
+                                prop.className "swt:iconify swt:fluent--play-24-regular swt:size-4"
+                            ]
+                            Html.span "Play from start"
+                        ]
+                    ]
+                    Html.span [
+                        prop.className "swt:text-xs swt:text-base-content/60"
+                        prop.text $"{completed.Count} of {steps.Length} features explored"
+                    ]
+                    Html.ol [
+                        prop.className "swt:flex swt:flex-col swt:gap-1"
+                        prop.children (steps |> Array.mapi sidebarStep |> Array.toList)
+                    ]
+                ]
+            ]
+
+        Html.div [
+            prop.className "swt:flex swt:h-full swt:min-h-0 swt:w-full swt:overflow-hidden"
+            if debug then
+                prop.testId "tutorial-overlay"
+            prop.children [
+                Html.div [
+                    prop.ref contentRef
+                    prop.className "swt:relative swt:min-w-0 swt:flex-1 swt:overflow-hidden"
+                    prop.children [
+                        children
+                        Html.div [
+                            prop.className "swt:absolute swt:inset-0 swt:z-40 swt:pointer-events-none"
+                            prop.children [ yield! spotlightPanels; stepCard ]
+                        ]
+                    ]
+                ]
+                sidebar
+            ]
+        ]

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
@@ -176,6 +176,13 @@ type TutorialOverlay =
                 |> Array.rev
                 |> Array.tryPick (fun step -> step.Checkpoint)
 
+        // The content is rebuilt only when the effective checkpoint or the restart
+        // generation changes - the same signal the KeyedFragment below remounts on.
+        // Without this, `render` runs on every overlay render (spotlight polling,
+        // card drags) and the reconciler discards the fresh subtree it builds.
+        let renderedContent =
+            React.useMemo ((fun () -> render effectiveCheckpoint), [| box generation; box effectiveCheckpoint |])
+
         let markCompleted stepId =
             let next = Set.add stepId latestCompleted.current
             latestCompleted.current <- next
@@ -760,7 +767,7 @@ type TutorialOverlay =
                         // the host rebuilds the state this step starts from.
                         React.KeyedFragment(
                             $"""tutorial-content-{generation}-{defaultArg effectiveCheckpoint "initial"}""",
-                            [ render effectiveCheckpoint ]
+                            [ renderedContent ]
                         )
                         Html.div [
                             prop.className "swt:absolute swt:inset-0 swt:z-40 swt:pointer-events-none"

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
@@ -39,6 +39,48 @@ module private TutorialSupport =
     [<Emit("(() => { try { $0.releasePointerCapture($1); } catch {} })()")>]
     let releasePointerCapture (_element: obj) (_pointerId: float) : unit = jsNative
 
+    // Selector lists often pair a region with controls inside it (a rail and
+    // its chevron, say) so that folded layouts still get a highlight. When
+    // both exist, ringing the region around the control's own ring is just
+    // noise - the innermost matches carry the meaning.
+    let private contains (outer: SpotlightRect) (inner: SpotlightRect) =
+        outer.Left <= inner.Left
+        && outer.Top <= inner.Top
+        && outer.Left + outer.Width >= inner.Left + inner.Width
+        && outer.Top + outer.Height >= inner.Top + inner.Height
+
+    let holePadding = 6.
+
+    // The dim's cutouts are one even-odd SVG path, where overlapping holes
+    // cancel back into dim - so rects whose padded holes would intersect are
+    // fused into their bounding box and highlighted as one region.
+    let private intersectsPadded pad (a: SpotlightRect) (b: SpotlightRect) =
+        a.Left - pad < b.Left + b.Width + pad
+        && b.Left - pad < a.Left + a.Width + pad
+        && a.Top - pad < b.Top + b.Height + pad
+        && b.Top - pad < a.Top + a.Height + pad
+
+    let private boundingBox (a: SpotlightRect) (b: SpotlightRect) =
+        let left = min a.Left b.Left
+        let top = min a.Top b.Top
+
+        {
+            Top = top
+            Left = left
+            Width = max (a.Left + a.Width) (b.Left + b.Width) - left
+            Height = max (a.Top + a.Height) (b.Top + b.Height) - top
+        }
+
+    let private mergeOverlapping (rects: SpotlightRect list) =
+        let rec add merged rect =
+            match merged |> List.tryFind (intersectsPadded holePadding rect) with
+            | Some other ->
+                let rest = merged |> List.filter (fun existing -> existing <> other)
+                add rest (boundingBox rect other)
+            | None -> rect :: merged
+
+        rects |> List.fold add [] |> List.rev
+
     let measure (container: HTMLElement) (selector: string option) : SpotlightState =
         let host = container.getBoundingClientRect ()
 
@@ -61,13 +103,24 @@ module private TutorialSupport =
             )
             |> Option.defaultValue []
 
+        let rects =
+            rects
+            |> List.filter (fun rect ->
+                rects
+                |> List.exists (fun other ->
+                    // Strictly larger, so identical rects survive as a pair
+                    // instead of eliminating each other.
+                    contains rect other && rect.Width * rect.Height > other.Width * other.Height
+                )
+                |> not
+            )
+            |> mergeOverlapping
+
         {
             Rects = rects
             HostWidth = host.width
             HostHeight = host.height
         }
-
-    let holePadding = 6.
 
     /// Minimum distance between the card and the host edges / the spotlight.
     let cardMargin = 12.

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
@@ -30,6 +30,15 @@ module private TutorialSupport =
     [<Emit("$0.scrollIntoView({ block: 'nearest', inline: 'nearest' })")>]
     let scrollIntoView (_element: Element) : unit = jsNative
 
+    // Pointer capture keeps fast drags glued to the card handle; it is only an
+    // enhancement, so failures (e.g. synthetic events without an active
+    // pointer) must not break the drag itself.
+    [<Emit("(() => { try { $0.setPointerCapture($1); } catch {} })()")>]
+    let setPointerCapture (_element: obj) (_pointerId: float) : unit = jsNative
+
+    [<Emit("(() => { try { $0.releasePointerCapture($1); } catch {} })()")>]
+    let releasePointerCapture (_element: obj) (_pointerId: float) : unit = jsNative
+
     let measure (container: HTMLElement) (selector: string option) : SpotlightState =
         let host = container.getBoundingClientRect ()
 
@@ -60,6 +69,14 @@ module private TutorialSupport =
 
     let holePadding = 6.
 
+    /// Matches the card's `swt:w-80` class.
+    let cardWidth = 320.
+
+    /// Minimum distance between the card and the host edges / the spotlight.
+    let cardMargin = 12.
+
+    let cardGap = 14.
+
 [<Erase; Mangle(false)>]
 type TutorialOverlay =
 
@@ -69,10 +86,18 @@ type TutorialOverlay =
     /// restart from the beginning. Explanation steps block interactions outside
     /// the spotlight; hands-on task steps highlight every selector match (e.g.
     /// a drag source and its dropzone) and keep the whole UI interactive.
+    /// `render` receives the active step's (inherited) checkpoint and its
+    /// result is remounted whenever that checkpoint changes, so every step
+    /// starts from the state its instructions assume.
     [<ReactComponent(true)>]
     static member Main
-        (steps: TutorialStep[], onClose: unit -> unit, children: ReactElement, ?title: string, ?debug: bool)
-        =
+        (
+            steps: TutorialStep[],
+            onClose: unit -> unit,
+            render: string option -> ReactElement,
+            ?title: string,
+            ?debug: bool
+        ) =
         let title = defaultArg title "Interactive tutorial"
         let debug = defaultArg debug false
         let contentRef = React.useElementRef ()
@@ -81,12 +106,25 @@ type TutorialOverlay =
         let latestCompleted = React.useRef completed
         let spotlight, setSpotlight = React.useState<SpotlightState option> None
         let lastSpotlight = React.useRef (None: SpotlightState option)
+        // Bumped by "Play from start" so a restart always remounts the content,
+        // even when the checkpoint key alone would not change.
+        let generation, setGeneration = React.useState 0
 
         let currentStep =
             if steps.Length = 0 then
                 None
             else
                 Some steps.[min activeIndex (steps.Length - 1)]
+
+        // A step without its own checkpoint continues from the nearest earlier
+        // one; the content only remounts when this effective key changes.
+        let effectiveCheckpoint =
+            if steps.Length = 0 then
+                None
+            else
+                steps.[.. min activeIndex (steps.Length - 1)]
+                |> Array.rev
+                |> Array.tryPick (fun step -> step.Checkpoint)
 
         let markCompleted stepId =
             let next = Set.add stepId latestCompleted.current
@@ -191,6 +229,7 @@ type TutorialOverlay =
             latestCompleted.current <- Set.empty
             setCompleted Set.empty
             setActiveIndex 0
+            setGeneration (generation + 1)
 
         let closeButton testId =
             Html.button [
@@ -316,6 +355,64 @@ type TutorialOverlay =
                 ]
               ]
 
+        // The card is measured after every commit so placement can use its real
+        // height (its content changes with the step and completion state).
+        let cardRef = React.useElementRef ()
+        let cardHeight, setCardHeight = React.useState 220.
+
+        React.useLayoutEffect (fun () ->
+            match cardRef.current with
+            | Some card ->
+                let measured = card.getBoundingClientRect().height
+
+                if abs (measured - cardHeight) > 0.5 then
+                    setCardHeight measured
+            | None -> ()
+        )
+
+        // Dragging the card by its header overrides automatic placement until
+        // the next step; automatic placement resumes there.
+        let manualPosition, setManualPosition = React.useState<(float * float) option> None
+        let cardDragOffset = React.useRef (None: (float * float) option)
+
+        React.useEffect ((fun () -> setManualPosition None), [| box activeIndex |])
+
+        let startCardDrag (event: PointerEvent) =
+            // Buttons in the header (close) keep their click behavior.
+            if isNull (TutorialSupport.closest event.target "button") then
+                match cardRef.current with
+                | Some card ->
+                    let cardRect = card.getBoundingClientRect ()
+
+                    cardDragOffset.current <- Some(event.clientX - cardRect.left, event.clientY - cardRect.top)
+
+                    TutorialSupport.setPointerCapture event.currentTarget event.pointerId
+                    event.preventDefault ()
+                | None -> ()
+
+        let moveCardDrag (event: PointerEvent) =
+            match cardDragOffset.current, contentRef.current with
+            | Some(offsetX, offsetY), Some host ->
+                let hostRect = host.getBoundingClientRect ()
+
+                let left =
+                    event.clientX - hostRect.left - offsetX
+                    |> min (hostRect.width - TutorialSupport.cardWidth)
+                    |> max 0.
+
+                let top =
+                    event.clientY - hostRect.top - offsetY
+                    |> min (hostRect.height - cardHeight)
+                    |> max 0.
+
+                setManualPosition (Some(left, top))
+            | _ -> ()
+
+        let endCardDrag (event: PointerEvent) =
+            if cardDragOffset.current.IsSome then
+                cardDragOffset.current <- None
+                TutorialSupport.releasePointerCapture event.currentTarget event.pointerId
+
         let stepCard =
             match currentStep with
             | None -> Html.none
@@ -323,29 +420,63 @@ type TutorialOverlay =
                 let isStepDone = completed.Contains step.Id
 
                 let positionProps =
-                    match spotlight with
-                    | Some {
-                               Rects = rect :: _
+                    match manualPosition, spotlight with
+                    | Some(left, top), _ -> [ style.left (length.px left); style.top (length.px top) ]
+                    | None,
+                      Some {
+                               Rects = (first :: _) as rects
                                HostWidth = hostWidth
                                HostHeight = hostHeight
                            } ->
-                        let cardWidth = 320.
+                        // The card must never cover a highlighted element: try
+                        // below, above, right and left of the (first) spotlight
+                        // rect and take the first spot that clears every
+                        // highlight; if the layout leaves no clear spot, take
+                        // the one covering the least of it.
+                        let highlighted = if step.Task.IsSome then rects else [ first ]
+                        let cardW = TutorialSupport.cardWidth
+                        let margin = TutorialSupport.cardMargin
+                        let gap = TutorialSupport.holePadding + TutorialSupport.cardGap
 
-                        let left =
-                            rect.Left + rect.Width / 2. - cardWidth / 2.
-                            |> min (hostWidth - cardWidth - 12.)
-                            |> max 12.
+                        let clampLeft value =
+                            value |> min (hostWidth - cardW - margin) |> max margin
 
-                        if rect.Top + rect.Height <= hostHeight * 0.55 then
-                            [
-                                style.top (length.px (rect.Top + rect.Height + 14.))
-                                style.left (length.px left)
-                            ]
-                        else
-                            [
-                                style.bottom (length.px (hostHeight - rect.Top + 14.))
-                                style.left (length.px left)
-                            ]
+                        let clampTop value =
+                            value |> min (hostHeight - cardHeight - margin) |> max margin
+
+                        let centeredLeft = clampLeft (first.Left + first.Width / 2. - cardW / 2.)
+
+                        let centeredTop = clampTop (first.Top + first.Height / 2. - cardHeight / 2.)
+
+                        let candidates = [
+                            centeredLeft, clampTop (first.Top + first.Height + gap)
+                            centeredLeft, clampTop (first.Top - gap - cardHeight)
+                            clampLeft (first.Left + first.Width + gap), centeredTop
+                            clampLeft (first.Left - gap - cardW), centeredTop
+                        ]
+
+                        let overlapArea (left: float, top: float) (rect: SpotlightRect) =
+                            let pad = TutorialSupport.holePadding
+
+                            let overlapWidth =
+                                min (left + cardW) (rect.Left + rect.Width + pad) - max left (rect.Left - pad)
+
+                            let overlapHeight =
+                                min (top + cardHeight) (rect.Top + rect.Height + pad) - max top (rect.Top - pad)
+
+                            max 0. overlapWidth * max 0. overlapHeight
+
+                        let left, top =
+                            candidates
+                            |> List.tryFind (fun candidate ->
+                                highlighted |> List.forall (fun rect -> overlapArea candidate rect = 0.)
+                            )
+                            |> Option.defaultWith (fun () ->
+                                candidates
+                                |> List.minBy (fun candidate -> highlighted |> List.sumBy (overlapArea candidate))
+                            )
+
+                        [ style.left (length.px left); style.top (length.px top) ]
                     | _ -> [
                         style.top (length.percent 50)
                         style.left (length.percent 50)
@@ -354,6 +485,7 @@ type TutorialOverlay =
 
                 Html.div [
                     prop.key "tutorial-step-card"
+                    prop.ref cardRef
                     prop.className
                         "swt:absolute swt:z-50 swt:pointer-events-auto swt:flex swt:w-80 swt:max-w-[calc(100%-1.5rem)] swt:flex-col swt:gap-2 swt:rounded-box swt:border swt:border-base-300 swt:bg-base-100 swt:p-4 swt:shadow-xl swt:motion-pop-in"
                     prop.style positionProps
@@ -361,7 +493,15 @@ type TutorialOverlay =
                         prop.testId "tutorial-step-card"
                     prop.children [
                         Html.div [
-                            prop.className "swt:flex swt:items-center swt:justify-between swt:gap-2"
+                            prop.className
+                                "swt:flex swt:cursor-move swt:touch-none swt:select-none swt:items-center swt:justify-between swt:gap-2"
+                            prop.title "Drag to move this card"
+                            prop.onPointerDown startCardDrag
+                            prop.onPointerMove moveCardDrag
+                            prop.onPointerUp endCardDrag
+                            prop.onPointerCancel endCardDrag
+                            if debug then
+                                prop.testId "tutorial-card-handle"
                             prop.children [
                                 Html.span [
                                     prop.className "swt:badge swt:badge-primary swt:badge-sm"
@@ -554,7 +694,13 @@ type TutorialOverlay =
                     prop.ref contentRef
                     prop.className "swt:relative swt:min-w-0 swt:flex-1 swt:overflow-hidden"
                     prop.children [
-                        children
+                        // The key remounts the content whenever the effective
+                        // checkpoint (or the restart generation) changes, so
+                        // the host rebuilds the state this step starts from.
+                        React.KeyedFragment(
+                            $"""tutorial-content-{generation}-{defaultArg effectiveCheckpoint "initial"}""",
+                            [ render effectiveCheckpoint ]
+                        )
                         Html.div [
                             prop.className "swt:absolute swt:inset-0 swt:z-40 swt:pointer-events-none"
                             prop.children [ yield! spotlightPanels; stepCard ]

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.fs
@@ -196,9 +196,18 @@ type TutorialOverlay =
                     | TutorialAdvance.OnEvent(eventType, selector) ->
                         let handler =
                             fun (event: Event) ->
+                                // Only events inside the wrapped content count: the
+                                // document-level listener would otherwise complete the
+                                // step from selector matches in unrelated host UI.
+                                let insideContent =
+                                    match contentRef.current with
+                                    | Some container ->
+                                        not (isNull event.target) && container.contains (unbox event.target)
+                                    | None -> false
+
                                 if
                                     isPending ()
-                                    && not (isNull event.target)
+                                    && insideContent
                                     && not (isNull (TutorialSupport.closest event.target selector))
                                 then
                                     markCompleted step.Id

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.stories.tsx
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.stories.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Main as TutorialOverlay } from './TutorialOverlay.fs.js';
+import {
+  Exports_step as step,
+  Exports_advanceManual as advanceManual,
+  Exports_advanceOnEvent as advanceOnEvent,
+  type TutorialStep,
+} from './Types.fs.js';
+
+/** Tiny host UI the tutorial walks through. */
+function DemoPanel() {
+  const [waterCount, setWaterCount] = React.useState(0);
+  const [name, setName] = React.useState('');
+
+  return (
+    <div className="swt:flex swt:h-full swt:flex-col swt:gap-4 swt:bg-base-200 swt:p-6">
+      <h2 className="swt:text-lg swt:font-semibold">Plant care demo</h2>
+      <button
+        type="button"
+        data-tutorial="demo-water"
+        className="swt:btn swt:btn-primary swt:w-fit"
+        onClick={() => setWaterCount((count) => count + 1)}
+      >
+        Water plant ({waterCount})
+      </button>
+      <label className="swt:flex swt:w-fit swt:flex-col swt:gap-1">
+        <span className="swt:text-sm">Plant name</span>
+        <input
+          data-tutorial="demo-name"
+          className="swt:input swt:input-bordered swt:input-sm"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </label>
+    </div>
+  );
+}
+
+const demoSteps: TutorialStep[] = [
+  step(
+    'intro',
+    'Welcome',
+    'This short tour shows the demo panel. Use the list on the right to jump around.',
+    undefined,
+    undefined,
+    advanceManual(),
+  ),
+  step(
+    'water',
+    'Watering',
+    'The highlighted button waters the plant and counts how often you did.',
+    "[data-tutorial='demo-water']",
+    'Click the Water plant button.',
+    advanceOnEvent('click', "[data-tutorial='demo-water']"),
+  ),
+  step(
+    'name',
+    'Naming',
+    'Every plant deserves a name; type one into the highlighted field.',
+    "[data-tutorial='demo-name']",
+    undefined,
+    advanceManual(),
+  ),
+  step(
+    'outro',
+    'Done',
+    'That is all there is - happy planting!',
+    undefined,
+    undefined,
+    advanceManual(),
+  ),
+];
+
+function Harness() {
+  const [closed, setClosed] = React.useState(false);
+
+  if (closed) {
+    return <p data-testid="tutorial-closed">Tutorial closed</p>;
+  }
+
+  return (
+    <div className="swt:h-screen">
+      <TutorialOverlay steps={demoSteps} onClose={() => setClosed(true)} title="Plant care tour" debug={true}>
+        <DemoPanel />
+      </TutorialOverlay>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Composite Components/TutorialOverlay',
+  component: TutorialOverlay,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof TutorialOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <Harness />,
+};
+
+export const SidebarListsStepsAndJumpsDirectly: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sidebar = within(await canvas.findByTestId('tutorial-sidebar'));
+    expect(sidebar.getByText('Plant care tour')).toBeInTheDocument();
+    expect(sidebar.getByText('Welcome')).toBeInTheDocument();
+    expect(sidebar.getByText('0 of 4 features explored')).toBeInTheDocument();
+
+    // Jumping straight to a feature explanation from the list.
+    await userEvent.click(canvas.getByTestId('tutorial-sidebar-step-name'));
+    const card = within(canvas.getByTestId('tutorial-step-card'));
+    expect(card.getByText('Naming')).toBeInTheDocument();
+    expect(card.getByText('Step 3 of 4')).toBeInTheDocument();
+
+    // The spotlight tracks the step target.
+    await waitFor(() => expect(canvas.getByTestId('tutorial-spotlight')).toBeInTheDocument());
+  },
+};
+
+export const TaskStepCompletesOnUserInteraction: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByTestId('tutorial-sidebar-step-water'));
+    const task = within(canvas.getByTestId('tutorial-task'));
+    expect(task.getByText(/Click the Water plant button/)).toBeInTheDocument();
+    expect(task.getByText('Try it:')).toBeInTheDocument();
+    expect(canvas.getByTestId('tutorial-next')).toHaveTextContent('Skip');
+
+    // The highlighted control stays interactive; performing the task marks
+    // the step completed without moving on by itself.
+    await waitFor(() => expect(canvas.getByTestId('tutorial-spotlight')).toBeInTheDocument());
+    await userEvent.click(canvas.getByText(/Water plant \(0\)/));
+    expect(canvas.getByText(/Water plant \(1\)/)).toBeInTheDocument();
+
+    await waitFor(() => expect(canvas.getByTestId('tutorial-next')).toHaveTextContent('Next'));
+    expect(within(canvas.getByTestId('tutorial-step-card')).getByText('Watering')).toBeInTheDocument();
+    expect(within(canvas.getByTestId('tutorial-task')).getByText('Completed:')).toBeInTheDocument();
+    expect(canvas.getByText('1 of 4 features explored')).toBeInTheDocument();
+
+    // The user moves on themselves.
+    await userEvent.click(canvas.getByTestId('tutorial-next'));
+    expect(within(canvas.getByTestId('tutorial-step-card')).getByText('Naming')).toBeInTheDocument();
+  },
+};
+
+export const SkipMovesOnAndCloseExits: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = within(await canvas.findByTestId('tutorial-step-card'));
+    expect(card.getByText('Welcome')).toBeInTheDocument();
+
+    // Manual step advances via Next, task step via Skip.
+    await userEvent.click(canvas.getByTestId('tutorial-next'));
+    expect(card.getByText('Watering')).toBeInTheDocument();
+    expect(canvas.getByTestId('tutorial-next')).toHaveTextContent('Skip');
+    await userEvent.click(canvas.getByTestId('tutorial-next'));
+    expect(card.getByText('Naming')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByTestId('tutorial-close'));
+    expect(canvas.getByTestId('tutorial-closed')).toBeInTheDocument();
+  },
+};
+
+export const PlayFromStartRestartsTheTour: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Make some progress first: skip past Welcome, then jump to the end.
+    await userEvent.click(await canvas.findByTestId('tutorial-next'));
+    await userEvent.click(canvas.getByTestId('tutorial-sidebar-step-outro'));
+    expect(canvas.getByText('1 of 4 features explored')).toBeInTheDocument();
+
+    // Restarting returns to the first step and resets the progress.
+    await userEvent.click(canvas.getByTestId('tutorial-play'));
+    const card = within(canvas.getByTestId('tutorial-step-card'));
+    expect(card.getByText('Welcome')).toBeInTheDocument();
+    expect(canvas.getByText('0 of 4 features explored')).toBeInTheDocument();
+  },
+};

--- a/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.stories.tsx
+++ b/src/Components/src/Composite/TutorialOverlay/TutorialOverlay.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
 import { Main as TutorialOverlay } from './TutorialOverlay.fs.js';
 import {
   Exports_step as step,
@@ -46,7 +46,10 @@ const demoSteps: TutorialStep[] = [
     undefined,
     undefined,
     advanceManual(),
+    undefined,
   ),
+  // Each task step names its own checkpoint: entering it (from any direction)
+  // remounts the demo panel, so the task always starts from a known state.
   step(
     'water',
     'Watering',
@@ -54,6 +57,7 @@ const demoSteps: TutorialStep[] = [
     "[data-tutorial='demo-water']",
     'Click the Water plant button.',
     advanceOnEvent('click', "[data-tutorial='demo-water']"),
+    'water-task',
   ),
   step(
     'name',
@@ -62,6 +66,7 @@ const demoSteps: TutorialStep[] = [
     "[data-tutorial='demo-name']",
     undefined,
     advanceManual(),
+    'name-task',
   ),
   step(
     'outro',
@@ -70,6 +75,7 @@ const demoSteps: TutorialStep[] = [
     undefined,
     undefined,
     advanceManual(),
+    undefined,
   ),
 ];
 
@@ -82,9 +88,13 @@ function Harness() {
 
   return (
     <div className="swt:h-screen">
-      <TutorialOverlay steps={demoSteps} onClose={() => setClosed(true)} title="Plant care tour" debug={true}>
-        <DemoPanel />
-      </TutorialOverlay>
+      <TutorialOverlay
+        steps={demoSteps}
+        onClose={() => setClosed(true)}
+        title="Plant care tour"
+        debug={true}
+        render={() => <DemoPanel />}
+      />
     </div>
   );
 }
@@ -165,6 +175,55 @@ export const SkipMovesOnAndCloseExits: Story = {
 
     await userEvent.click(canvas.getByTestId('tutorial-close'));
     expect(canvas.getByTestId('tutorial-closed')).toBeInTheDocument();
+  },
+};
+
+export const RevisitingATaskStepRestoresItsCheckpoint: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Complete the watering task, changing the underlying demo state.
+    await userEvent.click(await canvas.findByTestId('tutorial-sidebar-step-water'));
+    await userEvent.click(canvas.getByText(/Water plant \(0\)/));
+    expect(canvas.getByText(/Water plant \(1\)/)).toBeInTheDocument();
+
+    // Leaving for a step with another checkpoint and coming back remounts the
+    // content at the watering step's checkpoint: the task is doable again.
+    await userEvent.click(canvas.getByTestId('tutorial-next'));
+    expect(within(canvas.getByTestId('tutorial-step-card')).getByText('Naming')).toBeInTheDocument();
+    await userEvent.click(canvas.getByTestId('tutorial-back'));
+    expect(canvas.getByText(/Water plant \(0\)/)).toBeInTheDocument();
+
+    // Steps without their own checkpoint keep the running state: moving from
+    // Naming to Done (which inherits Naming's checkpoint) preserves the input.
+    await userEvent.click(canvas.getByTestId('tutorial-sidebar-step-name'));
+    await userEvent.type(canvas.getByTestId('tutorial-overlay').querySelector('input')!, 'Fern');
+    await userEvent.click(canvas.getByTestId('tutorial-next'));
+    expect(within(canvas.getByTestId('tutorial-step-card')).getByText('Done')).toBeInTheDocument();
+    expect(canvas.getByDisplayValue('Fern')).toBeInTheDocument();
+  },
+};
+
+export const StepCardIsDraggable: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = await canvas.findByTestId('tutorial-step-card');
+    const handle = canvas.getByTestId('tutorial-card-handle');
+    const before = card.getBoundingClientRect();
+
+    const handleRect = handle.getBoundingClientRect();
+    const startX = handleRect.left + 10;
+    const startY = handleRect.top + 5;
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: startX, clientY: startY });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: startX + 120, clientY: startY + 80 });
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: startX + 120, clientY: startY + 80 });
+
+    await waitFor(() => {
+      const after = card.getBoundingClientRect();
+      expect(after.left).toBeCloseTo(before.left + 120, 0);
+      expect(after.top).toBeCloseTo(before.top + 80, 0);
+    });
   },
 };
 

--- a/src/Components/src/Composite/TutorialOverlay/Types.fs
+++ b/src/Components/src/Composite/TutorialOverlay/Types.fs
@@ -1,0 +1,65 @@
+module Swate.Components.Composite.TutorialOverlay.Types
+
+open Fable.Core
+open Browser.Types
+
+/// How a tutorial step's completion is detected. Moving to the next step is
+/// always the user's click on Next/Skip; completion only changes what the
+/// card shows (success state, Skip turning into Next, sidebar checkmark).
+[<RequireQualifiedAccess>]
+type TutorialAdvance =
+    /// Completed by reading past it with the Next button.
+    | Manual
+    /// Completed once an event of the given type fires on (or inside) an
+    /// element matching the selector - this is what makes a step a hands-on task.
+    | OnEvent of eventType: string * selector: string
+    /// Completed once the polled condition returns true. The check receives the
+    /// tutorial content container, so it can query only the wrapped UI instead
+    /// of the whole document - useful for outcomes that are not a single click,
+    /// such as a drag landing or an element appearing.
+    | OnCondition of check: (HTMLElement -> bool)
+
+type TutorialStep = {
+    Id: string
+    Title: string
+    Description: string
+    /// CSS selector, scoped to the tutorial content, whose matches get the
+    /// spotlight. Steps with a task highlight every match (e.g. a drag source
+    /// and its dropzone) and keep the whole UI interactive; explanation steps
+    /// spotlight the first match and block interactions elsewhere. None dims
+    /// the whole surface lightly and centers the card.
+    TargetSelector: string option
+    /// Try-it instruction shown emphasized under the description.
+    Task: string option
+    Advance: TutorialAdvance
+}
+
+/// Plain-function constructors so Storybook/TypeScript hosts can build steps
+/// without reaching into Fable union runtime representations.
+[<Mangle(false)>]
+module Exports =
+
+    let advanceManual () = TutorialAdvance.Manual
+
+    let advanceOnEvent (eventType: string, selector: string) =
+        TutorialAdvance.OnEvent(eventType, selector)
+
+    let advanceOnCondition (check: HTMLElement -> bool) = TutorialAdvance.OnCondition check
+
+    let step
+        (
+            id: string,
+            title: string,
+            description: string,
+            targetSelector: string option,
+            task: string option,
+            advance: TutorialAdvance
+        ) : TutorialStep =
+        {
+            Id = id
+            Title = title
+            Description = description
+            TargetSelector = targetSelector
+            Task = task
+            Advance = advance
+        }

--- a/src/Components/src/Composite/TutorialOverlay/Types.fs
+++ b/src/Components/src/Composite/TutorialOverlay/Types.fs
@@ -32,6 +32,13 @@ type TutorialStep = {
     /// Try-it instruction shown emphasized under the description.
     Task: string option
     Advance: TutorialAdvance
+    /// Names the sandbox state this step starts from. Steps without one
+    /// inherit the nearest earlier checkpoint. Whenever the (inherited)
+    /// checkpoint of the active step differs from the one currently mounted,
+    /// the tutorial content is remounted through the host's render function -
+    /// so jumping or going back to a step always restores a state in which its
+    /// task can be fulfilled, no matter what earlier interactions changed.
+    Checkpoint: string option
 }
 
 /// Plain-function constructors so Storybook/TypeScript hosts can build steps
@@ -53,7 +60,8 @@ module Exports =
             description: string,
             targetSelector: string option,
             task: string option,
-            advance: TutorialAdvance
+            advance: TutorialAdvance,
+            checkpoint: string option
         ) : TutorialStep =
         {
             Id = id
@@ -62,4 +70,5 @@ module Exports =
             TargetSelector = targetSelector
             Task = task
             Advance = advance
+            Checkpoint = checkpoint
         }

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorMeasurement.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorMeasurement.fs
@@ -32,6 +32,14 @@ module private ConnectorDom =
         )
         |> Map.ofArray
 
+    let memberNodes (container: HTMLElement) =
+        querySelectorAll container "[data-provenance-member-node]"
+        |> Array.choose (fun node ->
+            let id = node.getAttribute "data-provenance-member-node"
+            if isNull id then None else Some(id, node)
+        )
+        |> Map.ofArray
+
 /// Measures connection handles and builds SVG connector paths between them.
 module ConnectorMeasure =
 
@@ -40,6 +48,7 @@ module ConnectorMeasure =
         Origin = container.getBoundingClientRect ()
         Nodes = ConnectorDom.connectionNodes container
         GroupNodes = ConnectorDom.groupNodes container
+        MemberNodes = ConnectorDom.memberNodes container
     }
 
     let private tryHandle (context: ConnectorMeasureContext) handle =
@@ -101,8 +110,9 @@ module ConnectorMeasure =
             |> Option.map (fun path -> path, midpointBetweenPoints start finish)
         | _ -> None
 
-    /// One sankey ribbon to lay out: the connection key, its group-card
-    /// endpoints, and the weight deciding its share of each card edge.
+    /// One sankey ribbon to lay out: the connection key, its endpoints (a
+    /// collapsed group card or an expanded card's member row each), and the
+    /// weight deciding its share of each endpoint edge.
     type SankeyRibbonRequest = {
         Key: string
         Source: ConnectionHandleRef
@@ -145,12 +155,31 @@ module ConnectorMeasure =
             Bottom = top + rect.height
         }
 
-    /// Lays out group-connection ribbons like a sankey chart: the ribbons
-    /// attached to a card split its facing edge proportionally to their
-    /// weights, so together they cover the card's whole side and follow its
-    /// size; each ribbon then tapers between its two edge shares. Ribbons on
-    /// one edge stack in the vertical order of their opposite cards, keeping
-    /// bundles from crossing right where they leave a card.
+    /// A ribbon endpoint is the whole card for collapsed groups and the single
+    /// member row for expanded ones, so member-level ribbons split row edges
+    /// exactly like group ribbons split card edges.
+    let private tryRibbonNode (context: ConnectorMeasureContext) (handle: ConnectionHandleRef) =
+        match handle.Kind with
+        | ConnectionHandleKind.GroupCard ->
+            let nodeId = DragDrop.groupNodeId handle.Side handle.Id
+
+            context.GroupNodes.TryFind nodeId |> Option.map (fun node -> nodeId, node)
+        | ConnectionHandleKind.GroupMember ->
+            handle.ParentGroupId
+            |> Option.bind (fun groupId ->
+                let nodeId = DragDrop.memberNodeId handle.Side groupId handle.Id
+
+                context.MemberNodes.TryFind nodeId |> Option.map (fun node -> nodeId, node)
+            )
+        | _ -> None
+
+    /// Lays out group- and member-connection ribbons like a sankey chart: the
+    /// ribbons attached to an endpoint (card or member row) split its facing
+    /// edge proportionally to their weights, so together they cover the whole
+    /// side and follow its size; each ribbon then tapers between its two edge
+    /// shares. Ribbons on one edge stack in the vertical order of their
+    /// opposite endpoints, keeping bundles from crossing right where they
+    /// leave a card.
     let measureSankeyRibbons
         (context: ConnectorMeasureContext)
         (requests: SankeyRibbonRequest list)
@@ -170,11 +199,8 @@ module ConnectorMeasure =
         let resolved =
             requests
             |> List.choose (fun request ->
-                let sourceNodeId = DragDrop.groupNodeId request.Source.Side request.Source.Id
-                let targetNodeId = DragDrop.groupNodeId request.Target.Side request.Target.Id
-
-                match context.GroupNodes.TryFind sourceNodeId, context.GroupNodes.TryFind targetNodeId with
-                | Some sourceNode, Some targetNode ->
+                match tryRibbonNode context request.Source, tryRibbonNode context request.Target with
+                | Some(sourceNodeId, sourceNode), Some(targetNodeId, targetNode) ->
                     Some {
                         Request = request
                         SourceNodeId = sourceNodeId

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorMeasurement.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorMeasurement.fs
@@ -24,6 +24,14 @@ module private ConnectorDom =
         )
         |> Map.ofArray
 
+    let groupNodes (container: HTMLElement) =
+        querySelectorAll container "[data-provenance-group-node]"
+        |> Array.choose (fun node ->
+            let id = node.getAttribute "data-provenance-group-node"
+            if isNull id then None else Some(id, node)
+        )
+        |> Map.ofArray
+
 /// Measures connection handles and builds SVG connector paths between them.
 module ConnectorMeasure =
 
@@ -31,6 +39,7 @@ module ConnectorMeasure =
         Container = container
         Origin = container.getBoundingClientRect ()
         Nodes = ConnectorDom.connectionNodes container
+        GroupNodes = ConnectorDom.groupNodes container
     }
 
     let private tryHandle (context: ConnectorMeasureContext) handle =
@@ -45,33 +54,42 @@ module ConnectorMeasure =
             Y = rect.top - origin.top + float context.Container.scrollTop + rect.height / 2.
         }
 
-    let pathBetweenPoints start finish =
-        let deltaX = finish.X - start.X
+    let private controlXs (startX: float) (finishX: float) =
+        let deltaX = finishX - startX
         let direction = if deltaX >= 0. then 1. else -1.
         // The bend scales with the horizontal span, so connectors between nearby
         // endpoints stay short stubs instead of looping past their targets.
         let bend = max 8. (abs deltaX / 2.)
-        let firstControlX = start.X + direction * bend
-        let secondControlX = finish.X - direction * bend
+        startX + direction * bend, finishX - direction * bend
+
+    let pathBetweenPoints start finish =
+        let firstControlX, secondControlX = controlXs start.X finish.X
         Some $"M {start.X} {start.Y} C {firstControlX} {start.Y}, {secondControlX} {finish.Y}, {finish.X} {finish.Y}"
+
+    /// Closed sankey-band outline between two card-edge segments: the top and
+    /// bottom curves share the horizontal bend of the centerline bezier, so a
+    /// band tapers smoothly between edge shares of different heights.
+    let private sankeyRibbonPath
+        (sourceX: float)
+        (sourceTop: float, sourceBottom: float)
+        (targetX: float)
+        (targetTop: float, targetBottom: float)
+        =
+        let firstControlX, secondControlX = controlXs sourceX targetX
+
+        $"M {sourceX} {sourceTop} "
+        + $"C {firstControlX} {sourceTop}, {secondControlX} {targetTop}, {targetX} {targetTop} "
+        + $"L {targetX} {targetBottom} "
+        + $"C {secondControlX} {targetBottom}, {firstControlX} {sourceBottom}, {sourceX} {sourceBottom} Z"
 
     /// Cubic-bezier midpoint of the same control points pathBetweenPoints uses.
     let midpointBetweenPoints start finish =
-        let deltaX = finish.X - start.X
-        let direction = if deltaX >= 0. then 1. else -1.
-        let bend = max 8. (abs deltaX / 2.)
-        let firstControlX = start.X + direction * bend
-        let secondControlX = finish.X - direction * bend
+        let firstControlX, secondControlX = controlXs start.X finish.X
 
         {
             X = (start.X + 3. * firstControlX + 3. * secondControlX + finish.X) / 8.
             Y = (start.Y + finish.Y) / 2.
         }
-
-    let pathBetweenHandles context source target =
-        match tryHandle context source, tryHandle context target with
-        | Some sourceNode, Some targetNode -> pathBetweenPoints (center context sourceNode) (center context targetNode)
-        | _ -> None
 
     let pathWithMidpointBetweenHandles context source target =
         match tryHandle context source, tryHandle context target with
@@ -82,6 +100,162 @@ module ConnectorMeasure =
             pathBetweenPoints start finish
             |> Option.map (fun path -> path, midpointBetweenPoints start finish)
         | _ -> None
+
+    /// One sankey ribbon to lay out: the connection key, its group-card
+    /// endpoints, and the weight deciding its share of each card edge.
+    type SankeyRibbonRequest = {
+        Key: string
+        Source: ConnectionHandleRef
+        Target: ConnectionHandleRef
+        Weight: float
+    }
+
+    /// Centerline, ribbon outline and midpoint of one laid-out sankey ribbon.
+    type SankeyRibbon = {
+        Path: string
+        RibbonPath: string
+        Midpoint: ConnectionPoint
+    }
+
+    type private SankeyRect = {
+        Left: float
+        Right: float
+        Top: float
+        Bottom: float
+    }
+
+    type private ResolvedRibbon = {
+        Request: SankeyRibbonRequest
+        SourceNodeId: string
+        TargetNodeId: string
+        SourceRect: SankeyRect
+        TargetRect: SankeyRect
+    }
+
+    let private cardRect (context: ConnectorMeasureContext) (node: HTMLElement) : SankeyRect =
+        let origin = context.Origin
+        let rect = node.getBoundingClientRect ()
+        let left = rect.left - origin.left + float context.Container.scrollLeft
+        let top = rect.top - origin.top + float context.Container.scrollTop
+
+        {
+            Left = left
+            Right = left + rect.width
+            Top = top
+            Bottom = top + rect.height
+        }
+
+    /// Lays out group-connection ribbons like a sankey chart: the ribbons
+    /// attached to a card split its facing edge proportionally to their
+    /// weights, so together they cover the card's whole side and follow its
+    /// size; each ribbon then tapers between its two edge shares. Ribbons on
+    /// one edge stack in the vertical order of their opposite cards, keeping
+    /// bundles from crossing right where they leave a card.
+    let measureSankeyRibbons
+        (context: ConnectorMeasureContext)
+        (requests: SankeyRibbonRequest list)
+        : Map<string, SankeyRibbon> =
+        // This runs once per animation frame while scrolling or dragging, and
+        // several ribbons usually share a card - read each card rect once.
+        let rectCache = System.Collections.Generic.Dictionary<string, SankeyRect>()
+
+        let cachedCardRect nodeId node =
+            match rectCache.TryGetValue nodeId with
+            | true, rect -> rect
+            | _ ->
+                let rect = cardRect context node
+                rectCache.[nodeId] <- rect
+                rect
+
+        let resolved =
+            requests
+            |> List.choose (fun request ->
+                let sourceNodeId = DragDrop.groupNodeId request.Source.Side request.Source.Id
+                let targetNodeId = DragDrop.groupNodeId request.Target.Side request.Target.Id
+
+                match context.GroupNodes.TryFind sourceNodeId, context.GroupNodes.TryFind targetNodeId with
+                | Some sourceNode, Some targetNode ->
+                    Some {
+                        Request = request
+                        SourceNodeId = sourceNodeId
+                        TargetNodeId = targetNodeId
+                        SourceRect = cachedCardRect sourceNodeId sourceNode
+                        TargetRect = cachedCardRect targetNodeId targetNode
+                    }
+                | _ -> None
+            )
+
+        let segments nodeIdOf (rectOf: ResolvedRibbon -> SankeyRect) (oppositeRectOf: ResolvedRibbon -> SankeyRect) =
+            resolved
+            |> List.groupBy nodeIdOf
+            |> List.collect (fun (_, ribbons) ->
+                let rect = rectOf ribbons.Head
+                let totalWeight = ribbons |> List.sumBy (fun ribbon -> max 1. ribbon.Request.Weight)
+                let height = rect.Bottom - rect.Top
+
+                ribbons
+                |> List.sortBy (fun ribbon ->
+                    let opposite = oppositeRectOf ribbon
+                    (opposite.Top + opposite.Bottom) / 2.
+                )
+                |> List.fold
+                    (fun (offset, allocated) ribbon ->
+                        let share = height * (max 1. ribbon.Request.Weight) / totalWeight
+
+                        offset + share,
+                        (ribbon.Request.Key, (rect.Top + offset, rect.Top + offset + share))
+                        :: allocated
+                    )
+                    (0., [])
+                |> snd
+            )
+            |> Map.ofList
+
+        let sourceSegments =
+            segments
+                (fun ribbon -> ribbon.SourceNodeId)
+                (fun ribbon -> ribbon.SourceRect)
+                (fun ribbon -> ribbon.TargetRect)
+
+        let targetSegments =
+            segments
+                (fun ribbon -> ribbon.TargetNodeId)
+                (fun ribbon -> ribbon.TargetRect)
+                (fun ribbon -> ribbon.SourceRect)
+
+        resolved
+        |> List.choose (fun ribbon ->
+            match sourceSegments.TryFind ribbon.Request.Key, targetSegments.TryFind ribbon.Request.Key with
+            | Some sourceSegment, Some targetSegment ->
+                // Ribbons run between whichever card edges face each other.
+                let sourceX, targetX =
+                    if ribbon.TargetRect.Left >= ribbon.SourceRect.Right then
+                        ribbon.SourceRect.Right, ribbon.TargetRect.Left
+                    else
+                        ribbon.SourceRect.Left, ribbon.TargetRect.Right
+
+                let start = {
+                    X = sourceX
+                    Y = (fst sourceSegment + snd sourceSegment) / 2.
+                }
+
+                let finish = {
+                    X = targetX
+                    Y = (fst targetSegment + snd targetSegment) / 2.
+                }
+
+                pathBetweenPoints start finish
+                |> Option.map (fun path ->
+                    ribbon.Request.Key,
+                    {
+                        Path = path
+                        RibbonPath = sankeyRibbonPath sourceX sourceSegment targetX targetSegment
+                        Midpoint = midpointBetweenPoints start finish
+                    }
+                )
+            | _ -> None
+        )
+        |> Map.ofList
 
     /// Rail connectors shorter than this are skipped entirely so dense layouts do not
     /// fill the rail gutters with overlapping stubs.

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
@@ -189,7 +189,7 @@ type ConnectorOverlay =
 
                     ConnectorObserver.observeMatching
                         container
-                        "[data-provenance-group-node],[data-provenance-connection-node],[data-provenance-resize-node]"
+                        "[data-provenance-group-node],[data-provenance-member-node],[data-provenance-connection-node],[data-provenance-resize-node]"
                         observer
 
                 let mutationFrame = ref (None: float option)

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorOverlay.fs
@@ -361,16 +361,26 @@ type ConnectorOverlay =
                                         ]
                                     ]
                                 | _ -> ()
-                                // A wide transparent stroke is the actual pointer/keyboard target,
-                                // so selecting a thin curve no longer needs pixel accuracy.
+                                // The pointer/keyboard target: for ribbons the filled band
+                                // itself (transparent fill still hit-tests), for lines a wide
+                                // transparent stroke so selecting a thin curve no longer
+                                // needs pixel accuracy.
                                 match measured.InteractiveConnection with
                                 | Some connection ->
+                                    let hitPath = measured.RibbonPath |> Option.defaultValue measured.Path
+
                                     Svg.path [
-                                        svg.d measured.Path
-                                        svg.custom ("style", ConnectorSvg.pathStyle measured.Path animatePaths)
-                                        svg.fill "none"
-                                        svg.stroke "transparent"
-                                        svg.strokeWidth 14
+                                        svg.d hitPath
+                                        svg.custom ("style", ConnectorSvg.pathStyle hitPath animatePaths)
+
+                                        match measured.RibbonPath with
+                                        | Some _ ->
+                                            svg.fill "transparent"
+                                            svg.stroke "none"
+                                        | None ->
+                                            svg.fill "none"
+                                            svg.stroke "transparent"
+                                            svg.strokeWidth 14
                                         svg.className
                                             "swt:pointer-events-auto swt:cursor-pointer swt:outline-none swt:shadow-none"
                                         svg.custom ("tabIndex", "0")

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
@@ -41,6 +41,7 @@ module ConnectorPaths =
             Source = source
             Target = target
             SkipWhenClose = skipWhenClose
+            SankeyWeight = None
         }
 
     let private groupById (inputGroups: DisplayGroup list) (outputGroups: DisplayGroup list) side groupId =
@@ -121,19 +122,24 @@ module ConnectorPaths =
             )
         )
         |> List.map (fun connection ->
-            spec
-                $"connection:{connection.Id}"
-                "provenance-connection"
-                "swt:text-primary"
-                2.25
-                None
-                (Some connection)
-                (Some $"Select connection {connection.Id}")
-                None
-                false
-                (ConnectorHandles.group ProvenanceSide.Input connection.SourceGroupId)
-                (ConnectorHandles.group ProvenanceSide.Output connection.TargetGroupId)
-        )
+            // Group connectors paint as sankey ribbons instead of graph edges;
+            // weighting by the underlying connection count makes heavy bundles
+            // claim a wider share of their cards' edges.
+            {
+                spec
+                    $"connection:{connection.Id}"
+                    "provenance-connection"
+                    "swt:text-primary"
+                    2.25
+                    None
+                    (Some connection)
+                    (Some $"Select connection {connection.Id}")
+                    None
+                    false
+                    (ConnectorHandles.group ProvenanceSide.Input connection.SourceGroupId)
+                    (ConnectorHandles.group ProvenanceSide.Output connection.TargetGroupId) with
+                    SankeyWeight = Some(float connection.ConnectionIds.Length)
+            })
 
     let memberConnectionSpecs
         (model: ProvenanceModel)
@@ -437,6 +443,9 @@ module ConnectorPaths =
                 AriaLabel = None
                 Color = None
                 Midpoint = None
+                // Aiming keeps the classic line; only committed group
+                // connections render as ribbons.
+                RibbonPath = None
             })
         )
 
@@ -473,18 +482,41 @@ module ConnectorPaths =
     /// Resolves specs against the measured DOM; specs whose handles are missing or
     /// (for rail connectors) too close together are dropped.
     let measure context (specs: ConnectorSpec list) : MeasuredConnector list =
+        // Sankey ribbons cannot be measured one by one: every group connection
+        // claims a weighted share of its cards' facing edges, so they are laid
+        // out together first and looked up per spec below.
+        let sankeyRibbons =
+            specs
+            |> List.choose (fun spec ->
+                spec.SankeyWeight
+                |> Option.map (fun weight ->
+                    ({
+                        Key = spec.Key
+                        Source = spec.Source
+                        Target = spec.Target
+                        Weight = weight
+                    }
+                    : ConnectorMeasure.SankeyRibbonRequest)
+                )
+            )
+            |> ConnectorMeasure.measureSankeyRibbons context
+
         specs
         |> List.choose (fun spec ->
             let measured =
-                if spec.SkipWhenClose then
+                match spec.SankeyWeight with
+                | Some _ ->
+                    sankeyRibbons.TryFind spec.Key
+                    |> Option.map (fun ribbon -> ribbon.Path, Some ribbon.RibbonPath, Some ribbon.Midpoint)
+                | None when spec.SkipWhenClose ->
                     ConnectorMeasure.pathBetweenDistantHandles context spec.Source spec.Target
-                    |> Option.map (fun path -> path, None)
-                else
+                    |> Option.map (fun path -> path, None, None)
+                | None ->
                     ConnectorMeasure.pathWithMidpointBetweenHandles context spec.Source spec.Target
-                    |> Option.map (fun (path, midpoint) -> path, Some midpoint)
+                    |> Option.map (fun (path, midpoint) -> path, None, Some midpoint)
 
             measured
-            |> Option.map (fun (path, midpoint) -> {
+            |> Option.map (fun (path, ribbonPath, midpoint) -> {
                 Key = spec.Key
                 Path = path
                 TestId = spec.TestId
@@ -495,5 +527,6 @@ module ConnectorPaths =
                 AriaLabel = spec.AriaLabel
                 Color = spec.Color
                 Midpoint = midpoint
+                RibbonPath = ribbonPath
             })
         )

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
@@ -201,12 +201,14 @@ module ConnectorPaths =
                         // Member connectors are ribbons too, so expanding a card
                         // fans its group ribbon out into per-member ribbons instead
                         // of falling back to plain lines. Each stands for exactly
-                        // one underlying connection, hence the unit weight.
+                        // one underlying connection, hence the unit weight. The
+                        // visual path inherits pointer-events:none from the SVG
+                        // root; only the separate hit path opts back in.
                         {
                             spec
                                 $"member:{displayConnection.Id}:{connectionId}"
                                 "provenance-member-connection"
-                                "swt:text-primary/70 swt:pointer-events-none"
+                                "swt:text-primary/70"
                                 2.0
                                 None
                                 (Some singleConnection)

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
@@ -198,18 +198,25 @@ module ConnectorPaths =
                                 ConnectionIds = [ connectionId ]
                         }
 
-                        spec
-                            $"member:{displayConnection.Id}:{connectionId}"
-                            "provenance-member-connection"
-                            "swt:text-primary/70 swt:pointer-events-none"
-                            2.0
-                            None
-                            (Some singleConnection)
-                            (Some $"Select connection {displayConnection.Id}")
-                            None
-                            false
-                            source
-                            target
+                        // Member connectors are ribbons too, so expanding a card
+                        // fans its group ribbon out into per-member ribbons instead
+                        // of falling back to plain lines. Each stands for exactly
+                        // one underlying connection, hence the unit weight.
+                        {
+                            spec
+                                $"member:{displayConnection.Id}:{connectionId}"
+                                "provenance-member-connection"
+                                "swt:text-primary/70 swt:pointer-events-none"
+                                2.0
+                                None
+                                (Some singleConnection)
+                                (Some $"Select connection {displayConnection.Id}")
+                                None
+                                false
+                                source
+                                target with
+                                SankeyWeight = Some 1.
+                        }
                     )
                 )
         )

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorRendering.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorRendering.fs
@@ -28,15 +28,49 @@ module ConnectorSvg =
             "d" ==> $"path('{path}')"
             "transition"
             ==> (if animate then
-                     "d 160ms ease, stroke-width 120ms ease, stroke-opacity 120ms ease"
+                     "d 160ms ease, stroke-width 120ms ease, stroke-opacity 120ms ease, fill-opacity 120ms ease"
                  else
-                     "stroke-width 120ms ease, stroke-opacity 120ms ease")
+                     "stroke-width 120ms ease, stroke-opacity 120ms ease, fill-opacity 120ms ease")
         ]
 
-    let strokeElements (measured: MeasuredConnector) strokeWidth strokeOpacity animate isNew debug =
-        let strokeColor = measured.Color |> Option.defaultValue "currentColor"
-        let debugAttributes = debugAttributes debug measured
+    /// Fill opacity for sankey ribbons, derived from the caller's stroke
+    /// opacity scale (1.0 emphasized / 0.85 default / 0.3 receded). Ribbons
+    /// stay translucent on purpose: overlapping bands compound and read as a
+    /// denser flow instead of hiding each other.
+    let private ribbonFillOpacity strokeOpacity =
+        if strokeOpacity >= 1.0 then 0.7
+        elif strokeOpacity <= 0.3 then 0.12
+        else 0.4
 
+    /// Sankey band: one translucent fill, no halo - crossings are meant to
+    /// stack visually. A draw-in dash animation cannot work on a fill, so new
+    /// ribbons fade in.
+    let private ribbonElements
+        (measured: MeasuredConnector)
+        (ribbonPath: string)
+        fillColor
+        fillOpacity
+        animate
+        isNew
+        debug
+        =
+        [
+            Svg.path [
+                svg.d ribbonPath
+                svg.custom ("style", pathStyle ribbonPath animate)
+                svg.fill fillColor
+                svg.custom ("fillOpacity", fillOpacity)
+                svg.stroke "none"
+                svg.className (measured.ClassName + (if isNew then " swt:connector-fade-in" else ""))
+                match measured.Color with
+                | Some color -> svg.custom ("data-provenance-color", color)
+                | None -> ()
+                if measured.InteractiveConnection.IsNone then
+                    yield! debugAttributes debug measured
+            ]
+        ]
+
+    let private lineElements (measured: MeasuredConnector) strokeColor strokeWidth strokeOpacity animate isNew debug =
         // Freshly created solid connectors draw themselves in along the curve; new
         // dashed rail connectors fade in instead, because a dash offset animation
         // would fight their dash pattern.
@@ -90,9 +124,17 @@ module ConnectorSvg =
                 | Some color -> svg.custom ("data-provenance-color", color)
                 | None -> ()
                 if measured.InteractiveConnection.IsNone then
-                    yield! debugAttributes
+                    yield! debugAttributes debug measured
             ]
         ]
+
+    let strokeElements (measured: MeasuredConnector) strokeWidth strokeOpacity animate isNew debug =
+        let paintColor = measured.Color |> Option.defaultValue "currentColor"
+
+        match measured.RibbonPath with
+        | Some ribbonPath ->
+            ribbonElements measured ribbonPath paintColor (ribbonFillOpacity strokeOpacity) animate isNew debug
+        | None -> lineElements measured paintColor strokeWidth strokeOpacity animate isNew debug
 
 module ConnectorContextMenu =
 

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorTypes.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorTypes.fs
@@ -24,6 +24,11 @@ type MeasuredConnector = {
     /// Curve midpoint, measured so summary badges (e.g. underlying-connection
     /// counts) can sit on the line without re-deriving the bezier.
     Midpoint: ConnectionPoint option
+    /// Closed sankey-ribbon outline. When set, the connector is painted as a
+    /// translucent filled band spanning its share of both card edges instead
+    /// of a stroked line; `Path` stays the centerline for the midpoint badge,
+    /// while the ribbon itself is the pointer target.
+    RibbonPath: string option
 }
 
 /// Logical connector between two handles, derived purely from model/UI state.
@@ -43,6 +48,11 @@ type ConnectorSpec = {
     Target: ConnectionHandleRef
     /// Rail connectors drop out entirely when their endpoints are too close.
     SkipWhenClose: bool
+    /// Weight for connectors drawn as sankey ribbons (group connections): the
+    /// ribbon claims this share of each card edge relative to the other
+    /// ribbons attached there, so together they cover the card's full side.
+    /// None keeps the stroked-line rendering.
+    SankeyWeight: float option
 }
 
 type ConnectorOverlayState = {
@@ -80,4 +90,7 @@ type ConnectorMeasureContext = {
     Container: HTMLElement
     Origin: ClientRect
     Nodes: Map<string, HTMLElement>
+    /// Group-card elements by their `data-provenance-group-node` id; sankey
+    /// ribbons measure whole card edges instead of the small handle circles.
+    GroupNodes: Map<string, HTMLElement>
 }

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorTypes.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorTypes.fs
@@ -48,10 +48,11 @@ type ConnectorSpec = {
     Target: ConnectionHandleRef
     /// Rail connectors drop out entirely when their endpoints are too close.
     SkipWhenClose: bool
-    /// Weight for connectors drawn as sankey ribbons (group connections): the
-    /// ribbon claims this share of each card edge relative to the other
-    /// ribbons attached there, so together they cover the card's full side.
-    /// None keeps the stroked-line rendering.
+    /// Weight for connectors drawn as sankey ribbons (group and member
+    /// connections): the ribbon claims this share of each endpoint edge (card
+    /// side or member-row side) relative to the other ribbons attached there,
+    /// so together they cover the edge completely. None keeps the
+    /// stroked-line rendering.
     SankeyWeight: float option
 }
 
@@ -93,4 +94,8 @@ type ConnectorMeasureContext = {
     /// Group-card elements by their `data-provenance-group-node` id; sankey
     /// ribbons measure whole card edges instead of the small handle circles.
     GroupNodes: Map<string, HTMLElement>
+    /// Member-row elements of expanded cards by their
+    /// `data-provenance-member-node` id; member-level sankey ribbons measure
+    /// whole row edges the way group ribbons measure card edges.
+    MemberNodes: Map<string, HTMLElement>
 }

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -234,21 +234,149 @@ type Controls =
         )
 
     [<ReactComponent>]
-    static member LayerPagination
+    static member private LayerPageArrow
         (
-            session: ProvenanceSession,
+            label: string,
+            iconClass: string,
+            target: ProvenanceLayerId option,
             onSelect: ProvenanceLayerId -> unit,
-            onAddLayer: ProvenanceSourceName -> unit,
-            ?debug: bool,
-            ?sourceColors: Map<ProvenanceSourceId, ProvenanceColor>,
-            ?onSetSourceColor: ProvenanceSourceId -> ProvenanceColor option -> unit,
-            ?seedSummary: string
+            testId: string,
+            ?debug: bool
         ) =
+        Html.button [
+            prop.type'.button
+            prop.className [
+                "swt:btn swt:btn-sm swt:btn-outline swt:w-10 swt:px-0"
+                if target.IsNone then
+                    "swt:opacity-40"
+            ]
+            prop.title label
+            prop.ariaLabel label
+            prop.disabled target.IsNone
+            if target.IsSome && defaultArg debug false then
+                prop.testId testId
+            prop.onClick (fun _ -> target |> Option.iter onSelect)
+            prop.children [
+                Html.i [ prop.className $"swt:iconify {iconClass} swt:size-4" ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member private LayerPageButton
+        (
+            layerId: ProvenanceLayerId,
+            name: string,
+            isActive: bool,
+            onSelect: ProvenanceLayerId -> unit,
+            ?sourceColor: ProvenanceColor,
+            ?debug: bool,
+            ?key: string
+        ) =
+        Html.button [
+            match key with
+            | Some key -> prop.key key
+            | None -> ()
+            prop.type'.button
+            prop.title $"View provenance layer {name}"
+            prop.ariaLabel $"View provenance layer {name}"
+            prop.custom ("data-provenance-layer-page", layerId)
+            prop.className [
+                "swt:btn swt:btn-sm swt:min-w-0 swt:px-3"
+                if isActive then
+                    "swt:btn-primary swt:font-semibold"
+                else
+                    "swt:btn-outline swt:opacity-50 swt:hover:opacity-100"
+            ]
+            // Equal-width slots keep the bar from resizing as the window moves.
+            prop.style [ style.custom ("width", "clamp(4.5rem, 18vw, 7rem)") ]
+            if defaultArg debug false then
+                prop.testId $"provenance-layer-{layerId}"
+                prop.custom ("data-provenance-layer-color", sourceColor |> Option.defaultValue "")
+            prop.onClick (fun _ -> onSelect layerId)
+            prop.children [
+                match sourceColor with
+                | Some color when color <> "" ->
+                    Html.span [
+                        prop.className "swt:size-2 swt:shrink-0 swt:rounded-full"
+                        prop.style [ style.backgroundColor color ]
+                    ]
+                | _ -> Html.none
+                Html.span [
+                    prop.className "swt:min-w-0 swt:truncate"
+                    prop.text name
+                ]
+            ]
+        ]
+
+    [<ReactComponent>]
+    static member private LayerJumpPopover
+        (session: ProvenanceSession, onSelect: ProvenanceLayerId -> unit, ?debug: bool)
+        =
+        let isOpen, setIsOpen = React.useState false
+
+        Popover.Popover(
+            isOpen = isOpen,
+            onOpenChange = setIsOpen,
+            ?debug =
+                (if defaultArg debug false then
+                     Some "provenance-layer-jump-popover"
+                 else
+                     None),
+            children =
+                React.Fragment [
+                    Popover.Trigger(
+                        Html.button [
+                            prop.title "Jump to layer"
+                            prop.ariaLabel "Jump to layer"
+                            prop.type'.button
+                            prop.className "swt:btn swt:btn-sm swt:btn-outline swt:w-10 swt:px-0 swt:font-semibold"
+                            if defaultArg debug false then
+                                prop.testId "provenance-layer-jump"
+                            prop.text "..."
+                        ]
+                    )
+                    Popover.Content(
+                        children =
+                            Html.div [
+                                prop.className "swt:flex swt:min-w-48 swt:flex-col swt:gap-2 swt:p-2"
+                                prop.children [
+                                    Html.label [ prop.className "swt:label"; prop.text "Jump to layer" ]
+                                    Html.select [
+                                        prop.className "swt:select swt:select-bordered swt:select-sm swt:w-full"
+                                        prop.ariaLabel "Select layer"
+                                        prop.title "Jump to a layer"
+                                        if defaultArg debug false then
+                                            prop.testId "provenance-layer-select"
+                                        prop.value session.ActiveLayerId
+                                        prop.onChange (fun (layerId: string) ->
+                                            onSelect layerId
+                                            setIsOpen false
+                                        )
+                                        prop.children [
+                                            for layerId in session.LayerOrder do
+                                                let layer = Session.layerById layerId session
+
+                                                Html.option [
+                                                    prop.key layerId
+                                                    prop.value layerId
+                                                    prop.text layer.Model.Source.Name
+                                                ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                    )
+                ]
+        )
+
+    [<ReactComponent>]
+    static member private AddLayerPopover
+        (session: ProvenanceSession, onAddLayer: ProvenanceSourceName -> unit, ?seedSummary: string, ?debug: bool)
+        =
         let defaultNextLayerName (session: ProvenanceSession) =
             $"Layer {session.LayerOrder.Length + 1}"
 
-        let isAddLayerOpen, setIsAddLayerOpen = React.useState false
-        let isLayerJumpOpen, setIsLayerJumpOpen = React.useState false
+        let isOpen, setIsOpen = React.useState false
         let layerName, setLayerName = React.useState (defaultNextLayerName session)
 
         React.useEffect ((fun () -> setLayerName (defaultNextLayerName session)), [| box session.LayerOrder.Length |])
@@ -259,45 +387,93 @@ type Controls =
             if not (String.IsNullOrWhiteSpace trimmed) then
                 onAddLayer trimmed
                 setLayerName (defaultNextLayerName session)
-                setIsAddLayerOpen false
+                setIsOpen false
 
-        let addLayerContent =
-            Html.form [
-                prop.className "swt:flex swt:min-w-56 swt:flex-col swt:gap-2"
-                prop.onSubmit (fun event ->
-                    event.preventDefault ()
-                    submitLayerName ()
-                )
-                prop.children [
-                    match seedSummary with
-                    | Some summary ->
-                        Html.p [
-                            prop.className "swt:max-w-56 swt:text-xs swt:text-base-content/70"
+        Popover.Popover(
+            isOpen = isOpen,
+            onOpenChange = setIsOpen,
+            ?debug =
+                (if defaultArg debug false then
+                     Some "provenance-add-layer-popover"
+                 else
+                     None),
+            children =
+                React.Fragment [
+                    Popover.Trigger(
+                        Html.button [
+                            prop.title "Add layer"
+                            prop.type'.button
+                            prop.className "swt:btn swt:btn-sm swt:btn-primary"
                             if defaultArg debug false then
-                                prop.testId "provenance-layer-seed-summary"
-                            prop.text summary
+                                prop.testId "provenance-add-layer"
+                            prop.children [
+                                Html.i [
+                                    prop.className "swt:iconify swt:fluent--add-square-multiple-20-regular swt:size-4"
+                                ]
+                                Html.span "Layer"
+                            ]
                         ]
-                    | None -> ()
-                    Html.label [ prop.className "swt:label"; prop.text "Layer name" ]
-                    Html.input [
-                        prop.ariaLabel "Layer name"
-                        prop.className "swt:input swt:input-bordered swt:input-sm"
-                        prop.required true
-                        prop.value layerName
-                        prop.onChange setLayerName
-                    ]
-                    Html.button [
-                        prop.type'.submit
-                        prop.className "swt:btn swt:btn-primary swt:btn-sm"
-                        prop.text "Create layer"
-                    ]
+                    )
+                    Popover.Content(
+                        children =
+                            Html.form [
+                                prop.className "swt:flex swt:min-w-56 swt:flex-col swt:gap-2 swt:p-2"
+                                prop.onSubmit (fun event ->
+                                    event.preventDefault ()
+                                    submitLayerName ()
+                                )
+                                prop.children [
+                                    // Announces which entities will seed the new layer's inputs, so
+                                    // the effect of the current selection (or its absence) is visible
+                                    // before the layer is created.
+                                    match seedSummary with
+                                    | Some summary ->
+                                        Html.p [
+                                            prop.className "swt:max-w-56 swt:text-xs swt:text-base-content/70"
+                                            if defaultArg debug false then
+                                                prop.testId "provenance-layer-seed-summary"
+                                            prop.text summary
+                                        ]
+                                    | None -> ()
+                                    Html.label [ prop.className "swt:label"; prop.text "Layer name" ]
+                                    Html.input [
+                                        prop.ariaLabel "Layer name"
+                                        prop.className "swt:input swt:input-bordered swt:input-sm"
+                                        prop.required true
+                                        prop.value layerName
+                                        prop.onChange setLayerName
+                                    ]
+                                    Html.button [
+                                        prop.type'.submit
+                                        prop.className "swt:btn swt:btn-primary swt:btn-sm"
+                                        prop.text "Create layer"
+                                    ]
+                                ]
+                            ]
+                    )
                 ]
-            ]
+        )
 
+    [<ReactComponent>]
+    static member LayerPagination
+        (
+            session: ProvenanceSession,
+            onSelect: ProvenanceLayerId -> unit,
+            onAddLayer: ProvenanceSourceName -> unit,
+            ?debug: bool,
+            ?sourceColors: Map<ProvenanceSourceId, ProvenanceColor>,
+            ?onSetSourceColor: ProvenanceSourceId -> ProvenanceColor option -> unit,
+            ?seedSummary: string
+        ) =
         let activeIndex =
             session.LayerOrder
             |> List.tryFindIndex (fun layerId -> layerId = session.ActiveLayerId)
             |> Option.defaultValue 0
+
+        // The active layer plus one neighbor on each side, clamped to the ends.
+        let visibleLayerIds =
+            let start = max 0 (min (activeIndex - 1) (session.LayerOrder.Length - 3))
+            session.LayerOrder |> List.skip start |> List.truncate 3
 
         let sourceColorOf (layer: ProvenanceLayer) =
             sourceColors
@@ -305,82 +481,10 @@ type Controls =
 
         let activeLayer = Session.layerById session.ActiveLayerId session
 
-        let arrowButton (label: string) (iconClass: string) (targetIndex: int) (testId: string) =
-            let target = session.LayerOrder |> List.tryItem targetIndex
-
-            Html.button [
-                prop.type'.button
-                prop.className [
-                    "swt:btn swt:btn-sm swt:btn-outline swt:w-10 swt:px-0"
-                    if target.IsNone then
-                        "swt:opacity-40"
-                ]
-                prop.title label
-                prop.ariaLabel label
-                prop.disabled target.IsNone
-                if target.IsSome && defaultArg debug false then
-                    prop.testId testId
-                prop.onClick (fun _ -> target |> Option.iter onSelect)
-                prop.children [
-                    Html.i [ prop.className $"swt:iconify {iconClass} swt:size-4" ]
-                ]
-            ]
-
-        let pageSlot layerId =
-            let layer = Session.layerById layerId session
-            let sourceColor = sourceColorOf layer
-            let isActive = layerId = session.ActiveLayerId
-
-            Html.button [
-                prop.key layerId
-                prop.type'.button
-                prop.title $"View provenance layer {layer.Model.Source.Name}"
-                prop.ariaLabel $"View provenance layer {layer.Model.Source.Name}"
-                prop.custom ("data-provenance-layer-page", layerId)
-                prop.className [
-                    "swt:btn swt:btn-sm swt:min-w-0 swt:px-3"
-                    if isActive then
-                        "swt:btn-primary swt:font-semibold"
-                    else
-                        "swt:btn-outline swt:opacity-60 swt:hover:opacity-100"
-                ]
-                prop.style [ style.custom ("width", "clamp(4.5rem, 18vw, 7rem)") ]
-                if defaultArg debug false then
-                    prop.testId $"provenance-layer-{layerId}"
-                    prop.custom ("data-provenance-layer-color", sourceColor |> Option.defaultValue "")
-                prop.onClick (fun _ -> onSelect layerId)
-                prop.children [
-                    match sourceColor with
-                    | Some color when color <> "" ->
-                        Html.span [
-                            prop.className "swt:size-2 swt:shrink-0 swt:rounded-full"
-                            prop.style [ style.backgroundColor color ]
-                        ]
-                    | _ -> Html.none
-                    Html.span [
-                        prop.className "swt:min-w-0 swt:truncate"
-                        prop.text layer.Model.Source.Name
-                    ]
-                ]
-            ]
-
-        let pageSlots =
-            let layerCount = session.LayerOrder.Length
-
-            if layerCount <= 3 then
-                [ 0..2 ] |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
-            elif activeIndex = 0 then
-                [ 0..2 ] |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
-            elif activeIndex = layerCount - 1 then
-                [ layerCount - 3 .. layerCount - 1 ]
-                |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
-            else
-                [ activeIndex - 1 .. activeIndex + 1 ]
-                |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
-
         Html.div [
             prop.className
                 "swt:pointer-events-auto swt:flex swt:max-w-full swt:min-w-0 swt:items-center swt:justify-center swt:gap-2 swt:rounded-box swt:border swt:border-base-content/20 swt:bg-base-100 swt:px-3 swt:py-2 swt:shadow-md swt:ring-1 swt:ring-base-300"
+            // A fixed bar width so the control does not shift as layer names change.
             prop.style [ style.custom ("width", "min(40rem, calc(100vw - 2rem))") ]
             prop.custom ("role", "navigation")
             prop.ariaLabel "Layer pagination"
@@ -393,75 +497,37 @@ type Controls =
                     if defaultArg debug false then
                         prop.testId "provenance-layer-pages"
                     prop.children [
-                        arrowButton
-                            "Previous layer"
-                            "swt:fluent--chevron-left-20-regular"
-                            (activeIndex - 1)
-                            "provenance-layer-prev"
-                        for layerId in pageSlots do
-                            pageSlot layerId
-                        arrowButton
-                            "Next layer"
-                            "swt:fluent--chevron-right-20-regular"
-                            (activeIndex + 1)
-                            "provenance-layer-next"
+                        Controls.LayerPageArrow(
+                            "Previous layer",
+                            "swt:fluent--chevron-left-20-regular",
+                            session.LayerOrder |> List.tryItem (activeIndex - 1),
+                            onSelect,
+                            "provenance-layer-prev",
+                            ?debug = debug
+                        )
+                        for layerId in visibleLayerIds do
+                            let layer = Session.layerById layerId session
+
+                            Controls.LayerPageButton(
+                                layerId,
+                                layer.Model.Source.Name,
+                                (layerId = session.ActiveLayerId),
+                                onSelect,
+                                ?sourceColor = sourceColorOf layer,
+                                ?debug = debug,
+                                key = layerId
+                            )
+                        Controls.LayerPageArrow(
+                            "Next layer",
+                            "swt:fluent--chevron-right-20-regular",
+                            session.LayerOrder |> List.tryItem (activeIndex + 1),
+                            onSelect,
+                            "provenance-layer-next",
+                            ?debug = debug
+                        )
                     ]
                 ]
-                Popover.Popover(
-                    isOpen = isLayerJumpOpen,
-                    onOpenChange = setIsLayerJumpOpen,
-                    ?debug =
-                        (if defaultArg debug false then
-                             Some "provenance-layer-jump-popover"
-                         else
-                             None),
-                    children =
-                        React.Fragment [
-                            Popover.Trigger(
-                                Html.button [
-                                    prop.title "Jump to layer"
-                                    prop.ariaLabel "Jump to layer"
-                                    prop.type'.button
-                                    prop.className
-                                        "swt:btn swt:btn-sm swt:btn-outline swt:w-10 swt:px-0 swt:font-semibold"
-                                    if defaultArg debug false then
-                                        prop.testId "provenance-layer-jump"
-                                    prop.text "..."
-                                ]
-                            )
-                            Popover.Content(
-                                children =
-                                    Html.div [
-                                        prop.className "swt:flex swt:min-w-48 swt:flex-col swt:gap-2 swt:p-2"
-                                        prop.children [
-                                            Html.label [ prop.className "swt:label"; prop.text "Jump to layer" ]
-                                            Html.select [
-                                                prop.className "swt:select swt:select-bordered swt:select-sm swt:w-full"
-                                                prop.ariaLabel "Select layer"
-                                                prop.title "Jump to a layer"
-                                                if defaultArg debug false then
-                                                    prop.testId "provenance-layer-select"
-                                                prop.value session.ActiveLayerId
-                                                prop.onChange (fun (layerId: string) ->
-                                                    onSelect layerId
-                                                    setIsLayerJumpOpen false
-                                                )
-                                                prop.children [
-                                                    for layerId in session.LayerOrder do
-                                                        let layer = Session.layerById layerId session
-
-                                                        Html.option [
-                                                            prop.key layerId
-                                                            prop.value layerId
-                                                            prop.text layer.Model.Source.Name
-                                                        ]
-                                                ]
-                                            ]
-                                        ]
-                                    ]
-                            )
-                        ]
-                )
+                Controls.LayerJumpPopover(session, onSelect, ?debug = debug)
                 match onSetSourceColor with
                 | Some setSourceColor ->
                     Controls.LayerColorButton(
@@ -471,41 +537,7 @@ type Controls =
                         triggerClassName = "swt:btn swt:btn-sm swt:btn-outline swt:min-h-8 swt:w-8 swt:px-0"
                     )
                 | None -> Html.none
-                Popover.Popover(
-                    isOpen = isAddLayerOpen,
-                    onOpenChange = setIsAddLayerOpen,
-                    ?debug =
-                        (if defaultArg debug false then
-                             Some "provenance-add-layer-popover"
-                         else
-                             None),
-                    children =
-                        React.Fragment [
-                            Popover.Trigger(
-                                Html.button [
-                                    prop.title "Add layer"
-                                    prop.type'.button
-                                    prop.className "swt:btn swt:btn-sm swt:btn-primary"
-                                    if defaultArg debug false then
-                                        prop.testId "provenance-add-layer"
-                                    prop.children [
-                                        Html.i [
-                                            prop.className
-                                                "swt:iconify swt:fluent--add-square-multiple-20-regular swt:size-4"
-                                        ]
-                                        Html.span "Layer"
-                                    ]
-                                ]
-                            )
-                            Popover.Content(
-                                children =
-                                    Html.div [
-                                        prop.className "swt:p-2"
-                                        prop.children [ addLayerContent ]
-                                    ]
-                            )
-                        ]
-                )
+                Controls.AddLayerPopover(session, onAddLayer, ?seedSummary = seedSummary, ?debug = debug)
             ]
         ]
 

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -199,11 +199,11 @@ type Controls =
                                 step
                                     1
                                     "Group"
-                                    "Click a property in a side rail to merge entities sharing its values into one card."
+                                    "Click an annotation in a side rail to merge entities sharing its values into one card."
                                 step
                                     2
                                     "Annotate"
-                                    "Expand a property's values and drag a value chip onto a card to set it for every member at once."
+                                    "Expand an annotation's values and drag a value chip onto a card to set it for every member at once."
                                 step
                                     3
                                     "Connect"
@@ -226,7 +226,7 @@ type Controls =
                                     (OriginSymbols.upstreamIcon "swt:size-4")
                                     "Value inherited from an upstream table"
                                 legendRow (lineSample false) "Input–output connection"
-                                legendRow (lineSample true) "Where a property or value occurs"
+                                legendRow (lineSample true) "Where an annotation or value occurs"
                             ]
                         ]
                     ]
@@ -1087,13 +1087,13 @@ type Controls =
                 if headers.IsEmpty then
                     Html.p [
                         prop.className "swt:text-sm swt:text-base-content/60 swt:text-center swt:py-8"
-                        prop.text "Drag properties here, then click one to group by it"
+                        prop.text "Drag annotations here, then click one to group by it"
                     ]
 
                     Html.div [
                         prop.className "swt:w-fit"
                         prop.children [
-                            Controls.AddValuePopover(None, onAddValue, label = "Add property", ?debug = debug)
+                            Controls.AddValuePopover(None, onAddValue, label = "Add annotation", ?debug = debug)
                         ]
                     ]
                 else
@@ -1103,7 +1103,7 @@ type Controls =
                             if side = ProvenanceSide.Output then
                                 "swt:self-end"
                         ]
-                        prop.title "Click a property to group this side's entities by its values"
+                        prop.title "Click an annotation to group this side's entities by its values"
                         prop.text "Group by"
                     ]
 
@@ -1161,7 +1161,7 @@ type Controls =
                                 "swt:self-end"
                         ]
                         prop.children [
-                            Controls.AddValuePopover(None, onAddValue, label = "Add property", ?debug = debug)
+                            Controls.AddValuePopover(None, onAddValue, label = "Add annotation", ?debug = debug)
                         ]
                     ]
             ]
@@ -1201,7 +1201,7 @@ type Controls =
         let category =
             nextHeader
             |> Option.map (fun next -> next.Category.Name)
-            |> Option.defaultValue "Property"
+            |> Option.defaultValue "Annotation"
 
         let nextValue = ValueDrafts.tryValue kind value term
         let canCreate = nextHeader.IsSome && nextValue.IsSome
@@ -1218,7 +1218,7 @@ type Controls =
                         Html.span [
                             prop.text (
                                 label
-                                |> Option.defaultValue (if header.IsSome then "Add value" else "Add property")
+                                |> Option.defaultValue (if header.IsSome then "Add value" else "Add annotation")
                             )
                         ]
                     ]
@@ -1237,7 +1237,7 @@ type Controls =
                         if header.IsNone then
                             Html.label [
                                 prop.className "swt:label"
-                                prop.text "Property category"
+                                prop.text "Annotation category"
                             ]
 
                             TermSearch.TermSearch(
@@ -1288,7 +1288,7 @@ type Controls =
                             prop.type'.submit
                             prop.disabled (not canCreate)
                             prop.className "swt:btn swt:btn-primary swt:btn-sm"
-                            prop.text (if header.IsSome then "Add value" else "Add property")
+                            prop.text (if header.IsSome then "Add value" else "Add annotation")
                         ]
                     ]
                 ],
@@ -1717,7 +1717,7 @@ type Controls =
                 ]
                 Html.input [
                     prop.className "swt:input swt:input-bordered swt:input-sm swt:w-full swt:pl-8"
-                    prop.placeholder "Search properties & values..."
+                    prop.placeholder "Search annotations & values..."
                     prop.value searchDraft
                     prop.onChange setSearchDraft
                 ]
@@ -1818,7 +1818,7 @@ type Controls =
                         ]
                     ],
                     React.Fragment [
-                        propertySortOption PropertySort.ValueCountDesc "Property Value Count"
+                        propertySortOption PropertySort.ValueCountDesc "Annotation Value Count"
                         propertySortOption PropertySort.NameAsc "Name"
                         propertySortOption PropertySort.ConnectionCountDesc "Connection Count"
                     ],
@@ -1853,7 +1853,7 @@ type Controls =
                 )
                 Html.select [
                     prop.className "swt:select swt:select-bordered swt:select-sm swt:w-20 swt:shrink-0"
-                    prop.ariaLabel "Filter by property value count"
+                    prop.ariaLabel "Filter by annotation value count"
                     prop.value (
                         match filters.ValueCountFilter with
                         | PropertyValueCountFilter.Any -> "Any"
@@ -1881,15 +1881,15 @@ type Controls =
                     prop.children [
                         originButton
                             PropertyOriginFilter.AnyUpstream
-                            "Show upstream properties"
+                            "Show upstream annotations"
                             (OriginSymbols.upstreamIcon "swt:size-4")
                         originButton
                             PropertyOriginFilter.CurrentOnly
-                            "Show current properties"
+                            "Show current annotations"
                             (OriginSymbols.currentIcon "swt:size-4")
                         originButton
                             PropertyOriginFilter.AnyOrigin
-                            "Show current and upstream properties"
+                            "Show current and upstream annotations"
                             (OriginSymbols.bothIcons "swt:size-4")
                     ]
                 ]
@@ -1917,11 +1917,11 @@ type Controls =
                     match currentColor with
                     | Some c when c <> "" -> prop.style [ style.backgroundColor c ]
                     | _ -> ()
-                    prop.ariaLabel $"Set color for property {header.Category.Name}"
+                    prop.ariaLabel $"Set color for annotation {header.Category.Name}"
                 ],
             content =
                 ColorPicker.content
-                    $"Choose color for property {header.Category.Name}"
+                    $"Choose color for annotation {header.Category.Name}"
                     draftColor
                     setDraftColor
                     onSetColor,

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -404,6 +404,8 @@ type Controls =
                             prop.title "Add layer"
                             prop.type'.button
                             prop.className "swt:btn swt:btn-sm swt:btn-primary"
+                            // Always-on anchor for the interactive tutorial's spotlight.
+                            prop.custom ("data-tutorial", "provenance-add-layer")
                             if defaultArg debug false then
                                 prop.testId "provenance-add-layer"
                             prop.children [
@@ -706,6 +708,9 @@ type Controls =
 
                 ]
                 prop.custom ("data-provenance-resize-node", "true")
+                // Always-on anchor so the tutorial can target this button
+                // without coupling to its title copy.
+                prop.custom ("data-tutorial-group-by", $"{side}:{header.Category.Name}")
                 if defaultArg debug false then
                     prop.testId $"provenance-property-{side}-{header.Category.Name}"
                 prop.onClick (fun _ -> onToggleSide header)
@@ -791,6 +796,9 @@ type Controls =
                 ]
                 if defaultArg debug false then
                     prop.testId $"provenance-property-expand-{side}-{header.Category.Name}"
+                // Always-on anchor so the tutorial can target the chevron
+                // without coupling to its aria-label copy.
+                prop.custom ("data-tutorial-expand-values", $"{side}:{header.Category.Name}")
                 prop.ariaLabel (
                     if expanded then
                         $"Collapse {header.Category.Name} values"

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -1741,6 +1741,7 @@ type Controls =
                 Html.input [
                     prop.className "swt:input swt:input-bordered swt:input-sm swt:w-full swt:pl-8"
                     prop.placeholder "Search annotations & values..."
+                    prop.ariaLabel "Search annotations & values"
                     prop.value searchDraft
                     prop.onChange setSearchDraft
                 ]

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -287,8 +287,10 @@ type Controls =
                 else
                     "swt:btn-outline swt:opacity-50 swt:hover:opacity-100"
             ]
-            // Equal-width slots keep the bar from resizing as the window moves.
-            prop.style [ style.custom ("width", "clamp(4.5rem, 18vw, 7rem)") ]
+            // Equal-width slots keep the bar from resizing as the window moves;
+            // percent-based so embeds at any width scale with their container
+            // instead of the viewport.
+            prop.style [ style.custom ("width", "clamp(4.5rem, 18%, 7rem)") ]
             if defaultArg debug false then
                 prop.testId $"provenance-layer-{layerId}"
                 prop.custom ("data-provenance-layer-color", sourceColor |> Option.defaultValue "")
@@ -314,6 +316,13 @@ type Controls =
         =
         let isOpen, setIsOpen = React.useState false
 
+        // The trigger doubles as the "layer x of n" indicator, so the window
+        // of three page buttons never hides how long the chain actually is.
+        let activeIndex =
+            session.LayerOrder
+            |> List.tryFindIndex (fun layerId -> layerId = session.ActiveLayerId)
+            |> Option.defaultValue 0
+
         Popover.Popover(
             isOpen = isOpen,
             onOpenChange = setIsOpen,
@@ -329,10 +338,11 @@ type Controls =
                             prop.title "Jump to layer"
                             prop.ariaLabel "Jump to layer"
                             prop.type'.button
-                            prop.className "swt:btn swt:btn-sm swt:btn-outline swt:w-10 swt:px-0 swt:font-semibold"
+                            prop.className
+                                "swt:btn swt:btn-sm swt:btn-outline swt:min-w-10 swt:shrink-0 swt:whitespace-nowrap swt:px-2 swt:font-semibold"
                             if defaultArg debug false then
                                 prop.testId "provenance-layer-jump"
-                            prop.text "..."
+                            prop.text $"{activeIndex + 1} / {session.LayerOrder.Length}"
                         ]
                     )
                     Popover.Content(
@@ -486,8 +496,10 @@ type Controls =
         Html.div [
             prop.className
                 "swt:pointer-events-auto swt:flex swt:max-w-full swt:min-w-0 swt:items-center swt:justify-center swt:gap-2 swt:rounded-box swt:border swt:border-base-content/20 swt:bg-base-100 swt:px-3 swt:py-2 swt:shadow-md swt:ring-1 swt:ring-base-300"
-            // A fixed bar width so the control does not shift as layer names change.
-            prop.style [ style.custom ("width", "min(40rem, calc(100vw - 2rem))") ]
+            // A fixed bar width so the control does not shift as layer names
+            // change; capped by the container, not the viewport, so embedded
+            // editors size the bar to themselves.
+            prop.style [ style.custom ("width", "min(40rem, 100%)") ]
             prop.custom ("role", "navigation")
             prop.ariaLabel "Layer pagination"
             prop.custom ("data-tutorial", "provenance-layer-pagination")

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -959,6 +959,9 @@ type Controls =
                 ]
                 if expanded then
                     Html.div [
+                        // Always-on anchor so the tutorial can ring the expanded
+                        // values without coupling to the debug test id.
+                        prop.custom ("data-tutorial-property-values", $"{side}:{header.Category.Name}")
                         prop.className [
                             // fade-in only: the chips carry connector anchors, so a slide
                             // would put the measured positions off during entry.

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -234,7 +234,7 @@ type Controls =
         )
 
     [<ReactComponent>]
-    static member LayerTabs
+    static member LayerPagination
         (
             session: ProvenanceSession,
             onSelect: ProvenanceLayerId -> unit,
@@ -248,6 +248,7 @@ type Controls =
             $"Layer {session.LayerOrder.Length + 1}"
 
         let isAddLayerOpen, setIsAddLayerOpen = React.useState false
+        let isLayerJumpOpen, setIsLayerJumpOpen = React.useState false
         let layerName, setLayerName = React.useState (defaultNextLayerName session)
 
         React.useEffect ((fun () -> setLayerName (defaultNextLayerName session)), [| box session.LayerOrder.Length |])
@@ -268,9 +269,6 @@ type Controls =
                     submitLayerName ()
                 )
                 prop.children [
-                    // Announces which entities will seed the new layer's inputs, so
-                    // the effect of the current selection (or its absence) is visible
-                    // before the layer is created.
                     match seedSummary with
                     | Some summary ->
                         Html.p [
@@ -296,64 +294,183 @@ type Controls =
                 ]
             ]
 
+        let activeIndex =
+            session.LayerOrder
+            |> List.tryFindIndex (fun layerId -> layerId = session.ActiveLayerId)
+            |> Option.defaultValue 0
+
+        let sourceColorOf (layer: ProvenanceLayer) =
+            sourceColors
+            |> Option.bind (fun colors -> colors |> Map.tryFind layer.Model.Source.Id)
+
+        let activeLayer = Session.layerById session.ActiveLayerId session
+
+        let arrowButton (label: string) (iconClass: string) (targetIndex: int) (testId: string) =
+            let target = session.LayerOrder |> List.tryItem targetIndex
+
+            Html.button [
+                prop.type'.button
+                prop.className [
+                    "swt:btn swt:btn-sm swt:btn-outline swt:w-10 swt:px-0"
+                    if target.IsNone then
+                        "swt:opacity-40"
+                ]
+                prop.title label
+                prop.ariaLabel label
+                prop.disabled target.IsNone
+                if target.IsSome && defaultArg debug false then
+                    prop.testId testId
+                prop.onClick (fun _ -> target |> Option.iter onSelect)
+                prop.children [
+                    Html.i [ prop.className $"swt:iconify {iconClass} swt:size-4" ]
+                ]
+            ]
+
+        let pageSlot layerId =
+            let layer = Session.layerById layerId session
+            let sourceColor = sourceColorOf layer
+            let isActive = layerId = session.ActiveLayerId
+
+            Html.button [
+                prop.key layerId
+                prop.type'.button
+                prop.title $"View provenance layer {layer.Model.Source.Name}"
+                prop.ariaLabel $"View provenance layer {layer.Model.Source.Name}"
+                prop.custom ("data-provenance-layer-page", layerId)
+                prop.className [
+                    "swt:btn swt:btn-sm swt:min-w-0 swt:px-3"
+                    if isActive then
+                        "swt:btn-primary swt:font-semibold"
+                    else
+                        "swt:btn-outline swt:opacity-60 swt:hover:opacity-100"
+                ]
+                prop.style [ style.custom ("width", "clamp(4.5rem, 18vw, 7rem)") ]
+                if defaultArg debug false then
+                    prop.testId $"provenance-layer-{layerId}"
+                    prop.custom ("data-provenance-layer-color", sourceColor |> Option.defaultValue "")
+                prop.onClick (fun _ -> onSelect layerId)
+                prop.children [
+                    match sourceColor with
+                    | Some color when color <> "" ->
+                        Html.span [
+                            prop.className "swt:size-2 swt:shrink-0 swt:rounded-full"
+                            prop.style [ style.backgroundColor color ]
+                        ]
+                    | _ -> Html.none
+                    Html.span [
+                        prop.className "swt:min-w-0 swt:truncate"
+                        prop.text layer.Model.Source.Name
+                    ]
+                ]
+            ]
+
+        let pageSlots =
+            let layerCount = session.LayerOrder.Length
+
+            if layerCount <= 3 then
+                [ 0..2 ] |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
+            elif activeIndex = 0 then
+                [ 0..2 ] |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
+            elif activeIndex = layerCount - 1 then
+                [ layerCount - 3 .. layerCount - 1 ]
+                |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
+            else
+                [ activeIndex - 1 .. activeIndex + 1 ]
+                |> List.choose (fun index -> session.LayerOrder |> List.tryItem index)
+
         Html.div [
-            prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
+            prop.className
+                "swt:pointer-events-auto swt:flex swt:max-w-full swt:min-w-0 swt:items-center swt:justify-center swt:gap-2 swt:rounded-box swt:border swt:border-base-content/20 swt:bg-base-100 swt:px-3 swt:py-2 swt:shadow-md swt:ring-1 swt:ring-base-300"
+            prop.style [ style.custom ("width", "min(40rem, calc(100vw - 2rem))") ]
+            prop.custom ("role", "navigation")
+            prop.ariaLabel "Layer pagination"
+            prop.custom ("data-tutorial", "provenance-layer-pagination")
+            if defaultArg debug false then
+                prop.testId "provenance-layer-pagination"
             prop.children [
-                for layerId in session.LayerOrder do
-                    let layer = Session.layerById layerId session
-
-                    let sourceColor =
-                        sourceColors
-                        |> Option.bind (fun colors -> colors |> Map.tryFind layer.Model.Source.Id)
-
-                    let layerButtonClasses = [
-                        "swt:btn swt:btn-sm swt:join-item"
-                        if layerId = session.ActiveLayerId then
-                            "swt:btn-primary"
-                        else
-                            "swt:btn-outline"
+                Html.div [
+                    prop.className "swt:flex swt:min-w-0 swt:flex-1 swt:items-center swt:justify-center swt:gap-1"
+                    if defaultArg debug false then
+                        prop.testId "provenance-layer-pages"
+                    prop.children [
+                        arrowButton
+                            "Previous layer"
+                            "swt:fluent--chevron-left-20-regular"
+                            (activeIndex - 1)
+                            "provenance-layer-prev"
+                        for layerId in pageSlots do
+                            pageSlot layerId
+                        arrowButton
+                            "Next layer"
+                            "swt:fluent--chevron-right-20-regular"
+                            (activeIndex + 1)
+                            "provenance-layer-next"
                     ]
-
-                    let swatchButtonClass =
-                        [
-                            yield! layerButtonClasses
-                            "swt:min-h-8 swt:w-8 swt:px-0"
-                        ]
-                        |> String.concat " "
-
-                    Html.div [
-                        prop.className "swt:join"
-                        prop.children [
-                            match onSetSourceColor with
-                            | Some setSourceColor ->
-                                Controls.LayerColorButton(
-                                    layer.Model.Source.Id,
-                                    sourceColor,
-                                    setSourceColor layer.Model.Source.Id,
-                                    triggerClassName = swatchButtonClass
-                                )
-                            | None ->
-                                Html.span [
-                                    prop.className [
-                                        yield! layerButtonClasses
-                                        "swt:min-h-8 swt:w-8 swt:px-0"
-                                    ]
-                                    match sourceColor with
-                                    | Some color when color <> "" -> prop.style [ style.backgroundColor color ]
-                                    | _ -> ()
+                ]
+                Popover.Popover(
+                    isOpen = isLayerJumpOpen,
+                    onOpenChange = setIsLayerJumpOpen,
+                    ?debug =
+                        (if defaultArg debug false then
+                             Some "provenance-layer-jump-popover"
+                         else
+                             None),
+                    children =
+                        React.Fragment [
+                            Popover.Trigger(
+                                Html.button [
+                                    prop.title "Jump to layer"
+                                    prop.ariaLabel "Jump to layer"
+                                    prop.type'.button
+                                    prop.className
+                                        "swt:btn swt:btn-sm swt:btn-outline swt:w-10 swt:px-0 swt:font-semibold"
+                                    if defaultArg debug false then
+                                        prop.testId "provenance-layer-jump"
+                                    prop.text "..."
                                 ]
-                            Html.button [
-                                prop.title $"View provenance layer {layer.Model.Source.Name}"
-                                prop.className layerButtonClasses
-                                prop.ariaLabel $"View provenance layer {layer.Model.Source.Name}"
-                                if defaultArg debug false then
-                                    prop.testId $"provenance-layer-{layerId}"
-                                    prop.custom ("data-provenance-layer-color", sourceColor |> Option.defaultValue "")
-                                prop.onClick (fun _ -> onSelect layerId)
-                                prop.children [ Html.span layer.Model.Source.Name ]
-                            ]
+                            )
+                            Popover.Content(
+                                children =
+                                    Html.div [
+                                        prop.className "swt:flex swt:min-w-48 swt:flex-col swt:gap-2 swt:p-2"
+                                        prop.children [
+                                            Html.label [ prop.className "swt:label"; prop.text "Jump to layer" ]
+                                            Html.select [
+                                                prop.className "swt:select swt:select-bordered swt:select-sm swt:w-full"
+                                                prop.ariaLabel "Select layer"
+                                                prop.title "Jump to a layer"
+                                                if defaultArg debug false then
+                                                    prop.testId "provenance-layer-select"
+                                                prop.value session.ActiveLayerId
+                                                prop.onChange (fun (layerId: string) ->
+                                                    onSelect layerId
+                                                    setIsLayerJumpOpen false
+                                                )
+                                                prop.children [
+                                                    for layerId in session.LayerOrder do
+                                                        let layer = Session.layerById layerId session
+
+                                                        Html.option [
+                                                            prop.key layerId
+                                                            prop.value layerId
+                                                            prop.text layer.Model.Source.Name
+                                                        ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                            )
                         ]
-                    ]
+                )
+                match onSetSourceColor with
+                | Some setSourceColor ->
+                    Controls.LayerColorButton(
+                        activeLayer.Model.Source.Id,
+                        sourceColorOf activeLayer,
+                        setSourceColor activeLayer.Model.Source.Id,
+                        triggerClassName = "swt:btn swt:btn-sm swt:btn-outline swt:min-h-8 swt:w-8 swt:px-0"
+                    )
+                | None -> Html.none
                 Popover.Popover(
                     isOpen = isAddLayerOpen,
                     onOpenChange = setIsAddLayerOpen,
@@ -926,6 +1043,8 @@ type Controls =
                     "swt:items-center swt:justify-center"
             ]
             prop.custom ("data-provenance-drop-state", dropState)
+            // Always-on anchor for the interactive tutorial's spotlight.
+            prop.custom ("data-tutorial", $"provenance-rail-{side}")
             if defaultArg debug false then
                 prop.testId $"provenance-property-rail-{side}"
 
@@ -1525,6 +1644,54 @@ type Controls =
                 ]
         )
 
+    /// The overall search over properties, values and groups. Debounced, so
+    /// typing updates the input immediately but filters only settle afterwards.
+    [<ReactComponent>]
+    static member SearchBar(searchText: string, onSearch: string -> unit, ?debug: bool) =
+        let searchDraft, setSearchDraft = React.useState searchText
+        let latestSearchText = React.useRef searchText
+        let latestOnSearch = React.useRef onSearch
+
+        // useLayoutEffect (not a render-phase write) so a discarded render
+        // under concurrent rendering / StrictMode never leaves these pointing
+        // at a searchText/onSearch value that was never actually committed.
+        React.useLayoutEffect (fun () ->
+            latestSearchText.current <- searchText
+            latestOnSearch.current <- onSearch
+        )
+
+        let debouncedSearchDraft = React.useDebounce (searchDraft, 300)
+
+        React.useEffect ((fun () -> setSearchDraft searchText), [| box searchText |])
+
+        React.useEffect (
+            (fun () ->
+                if debouncedSearchDraft <> latestSearchText.current then
+                    latestOnSearch.current debouncedSearchDraft
+            ),
+            [| box debouncedSearchDraft |]
+        )
+
+        Html.div [
+            prop.className "swt:relative swt:flex swt:w-40 swt:shrink-0 swt:items-center"
+            // Always-on anchor for the interactive tutorial's spotlight.
+            prop.custom ("data-tutorial", "provenance-search")
+            if defaultArg debug false then
+                prop.testId "provenance-search"
+            prop.children [
+                Html.i [
+                    prop.className
+                        "swt:iconify swt:fluent--search-20-regular swt:absolute swt:left-2 swt:size-4 swt:text-base-content/50"
+                ]
+                Html.input [
+                    prop.className "swt:input swt:input-bordered swt:input-sm swt:w-full swt:pl-8"
+                    prop.placeholder "Search properties & values..."
+                    prop.value searchDraft
+                    prop.onChange setSearchDraft
+                ]
+            ]
+        ]
+
     [<ReactComponent>]
     static member FilterToolbar
         (
@@ -1538,29 +1705,6 @@ type Controls =
         ) =
         let sortOpen, setSortOpen = React.useState false
         let groupSortOpen, setGroupSortOpen = React.useState false
-        let searchDraft, setSearchDraft = React.useState filters.SearchText
-        let latestSearchText = React.useRef filters.SearchText
-        let latestOnSearch = React.useRef onSearch
-
-        // useLayoutEffect (not a render-phase write) so a discarded render
-        // under concurrent rendering / StrictMode never leaves these pointing
-        // at a filters/onSearch value that was never actually committed.
-        React.useLayoutEffect (fun () ->
-            latestSearchText.current <- filters.SearchText
-            latestOnSearch.current <- onSearch
-        )
-
-        let debouncedSearchDraft = React.useDebounce (searchDraft, 300)
-
-        React.useEffect ((fun () -> setSearchDraft filters.SearchText), [| box filters.SearchText |])
-
-        React.useEffect (
-            (fun () ->
-                if debouncedSearchDraft <> latestSearchText.current then
-                    latestOnSearch.current debouncedSearchDraft
-            ),
-            [| box debouncedSearchDraft |]
-        )
 
         let propertySortOption sort label =
             let active = filters.PropertySort = sort
@@ -1618,25 +1762,13 @@ type Controls =
             ]
 
         Html.div [
-            prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2 swt:p-2"
+            prop.className "swt:flex swt:min-w-0 swt:shrink swt:flex-wrap swt:items-center swt:gap-2"
+            // Always-on anchor for the interactive tutorial's spotlight.
+            prop.custom ("data-tutorial", "provenance-filter-toolbar")
             if defaultArg debug false then
                 prop.testId "provenance-filter-toolbar"
             prop.children [
-                Html.div [
-                    prop.className "swt:relative swt:flex swt:items-center"
-                    prop.children [
-                        Html.i [
-                            prop.className
-                                "swt:iconify swt:fluent--search-20-regular swt:absolute swt:left-2 swt:size-4 swt:text-base-content/50"
-                        ]
-                        Html.input [
-                            prop.className "swt:input swt:input-bordered swt:input-sm swt:pl-8"
-                            prop.placeholder "Search properties & values..."
-                            prop.value searchDraft
-                            prop.onChange setSearchDraft
-                        ]
-                    ]
-                ]
+                Controls.SearchBar(filters.SearchText, onSearch, ?debug = debug)
                 Dropdown.Main(
                     sortOpen,
                     setSortOpen,
@@ -1688,7 +1820,7 @@ type Controls =
                         "swt:w-52 swt:max-w-none swt:menu swt:bg-base-200 swt:rounded-box swt:z-99 swt:p-2 swt:shadow-sm swt:top-110%"
                 )
                 Html.select [
-                    prop.className "swt:select swt:select-bordered swt:select-sm"
+                    prop.className "swt:select swt:select-bordered swt:select-sm swt:w-20 swt:shrink-0"
                     prop.ariaLabel "Filter by property value count"
                     prop.value (
                         match filters.ValueCountFilter with

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -1083,7 +1083,7 @@ type Controls =
         Html.aside [
             prop.ref droppable.setNodeRef
             prop.className [
-                "swt:flex swt:min-w-0 swt:flex-col swt:gap-2 swt:rounded swt:border swt:border-dashed swt:border-base-content/25 swt:border-2 swt:p-3 swt:transition-colors"
+                "swt:flex swt:min-h-[32rem] swt:min-w-0 swt:flex-col swt:gap-2 swt:rounded swt:border swt:border-dashed swt:border-base-content/25 swt:border-2 swt:p-3 swt:transition-colors"
                 if dropState = "rejecting" then
                     "swt:border-warning swt:bg-warning/10 swt:ring-2 swt:ring-warning/30"
                 elif droppable.isOver then

--- a/src/Components/src/Page/ProvenanceGrouping/ControlsSupport.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ControlsSupport.fs
@@ -141,4 +141,4 @@ module TermSearchMapping =
 /// Creates editor-owned generic provenance kinds for user-created values.
 module KindNames =
 
-    let editorProperty = ProvenanceKind.create "editor:property" "Property"
+    let editorProperty = ProvenanceKind.create "editor:property" "Annotation"

--- a/src/Components/src/Page/ProvenanceGrouping/EditorActions.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorActions.fs
@@ -99,7 +99,7 @@ module SessionErrors =
     let private editText error =
         match error with
         | EditError.PropertyNotFound _ ->
-            "This property value no longer exists. It may have been changed by a newer edit."
+            "This annotation value no longer exists. It may have been changed by a newer edit."
         | EditError.SetNotFound setId -> $"The entity '{setId}' no longer exists in this layer."
         | EditError.ConnectionNotFound _ -> "This connection no longer exists."
         | EditError.TableNotLoaded tableName -> $"The table '{tableName}' is not loaded."
@@ -125,10 +125,10 @@ module AssignmentErrors =
         match error with
         | ValueAssignmentError.EmptyTarget -> "Drop a value onto a group with at least one entity."
         | ValueAssignmentError.MixedPropertyValueCounts header ->
-            $"Cannot assign {header.Category.Name}: every target must either have no value or exactly one value for this property."
+            $"Cannot assign {header.Category.Name}: every target must either have no value or exactly one value for this annotation."
         | ValueAssignmentError.MultiplePropertyValues(header, setIds) ->
             let targets = setIds |> String.concat ", "
-            $"Cannot overwrite {header.Category.Name}: {targets} already has multiple values for this property."
+            $"Cannot overwrite {header.Category.Name}: {targets} already has multiple values for this annotation."
 
 /// Session-changing actions that publish patches back to the host component.
 module EditorActions =

--- a/src/Components/src/Page/ProvenanceGrouping/EditorPanels.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorPanels.fs
@@ -236,20 +236,7 @@ module EditorPanels =
     let private groupTitle (groups: DisplayGroup list) groupId =
         groups
         |> List.tryFind (fun group -> group.Id = groupId)
-        |> Option.map (fun group ->
-            match group.GroupingValues with
-            | [] ->
-                group.Members
-                |> List.tryHead
-                |> Option.map (fun member' -> member'.Name)
-                |> Option.defaultValue groupId
-            | values ->
-                values
-                |> List.map (fun value ->
-                    $"{value.Key.Header.Category.Name}: {Formatting.formatValue value.Value value.Unit}"
-                )
-                |> String.concat ", "
-        )
+        |> Option.map GroupCardData.title
         |> Option.defaultValue groupId
 
     let connectionDetails

--- a/src/Components/src/Page/ProvenanceGrouping/EditorPanels.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorPanels.fs
@@ -35,7 +35,7 @@ module EditorPanels =
             ]
             |> List.distinct
 
-        let headerText = headers |> List.tryHead |> Option.defaultValue "property"
+        let headerText = headers |> List.tryHead |> Option.defaultValue "annotation"
 
         let valueText =
             pending.Batch.Overwrites
@@ -53,7 +53,7 @@ module EditorPanels =
                 $"Apply {headerText} value to {pending.AffectedGroupCount} selected groups?"
             else
                 match headers with
-                | _ :: _ :: _ -> $"Overwrite {overwriteCount} values across {headers.Length} properties?"
+                | _ :: _ :: _ -> $"Overwrite {overwriteCount} values across {headers.Length} annotations?"
                 | _ when overwriteCount > 1 -> $"Overwrite {overwriteCount} {headerText} values?"
                 | _ -> $"Overwrite {headerText} value?"
 

--- a/src/Components/src/Page/ProvenanceGrouping/EditorSurface.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorSurface.fs
@@ -199,7 +199,7 @@ module EditorSurface =
                 prop.children [
                     Html.span [
                         prop.className "swt:min-w-0 swt:truncate"
-                        prop.text (label |> Option.defaultValue "Property")
+                        prop.text (label |> Option.defaultValue "Annotation")
                     ]
                 ]
             ]

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -67,7 +67,8 @@ module private EntityType =
         ]
 
 /// Derives display text and property chips for one provenance group card.
-module private GroupCardData =
+/// Public so the detail panels can reuse the same title derivation.
+module GroupCardData =
 
     /// Loaded endpoint kind for one member, resolved from the side-specific set map.
     let endpointKind side (model: ProvenanceModel) (setId: ProvenanceSetId) =
@@ -77,12 +78,6 @@ module private GroupCardData =
             | ProvenanceSide.Output -> model.OutputSets
 
         sets.TryFind setId |> Option.map (fun set -> set.Header.Kind)
-
-    let values (group: DisplayGroup) (model: ProvenanceModel) =
-        group.Members
-        |> List.collect (fun member' -> member'.PropertyValueIds)
-        |> List.distinct
-        |> List.choose (fun id -> model.PropertyValues.TryFind id)
 
     let memberValues (member': DisplayMember) (model: ProvenanceModel) =
         member'.PropertyValueIds
@@ -99,7 +94,11 @@ module private GroupCardData =
 
     let title (group: DisplayGroup) =
         match tabs group with
-        | [] -> group.Members.Head.Name
+        | [] ->
+            group.Members
+            |> List.tryHead
+            |> Option.map (fun member' -> member'.Name)
+            |> Option.defaultValue group.Id
         | tabs ->
             tabs
             |> List.map (fun value ->
@@ -471,91 +470,77 @@ type GroupCard =
                         ]
                     | _ -> Html.none
 
-                match tabs with
-                | [] ->
-                    // A card without grouping values is always a single loaded endpoint,
-                    // so the type line sits above its name to mirror the expanded member rows.
-                    Html.div [
-                        prop.className "swt:flex swt:cursor-pointer swt:items-start swt:gap-2"
-                        prop.onClick handleExpandClick
-                        if defaultArg debug false then
-                            prop.testId $"provenance-group-expand-surface-{side}-{group.Id}"
-                        prop.children [
-                            selectionCheckbox
-                            Html.div [
-                                prop.className "swt:flex swt:min-w-0 swt:grow swt:flex-col swt:gap-0.5"
-                                prop.title title
-                                prop.children [
-                                    match GroupCardData.endpointKind side model group.Members.Head.SetId with
-                                    | Some kind -> EntityType.line (EntityType.descriptor kind)
-                                    | None -> Html.none
-                                    Html.h3 [
-                                        prop.className "swt:min-w-0 swt:truncate swt:text-sm swt:font-semibold"
+                // Every card is drawn as a file organizer: one tab per grouping value
+                // sits on top of a folder body that holds the members' type symbols.
+                // A card without grouping values is always a single loaded endpoint;
+                // it shares the same silhouette and gets one neutral name tab instead.
+                // Hovering or focusing a grouping-value tab highlights that value.
+                let symbolIcon (descriptor: EntityType.Descriptor) =
+                    Html.i [
+                        prop.className $"swt:iconify {descriptor.Icon} swt:size-4 swt:shrink-0"
+                    ]
+
+                let countLabel count =
+                    Html.span [
+                        prop.className "swt:text-xs swt:font-semibold"
+                        prop.text (string count)
+                    ]
+
+                // When few enough to fit, every member contributes one symbol
+                // side by side; otherwise the preview collapses to the dominant type
+                // symbol with a count.
+                let memberDescriptors =
+                    group.Members
+                    |> List.choose (fun member' ->
+                        GroupCardData.endpointKind side model member'.SetId
+                        |> Option.map EntityType.descriptor
+                    )
+
+                let maxInlineSymbols = 4
+
+                // The tab bar escapes the card padding so the tabs sit flush on the
+                // card's top edge, like register tabs on an archive folder.
+                let tabBarMargins =
+                    match density with
+                    | Density.EditorDensity.Compact -> "swt:-mx-1.5 swt:-mt-1.5"
+                    | _ -> "swt:-mx-2.5 swt:-mt-2.5"
+
+                // Each grouping-value tab gets its own color, like the colored index
+                // tabs of an expanding file organizer.
+                let tabPalette = [|
+                    "swt:bg-primary swt:text-primary-content"
+                    "swt:bg-secondary swt:text-secondary-content"
+                    "swt:bg-accent swt:text-accent-content"
+                    "swt:bg-info swt:text-info-content"
+                    "swt:bg-success swt:text-success-content"
+                    "swt:bg-warning swt:text-warning-content"
+                    "swt:bg-error swt:text-error-content"
+                |]
+
+                Html.div [
+                    prop.className "swt:flex swt:min-w-0 swt:cursor-pointer swt:flex-col swt:gap-2"
+                    prop.onClick handleExpandClick
+                    if defaultArg debug false then
+                        prop.testId $"provenance-group-expand-surface-{side}-{group.Id}"
+                    prop.children [
+                        Html.div [
+                            prop.className [
+                                "swt:flex swt:min-w-0 swt:items-end swt:gap-1 swt:border-b swt:border-base-300 swt:px-3 swt:pt-1"
+                                tabBarMargins
+                            ]
+                            prop.children [
+                                match tabs with
+                                | [] ->
+                                    // Neutral label tab: same silhouette as a grouping-value
+                                    // tab but muted and inert, so the endpoint name cannot
+                                    // be mistaken for a grouping value.
+                                    Html.span [
+                                        prop.className
+                                            "swt:min-w-0 swt:grow swt:truncate swt:rounded-t-md swt:bg-base-300 swt:px-3 swt:py-1 swt:text-xs swt:font-semibold swt:text-base-content/80"
+                                        prop.title title
                                         prop.text title
                                     ]
-                                ]
-                            ]
-                            connectionBadge
-                        ]
-                    ]
-                | tabs ->
-                    // A grouped card is drawn as a file organizer: one tab per grouping
-                    // value sits on top of a folder body that holds the members' type
-                    // symbols. Hovering or focusing a tab highlights that grouping value.
-                    let symbolIcon (descriptor: EntityType.Descriptor) =
-                        Html.i [
-                            prop.className $"swt:iconify {descriptor.Icon} swt:size-4 swt:shrink-0"
-                        ]
-
-                    let countLabel count =
-                        Html.span [
-                            prop.className "swt:text-xs swt:font-semibold"
-                            prop.text (string count)
-                        ]
-
-                    // When few enough to fit, every member contributes one symbol
-                    // side by side; otherwise the preview collapses to the dominant type
-                    // symbol with a count.
-                    let memberDescriptors =
-                        group.Members
-                        |> List.choose (fun member' ->
-                            GroupCardData.endpointKind side model member'.SetId
-                            |> Option.map EntityType.descriptor
-                        )
-
-                    let maxInlineSymbols = 4
-
-                    // The tab bar escapes the card padding so the tabs sit flush on the
-                    // card's top edge, like register tabs on an archive folder.
-                    let tabBarMargins =
-                        match density with
-                        | Density.EditorDensity.Compact -> "swt:-mx-1.5 swt:-mt-1.5"
-                        | _ -> "swt:-mx-2.5 swt:-mt-2.5"
-
-                    // Each tab gets its own color, like the colored index tabs of an
-                    // expanding file organizer.
-                    let tabPalette = [|
-                        "swt:bg-primary swt:text-primary-content"
-                        "swt:bg-secondary swt:text-secondary-content"
-                        "swt:bg-accent swt:text-accent-content"
-                        "swt:bg-info swt:text-info-content"
-                        "swt:bg-success swt:text-success-content"
-                        "swt:bg-warning swt:text-warning-content"
-                        "swt:bg-error swt:text-error-content"
-                    |]
-
-                    Html.div [
-                        prop.className "swt:flex swt:min-w-0 swt:cursor-pointer swt:flex-col swt:gap-2"
-                        prop.onClick handleExpandClick
-                        if defaultArg debug false then
-                            prop.testId $"provenance-group-expand-surface-{side}-{group.Id}"
-                        prop.children [
-                            Html.div [
-                                prop.className [
-                                    "swt:flex swt:min-w-0 swt:items-end swt:gap-1 swt:border-b swt:border-base-300 swt:px-3 swt:pt-1"
-                                    tabBarMargins
-                                ]
-                                prop.children [
+                                | tabs ->
                                     for index, groupingValue in List.indexed tabs do
                                         let category = groupingValue.Key.Header.Category.Name
 
@@ -588,70 +573,69 @@ type GroupCard =
                                                      None),
                                             key = $"{index}:{category}={valueText}"
                                         )
-                                ]
                             ]
-                            Html.div [
-                                prop.className "swt:flex swt:items-center swt:gap-2"
-                                prop.children [
-                                    selectionCheckbox
-                                    // The expand trigger is drawn as a folder: a clipped back
-                                    // panel with its own index tab, the members' type symbols
-                                    // resting inside, and a front pocket they tuck behind.
-                                    Html.button [
-                                        prop.type'.button
-                                        prop.ariaLabel "Show members"
-                                        prop.title "Show members"
-                                        prop.onClick (fun _ -> onExpand ())
-                                        prop.className
-                                            "swt:group swt:relative swt:w-fit swt:max-w-full swt:cursor-pointer"
-                                        prop.children [
-                                            Html.span [
-                                                prop.ariaHidden true
-                                                prop.className
-                                                    "swt:absolute swt:inset-0 swt:rounded-md swt:bg-base-300 swt:transition-colors swt:group-hover:bg-primary/30 swt:[clip-path:polygon(0_0,2.5rem_0,3.25rem_0.5rem,100%_0.5rem,100%_100%,0_100%)]"
-                                            ]
-                                            Html.span [
-                                                prop.ariaHidden true
-                                                prop.className
-                                                    "swt:relative swt:flex swt:min-h-9 swt:items-center swt:gap-1 swt:px-3 swt:pb-2.5 swt:pt-3.5 swt:text-base-content/80"
-                                                if defaultArg debug false then
-                                                    prop.testId $"provenance-group-symbols-{side}-{group.Id}"
-                                                prop.children [
-                                                    match memberDescriptors with
-                                                    | [] -> countLabel group.Members.Length
-                                                    | descriptors when descriptors.Length <= maxInlineSymbols ->
-                                                        for index, descriptor in List.indexed descriptors do
-                                                            Html.span [
-                                                                prop.key (string index)
-                                                                prop.children [ symbolIcon descriptor ]
-                                                            ]
-                                                    | descriptors ->
-                                                        let dominant =
-                                                            descriptors
-                                                            |> List.countBy (fun descriptor -> descriptor.Label)
-                                                            |> List.maxBy snd
-                                                            |> fst
+                        ]
+                        Html.div [
+                            prop.className "swt:flex swt:items-center swt:gap-2"
+                            prop.children [
+                                selectionCheckbox
+                                // The expand trigger is drawn as a folder: a clipped back
+                                // panel with its own index tab, the members' type symbols
+                                // resting inside, and a front pocket they tuck behind.
+                                Html.button [
+                                    prop.type'.button
+                                    prop.ariaLabel "Show members"
+                                    prop.title "Show members"
+                                    prop.onClick (fun _ -> onExpand ())
+                                    prop.className "swt:group swt:relative swt:w-fit swt:max-w-full swt:cursor-pointer"
+                                    prop.children [
+                                        Html.span [
+                                            prop.ariaHidden true
+                                            prop.className
+                                                "swt:absolute swt:inset-0 swt:rounded-md swt:bg-base-300 swt:transition-colors swt:group-hover:bg-primary/30 swt:[clip-path:polygon(0_0,2.5rem_0,3.25rem_0.5rem,100%_0.5rem,100%_100%,0_100%)]"
+                                        ]
+                                        Html.span [
+                                            prop.ariaHidden true
+                                            prop.className
+                                                "swt:relative swt:flex swt:min-h-9 swt:items-center swt:gap-1 swt:px-3 swt:pb-2.5 swt:pt-3.5 swt:text-base-content/80"
+                                            if defaultArg debug false then
+                                                prop.testId $"provenance-group-symbols-{side}-{group.Id}"
+                                            prop.children [
+                                                match memberDescriptors with
+                                                | [] -> countLabel group.Members.Length
+                                                | descriptors when descriptors.Length <= maxInlineSymbols ->
+                                                    for index, descriptor in List.indexed descriptors do
+                                                        Html.span [
+                                                            prop.key (string index)
+                                                            prop.children [ symbolIcon descriptor ]
+                                                        ]
+                                                | descriptors ->
+                                                    let dominant =
+                                                        descriptors
+                                                        |> List.countBy (fun descriptor -> descriptor.Label)
+                                                        |> List.maxBy snd
+                                                        |> fst
 
-                                                        let icon =
-                                                            descriptors
-                                                            |> List.find (fun descriptor -> descriptor.Label = dominant)
+                                                    let icon =
+                                                        descriptors
+                                                        |> List.find (fun descriptor -> descriptor.Label = dominant)
 
-                                                        symbolIcon icon
-                                                        countLabel descriptors.Length
-                                                ]
-                                            ]
-                                            Html.span [
-                                                prop.ariaHidden true
-                                                prop.className
-                                                    "swt:absolute swt:inset-x-0 swt:bottom-0 swt:h-[35%] swt:rounded-b-md swt:bg-base-200 swt:transition-colors swt:group-hover:bg-primary/20"
+                                                    symbolIcon icon
+                                                    countLabel descriptors.Length
                                             ]
                                         ]
+                                        Html.span [
+                                            prop.ariaHidden true
+                                            prop.className
+                                                "swt:absolute swt:inset-x-0 swt:bottom-0 swt:h-[35%] swt:rounded-b-md swt:bg-base-200 swt:transition-colors swt:group-hover:bg-primary/20"
+                                        ]
                                     ]
-                                    connectionBadge
                                 ]
+                                connectionBadge
                             ]
                         ]
                     ]
+                ]
 
                 if expanded then
                     Html.ul [

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -586,6 +586,8 @@ type GroupCard =
                                     prop.type'.button
                                     prop.ariaLabel "Show members"
                                     prop.title "Show members"
+                                    // Always-on anchor for the interactive tutorial's spotlight.
+                                    prop.custom ("data-tutorial", "provenance-show-members")
                                     prop.onClick (fun _ -> onExpand ())
                                     prop.className "swt:group swt:relative swt:w-fit swt:max-w-full swt:cursor-pointer"
                                     prop.children [

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -421,6 +421,10 @@ type GroupCard =
             prop.ref setArticleRef
             prop.custom ("data-provenance-group-node", DragDrop.groupNodeId side group.Id)
             prop.custom ("data-provenance-group-drop-id", DragDrop.groupDropId side group.Id)
+            // Member count as an attribute so hosts (e.g. the tutorial) can
+            // single out cards whose connections resolve without a member
+            // pairing prompt (1x1 connects publish directly).
+            prop.custom ("data-provenance-card-members", string group.Members.Length)
             prop.onMouseEnter (fun _ -> publishHover ())
             prop.onMouseLeave (fun _ -> clearHover ())
             prop.className [
@@ -641,6 +645,8 @@ type GroupCard =
 
                 if expanded then
                     Html.ul [
+                        // Always-on anchor for the interactive tutorial's spotlight.
+                        prop.custom ("data-tutorial", "provenance-group-members")
                         prop.className [
                             // fade-in only: the member rows carry connector anchors, so a
                             // slide would put the measured positions off during entry.

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -727,7 +727,7 @@ type GroupCard =
                                                     if memberValues.IsEmpty then
                                                         Html.p [
                                                             prop.className "swt:text-xs swt:text-base-content/60"
-                                                            prop.text "No property values"
+                                                            prop.text "No annotation values"
                                                         ]
                                                     else
                                                         Html.div [

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -668,6 +668,12 @@ type GroupCard =
 
                                 Html.li [
                                     prop.className "swt:relative"
+                                    // Sankey ribbons for member-level connections span this
+                                    // row's facing edge, the way group ribbons span card edges.
+                                    prop.custom (
+                                        "data-provenance-member-node",
+                                        DragDrop.memberNodeId side group.Id member'.SetId
+                                    )
                                     prop.children [
                                         Controls.ConnectionAnchor(
                                             memberPropertyAnchor,

--- a/src/Components/src/Page/ProvenanceGrouping/Interaction.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Interaction.fs
@@ -68,6 +68,9 @@ module DragDrop =
     let groupNodeId side groupId =
         $"provenance-node::{side}::{encode groupId}"
 
+    let memberNodeId side groupId setId =
+        $"provenance-member-node::{side}::{encode groupId}::{encode setId}"
+
     let private handleKindText kind =
         match kind with
         | ConnectionHandleKind.GroupCard -> "GroupCard"

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -45,6 +45,11 @@ type ProvenanceGrouping =
         let rootRef = React.useElementRef ()
         let tier, setTier = React.useState LayoutTier.Wide
         let openRail, setOpenRail = React.useState<ProvenanceSide option> initialOpenRail
+
+        // Optical side hiding: the hidden side's rail and cards leave the layout,
+        // but every state rule (placements, grouping, connections) keeps running
+        // on both sides, so revealing the side restores it unchanged.
+        let hiddenSide, setHiddenSide = React.useState<ProvenanceSide option> None
         let density, setDensity = React.useState Density.EditorDensity.Comfortable
         let isPropertyShelfExpanded, setIsPropertyShelfExpanded = React.useState true
         let isTutorialOpen, setIsTutorialOpen = React.useState false
@@ -813,8 +818,75 @@ type ProvenanceGrouping =
             | ProvenanceSide.Input -> "input"
             | ProvenanceSide.Output -> "output"
 
+        let visibleSideFor hidden =
+            match hidden with
+            | ProvenanceSide.Input -> ProvenanceSide.Output
+            | ProvenanceSide.Output -> ProvenanceSide.Input
+
         let toggleRail side =
             setOpenRail (if openRail = Some side then None else Some side)
+
+        // Hiding a side removes its rail and cards from the layout, and really
+        // relocates every switchable annotation on it to the visible rail - a
+        // permanent move, so the property stays put once the side is revealed and
+        // any solo grouping it held on the hidden side is dropped (it can no longer
+        // be managed). Non-switchable annotations stay parked until the side is
+        // shown again. Hiding one side always reveals the other.
+        let hideSide (side: ProvenanceSide) =
+            let hiddenSideId =
+                match side with
+                | ProvenanceSide.Input -> layer.InputSideId
+                | ProvenanceSide.Output -> layer.OutputSideId
+
+            applyUiState (
+                State.SideVisibility.consolidateToVisible
+                    layer.Id
+                    side
+                    hiddenSideId
+                    (fun header -> PropertyRails.canSwitchHeader header layer.Model)
+            )
+
+            setHiddenSide (Some side)
+
+        // Icon-only (a left/right panel glyph naming the column it governs) keeps
+        // the pair from wrapping the already-dense toolbar onto a second row.
+        let sideVisibilityToggle (side: ProvenanceSide) =
+            let isVisible = hiddenSide <> Some side
+            let sideText = railSideLabel side
+
+            let label =
+                if isVisible then
+                    $"Hide {sideText}s and their annotations"
+                else
+                    $"Show {sideText}s and their annotations"
+
+            Html.button [
+                prop.type'.button
+                prop.title label
+                prop.className [
+                    "swt:btn swt:btn-xs swt:btn-square"
+                    if isVisible then "swt:btn-primary" else "swt:btn-ghost"
+                ]
+                prop.custom ("aria-pressed", isVisible)
+                prop.ariaLabel label
+                // Always-on anchor for the interactive tutorial's spotlight.
+                prop.custom ("data-tutorial", $"provenance-side-visibility-{side}")
+                if debug then
+                    prop.testId $"provenance-side-visibility-{side}"
+                prop.onClick (fun _ -> if isVisible then hideSide side else setHiddenSide None)
+                prop.children [
+                    Html.i [
+                        prop.className [
+                            "swt:iconify swt:size-4"
+                            match side, isVisible with
+                            | ProvenanceSide.Input, true -> "swt:fluent--panel-left-20-regular"
+                            | ProvenanceSide.Input, false -> "swt:fluent--panel-left-20-filled"
+                            | ProvenanceSide.Output, true -> "swt:fluent--panel-right-20-regular"
+                            | ProvenanceSide.Output, false -> "swt:fluent--panel-right-20-filled"
+                        ]
+                    ]
+                ]
+            ]
 
         let isRejectedPropertyRailDrop targetSide =
             let headerCannotSwitch sourceSide headerId =
@@ -1211,6 +1283,7 @@ type ProvenanceGrouping =
             [
                 string tier
                 string openRail
+                string hiddenSide
                 string density
                 string isPropertyShelfExpanded
                 string panelRatios.Left
@@ -1269,11 +1342,62 @@ type ProvenanceGrouping =
                 |]
             )
 
+        // One side hidden (wide or medium): the visible rail and its cards form a
+        // single cluster centered in the editor instead of stretching across it with
+        // the cards hugging one edge. Two equal `1fr` spacer columns flank the cluster,
+        // so whatever space is left over is split evenly on both sides at any width -
+        // unlike `justify-center`, which only centers space beyond the tracks' max and
+        // so leaves the cluster flush whenever the editor is not much wider than it.
+        // The card column keeps the same generous minimum the two-column middle panel
+        // gives it, and a fixed gutter track carries the rail-to-card connectors. No
+        // splitter: there is only one rail, and the bounded tracks keep it balanced.
+        let soloSurface (visibleSide: ProvenanceSide) =
+            let railTrack = "minmax(10rem, 16rem)"
+            let cardTrack = "minmax(24rem, 44rem)"
+
+            let gutter =
+                match density with
+                | Density.EditorDensity.Compact -> "3rem"
+                | _ -> "4rem"
+
+            let filler () = Html.div [ prop.ariaHidden true ]
+
+            Html.div [
+                prop.key layer.Id
+                prop.ref surfaceRef
+                prop.className "swt:relative swt:mx-4 swt:grid swt:min-w-0 swt:items-start swt:motion-fade-in"
+                prop.style [
+                    style.custom (
+                        "gridTemplateColumns",
+                        match visibleSide with
+                        | ProvenanceSide.Input -> $"minmax(0,1fr) {railTrack} {gutter} {cardTrack} minmax(0,1fr)"
+                        | ProvenanceSide.Output -> $"minmax(0,1fr) {cardTrack} {gutter} {railTrack} minmax(0,1fr)"
+                    )
+                ]
+                if debug then
+                    prop.testId "provenance-surface"
+                prop.children [
+                    connectorOverlay
+                    filler ()
+                    match visibleSide with
+                    | ProvenanceSide.Input ->
+                        railColumn ProvenanceSide.Input
+                        filler ()
+                        groupColumnFor ProvenanceSide.Input
+                    | ProvenanceSide.Output ->
+                        groupColumnFor ProvenanceSide.Output
+                        filler ()
+                        railColumn ProvenanceSide.Output
+                    filler ()
+                ]
+            ]
+
         // Keying the surface by layer remounts it on layer switches, so the change
         // fades in as one deliberate transition instead of flashing in place.
         let surface =
-            match tier with
-            | LayoutTier.Wide ->
+            match tier, hiddenSide with
+            | (LayoutTier.Wide | LayoutTier.Medium), Some hidden -> soloSurface (visibleSideFor hidden)
+            | LayoutTier.Wide, None ->
                 Html.div [
                     prop.key layer.Id
                     prop.ref surfaceRef
@@ -1295,6 +1419,7 @@ type ProvenanceGrouping =
                             (nudgeSplit Splitter.Left)
                             resetSplit
                             debug
+
                         Html.div [
                             // The wide column gap is the gutter the group-to-group
                             // connectors are drawn in.
@@ -1309,6 +1434,7 @@ type ProvenanceGrouping =
                                 groupColumnFor ProvenanceSide.Output
                             ]
                         ]
+
                         Splitter.handle
                             Splitter.Right
                             (activeSplit = Some Splitter.Right)
@@ -1321,7 +1447,7 @@ type ProvenanceGrouping =
                         railColumn ProvenanceSide.Output
                     ]
                 ]
-            | LayoutTier.Medium ->
+            | LayoutTier.Medium, None ->
                 let railTrack side =
                     if openRail = Some side then
                         "minmax(10rem, 16rem)"
@@ -1355,7 +1481,7 @@ type ProvenanceGrouping =
                         mediumRailColumn ProvenanceSide.Output
                     ]
                 ]
-            | LayoutTier.Narrow ->
+            | LayoutTier.Narrow, _ ->
                 // Stacked cards cannot host readable connector curves; connection
                 // badges on the cards carry that information instead.
                 Html.div [
@@ -1366,10 +1492,18 @@ type ProvenanceGrouping =
                     if debug then
                         prop.testId "provenance-surface"
                     prop.children [
-                        narrowRailSection ProvenanceSide.Input
-                        groupColumnFor ProvenanceSide.Input
-                        groupColumnFor ProvenanceSide.Output
-                        narrowRailSection ProvenanceSide.Output
+                        match hiddenSide with
+                        | Some ProvenanceSide.Output ->
+                            narrowRailSection ProvenanceSide.Input
+                            groupColumnFor ProvenanceSide.Input
+                        | Some ProvenanceSide.Input ->
+                            narrowRailSection ProvenanceSide.Output
+                            groupColumnFor ProvenanceSide.Output
+                        | None ->
+                            narrowRailSection ProvenanceSide.Input
+                            groupColumnFor ProvenanceSide.Input
+                            groupColumnFor ProvenanceSide.Output
+                            narrowRailSection ProvenanceSide.Output
                     ]
                 ]
 
@@ -1437,6 +1571,8 @@ type ProvenanceGrouping =
                                                     Html.span "Undo"
                                                 ]
                                             ]
+                                            sideVisibilityToggle ProvenanceSide.Input
+                                            sideVisibilityToggle ProvenanceSide.Output
                                             Html.button [
                                                 prop.title (
                                                     if showPropertyHeaderConnectors then

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -12,6 +12,7 @@ open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Grouping
 open Swate.Components.Shared.ProvenanceGrouping.Edit
 open Swate.Components.Shared.ProvenanceGrouping.Session
+open Swate.Components.Shared.ProvenanceGrouping.Fixtures
 open Swate.Components.Page.ProvenanceGrouping.Types
 
 [<Erase; Mangle(false)>]
@@ -31,9 +32,10 @@ type ProvenanceGrouping =
         let openRail, setOpenRail = React.useState<ProvenanceSide option> None
         let density, setDensity = React.useState Density.EditorDensity.Comfortable
         let isPropertyShelfExpanded, setIsPropertyShelfExpanded = React.useState true
+        let isTutorialOpen, setIsTutorialOpen = React.useState false
 
-        let propertyShelfFolderExpansion, setPropertyShelfFolderExpansion =
-            React.useState<(ProvenanceLayerId * Set<string>) option> None
+        let propertyShelfActiveFolder, setPropertyShelfActiveFolder =
+            React.useState<(ProvenanceLayerId * string) option> None
 
         let showPropertyHeaderConnectors, setShowPropertyHeaderConnectors =
             React.useState true
@@ -304,24 +306,15 @@ type ProvenanceGrouping =
                 |]
             )
 
-        let defaultPropertyShelfFolderIds =
-            React.useMemo (
-                (fun () ->
-                    propertyShelfFolders
-                    |> List.tryHead
-                    |> Option.map (fun folder -> Set.singleton folder.Id)
-                    |> Option.defaultValue Set.empty
-                ),
-                [| box propertyShelfFolders |]
-            )
+        // The shelf falls back to its first tab internally, so only a
+        // selection made on the current layer is forwarded.
+        let propertyShelfActiveFolderId =
+            match propertyShelfActiveFolder with
+            | Some(selectedLayerId, folderId) when selectedLayerId = layer.Id -> Some folderId
+            | _ -> None
 
-        let propertyShelfExpandedFolderIds =
-            match propertyShelfFolderExpansion with
-            | Some(expandedLayerId, folderIds) when expandedLayerId = layer.Id -> folderIds
-            | _ -> defaultPropertyShelfFolderIds
-
-        let setPropertyShelfExpandedFolderIds folderIds =
-            setPropertyShelfFolderExpansion (Some(latestLayer.current.Id, folderIds))
+        let setPropertyShelfActiveFolderId folderId =
+            setPropertyShelfActiveFolder (Some(latestLayer.current.Id, folderId))
 
         let setPropertyShelfFolderColor folderId color =
             applyUiState (PropertyShelf.setFolderColor latestSession.current folderId color)
@@ -332,6 +325,8 @@ type ProvenanceGrouping =
                     Html.section [
                         prop.className
                             "swt:flex swt:min-w-0 swt:flex-col swt:gap-3 swt:rounded-lg swt:border swt:border-base-300 swt:bg-base-100/80 swt:p-3 swt:shadow-sm"
+                        // Always-on anchor for the interactive tutorial's spotlight.
+                        prop.custom ("data-tutorial", "provenance-property-shelf")
                         if debug then
                             prop.testId "provenance-property-shelf"
                         prop.children [
@@ -398,8 +393,8 @@ type ProvenanceGrouping =
                                     (fun _ item ->
                                         DragDrop.folderPropertyDragId item.Payload.SourceSide item.Payload.Header
                                     ),
-                                    expandedFolderIds = propertyShelfExpandedFolderIds,
-                                    onExpandedFolderIdsChange = setPropertyShelfExpandedFolderIds,
+                                    ?activeFolderId = propertyShelfActiveFolderId,
+                                    onActiveFolderIdChange = setPropertyShelfActiveFolderId,
                                     onSetFolderColor = setPropertyShelfFolderColor,
                                     className = "swt:min-w-0 swt:motion-pop-in",
                                     debug = debug
@@ -410,7 +405,7 @@ type ProvenanceGrouping =
                 [|
                     box propertyShelfFolders
                     box isPropertyShelfExpanded
-                    box propertyShelfExpandedFolderIds
+                    box propertyShelfActiveFolderId
                 |]
             )
 
@@ -1391,32 +1386,26 @@ type ProvenanceGrouping =
                             "swt:sticky swt:top-0 swt:z-20 swt:flex swt:flex-col swt:gap-4 swt:bg-base-200 swt:p-4"
                         prop.children [
                             Html.div [
-                                prop.className "swt:flex swt:flex-wrap swt:items-center swt:justify-between swt:gap-2"
+                                prop.className "swt:flex swt:min-w-0 swt:flex-wrap swt:items-center swt:gap-2"
+                                if debug then
+                                    prop.testId "provenance-top-controls"
                                 prop.children [
-                                    Controls.LayerTabs(
-                                        session,
-                                        (fun layerId ->
-                                            Session.selectLayer layerId latestSession.current |> publishResult false
-                                        ),
-                                        (fun name ->
-                                            let currentInputGroups, currentOutputGroups = latestGroups.current
-
-                                            EditorActions.addLayer
-                                                latestSession.current
-                                                latestLayer.current.Id
-                                                currentInputGroups
-                                                currentOutputGroups
-                                                latestUiState.current
-                                                name
-                                                publish
-                                        ),
-                                        sourceColors = uiState.PropertyColors.SourceColors,
-                                        onSetSourceColor = setSourceColor,
-                                        seedSummary = layerSeedSummary,
+                                    // Search, sort and filters sit on one line
+                                    // above the property shelf.
+                                    Controls.FilterToolbar(
+                                        uiState.Filters,
+                                        (fun text -> applyUiState (State.Filters.setSearch text)),
+                                        setPropertySort,
+                                        (fun sort -> applyUiState (State.Filters.setGroupSort sort)),
+                                        (fun filter -> applyUiState (State.Filters.setValueCountFilter filter)),
+                                        (fun filter -> applyUiState (State.Filters.setOriginFilter filter)),
                                         debug = debug
                                     )
                                     Html.div [
-                                        prop.className "swt:flex swt:flex-wrap swt:items-center swt:gap-2"
+                                        prop.className
+                                            "swt:ml-auto swt:flex swt:shrink-0 swt:flex-wrap swt:items-center swt:gap-2"
+                                        if debug then
+                                            prop.testId "provenance-view-actions"
                                         prop.children [
                                             Html.button [
                                                 prop.type'.button
@@ -1510,20 +1499,27 @@ type ProvenanceGrouping =
                                                 prop.text "Compact"
                                             ]
                                             Controls.HelpLegend(debug = debug)
+                                            Html.button [
+                                                prop.type'.button
+                                                prop.className "swt:btn swt:btn-ghost swt:btn-xs"
+                                                prop.title "Open the interactive tutorial"
+                                                prop.ariaLabel "Open the interactive tutorial"
+                                                if debug then
+                                                    prop.testId "provenance-tutorial-trigger"
+                                                prop.onClick (fun _ -> setIsTutorialOpen true)
+                                                prop.children [
+                                                    Html.i [
+                                                        prop.className
+                                                            "swt:iconify swt:fluent--lightbulb-20-regular swt:size-4"
+                                                    ]
+                                                    Html.span "Tutorial"
+                                                ]
+                                            ]
                                         ]
                                     ]
                                 ]
                             ]
                             propertyShelf
-                            Controls.FilterToolbar(
-                                uiState.Filters,
-                                (fun text -> applyUiState (State.Filters.setSearch text)),
-                                setPropertySort,
-                                (fun sort -> applyUiState (State.Filters.setGroupSort sort)),
-                                (fun filter -> applyUiState (State.Filters.setValueCountFilter filter)),
-                                (fun filter -> applyUiState (State.Filters.setOriginFilter filter)),
-                                debug = debug
-                            )
                             // The selection bar keeps the otherwise invisible group
                             // selection visible: it drives fan-out drops and layer seeding.
                             if selectedGroupCount > 0 then
@@ -1630,6 +1626,46 @@ type ProvenanceGrouping =
                         connections
                         uiState.Detail
                         removeDisplayConnection
+
+                    // Layer navigation is pinned to the bottom, but only the
+                    // centered pagination control itself is visually boxed.
+                    Html.div [
+                        prop.className
+                            "swt:pointer-events-none swt:sticky swt:bottom-0 swt:z-20 swt:mt-auto swt:flex swt:justify-center swt:px-4 swt:py-2"
+                        prop.children [
+                            Controls.LayerPagination(
+                                session,
+                                (fun layerId ->
+                                    Session.selectLayer layerId latestSession.current |> publishResult false
+                                ),
+                                (fun name ->
+                                    let currentInputGroups, currentOutputGroups = latestGroups.current
+
+                                    EditorActions.addLayer
+                                        latestSession.current
+                                        latestLayer.current.Id
+                                        currentInputGroups
+                                        currentOutputGroups
+                                        latestUiState.current
+                                        name
+                                        publish
+                                ),
+                                sourceColors = uiState.PropertyColors.SourceColors,
+                                onSetSourceColor = setSourceColor,
+                                seedSummary = layerSeedSummary,
+                                debug = debug
+                            )
+                        ]
+                    ]
+
+                    // The tour runs on a sandboxed sample-data editor instance, so
+                    // trying the interactions cannot touch the host's session.
+                    if isTutorialOpen then
+                        ProvenanceTutorial.Modal(
+                            (fun () -> setIsTutorialOpen false),
+                            ProvenanceGrouping.Editor(sampleModel (), ignore, debug = debug),
+                            debug = debug
+                        )
                 ]
             ]
 

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -1418,6 +1418,10 @@ type ProvenanceGrouping =
                                                 prop.className "swt:btn swt:btn-xs swt:btn-ghost"
                                                 prop.title "Undo last change"
                                                 prop.ariaLabel "Undo last change"
+                                                // Always-on anchor for the interactive tutorial;
+                                                // its enabled state doubles as the connect step's
+                                                // "an edit was published" completion signal.
+                                                prop.custom ("data-tutorial", "provenance-undo")
                                                 prop.disabled undoSession.IsNone
                                                 if debug then
                                                     prop.testId "provenance-undo"

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -352,36 +352,27 @@ type ProvenanceGrouping =
                                         prop.className
                                             "swt:flex swt:min-w-0 swt:items-center swt:gap-2 swt:text-sm swt:font-medium"
                                         prop.children [
-                                            Html.i [
-                                                prop.className [
-                                                    "swt:iconify swt:size-5 swt:shrink-0"
-                                                    if isPropertyShelfExpanded then
-                                                        "swt:fluent--folder-open-24-regular"
-                                                    else
-                                                        "swt:fluent--folder-24-regular"
-                                                ]
-                                            ]
                                             Html.span [
                                                 prop.className "swt:min-w-0 swt:truncate"
-                                                prop.text "Available properties by source"
+                                                prop.text "Annotations"
                                             ]
                                         ]
                                     ]
                                     Html.button [
                                         prop.title (
                                             if isPropertyShelfExpanded then
-                                                "Minimize property folders"
+                                                "Minimize annotation folders"
                                             else
-                                                "Expand property folders"
+                                                "Expand annotation folders"
                                         )
                                         prop.type'.button
                                         prop.className "swt:btn swt:btn-ghost swt:btn-xs swt:size-8 swt:p-0"
                                         prop.custom ("aria-expanded", isPropertyShelfExpanded)
                                         prop.ariaLabel (
                                             if isPropertyShelfExpanded then
-                                                "Minimize property folders"
+                                                "Minimize annotation folders"
                                             else
-                                                "Expand property folders"
+                                                "Expand annotation folders"
                                         )
                                         if debug then
                                             prop.testId "provenance-property-shelf-toggle"
@@ -1121,9 +1112,9 @@ type ProvenanceGrouping =
                         Html.button [
                             prop.title (
                                 if side = ProvenanceSide.Input then
-                                    "Hide input properties"
+                                    "Hide input annotations"
                                 else
-                                    "Hide output properties"
+                                    "Hide output annotations"
                             )
                             prop.type'.button
                             prop.className [
@@ -1131,7 +1122,7 @@ type ProvenanceGrouping =
                                 if side = ProvenanceSide.Output then
                                     "swt:self-end"
                             ]
-                            prop.ariaLabel $"Hide {railSideLabel side} properties"
+                            prop.ariaLabel $"Hide {railSideLabel side} annotations"
                             if debug then
                                 prop.testId $"provenance-rail-toggle-{side}"
                             prop.onClick (fun _ -> toggleRail side)
@@ -1155,21 +1146,21 @@ type ProvenanceGrouping =
                 Html.button [
                     prop.title (
                         if side = ProvenanceSide.Input then
-                            "Show input properties"
+                            "Show input annotations"
                         else
-                            "Show output properties"
+                            "Show output annotations"
                     )
                     prop.type'.button
                     prop.className
                         "swt:btn swt:btn-ghost swt:btn-xs swt:h-auto swt:min-h-24 swt:w-fit swt:px-1 swt:py-2"
-                    prop.ariaLabel $"Show {railSideLabel side} properties"
+                    prop.ariaLabel $"Show {railSideLabel side} annotations"
                     if debug then
                         prop.testId $"provenance-rail-toggle-{side}"
                     prop.onClick (fun _ -> toggleRail side)
                     prop.children [
                         Html.span [
                             prop.className "swt:[writing-mode:vertical-rl] swt:text-xs"
-                            prop.text "Properties"
+                            prop.text "Annotations"
                         ]
                     ]
                 ]
@@ -1184,9 +1175,9 @@ type ProvenanceGrouping =
                         prop.className "swt:btn swt:btn-ghost swt:btn-xs swt:w-fit"
                         prop.ariaLabel (
                             if openRail = Some side then
-                                $"Hide {railSideLabel side} properties"
+                                $"Hide {railSideLabel side} annotations"
                             else
-                                $"Show {railSideLabel side} properties"
+                                $"Show {railSideLabel side} annotations"
                         )
                         if debug then
                             prop.testId $"provenance-rail-toggle-{side}"
@@ -1203,8 +1194,8 @@ type ProvenanceGrouping =
                             ]
                             Html.span (
                                 match side with
-                                | ProvenanceSide.Input -> "Input properties"
-                                | ProvenanceSide.Output -> "Output properties"
+                                | ProvenanceSide.Input -> "Input annotations"
+                                | ProvenanceSide.Output -> "Output annotations"
                             )
                         ]
                     ]
@@ -1442,9 +1433,9 @@ type ProvenanceGrouping =
                                             Html.button [
                                                 prop.title (
                                                     if showPropertyHeaderConnectors then
-                                                        "Hide property header connectors"
+                                                        "Hide annotation header connectors"
                                                     else
-                                                        "Show property header connectors"
+                                                        "Show annotation header connectors"
                                                 )
                                                 prop.type'.button
                                                 prop.className [
@@ -1457,9 +1448,9 @@ type ProvenanceGrouping =
                                                 prop.custom ("aria-pressed", showPropertyHeaderConnectors)
                                                 prop.ariaLabel (
                                                     if showPropertyHeaderConnectors then
-                                                        "Hide property header connectors"
+                                                        "Hide annotation header connectors"
                                                     else
-                                                        "Show property header connectors"
+                                                        "Show annotation header connectors"
                                                 )
                                                 if debug then
                                                     prop.testId "provenance-property-connectors-toggle"
@@ -1476,7 +1467,7 @@ type ProvenanceGrouping =
                                                                 "swt:fluent--eye-hide-20-regular"
                                                         ]
                                                     ]
-                                                    Html.span "Property connectors"
+                                                    Html.span "Annotation connectors"
                                                 ]
                                             ]
                                             Html.button [

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -20,16 +20,31 @@ type ProvenanceGrouping =
 
     [<ReactComponent(true)>]
     static member Main
-        (session: ProvenanceSession, onChange: ProvenanceEditorChange -> unit, ?height: int, ?debug: bool)
-        =
+        (
+            session: ProvenanceSession,
+            onChange: ProvenanceEditorChange -> unit,
+            ?height: int,
+            ?debug: bool,
+            ?initUiState: ProvenanceSession -> UiState,
+            ?initialOpenRail: ProvenanceSide
+        ) =
         let debug = defaultArg debug false
-        let rawUiState, setUiState = React.useState (fun () -> State.init session)
+
+        // The tutorial sandbox seeds checkpoints through initUiState (e.g.
+        // "Species already sits on the input rail"); regular hosts start fresh.
+        let rawUiState, setUiState =
+            React.useState (fun () ->
+                match initUiState with
+                | Some init -> init session
+                | None -> State.init session
+            )
+
         let activeDrag, setActiveDrag = React.useState<ActiveDrag option> None
         let surfaceRef = React.useElementRef ()
         let splitDrag = React.useRef (None: Splitter.SplitterSide option)
         let rootRef = React.useElementRef ()
         let tier, setTier = React.useState LayoutTier.Wide
-        let openRail, setOpenRail = React.useState<ProvenanceSide option> None
+        let openRail, setOpenRail = React.useState<ProvenanceSide option> initialOpenRail
         let density, setDensity = React.useState Density.EditorDensity.Comfortable
         let isPropertyShelfExpanded, setIsPropertyShelfExpanded = React.useState true
         let isTutorialOpen, setIsTutorialOpen = React.useState false
@@ -1660,10 +1675,22 @@ type ProvenanceGrouping =
 
                     // The tour runs on a sandboxed sample-data editor instance, so
                     // trying the interactions cannot touch the host's session.
+                    // The overlay rebuilds it from the step's checkpoint seed
+                    // whenever the active step's checkpoint changes.
                     if isTutorialOpen then
                         ProvenanceTutorial.Modal(
                             (fun () -> setIsTutorialOpen false),
-                            ProvenanceGrouping.Editor(sampleModel (), ignore, debug = debug),
+                            (fun checkpoint ->
+                                let seed = ProvenanceTutorialSteps.checkpointSeed checkpoint
+
+                                ProvenanceGrouping.Editor(
+                                    sampleModel (),
+                                    ignore,
+                                    debug = debug,
+                                    initUiState = seed.InitUiState,
+                                    ?initialOpenRail = seed.OpenRail
+                                )
+                            ),
                             debug = debug
                         )
                 ]
@@ -1708,12 +1735,25 @@ type ProvenanceGrouping =
 
     [<ReactComponent>]
     static member Editor
-        (initialModel: ProvenanceModel, onChange: ProvenanceEditorChange -> unit, ?height: int, ?debug: bool)
-        =
+        (
+            initialModel: ProvenanceModel,
+            onChange: ProvenanceEditorChange -> unit,
+            ?height: int,
+            ?debug: bool,
+            ?initUiState: ProvenanceSession -> UiState,
+            ?initialOpenRail: ProvenanceSide
+        ) =
         let session, setSession = React.useState (fun () -> Session.init initialModel)
 
         let change (next: ProvenanceEditorChange) =
             setSession next.Session
             onChange next
 
-        ProvenanceGrouping.Main(session, change, ?height = height, ?debug = debug)
+        ProvenanceGrouping.Main(
+            session,
+            change,
+            ?height = height,
+            ?debug = debug,
+            ?initUiState = initUiState,
+            ?initialOpenRail = initialOpenRail
+        )

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -12,7 +12,6 @@ open Swate.Components.Shared.ProvenanceGrouping.Types
 open Swate.Components.Shared.ProvenanceGrouping.Grouping
 open Swate.Components.Shared.ProvenanceGrouping.Edit
 open Swate.Components.Shared.ProvenanceGrouping.Session
-open Swate.Components.Shared.ProvenanceGrouping.Fixtures
 open Swate.Components.Page.ProvenanceGrouping.Types
 
 [<Erase; Mangle(false)>]
@@ -1234,6 +1233,10 @@ type ProvenanceGrouping =
                     prop.className
                         "swt:btn swt:btn-ghost swt:btn-xs swt:h-auto swt:min-h-24 swt:w-fit swt:px-1 swt:py-2"
                     prop.ariaLabel $"Show {railSideLabel side} annotations"
+                    // Stable hook for the interactive tutorial: this collapsed
+                    // strip is the fallback spotlight target when the rail folds,
+                    // so the tour must find it without coupling to aria-label copy.
+                    prop.custom ("data-tutorial", $"provenance-rail-toggle-{side}")
                     if debug then
                         prop.testId $"provenance-rail-toggle-{side}"
                     prop.onClick (fun _ -> toggleRail side)
@@ -1259,6 +1262,11 @@ type ProvenanceGrouping =
                             else
                                 $"Show {railSideLabel side} annotations"
                         )
+                        // Stable hook for the interactive tutorial's fallback
+                        // spotlight, only while folded - once open, the rail
+                        // panel's own data-tutorial anchor is the target.
+                        if openRail <> Some side then
+                            prop.custom ("data-tutorial", $"provenance-rail-toggle-{side}")
                         if debug then
                             prop.testId $"provenance-rail-toggle-{side}"
                         prop.onClick (fun _ -> toggleRail side)

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -368,6 +368,9 @@ type ProvenanceGrouping =
                                         prop.type'.button
                                         prop.className "swt:btn swt:btn-ghost swt:btn-xs swt:size-8 swt:p-0"
                                         prop.custom ("aria-expanded", isPropertyShelfExpanded)
+                                        // Always-on anchor (paired with aria-expanded) so the
+                                        // tutorial can point at the toggle of a minimized shelf.
+                                        prop.custom ("data-tutorial", "provenance-property-shelf-toggle")
                                         prop.ariaLabel (
                                             if isPropertyShelfExpanded then
                                                 "Minimize annotation folders"

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -1687,7 +1687,7 @@ type ProvenanceGrouping =
                                 let seed = ProvenanceTutorialSteps.checkpointSeed checkpoint
 
                                 ProvenanceGrouping.Editor(
-                                    sampleModel (),
+                                    seed.Model(),
                                     ignore,
                                     debug = debug,
                                     initUiState = seed.InitUiState,

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -440,6 +440,11 @@ type ProvenanceGrouping =
             |]
         )
 
+        // Side hiding consolidates annotations onto the visible rail for the layer
+        // it runs on, so the flag must not carry over to another layer whose hidden
+        // side was never consolidated. Reveal both sides again on every layer switch.
+        React.useEffect ((fun () -> setHiddenSide None), [| box layer.Id |])
+
         // Splitter drags write the grid template straight to the DOM per animation
         // frame and commit the ratios to state once on release; committing per
         // pointermove re-rendered the entire editor for every mouse step.

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -1509,22 +1509,27 @@ type ProvenanceGrouping =
                                                 prop.text "Compact"
                                             ]
                                             Controls.HelpLegend(debug = debug)
-                                            Html.button [
-                                                prop.type'.button
-                                                prop.className "swt:btn swt:btn-ghost swt:btn-xs"
-                                                prop.title "Open the interactive tutorial"
-                                                prop.ariaLabel "Open the interactive tutorial"
-                                                if debug then
-                                                    prop.testId "provenance-tutorial-trigger"
-                                                prop.onClick (fun _ -> setIsTutorialOpen true)
-                                                prop.children [
-                                                    Html.i [
-                                                        prop.className
-                                                            "swt:iconify swt:fluent--lightbulb-20-regular swt:size-4"
+                                            // The tutorial's sandboxed editor (marked by its
+                                            // initUiState seed) must not offer a tutorial of
+                                            // its own - task steps keep the whole surface
+                                            // interactive, so the trigger would nest modals.
+                                            if initUiState.IsNone then
+                                                Html.button [
+                                                    prop.type'.button
+                                                    prop.className "swt:btn swt:btn-ghost swt:btn-xs"
+                                                    prop.title "Open the interactive tutorial"
+                                                    prop.ariaLabel "Open the interactive tutorial"
+                                                    if debug then
+                                                        prop.testId "provenance-tutorial-trigger"
+                                                    prop.onClick (fun _ -> setIsTutorialOpen true)
+                                                    prop.children [
+                                                        Html.i [
+                                                            prop.className
+                                                                "swt:iconify swt:fluent--lightbulb-20-regular swt:size-4"
+                                                        ]
+                                                        Html.span "Tutorial"
                                                     ]
-                                                    Html.span "Tutorial"
                                                 ]
-                                            ]
                                         ]
                                     ]
                                 ]

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -2701,9 +2701,14 @@ export const OpensInteractiveTutorialOnSampleData: Story = {
     expect(modal.getByText('Provenance editor tour')).toBeInTheDocument();
     expect(within(modal.getByTestId('tutorial-step-card')).getByText('Welcome')).toBeInTheDocument();
 
-    // The feature list jumps straight to any step's explanation.
+    // The feature list jumps straight to any step's explanation; the sandbox
+    // remounts at that step's checkpoint, so the state its task needs (here:
+    // inputs already grouped by Species) exists without doing earlier steps.
     await userEvent.click(modal.getByTestId('tutorial-sidebar-step-members'));
     expect(within(modal.getByTestId('tutorial-step-card')).getByText('Inspect group members')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(modal.getByTestId('provenance-group-Input-input:Species=Arabidopsis')).toBeInTheDocument(),
+    );
 
     // Closing returns to the host editor without any writeback patches.
     await userEvent.click(modal.getByTestId('tutorial-close'));

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -520,7 +520,18 @@ export const ToolbarUsesSinglePropertySortAndOriginButtons: Story = {
 };
 
 export const TopControlsShareOneRowWhenSpaceAllows: Story = {
-  render: () => <Harness />,
+  // The controls row wraps by design (flex-wrap) once it runs out of width, so
+  // this story must guarantee the ample width its name promises. At the default
+  // 1280px browser viewport the row sits right at the edge - it fits under one
+  // platform's font metrics and wraps under another's (Windows passes, Linux CI
+  // wraps by a row), which is what made this test flaky. A fixed wide wrapper
+  // pins the layout well clear of that edge so the single-row assertion is
+  // deterministic regardless of the runner's font rendering.
+  render: () => (
+    <div style={{ width: 1600 }}>
+      <Harness />
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const topControls = canvas.getByTestId('provenance-top-controls');

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -160,8 +160,9 @@ export const ExpandedGroupsShowMemberHoverValues: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    expect(within(canvas.getByText('Output A').closest('article')!).queryByRole('button', { name: 'Show members' }))
-      .not.toBeInTheDocument();
+    // Single-entry cards share the folder silhouette, so they expand the same way.
+    expect(within(canvas.getByText('Output A').closest('article')!).getByRole('button', { name: 'Show members' }))
+      .toBeInTheDocument();
 
     await groupByProperty(canvas, 'Output', 'Species');
     const grouped = await waitFor(() => canvas.getByTestId('provenance-group-Output-output:Species=Arabidopsis'));
@@ -230,9 +231,13 @@ export const ShowsFileTypeForDataEndpoints: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // A Data endpoint surfaces as a "File" type line above the single-entity card name.
+    // A Data endpoint shows its type as a document symbol in the folder body;
+    // the "File" type line appears on the expanded member row.
     const card = await waitFor(() => canvas.getByText('Data Output A').closest('article')!);
-    expect(card).toHaveTextContent('File');
+    expect(card.querySelector('[class*="fluent--document"]')).toBeInTheDocument();
+
+    await userEvent.click(within(card).getByRole('button', { name: 'Show members' }));
+    await waitFor(() => expect(card).toHaveTextContent('File'));
   },
 };
 

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -1693,6 +1693,118 @@ export const AddsNewPropertyFromRail: Story = {
   },
 };
 
+export const HidingASideCentersTheRemainingSide: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByTestId('provenance-property-rail-Output')).toBeInTheDocument();
+    expect(canvas.getByText('Output A')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByTestId('provenance-side-visibility-Output'));
+
+    await waitFor(() => {
+      expect(canvas.queryByTestId('provenance-property-rail-Output')).not.toBeInTheDocument();
+      expect(canvas.queryByText('Output A')).not.toBeInTheDocument();
+    });
+    // The kept side and its rail stay on screen; only the hidden side leaves.
+    expect(canvas.getByTestId('provenance-property-rail-Input')).toBeInTheDocument();
+    expect(canvas.getByText('Input A')).toBeInTheDocument();
+
+    // The visible side sits as a centered cluster: the rail is not flush to the
+    // left edge, the card column keeps a generous width (no compact-container
+    // downshift), and the empty space is balanced on both sides.
+    {
+      const surface = canvas.getByTestId('provenance-surface');
+      const groupColumn = Array.from(surface.children).find((element) =>
+        element.querySelector('[data-provenance-group-node^="provenance-node::Input::"]'),
+      ) as HTMLElement;
+      const sr = surface.getBoundingClientRect();
+      const railLeft = canvas.getByTestId('provenance-property-rail-Input').getBoundingClientRect().left;
+      const gc = groupColumn.getBoundingClientRect();
+      const leftGap = railLeft - sr.left;
+      const rightGap = sr.right - gc.right;
+      expect(gc.width).toBeGreaterThan(360);
+      expect(leftGap).toBeGreaterThan(24);
+      expect(rightGap).toBeGreaterThan(24);
+      // Equal spacers keep the cluster genuinely centered, not merely off the edge.
+      expect(Math.abs(leftGap - rightGap)).toBeLessThan(32);
+    }
+
+    await userEvent.click(canvas.getByTestId('provenance-side-visibility-Output'));
+
+    await waitFor(() => {
+      expect(canvas.getByTestId('provenance-property-rail-Output')).toBeInTheDocument();
+      expect(canvas.getByText('Output A')).toBeInTheDocument();
+    });
+  },
+};
+
+export const SwitchableAnnotationFollowsVisibleSideWhenItsSideIsHidden: Story = {
+  render: () => <Harness fixture="switchableProperty" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Drag Batch onto the output rail. Batch can switch sides because it exists
+    // on both input and output sets.
+    await ensurePropertyInRail(canvas, 'Output', 'Batch');
+    expect(canvas.queryByTestId('provenance-property-Input-Batch')).not.toBeInTheDocument();
+
+    // With outputs hidden, the switchable annotation moves onto the input rail.
+    await toggleSideVisibility(canvas, 'Output', () =>
+      expect(canvas.queryByTestId('provenance-property-rail-Output')).not.toBeInTheDocument(),
+    );
+    expect(canvas.getByTestId('provenance-property-Input-Batch')).toBeInTheDocument();
+
+    // The move is permanent: revealing the output side leaves Batch on the input
+    // rail rather than sending it back.
+    await toggleSideVisibility(canvas, 'Output', () =>
+      expect(canvas.getByTestId('provenance-property-rail-Output')).toBeInTheDocument(),
+    );
+    expect(canvas.getByTestId('provenance-property-Input-Batch')).toBeInTheDocument();
+    expect(canvas.queryByTestId('provenance-property-Output-Batch')).not.toBeInTheDocument();
+  },
+};
+
+export const GroupBothOnVisibleSideAppliesToHiddenSideWhenRevealed: Story = {
+  render: () => <Harness fixture="switchableProperty" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await toggleSideVisibility(canvas, 'Output', () =>
+      expect(canvas.queryByTestId('provenance-property-rail-Output')).not.toBeInTheDocument(),
+    );
+
+    // Batch now sits on the visible input rail; grouping "both" from here must
+    // still drive the hidden output side.
+    await showPropertyControls(canvas, 'Input', 'Batch');
+    for (
+      let attempt = 0;
+      attempt < 3 && !canvas.queryByTestId('provenance-group-Input-input:Batch=A');
+      attempt += 1
+    ) {
+      fireEvent.click(canvas.getByTestId('provenance-property-both-Input-Batch'));
+      await waitFor(
+        () => expect(canvas.getByTestId('provenance-group-Input-input:Batch=A')).toBeInTheDocument(),
+        { timeout: 1000 },
+      ).catch(() => undefined);
+    }
+    await waitFor(() =>
+      expect(canvas.getByTestId('provenance-group-Input-input:Batch=A')).toBeInTheDocument(),
+    );
+
+    // Showing the output side reveals the grouping the same action produced there.
+    await toggleSideVisibility(canvas, 'Output', () =>
+      expect(canvas.getByTestId('provenance-property-rail-Output')).toBeInTheDocument(),
+    );
+
+    await waitFor(() => {
+      expect(canvas.getByTestId('provenance-group-Output-output:Batch=A')).toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Output-output:Batch=B')).toBeInTheDocument();
+    });
+  },
+};
+
 let nextPointerId = 100;
 
 function allocatePointerId() {
@@ -1901,6 +2013,26 @@ async function openShelfFolder(canvas: ReturnType<typeof within>, folder: HTMLEl
 
   await waitFor(() => expect(currentFolder()).toHaveAttribute('aria-selected', 'true'));
   return within(canvas.getByTestId('foldered-draggable-item-row'));
+}
+
+// Clicking the visibility toggle right after a drag is flaky (dnd-kit's pointer
+// sensor can swallow the first click), so retry until the layout settles.
+async function toggleSideVisibility(
+  canvas: ReturnType<typeof within>,
+  side: 'Input' | 'Output',
+  settled: () => void | Promise<void>,
+) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    fireEvent.click(canvas.getByTestId(`provenance-side-visibility-${side}`));
+    try {
+      await waitFor(async () => await settled(), { timeout: 1500 });
+      return;
+    } catch {
+      // Retry the click on the next iteration.
+    }
+  }
+
+  await waitFor(async () => await settled());
 }
 
 async function createLayer(canvas: ReturnType<typeof within>, name: string) {
@@ -2762,7 +2894,7 @@ export const TutorialTaskStepCompletesInsideSandbox: Story = {
     // The click task completes in place as well; the user moves on themselves.
     await userEvent.click(modal.getByTestId('provenance-property-Input-Species'));
     await waitFor(() => expect(modal.getByTestId('tutorial-next')).toHaveTextContent('Next'), { timeout: 5000 });
-    expect(modal.getByText('2 of 13 features explored')).toBeInTheDocument();
+    expect(modal.getByText('2 of 14 features explored')).toBeInTheDocument();
     await userEvent.click(modal.getByTestId('tutorial-next'));
     expect(within(modal.getByTestId('tutorial-step-card')).getByText('Inspect group members')).toBeInTheDocument();
   },

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -2540,6 +2540,8 @@ export const LayerPaginationUsesNeighborWindowAndArrowSwitches: Story = {
       expect(layerPageIds(canvas)).toEqual(['layer-1', 'layer-2', 'layer-3']);
       expect(canvas.getByTestId('provenance-layer-layer-3')).toHaveClass('swt:btn-primary');
     });
+    // The jump trigger doubles as the layer position indicator.
+    expect(pagination.getByTestId('provenance-layer-jump')).toHaveTextContent('3 / 3');
     expect(canvas.getByTestId('provenance-layer-layer-2')).toHaveClass('swt:opacity-50');
     expect(canvas.queryByTestId('provenance-layer-next')).not.toBeInTheDocument();
     expect(pagination.getByTestId('provenance-layer-prev').querySelector('[class*="fluent--chevron-left"]'))
@@ -2562,6 +2564,7 @@ export const LayerPaginationUsesNeighborWindowAndArrowSwitches: Story = {
       expect(layerPageIds(canvas)).toEqual(['layer-1', 'layer-2', 'layer-3']);
       expect(canvas.getByTestId('provenance-layer-layer-1')).toHaveClass('swt:btn-primary');
     });
+    expect(pagination.getByTestId('provenance-layer-jump')).toHaveTextContent('1 / 3');
     expect(canvas.queryByTestId('provenance-layer-prev')).not.toBeInTheDocument();
     expect(pagination.getByTestId('provenance-layer-next').querySelector('[class*="fluent--chevron-right"]'))
       .toBeInTheDocument();

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -99,7 +99,7 @@ function HarnessState({
       )}
       <ProvenanceGrouping
         session={session}
-        height={680}
+        height={960}
         debug={debug}
         onChange={(change: any) => {
           setSession(change.Session);

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -2714,6 +2714,9 @@ export const OpensInteractiveTutorialOnSampleData: Story = {
     expect(modal.getByText('Provenance editor tour')).toBeInTheDocument();
     expect(within(modal.getByTestId('tutorial-step-card')).getByText('Welcome')).toBeInTheDocument();
 
+    // The sandboxed editor must not offer a tutorial of its own (no nesting).
+    expect(modal.queryByTestId('provenance-tutorial-trigger')).not.toBeInTheDocument();
+
     // The feature list jumps straight to any step's explanation; the sandbox
     // remounts at that step's checkpoint, so the state its task needs (here:
     // inputs already grouped by Species) exists without doing earlier steps.

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -526,13 +526,21 @@ export const TopControlsShareOneRowWhenSpaceAllows: Story = {
     const originFilter = canvas.getByRole('button', { name: /^Show upstream properties$/i });
 
     const rowTop = (element: HTMLElement) => Math.round(element.getBoundingClientRect().top);
+    const rowCenter = (element: HTMLElement) => {
+      const rect = element.getBoundingClientRect();
+      return rect.top + rect.height / 2;
+    };
 
     expect(topControls).toContainElement(toolbar);
     expect(topControls).toContainElement(viewActions);
     expect(rowTop(toolbar)).toBe(rowTop(search));
     expect(rowTop(search)).toBe(rowTop(valueFilter));
     expect(rowTop(search)).toBe(rowTop(originFilter));
-    expect(rowTop(toolbar)).toBe(rowTop(viewActions));
+    // The view actions are deliberately smaller (btn-xs) than the toolbar
+    // controls, so on the shared items-center row their tops differ while the
+    // vertical centers align; a wrap onto a second row would offset the
+    // center by a full row height.
+    expect(Math.abs(rowCenter(toolbar) - rowCenter(viewActions))).toBeLessThanOrEqual(1);
   },
 };
 

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -2762,7 +2762,7 @@ export const TutorialTaskStepCompletesInsideSandbox: Story = {
     // The click task completes in place as well; the user moves on themselves.
     await userEvent.click(modal.getByTestId('provenance-property-Input-Species'));
     await waitFor(() => expect(modal.getByTestId('tutorial-next')).toHaveTextContent('Next'), { timeout: 5000 });
-    expect(modal.getByText('2 of 12 features explored')).toBeInTheDocument();
+    expect(modal.getByText('2 of 13 features explored')).toBeInTheDocument();
     await userEvent.click(modal.getByTestId('tutorial-next'));
     expect(within(modal.getByTestId('tutorial-step-card')).getByText('Inspect group members')).toBeInTheDocument();
   },

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -345,10 +345,10 @@ export const PropertiesStartInOriginFoldersAndSideDropZonesAreEmpty: Story = {
       expect(within(canvas.getByTestId('foldered-draggable-item-row')).getByRole('button', { name: /^Drag Species$/ }))
         .toBeVisible());
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Minimize property folders' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Minimize annotation folders' }));
     await waitFor(() => expect(canvas.queryByTestId('foldered-draggable-list')).not.toBeInTheDocument());
 
-    await userEvent.click(canvas.getByRole('button', { name: 'Expand property folders' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Expand annotation folders' }));
     await waitFor(() => expect(canvas.getByTestId('foldered-draggable-list')).toBeInTheDocument());
     await waitFor(() =>
       expect(within(canvas.getByTestId('foldered-draggable-item-row')).getByRole('button', { name: /^Drag Species$/ }))
@@ -502,18 +502,18 @@ export const ToolbarUsesSinglePropertySortAndOriginButtons: Story = {
     const canvas = within(canvasElement);
     const toolbar = within(canvas.getByTestId('provenance-filter-toolbar'));
 
-    expect(toolbar.getByPlaceholderText('Search properties & values...')).toBeInTheDocument();
+    expect(toolbar.getByPlaceholderText('Search annotations & values...')).toBeInTheDocument();
 
     await userEvent.click(toolbar.getByRole('button', { name: /^Sort By$/i }));
-    expect(toolbar.getByRole('button', { name: /^Property Value Count$/i })).toBeInTheDocument();
+    expect(toolbar.getByRole('button', { name: /^Annotation Value Count$/i })).toBeInTheDocument();
     expect(toolbar.getByRole('button', { name: /^Name$/i })).toBeInTheDocument();
     expect(toolbar.getAllByRole('button', { name: /^Connection Count$/i })).toHaveLength(1);
 
-    expect(toolbar.getByRole('button', { name: /^Show upstream properties$/i }).querySelector('[class*="fluent--arrow-up-20"]'))
+    expect(toolbar.getByRole('button', { name: /^Show upstream annotations$/i }).querySelector('[class*="fluent--arrow-up-20"]'))
       .toBeInTheDocument();
-    expect(toolbar.getByRole('button', { name: /^Show current properties$/i }).querySelector('[class*="fluent--circle-20-filled"]'))
+    expect(toolbar.getByRole('button', { name: /^Show current annotations$/i }).querySelector('[class*="fluent--circle-20-filled"]'))
       .toBeInTheDocument();
-    const both = toolbar.getByRole('button', { name: /^Show current and upstream properties$/i });
+    const both = toolbar.getByRole('button', { name: /^Show current and upstream annotations$/i });
     expect(both.querySelector('[class*="fluent--arrow-up-20"]')).toBeInTheDocument();
     expect(both.querySelector('[class*="fluent--circle-20-filled"]')).toBeInTheDocument();
   },
@@ -527,8 +527,8 @@ export const TopControlsShareOneRowWhenSpaceAllows: Story = {
     const toolbar = canvas.getByTestId('provenance-filter-toolbar');
     const search = canvas.getByTestId('provenance-search');
     const viewActions = canvas.getByTestId('provenance-view-actions');
-    const valueFilter = canvas.getByRole('combobox', { name: 'Filter by property value count' });
-    const originFilter = canvas.getByRole('button', { name: /^Show upstream properties$/i });
+    const valueFilter = canvas.getByRole('combobox', { name: 'Filter by annotation value count' });
+    const originFilter = canvas.getByRole('button', { name: /^Show upstream annotations$/i });
 
     const rowTop = (element: HTMLElement) => Math.round(element.getBoundingClientRect().top);
     const rowCenter = (element: HTMLElement) => {
@@ -554,7 +554,7 @@ export const SearchInputUpdatesImmediatelyButFiltersAfterDebounce: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const toolbar = within(canvas.getByTestId('provenance-filter-toolbar'));
-    const search = toolbar.getByPlaceholderText('Search properties & values...') as HTMLInputElement;
+    const search = toolbar.getByPlaceholderText('Search annotations & values...') as HTMLInputElement;
 
     await ensurePropertyInRail(canvas, 'Output', 'Species');
     await ensurePropertyInRail(canvas, 'Output', 'Analysis');
@@ -642,7 +642,7 @@ export const AddedRailPropertiesAreCurrentAndPinnedToTheirSide: Story = {
     expect(within(inputRail.getByTestId('provenance-property-Input-Treatment')).getByTitle('Current')).toBeInTheDocument();
     expect(outputRail.queryByTestId('provenance-property-Output-Treatment')).not.toBeInTheDocument();
 
-    await userEvent.click(within(canvas.getByTestId('provenance-filter-toolbar')).getByRole('button', { name: /^Show current properties$/i }));
+    await userEvent.click(within(canvas.getByTestId('provenance-filter-toolbar')).getByRole('button', { name: /^Show current annotations$/i }));
     await waitFor(() => expect(inputRail.getByTestId('provenance-property-Input-Treatment')).toBeInTheDocument());
     expect(outputRail.queryByTestId('provenance-property-Output-Treatment')).not.toBeInTheDocument();
 
@@ -682,7 +682,7 @@ export const PropertyRailExpandsValuesAndAddControls: Story = {
     const outputRail = within(canvas.getByTestId('provenance-property-rail-Output'));
 
     expect(outputRail.queryByText('Arabidopsis')).not.toBeInTheDocument();
-    expect(outputRail.getByText('Add property')).toBeInTheDocument();
+    expect(outputRail.getByText('Add annotation')).toBeInTheDocument();
 
     const panel = await expandProperty(canvas, 'Output', 'Species');
     const arabidopsis = panel.getByText('Arabidopsis').closest('button, div')!;
@@ -1284,7 +1284,7 @@ export const ConnectionDetailsShowEntityPairsWithoutPropertyCreation: Story = {
     expect(within(details).getByTestId('provenance-connection-pairs')).toHaveTextContent('→');
     expect(details).toHaveTextContent(/connection/i);
     expect(within(details).queryByText(/Add value/i)).not.toBeInTheDocument();
-    expect(within(details).queryByText(/Add property/i)).not.toBeInTheDocument();
+    expect(within(details).queryByText(/Add annotation/i)).not.toBeInTheDocument();
     expect(within(details).getByRole('button', { name: /remove connection/i })).toBeInTheDocument();
   },
 };
@@ -2108,8 +2108,8 @@ async function addRailProperty(
   valueText: string,
 ) {
   const rail = within(canvas.getByTestId(`provenance-property-rail-${side}`));
-  const addPropertyTrigger = within(rail.getByTestId('popover_trigger_provenance-add-value-Property'))
-    .getByText('Add property')
+  const addPropertyTrigger = within(rail.getByTestId('popover_trigger_provenance-add-value-Annotation'))
+    .getByText('Add annotation')
     .closest('button')!;
   fireEvent.click(addPropertyTrigger);
   const category = await waitFor(() => screen.getAllByTestId('term-search-input')[0]).catch(async () => {
@@ -2120,7 +2120,7 @@ async function addRailProperty(
   await userEvent.keyboard('{Escape}');
   await userEvent.type(screen.getByRole('textbox', { name: new RegExp(`${propertyName} value`, 'i') }), valueText);
   const submit = screen
-    .getAllByRole('button', { name: /^Add property$/i })
+    .getAllByRole('button', { name: /^Add annotation$/i })
     .find((button) => button.getAttribute('type') === 'submit')!;
   await userEvent.click(submit);
   await userEvent.keyboard('{Escape}');
@@ -2751,7 +2751,7 @@ export const TutorialTaskStepCompletesInsideSandbox: Story = {
     await waitFor(() => expect(modal.getByTestId('tutorial-next')).toHaveTextContent('Next'), { timeout: 5000 });
     expect(within(modal.getByTestId('tutorial-task')).getByText('Completed:')).toBeInTheDocument();
     await userEvent.click(modal.getByTestId('tutorial-next'));
-    expect(within(modal.getByTestId('tutorial-step-card')).getByText('Group by a property')).toBeInTheDocument();
+    expect(within(modal.getByTestId('tutorial-step-card')).getByText('Group by an annotation')).toBeInTheDocument();
 
     // The click task completes in place as well; the user moves on themselves.
     await userEvent.click(modal.getByTestId('provenance-property-Input-Species'));

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -389,7 +389,7 @@ export const FolderColorPreviewSyncsLayerTabAndRailProperty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await setFolderPreviewColor(canvas.getByTestId('foldered-draggable-folder-source-fixture-assay-table'), '#be185d');
+    await setFolderPreviewColor(canvas, canvas.getByTestId('foldered-draggable-folder-source-fixture-assay-table'), '#be185d');
 
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-layer-layer-1')).toHaveAttribute(
@@ -411,7 +411,7 @@ export const NonLayerFolderColorAppliesToShelfAndRailProperties: Story = {
       'foldered-draggable-folder-source-fixture-previous-study-table',
     );
 
-    await setFolderPreviewColor(previousContextFolder, '#0891b2');
+    await setFolderPreviewColor(canvas, previousContextFolder, '#0891b2');
 
     const previousContextShelf = await openShelfFolder(canvas, previousContextFolder);
     const shelfPropertyButton = previousContextShelf.getByRole('button', { name: /^Drag Previous Treatment$/ });
@@ -511,6 +511,28 @@ export const ToolbarUsesSinglePropertySortAndOriginButtons: Story = {
     const both = toolbar.getByRole('button', { name: /^Show current and upstream properties$/i });
     expect(both.querySelector('[class*="fluent--arrow-up-20"]')).toBeInTheDocument();
     expect(both.querySelector('[class*="fluent--circle-20-filled"]')).toBeInTheDocument();
+  },
+};
+
+export const TopControlsShareOneRowWhenSpaceAllows: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const topControls = canvas.getByTestId('provenance-top-controls');
+    const toolbar = canvas.getByTestId('provenance-filter-toolbar');
+    const search = canvas.getByTestId('provenance-search');
+    const viewActions = canvas.getByTestId('provenance-view-actions');
+    const valueFilter = canvas.getByRole('combobox', { name: 'Filter by property value count' });
+    const originFilter = canvas.getByRole('button', { name: /^Show upstream properties$/i });
+
+    const rowTop = (element: HTMLElement) => Math.round(element.getBoundingClientRect().top);
+
+    expect(topControls).toContainElement(toolbar);
+    expect(topControls).toContainElement(viewActions);
+    expect(rowTop(toolbar)).toBe(rowTop(search));
+    expect(rowTop(search)).toBe(rowTop(valueFilter));
+    expect(rowTop(search)).toBe(rowTop(originFilter));
+    expect(rowTop(toolbar)).toBe(rowTop(viewActions));
   },
 };
 
@@ -1856,14 +1878,15 @@ function shelfFolders(canvas: ReturnType<typeof within>) {
 }
 
 async function openShelfFolder(canvas: ReturnType<typeof within>, folder: HTMLElement) {
+  // Folders render as index-card tabs; clicking the tab activates its card.
   const folderTestId = folder.getAttribute('data-testid')!;
   const currentFolder = () => canvas.getByTestId(folderTestId);
 
-  if (currentFolder().getAttribute('aria-expanded') !== 'true') {
-    await userEvent.click(within(currentFolder()).getByRole('button', { name: /^Expand / }));
+  if (currentFolder().getAttribute('aria-selected') !== 'true') {
+    await userEvent.click(currentFolder());
   }
 
-  await waitFor(() => expect(currentFolder()).toHaveAttribute('aria-expanded', 'true'));
+  await waitFor(() => expect(currentFolder()).toHaveAttribute('aria-selected', 'true'));
   return within(canvas.getByTestId('foldered-draggable-item-row'));
 }
 
@@ -1874,6 +1897,14 @@ async function createLayer(canvas: ReturnType<typeof within>, name: string) {
   await userEvent.clear(input);
   await userEvent.type(input, name);
   await userEvent.click(dialog.getByRole('button', { name: 'Create layer' }));
+}
+
+function layerPageIds(canvas: ReturnType<typeof within>) {
+  return Array.from(
+    canvas
+      .getByTestId('provenance-layer-pages')
+      .querySelectorAll<HTMLElement>('[data-provenance-layer-page]'),
+  ).map((page) => page.getAttribute('data-provenance-layer-page'));
 }
 
 async function shelfProperty(canvas: ReturnType<typeof within>, propertyName: string) {
@@ -1920,8 +1951,12 @@ function propertyColorSwatch(property: HTMLElement) {
   return swatch;
 }
 
-async function setFolderPreviewColor(folder: HTMLElement, color: string) {
-  const trigger = within(folder).getByRole('button', { name: /^Set color for folder / });
+async function setFolderPreviewColor(canvas: ReturnType<typeof within>, folder: HTMLElement, color: string) {
+  // The color control sits in the active card's header, so the folder's tab
+  // must be active first.
+  await openShelfFolder(canvas, folder);
+  const card = canvas.getByTestId('foldered-draggable-card');
+  const trigger = within(card).getByRole('button', { name: /^Set color for folder / });
   const triggerLabel = trigger.getAttribute('aria-label') ?? '';
   const inputLabel = triggerLabel.replace(/^Set /, 'Choose ');
 
@@ -2476,6 +2511,50 @@ export const LayerTabsUseSourceColorsAndSideRails: Story = {
   },
 };
 
+export const LayerPaginationUsesNeighborWindowAndArrowSwitches: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await createLayer(canvas, 'Layer 2');
+    await createLayer(canvas, 'Layer 3');
+
+    const pagination = within(canvas.getByTestId('provenance-layer-pagination'));
+    expect(canvas.queryByTestId('provenance-layer-select')).not.toBeInTheDocument();
+    expect(pagination.getByTestId('provenance-add-layer')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(layerPageIds(canvas)).toEqual(['layer-1', 'layer-2', 'layer-3']);
+      expect(canvas.getByTestId('provenance-layer-layer-3')).toHaveClass('swt:btn-primary');
+    });
+    expect(canvas.getByTestId('provenance-layer-layer-2')).toHaveClass('swt:opacity-50');
+    expect(canvas.queryByTestId('provenance-layer-next')).not.toBeInTheDocument();
+    expect(pagination.getByTestId('provenance-layer-prev').querySelector('[class*="fluent--chevron-left"]'))
+      .toBeInTheDocument();
+
+    await userEvent.click(pagination.getByTestId('provenance-layer-prev'));
+
+    await waitFor(() => {
+      expect(layerPageIds(canvas)).toEqual(['layer-1', 'layer-2', 'layer-3']);
+      expect(canvas.getByTestId('provenance-layer-layer-2')).toHaveClass('swt:btn-primary');
+    });
+    expect(canvas.getByTestId('provenance-layer-layer-1')).toHaveClass('swt:opacity-50');
+    expect(canvas.getByTestId('provenance-layer-layer-3')).toHaveClass('swt:opacity-50');
+    expect(pagination.getByTestId('provenance-layer-next').querySelector('[class*="fluent--chevron-right"]'))
+      .toBeInTheDocument();
+
+    await userEvent.click(pagination.getByTestId('provenance-layer-prev'));
+
+    await waitFor(() => {
+      expect(layerPageIds(canvas)).toEqual(['layer-1', 'layer-2', 'layer-3']);
+      expect(canvas.getByTestId('provenance-layer-layer-1')).toHaveClass('swt:btn-primary');
+    });
+    expect(canvas.queryByTestId('provenance-layer-prev')).not.toBeInTheDocument();
+    expect(pagination.getByTestId('provenance-layer-next').querySelector('[class*="fluent--chevron-right"]'))
+      .toBeInTheDocument();
+  },
+};
+
 export const AddsLayerFromMixedSelection: Story = {
   render: () => <Harness />,
   play: async ({ canvasElement }) => {
@@ -2531,8 +2610,8 @@ export const CreatesNamedLayer: Story = {
     await waitFor(() => {
       const layer = canvas.getByTestId('provenance-layer-layer-2');
       expect(layer).toHaveClass('swt:btn-primary');
-      expect(layer).toHaveTextContent('Extraction');
       expect(layer).toHaveAccessibleName('View provenance layer Extraction');
+      expect(layer).toHaveTextContent('Extraction');
     });
   },
 };
@@ -2609,5 +2688,58 @@ export const StrictModeSmoke: Story = {
     await waitFor(() => {
       expect(canvas.getByTestId('provenance-patch-preview')).toHaveTextContent('No patches emitted.');
     });
+  },
+};
+
+export const OpensInteractiveTutorialOnSampleData: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByTestId('provenance-tutorial-trigger'));
+
+    const modal = within(canvas.getByTestId('provenance-tutorial-modal'));
+    expect(modal.getByText('Provenance editor tour')).toBeInTheDocument();
+    expect(within(modal.getByTestId('tutorial-step-card')).getByText('Welcome')).toBeInTheDocument();
+
+    // The feature list jumps straight to any step's explanation.
+    await userEvent.click(modal.getByTestId('tutorial-sidebar-step-members'));
+    expect(within(modal.getByTestId('tutorial-step-card')).getByText('Inspect group members')).toBeInTheDocument();
+
+    // Closing returns to the host editor without any writeback patches.
+    await userEvent.click(modal.getByTestId('tutorial-close'));
+    expect(canvas.queryByTestId('provenance-tutorial-modal')).not.toBeInTheDocument();
+    expect(canvas.getByTestId('provenance-patch-preview')).toHaveTextContent('No patches emitted.');
+  },
+};
+
+export const TutorialTaskStepCompletesInsideSandbox: Story = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByTestId('provenance-tutorial-trigger'));
+    const modal = within(canvas.getByTestId('provenance-tutorial-modal'));
+
+    // Jump to the shelf-to-rail step and fulfil it by dragging Species into
+    // the sandbox's input rail; the polled condition marks the step completed
+    // and Skip becomes Next. The modal's feature list narrows the editor into
+    // the medium tier, so the rail sits behind its fold toggle first.
+    await userEvent.click(modal.getByTestId('tutorial-sidebar-step-shelf-to-rail'));
+    expect(modal.getByTestId('tutorial-next')).toHaveTextContent('Skip');
+    if (!modal.queryByTestId('provenance-property-rail-Input')) {
+      await userEvent.click(modal.getByTestId('provenance-rail-toggle-Input'));
+    }
+    const source = await shelfProperty(modal, 'Species');
+    await dragByPointer(source, modal.getByTestId('provenance-property-rail-Input'));
+    await waitFor(() => expect(modal.getByTestId('tutorial-next')).toHaveTextContent('Next'), { timeout: 5000 });
+    expect(within(modal.getByTestId('tutorial-task')).getByText('Completed:')).toBeInTheDocument();
+    await userEvent.click(modal.getByTestId('tutorial-next'));
+    expect(within(modal.getByTestId('tutorial-step-card')).getByText('Group by a property')).toBeInTheDocument();
+
+    // The click task completes in place as well; the user moves on themselves.
+    await userEvent.click(modal.getByTestId('provenance-property-Input-Species'));
+    await waitFor(() => expect(modal.getByTestId('tutorial-next')).toHaveTextContent('Next'), { timeout: 5000 });
+    expect(modal.getByText('2 of 12 features explored')).toBeInTheDocument();
+    await userEvent.click(modal.getByTestId('tutorial-next'));
+    expect(within(modal.getByTestId('tutorial-step-card')).getByText('Inspect group members')).toBeInTheDocument();
   },
 };

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -487,6 +487,76 @@ module PropertyPlacement =
         }
         |> RailOrder.appendHeader layerId side header
 
+/// Consolidates a hidden side's switchable annotations onto the still-visible rail.
+module SideVisibility =
+
+    /// Real, permanent move (revealing the side does not send them back): every
+    /// annotation on the hidden side that the model lets switch sides is relocated
+    /// to the visible rail, following the cards that stay on screen. A solo grouping
+    /// the header held on the now-hidden side is dropped, since it can no longer be
+    /// seen or managed; group-both assignments are cross-side and left intact.
+    let consolidateToVisible
+        layerId
+        (hiddenSide: ProvenanceSide)
+        (hiddenSideId: ProvenanceLayerSideId)
+        (canSwitch: ProvenancePropertyHeader -> bool)
+        state
+        =
+        let visibleSide =
+            match hiddenSide with
+            | ProvenanceSide.Input -> ProvenanceSide.Output
+            | ProvenanceSide.Output -> ProvenanceSide.Input
+
+        let hiddenScope = scopeForSide hiddenSide
+
+        let placedHeaders =
+            state.PropertyRailPlacements
+            |> Map.toList
+            |> List.choose (fun ((placementLayerId, key), side) ->
+                if placementLayerId = layerId && side = hiddenSide then
+                    Some key.Header
+                else
+                    None
+            )
+
+        let soloGroupedHeaders =
+            (Sides.get hiddenSideId state).GroupingAssignments
+            |> List.filter (fun assignment -> assignment.Scope = hiddenScope)
+            |> List.map (fun assignment -> assignment.Key.Header)
+
+        let headers =
+            [ yield! placedHeaders; yield! soloGroupedHeaders ]
+            |> List.distinct
+            |> List.filter canSwitch
+
+        headers
+        |> List.fold
+            (fun state header ->
+                let key = Keys.groupingKey header
+
+                let withoutSolo =
+                    Sides.update
+                        hiddenSideId
+                        (fun current -> {
+                            current with
+                                GroupingAssignments =
+                                    current.GroupingAssignments
+                                    |> List.filter (fun assignment ->
+                                        not (assignment.Key = key && assignment.Scope = hiddenScope)
+                                    )
+                        })
+                        state
+
+                {
+                    withoutSolo with
+                        PropertyRailPlacements =
+                            withoutSolo.PropertyRailPlacements |> Map.add (layerId, key) visibleSide
+                }
+                |> RailOrder.removeHeader layerId hiddenSide header
+                |> RailOrder.appendHeader layerId visibleSide header
+            )
+            state
+
 /// Tracks expanded property value panels on the side rails.
 module PropertyExpansion =
 

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -33,7 +33,7 @@ module ProvenanceTutorialSteps =
     // On medium/narrow layouts the input rail folds behind a toggle button;
     // the fallback keeps the spotlight meaningful there.
     let private inputRail =
-        "[data-tutorial='provenance-rail-Input'], button[aria-label='Show input properties']"
+        "[data-tutorial='provenance-rail-Input'], button[aria-label='Show input annotations']"
 
     let private explain id title description selector = {
         Id = id
@@ -76,18 +76,18 @@ module ProvenanceTutorialSteps =
             "[data-tutorial='provenance-layer-pagination']"
         explain
             "shelf"
-            "Property shelf"
-            "All properties known for this layer, grouped into index-card tabs per source table. The active card lists its properties and has its own small search; properties wait here until you pull them onto a side rail."
+            "Annotation shelf"
+            "All annotations known for this layer, grouped into index-card tabs per source table. The active card lists its annotations and has its own small search; annotations wait here until you pull them onto a side rail."
             "[data-tutorial='provenance-property-shelf']"
         explain
             "rails"
-            "Property rails"
-            "The left rail holds input-side properties, the right rail output-side ones. Rails start empty; properties you drop here become available for grouping and annotation. On narrow screens the rails fold behind 'Properties' toggles."
+            "Annotation rails"
+            "The left rail holds input-side annotations, the right rail output-side ones. Rails start empty; annotations you drop here become available for grouping and value assignment. On narrow screens the rails fold behind 'Annotations' toggles."
             inputRail
         {
             Id = "shelf-to-rail"
-            Title = "Pull a property onto a rail"
-            Description = "Dragging a property out of its shelf folder onto a rail activates it for that side."
+            Title = "Pull an annotation onto a rail"
+            Description = "Dragging an annotation out of its shelf folder onto a rail activates it for that side."
             // Highlights the drag source (the Species shelf item, once its
             // folder is open) and the dropzone (rail or, on folded layouts,
             // its toggle) together; task steps keep the whole surface
@@ -105,10 +105,10 @@ module ProvenanceTutorialSteps =
         }
         task
             "group"
-            "Group by a property"
-            "Clicking a rail property merges all entities that share a value into one card - four inputs become two species cards."
+            "Group by an annotation"
+            "Clicking a rail annotation merges all entities that share a value into one card - four inputs become two species cards."
             speciesGroupButton
-            "Click the Species property in the left rail to group the inputs by species."
+            "Click the Species annotation in the left rail to group the inputs by species."
             speciesGroupButton
             "species-on-rail"
         task
@@ -121,12 +121,12 @@ module ProvenanceTutorialSteps =
             "species-grouped"
         task
             "values"
-            "Property values"
-            "A rail property expands into its distinct values. Drag a value chip onto a card to assign it to every member at once - or add brand-new values first."
+            "Annotation values"
+            "A rail annotation expands into its distinct values. Drag a value chip onto a card to assign it to every member at once - or add brand-new values first."
             // The chevron only enters the layout while its row is hovered, so
             // the rail stays the fallback highlight until then.
             $"button[aria-label='Expand Species values'], {inputRail}"
-            "Hover the Species property in the left rail, then click the chevron next to it to expand its values."
+            "Hover the Species annotation in the left rail, then click the chevron next to it to expand its values."
             "button[aria-label='Expand Species values']"
             "species-values"
         {
@@ -148,7 +148,7 @@ module ProvenanceTutorialSteps =
         explain
             "filters"
             "Search, sort and filter"
-            "The toolbar narrows big models down: search properties and groups, sort by name or connection count, and filter by value coverage or origin."
+            "The toolbar narrows big models down: search annotations and groups, sort by name or connection count, and filter by value coverage or origin."
             "[data-tutorial='provenance-filter-toolbar']"
         explain
             "undo"

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -32,9 +32,11 @@ module ProvenanceTutorialSteps =
     let private speciesGroupButton = "button[data-tutorial-group-by='Input:Species']"
 
     // On medium/narrow layouts the input rail folds behind a toggle button;
-    // the fallback keeps the spotlight meaningful there.
+    // the fallback keeps the spotlight meaningful there. Both anchors are
+    // always-rendered data-tutorial hooks, so rewording a label cannot break
+    // the tour (the toggle only carries its hook while the rail is folded).
     let private inputRail =
-        "[data-tutorial='provenance-rail-Input'], button[aria-label='Show input annotations']"
+        "[data-tutorial='provenance-rail-Input'], [data-tutorial='provenance-rail-toggle-Input']"
 
     // The Species drag source can be hidden two ways before the drag can even
     // start: the whole shelf minimized behind its toggle, or another folder

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -4,6 +4,18 @@ open Fable.Core
 open Feliz
 open Swate.Components.Composite.TutorialOverlay
 open Swate.Components.Composite.TutorialOverlay.Types
+open Swate.Components.Shared.ProvenanceGrouping
+open Swate.Components.Shared.ProvenanceGrouping.Types
+open Swate.Components.Shared.ProvenanceGrouping.Session
+open Swate.Components.Page.ProvenanceGrouping.Types
+
+/// How the tutorial sandbox should be seeded when a checkpoint is (re)entered:
+/// the UI state the sample editor starts from and which rail begins unfolded
+/// on layouts that collapse the rails.
+type ProvenanceTutorialCheckpoint = {
+    InitUiState: ProvenanceSession -> UiState
+    OpenRail: ProvenanceSide option
+}
 
 /// The guided tour through the provenance editor's features. Selectors rely on
 /// always-rendered hooks: `data-tutorial` anchors, the stable `title`/`aria-label`
@@ -30,15 +42,20 @@ module ProvenanceTutorialSteps =
         TargetSelector = Some selector
         Task = None
         Advance = TutorialAdvance.Manual
+        Checkpoint = None
     }
 
-    let private task id title description selector instruction eventSelector = {
+    // Every hands-on step carries its own checkpoint, so jumping or going back
+    // to it always rebuilds the sandbox state its instructions assume - no
+    // matter what the user changed on other steps.
+    let private task id title description selector instruction eventSelector checkpoint = {
         Id = id
         Title = title
         Description = description
         TargetSelector = Some selector
         Task = Some instruction
         Advance = TutorialAdvance.OnEvent("click", eventSelector)
+        Checkpoint = Some checkpoint
     }
 
     let all: TutorialStep[] = [|
@@ -50,6 +67,7 @@ module ProvenanceTutorialSteps =
             TargetSelector = None
             Task = None
             Advance = TutorialAdvance.Manual
+            Checkpoint = None
         }
         explain
             "layers"
@@ -83,6 +101,7 @@ module ProvenanceTutorialSteps =
                 TutorialAdvance.OnCondition(fun container ->
                     container.querySelector speciesGroupButton |> isNull |> not
                 )
+            Checkpoint = Some "fresh-editor"
         }
         task
             "group"
@@ -91,6 +110,7 @@ module ProvenanceTutorialSteps =
             speciesGroupButton
             "Click the Species property in the left rail to group the inputs by species."
             speciesGroupButton
+            "species-on-rail"
         task
             "members"
             "Inspect group members"
@@ -98,6 +118,7 @@ module ProvenanceTutorialSteps =
             "button[title='Show members']"
             "Click 'Show members' on one of the grouped cards."
             "button[title='Show members']"
+            "species-grouped"
         task
             "values"
             "Property values"
@@ -107,6 +128,7 @@ module ProvenanceTutorialSteps =
             $"button[aria-label='Expand Species values'], {inputRail}"
             "Hover the Species property in the left rail, then click the chevron next to it to expand its values."
             "button[aria-label='Expand Species values']"
+            "species-values"
         {
             Id = "connect"
             Title = "Connect inputs to outputs"
@@ -121,6 +143,7 @@ module ProvenanceTutorialSteps =
                     "click",
                     "[data-provenance-connection-drop-id^='provenance-connection-drop|GroupCard|Output']"
                 )
+            Checkpoint = Some "species-connect"
         }
         explain
             "filters"
@@ -139,13 +162,51 @@ module ProvenanceTutorialSteps =
             "button[title='Add layer']"
     |]
 
+    // -- Checkpoint seeds ---------------------------------------------------
+    // Seeding applies exactly the state transitions the earlier hands-on steps
+    // would have produced (rail placement, grouping toggle), so a rebuilt
+    // sandbox is indistinguishable from one the user worked through.
+
+    let private speciesHeader =
+        Fixtures.propertyHeader Fixtures.FixtureKinds.characteristicProperty "Species"
+
+    let private withSpeciesOnInputRail (session: ProvenanceSession) (state: UiState) =
+        let layer = Session.activeLayer session
+        State.PropertyPlacement.place layer.Id ProvenanceSide.Input speciesHeader state
+
+    let private withSpeciesGrouped (session: ProvenanceSession) (state: UiState) =
+        let layer = Session.activeLayer session
+
+        withSpeciesOnInputRail session state
+        |> State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input speciesHeader
+
+    /// Resolves the overlay's (inherited) checkpoint key to the sandbox seed to
+    /// rebuild; unknown keys fall back to a fresh sample editor.
+    let checkpointSeed (checkpoint: string option) : ProvenanceTutorialCheckpoint =
+        match checkpoint with
+        | Some "species-on-rail" -> {
+            InitUiState = fun session -> State.init session |> withSpeciesOnInputRail session
+            OpenRail = Some ProvenanceSide.Input
+          }
+        | Some "species-grouped"
+        | Some "species-values"
+        | Some "species-connect" -> {
+            InitUiState = fun session -> State.init session |> withSpeciesGrouped session
+            OpenRail = Some ProvenanceSide.Input
+          }
+        | _ -> {
+            InitUiState = State.init
+            OpenRail = None
+          }
+
 [<Erase; Mangle(false)>]
 type ProvenanceTutorial =
 
     /// Full-screen tutorial: the interactive tour chrome wrapped around a
-    /// sandbox editor instance the host passes in (seeded with sample data).
+    /// sandboxed sample-data editor the host builds per checkpoint - the
+    /// overlay remounts it whenever the active step's checkpoint changes.
     [<ReactComponent>]
-    static member Modal(onClose: unit -> unit, editor: ReactElement, ?debug: bool) =
+    static member Modal(onClose: unit -> unit, renderEditor: string option -> ReactElement, ?debug: bool) =
         let debug = defaultArg debug false
 
         Html.div [
@@ -156,7 +217,7 @@ type ProvenanceTutorial =
                 TutorialOverlay.Main(
                     ProvenanceTutorialSteps.all,
                     onClose,
-                    editor,
+                    renderEditor,
                     title = "Provenance editor tour",
                     debug = debug
                 )

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -10,9 +10,10 @@ open Swate.Components.Shared.ProvenanceGrouping.Session
 open Swate.Components.Page.ProvenanceGrouping.Types
 
 /// How the tutorial sandbox should be seeded when a checkpoint is (re)entered:
-/// the UI state the sample editor starts from and which rail begins unfolded
-/// on layouts that collapse the rails.
+/// the sample model to load, the UI state the editor starts from, and which
+/// rail begins unfolded on layouts that collapse the rails.
 type ProvenanceTutorialCheckpoint = {
+    Model: unit -> ProvenanceModel
     InitUiState: ProvenanceSession -> UiState
     OpenRail: ProvenanceSide option
 }
@@ -49,8 +50,11 @@ module ProvenanceTutorialSteps =
     let private inputGroupCards =
         "[data-provenance-group-node^='provenance-node::Input::']"
 
-    let private outputGroupCards =
-        "[data-provenance-group-node^='provenance-node::Output::']"
+    // The extra input the assign checkpoint's model carries: the only card
+    // without a species value (inputs own one, outputs inherit one through
+    // their connections), so it is the one drop that assigns cleanly - and
+    // the one whose card visibly regroups on success.
+    let private inputECard = "[data-provenance-group-node$='input-e']"
 
     // The undo button enables on the first published edit, which makes it the
     // success signal for free-form tasks whose outcome is an edit rather than
@@ -164,12 +168,14 @@ module ProvenanceTutorialSteps =
             Id = "assign"
             Title = "Assign values to cards"
             Description =
-                "Value chips are live: drop one onto a card and the value is assigned to every member of that card. Where a member already has a different value, a prompt asks before overwriting."
-            // Rings the expanded value chips (the drag sources) and the output
-            // cards - the drop targets without a species value, so the invited
-            // drop applies cleanly instead of hitting the overwrite prompt.
-            TargetSelector = Some $"[data-tutorial-property-values='Input:Species'], {outputGroupCards}"
-            Task = Some "Drag one of the species value chips onto an output card - outputs have no species value yet."
+                "Value chips are live: drop one onto a card and the value is assigned to every member of that card. Input E has no species value yet, which is why it sits ungrouped - give it one and it joins the matching species card. Outputs need no drops at all: they inherit their values from connected inputs."
+            // Rings the expanded value chips (the drag sources) and Input E -
+            // the one card where the drop assigns cleanly and visibly (it
+            // regroups); every other card's own or inherited species value
+            // would route the drop into the overwrite handling instead.
+            TargetSelector = Some $"[data-tutorial-property-values='Input:Species'], {inputECard}"
+            Task =
+                Some "Drag a species value chip onto the ungrouped Input E card and watch it join that species group."
             Advance = TutorialAdvance.OnCondition editPublished
             Checkpoint = Some "species-values-expanded"
         }
@@ -237,26 +243,48 @@ module ProvenanceTutorialSteps =
         withSpeciesGrouped session state
         |> State.PropertyExpansion.toggle layer.Id ProvenanceSide.Input speciesHeader
 
+    /// The stock sample plus one input without any annotation values. Every
+    /// stock entity already has a species (inputs their own, outputs an
+    /// inherited one), so the assign step adds the one card a species drop
+    /// lands on cleanly - and it regroups on success, so the assignment is
+    /// impossible to miss.
+    let private assignSampleModel () =
+        let baseModel = Fixtures.sampleModel ()
+
+        let inputHeader =
+            Fixtures.ioHeader Fixtures.FixtureKinds.sampleEndpoint "Input [Sample Name]"
+
+        let inputE = Fixtures.inputSet "input-e" baseModel.Source inputHeader "Input E" []
+
+        {
+            baseModel with
+                InputSets = baseModel.InputSets |> Map.add inputE.Id inputE
+        }
+
     /// Resolves the overlay's (inherited) checkpoint key to the sandbox seed to
     /// rebuild; "fresh-editor" (the shelf-to-rail step) and unknown keys both
     /// fall back to a fresh sample editor with no rail unfolded.
     let checkpointSeed (checkpoint: string option) : ProvenanceTutorialCheckpoint =
         match checkpoint with
         | Some "species-on-rail" -> {
+            Model = Fixtures.sampleModel
             InitUiState = fun session -> State.init session |> withSpeciesOnInputRail session
             OpenRail = Some ProvenanceSide.Input
           }
         | Some "species-grouped"
         | Some "species-values"
         | Some "species-connect" -> {
+            Model = Fixtures.sampleModel
             InitUiState = fun session -> State.init session |> withSpeciesGrouped session
             OpenRail = Some ProvenanceSide.Input
           }
         | Some "species-values-expanded" -> {
+            Model = assignSampleModel
             InitUiState = fun session -> State.init session |> withSpeciesValuesExpanded session
             OpenRail = Some ProvenanceSide.Input
           }
         | _ -> {
+            Model = Fixtures.sampleModel
             InitUiState = State.init
             OpenRail = None
           }

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -35,6 +35,31 @@ module ProvenanceTutorialSteps =
     let private inputRail =
         "[data-tutorial='provenance-rail-Input'], button[aria-label='Show input annotations']"
 
+    // The Species drag source can be hidden two ways before the drag can even
+    // start: the whole shelf minimized behind its toggle, or another folder
+    // tab active. Highlight whichever control currently leads to the item, so
+    // every click on the way to the drag is guided too.
+    let private speciesShelfSource =
+        "button[data-foldered-item-label='Species'], "
+        + "[role='tab'][data-foldered-folder-label='assay-table'][aria-selected='false'], "
+        + "[data-tutorial='provenance-property-shelf-toggle'][aria-expanded='false']"
+
+    // Every input-side card: they are what visibly merges when grouping kicks
+    // in, so the group step rings them alongside the button that causes it.
+    let private inputGroupCards =
+        "[data-provenance-group-node^='provenance-node::Input::']"
+
+    let private outputGroupCards =
+        "[data-provenance-group-node^='provenance-node::Output::']"
+
+    // The undo button enables on the first published edit, which makes it the
+    // success signal for free-form tasks whose outcome is an edit rather than
+    // a single click (assigning a value, creating a connection).
+    let private editPublished (container: Browser.Types.HTMLElement) =
+        container.querySelector "[data-tutorial='provenance-undo']:enabled"
+        |> isNull
+        |> not
+
     let private explain id title description selector = {
         Id = id
         Title = title
@@ -88,11 +113,11 @@ module ProvenanceTutorialSteps =
             Id = "shelf-to-rail"
             Title = "Pull an annotation onto a rail"
             Description = "Dragging an annotation out of its shelf folder onto a rail activates it for that side."
-            // Highlights the drag source (the Species shelf item, once its
-            // folder is open) and the dropzone (rail or, on folded layouts,
-            // its toggle) together; task steps keep the whole surface
-            // interactive so the drag can travel between them.
-            TargetSelector = Some $"button[data-foldered-item-label='Species'], {inputRail}"
+            // Highlights the way to the drag source (shelf toggle, folder
+            // tab, then the Species item itself) and the dropzone (rail or,
+            // on folded layouts, its toggle) together; task steps keep the
+            // whole surface interactive so the drag can travel between them.
+            TargetSelector = Some $"{speciesShelfSource}, {inputRail}"
             Task =
                 Some
                     "Drag Species from the assay-table card in the shelf onto the dashed left rail (unfold the rail first if it is collapsed)."
@@ -107,7 +132,9 @@ module ProvenanceTutorialSteps =
             "group"
             "Group by an annotation"
             "Clicking a rail annotation merges all entities that share a value into one card - four inputs become two species cards."
-            speciesGroupButton
+            // The input cards are in the spotlight too: they are what reacts
+            // to the click, merging from four cards into two.
+            $"{speciesGroupButton}, {inputGroupCards}"
             "Click the Species annotation in the left rail to group the inputs by species."
             speciesGroupButton
             "species-on-rail"
@@ -115,7 +142,9 @@ module ProvenanceTutorialSteps =
             "members"
             "Inspect group members"
             "Grouped cards summarize their members. Expanding a card lists every member with its own values and connection handles."
-            "button[data-tutorial='provenance-show-members']"
+            // The member list only exists after the click; the polling
+            // spotlight picks it up the moment it unfolds.
+            "button[data-tutorial='provenance-show-members'], [data-tutorial='provenance-group-members']"
             "Click 'Show members' on one of the grouped cards."
             "button[data-tutorial='provenance-show-members']"
             "species-grouped"
@@ -124,32 +153,47 @@ module ProvenanceTutorialSteps =
             "Annotation values"
             "A rail annotation expands into its distinct values. Drag a value chip onto a card to assign it to every member at once - or add brand-new values first."
             // The rail stays the fallback highlight for folded layouts, where
-            // the chevron does not exist until the rail is unfolded.
-            $"button[data-tutorial-expand-values='Input:Species'], {inputRail}"
+            // the chevron does not exist until the rail is unfolded; the
+            // values panel joins the spotlight once the chevron opens it, so
+            // the chips the description talks about are ringed as they appear.
+            $"button[data-tutorial-expand-values='Input:Species'], [data-tutorial-property-values='Input:Species'], {inputRail}"
             "Click the chevron next to the Species annotation in the left rail to expand its values."
             "button[data-tutorial-expand-values='Input:Species']"
             "species-values"
         {
+            Id = "assign"
+            Title = "Assign values to cards"
+            Description =
+                "Value chips are live: drop one onto a card and the value is assigned to every member of that card. Where a member already has a different value, a prompt asks before overwriting."
+            // Rings the expanded value chips (the drag sources) and the output
+            // cards - the drop targets without a species value, so the invited
+            // drop applies cleanly instead of hitting the overwrite prompt.
+            TargetSelector = Some $"[data-tutorial-property-values='Input:Species'], {outputGroupCards}"
+            Task = Some "Drag one of the species value chips onto an output card - outputs have no species value yet."
+            Advance = TutorialAdvance.OnCondition editPublished
+            Checkpoint = Some "species-values-expanded"
+        }
+        {
             Id = "connect"
             Title = "Connect inputs to outputs"
             Description =
-                "The round handles on the facing edges of cards create input-to-output connections. Drag from handle to handle, or tap one and then the other."
-            // Rings every card's connection handle, marking both ends of the
-            // tap-tap (or drag) gesture.
-            TargetSelector = Some "[data-provenance-connection-drop-id^='provenance-connection-drop|GroupCard|']"
+                "The round handles on the facing edges of cards create input-to-output connections; the dashed lines are connections the sample data already has. Drag from handle to handle, or tap one and then the other. Cards holding several members first ask how their members should pair up."
+            // Rings only the handles of single-member cards: connecting two of
+            // those publishes directly, so the invited gesture never runs into
+            // the member pairing prompt (multi-member handles stay usable,
+            // the prompt is just explained rather than spotlighted).
+            TargetSelector =
+                Some(
+                    "[data-provenance-card-members='1'] "
+                    + "[data-provenance-connection-drop-id^='provenance-connection-drop|GroupCard|']"
+                )
             Task =
                 Some
-                    "Connect an input card to an output card: drag between the round handles, or tap one and then the other."
-            // The undo button enables on the first published edit, and creating
-            // the connection is the only edit this step leads to - so both the
-            // drag and the tap-tap gesture complete it, while merely arming a
-            // handle (which publishes nothing) does not.
-            Advance =
-                TutorialAdvance.OnCondition(fun container ->
-                    container.querySelector "[data-tutorial='provenance-undo']:enabled"
-                    |> isNull
-                    |> not
-                )
+                    "Create a connection that does not exist yet - drag from the Chlamydomonas card's round handle to Output E's handle, or tap one and then the other."
+            // Creating the connection is the only edit this step leads to - so
+            // both the drag and the tap-tap gesture complete it, while merely
+            // arming a handle (which publishes nothing) does not.
+            Advance = TutorialAdvance.OnCondition editPublished
             Checkpoint = Some "species-connect"
         }
         explain
@@ -187,6 +231,12 @@ module ProvenanceTutorialSteps =
         withSpeciesOnInputRail session state
         |> State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input speciesHeader
 
+    let private withSpeciesValuesExpanded (session: ProvenanceSession) (state: UiState) =
+        let layer = Session.activeLayer session
+
+        withSpeciesGrouped session state
+        |> State.PropertyExpansion.toggle layer.Id ProvenanceSide.Input speciesHeader
+
     /// Resolves the overlay's (inherited) checkpoint key to the sandbox seed to
     /// rebuild; "fresh-editor" (the shelf-to-rail step) and unknown keys both
     /// fall back to a fresh sample editor with no rail unfolded.
@@ -200,6 +250,10 @@ module ProvenanceTutorialSteps =
         | Some "species-values"
         | Some "species-connect" -> {
             InitUiState = fun session -> State.init session |> withSpeciesGrouped session
+            OpenRail = Some ProvenanceSide.Input
+          }
+        | Some "species-values-expanded" -> {
+            InitUiState = fun session -> State.init session |> withSpeciesValuesExpanded session
             OpenRail = Some ProvenanceSide.Input
           }
         | _ -> {

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -18,17 +18,17 @@ type ProvenanceTutorialCheckpoint = {
 }
 
 /// The guided tour through the provenance editor's features. Selectors rely on
-/// always-rendered hooks: `data-tutorial` anchors, the stable `title`/`aria-label`
-/// texts of toolbar buttons, and the `data-provenance-*` measurement attributes.
+/// always-rendered hooks only - `data-tutorial*` anchors and the
+/// `data-provenance-*` measurement attributes - never on `title`/`aria-label`
+/// copy, so rewording a button cannot silently break the tour.
 /// The tour runs against the sample fixture session, so the task steps can name
 /// concrete properties (Species) and predict which cards exist.
 module ProvenanceTutorialSteps =
 
-    // The Species rail button carries this title until Species is grouped, and
-    // it only exists at all once Species has been dragged out of the shelf -
-    // which makes it both the drag step's success condition and the group
-    // step's click target.
-    let private speciesGroupButton = "button[title='Group input entities by Species']"
+    // The Species rail button only exists once Species has been dragged out of
+    // the shelf - which makes it both the drag step's success condition and
+    // the group step's click target.
+    let private speciesGroupButton = "button[data-tutorial-group-by='Input:Species']"
 
     // On medium/narrow layouts the input rail folds behind a toggle button;
     // the fallback keeps the spotlight meaningful there.
@@ -92,7 +92,7 @@ module ProvenanceTutorialSteps =
             // folder is open) and the dropzone (rail or, on folded layouts,
             // its toggle) together; task steps keep the whole surface
             // interactive so the drag can travel between them.
-            TargetSelector = Some $"button[aria-label='Drag Species'], {inputRail}"
+            TargetSelector = Some $"button[data-foldered-item-label='Species'], {inputRail}"
             Task =
                 Some
                     "Drag Species from the assay-table card in the shelf onto the dashed left rail (unfold the rail first if it is collapsed)."
@@ -115,19 +115,19 @@ module ProvenanceTutorialSteps =
             "members"
             "Inspect group members"
             "Grouped cards summarize their members. Expanding a card lists every member with its own values and connection handles."
-            "button[title='Show members']"
+            "button[data-tutorial='provenance-show-members']"
             "Click 'Show members' on one of the grouped cards."
-            "button[title='Show members']"
+            "button[data-tutorial='provenance-show-members']"
             "species-grouped"
         task
             "values"
             "Annotation values"
             "A rail annotation expands into its distinct values. Drag a value chip onto a card to assign it to every member at once - or add brand-new values first."
-            // The chevron only enters the layout while its row is hovered, so
-            // the rail stays the fallback highlight until then.
-            $"button[aria-label='Expand Species values'], {inputRail}"
-            "Hover the Species annotation in the left rail, then click the chevron next to it to expand its values."
-            "button[aria-label='Expand Species values']"
+            // The rail stays the fallback highlight for folded layouts, where
+            // the chevron does not exist until the rail is unfolded.
+            $"button[data-tutorial-expand-values='Input:Species'], {inputRail}"
+            "Click the chevron next to the Species annotation in the left rail to expand its values."
+            "button[data-tutorial-expand-values='Input:Species']"
             "species-values"
         {
             Id = "connect"
@@ -154,12 +154,12 @@ module ProvenanceTutorialSteps =
             "undo"
             "Undo"
             "Every published edit can be taken back with one step - even after switching layers. The button is enabled whenever there is something to undo."
-            "button[title='Undo last change']"
+            "[data-tutorial='provenance-undo']"
         explain
             "add-layer"
             "Continue the chain"
             "Select cards with their checkboxes and press 'Add layer': the selection seeds the inputs of the new layer, growing the provenance chain table by table."
-            "button[title='Add layer']"
+            "[data-tutorial='provenance-add-layer']"
     |]
 
     // -- Checkpoint seeds ---------------------------------------------------
@@ -181,7 +181,8 @@ module ProvenanceTutorialSteps =
         |> State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input speciesHeader
 
     /// Resolves the overlay's (inherited) checkpoint key to the sandbox seed to
-    /// rebuild; unknown keys fall back to a fresh sample editor.
+    /// rebuild; "fresh-editor" (the shelf-to-rail step) and unknown keys both
+    /// fall back to a fresh sample editor with no rail unfolded.
     let checkpointSeed (checkpoint: string option) : ProvenanceTutorialCheckpoint =
         match checkpoint with
         | Some "species-on-rail" -> {

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -137,11 +137,18 @@ module ProvenanceTutorialSteps =
             // Rings every card's connection handle, marking both ends of the
             // tap-tap (or drag) gesture.
             TargetSelector = Some "[data-provenance-connection-drop-id^='provenance-connection-drop|GroupCard|']"
-            Task = Some "Tap the round handle on an input card, then tap the handle of an output card."
+            Task =
+                Some
+                    "Connect an input card to an output card: drag between the round handles, or tap one and then the other."
+            // The undo button enables on the first published edit, and creating
+            // the connection is the only edit this step leads to - so both the
+            // drag and the tap-tap gesture complete it, while merely arming a
+            // handle (which publishes nothing) does not.
             Advance =
-                TutorialAdvance.OnEvent(
-                    "click",
-                    "[data-provenance-connection-drop-id^='provenance-connection-drop|GroupCard|Output']"
+                TutorialAdvance.OnCondition(fun container ->
+                    container.querySelector "[data-tutorial='provenance-undo']:enabled"
+                    |> isNull
+                    |> not
                 )
             Checkpoint = Some "species-connect"
         }

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -1,0 +1,164 @@
+namespace Swate.Components.Page.ProvenanceGrouping
+
+open Fable.Core
+open Feliz
+open Swate.Components.Composite.TutorialOverlay
+open Swate.Components.Composite.TutorialOverlay.Types
+
+/// The guided tour through the provenance editor's features. Selectors rely on
+/// always-rendered hooks: `data-tutorial` anchors, the stable `title`/`aria-label`
+/// texts of toolbar buttons, and the `data-provenance-*` measurement attributes.
+/// The tour runs against the sample fixture session, so the task steps can name
+/// concrete properties (Species) and predict which cards exist.
+module ProvenanceTutorialSteps =
+
+    // The Species rail button carries this title until Species is grouped, and
+    // it only exists at all once Species has been dragged out of the shelf -
+    // which makes it both the drag step's success condition and the group
+    // step's click target.
+    let private speciesGroupButton = "button[title='Group input entities by Species']"
+
+    // On medium/narrow layouts the input rail folds behind a toggle button;
+    // the fallback keeps the spotlight meaningful there.
+    let private inputRail =
+        "[data-tutorial='provenance-rail-Input'], button[aria-label='Show input properties']"
+
+    let private explain id title description selector = {
+        Id = id
+        Title = title
+        Description = description
+        TargetSelector = Some selector
+        Task = None
+        Advance = TutorialAdvance.Manual
+    }
+
+    let private task id title description selector instruction eventSelector = {
+        Id = id
+        Title = title
+        Description = description
+        TargetSelector = Some selector
+        Task = Some instruction
+        Advance = TutorialAdvance.OnEvent("click", eventSelector)
+    }
+
+    let all: TutorialStep[] = [|
+        {
+            Id = "welcome"
+            Title = "Welcome"
+            Description =
+                "This tour runs on sample data, so nothing you do here touches your real tables. Each step highlights one feature; hands-on steps advance once you try the interaction yourself, the rest move on with Next. Use the list on the right to jump around."
+            TargetSelector = None
+            Task = None
+            Advance = TutorialAdvance.Manual
+        }
+        explain
+            "layers"
+            "Layer navigation"
+            "The bar at the bottom pages through the tables of the provenance chain: arrows step to the previous or next layer, the dropdown jumps anywhere directly, and the Layer button adds a follow-up layer that continues from the current outputs."
+            "[data-tutorial='provenance-layer-pagination']"
+        explain
+            "shelf"
+            "Property shelf"
+            "All properties known for this layer, grouped into index-card tabs per source table. The active card lists its properties and has its own small search; properties wait here until you pull them onto a side rail."
+            "[data-tutorial='provenance-property-shelf']"
+        explain
+            "rails"
+            "Property rails"
+            "The left rail holds input-side properties, the right rail output-side ones. Rails start empty; properties you drop here become available for grouping and annotation. On narrow screens the rails fold behind 'Properties' toggles."
+            inputRail
+        {
+            Id = "shelf-to-rail"
+            Title = "Pull a property onto a rail"
+            Description = "Dragging a property out of its shelf folder onto a rail activates it for that side."
+            // Highlights the drag source (the Species shelf item, once its
+            // folder is open) and the dropzone (rail or, on folded layouts,
+            // its toggle) together; task steps keep the whole surface
+            // interactive so the drag can travel between them.
+            TargetSelector = Some $"button[aria-label='Drag Species'], {inputRail}"
+            Task =
+                Some
+                    "Drag Species from the assay-table card in the shelf onto the dashed left rail (unfold the rail first if it is collapsed)."
+            // Done once the Species button exists in the (sandboxed) rail.
+            Advance =
+                TutorialAdvance.OnCondition(fun container ->
+                    container.querySelector speciesGroupButton |> isNull |> not
+                )
+        }
+        task
+            "group"
+            "Group by a property"
+            "Clicking a rail property merges all entities that share a value into one card - four inputs become two species cards."
+            speciesGroupButton
+            "Click the Species property in the left rail to group the inputs by species."
+            speciesGroupButton
+        task
+            "members"
+            "Inspect group members"
+            "Grouped cards summarize their members. Expanding a card lists every member with its own values and connection handles."
+            "button[title='Show members']"
+            "Click 'Show members' on one of the grouped cards."
+            "button[title='Show members']"
+        task
+            "values"
+            "Property values"
+            "A rail property expands into its distinct values. Drag a value chip onto a card to assign it to every member at once - or add brand-new values first."
+            // The chevron only enters the layout while its row is hovered, so
+            // the rail stays the fallback highlight until then.
+            $"button[aria-label='Expand Species values'], {inputRail}"
+            "Hover the Species property in the left rail, then click the chevron next to it to expand its values."
+            "button[aria-label='Expand Species values']"
+        {
+            Id = "connect"
+            Title = "Connect inputs to outputs"
+            Description =
+                "The round handles on the facing edges of cards create input-to-output connections. Drag from handle to handle, or tap one and then the other."
+            // Rings every card's connection handle, marking both ends of the
+            // tap-tap (or drag) gesture.
+            TargetSelector = Some "[data-provenance-connection-drop-id^='provenance-connection-drop|GroupCard|']"
+            Task = Some "Tap the round handle on an input card, then tap the handle of an output card."
+            Advance =
+                TutorialAdvance.OnEvent(
+                    "click",
+                    "[data-provenance-connection-drop-id^='provenance-connection-drop|GroupCard|Output']"
+                )
+        }
+        explain
+            "filters"
+            "Search, sort and filter"
+            "The toolbar narrows big models down: search properties and groups, sort by name or connection count, and filter by value coverage or origin."
+            "[data-tutorial='provenance-filter-toolbar']"
+        explain
+            "undo"
+            "Undo"
+            "Every published edit can be taken back with one step - even after switching layers. The button is enabled whenever there is something to undo."
+            "button[title='Undo last change']"
+        explain
+            "add-layer"
+            "Continue the chain"
+            "Select cards with their checkboxes and press 'Add layer': the selection seeds the inputs of the new layer, growing the provenance chain table by table."
+            "button[title='Add layer']"
+    |]
+
+[<Erase; Mangle(false)>]
+type ProvenanceTutorial =
+
+    /// Full-screen tutorial: the interactive tour chrome wrapped around a
+    /// sandbox editor instance the host passes in (seeded with sample data).
+    [<ReactComponent>]
+    static member Modal(onClose: unit -> unit, editor: ReactElement, ?debug: bool) =
+        let debug = defaultArg debug false
+
+        Html.div [
+            prop.className "swt:fixed swt:inset-0 swt:z-50 swt:bg-base-200"
+            if debug then
+                prop.testId "provenance-tutorial-modal"
+            prop.children [
+                TutorialOverlay.Main(
+                    ProvenanceTutorialSteps.all,
+                    onClose,
+                    editor,
+                    title = "Provenance editor tour",
+                    debug = debug
+                )
+            ]
+        ]

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -208,6 +208,11 @@ module ProvenanceTutorialSteps =
             "The toolbar narrows big models down: search annotations and groups, sort by name or connection count, and filter by value coverage or origin."
             "[data-tutorial='provenance-filter-toolbar']"
         explain
+            "focus-side"
+            "Focus one side"
+            "The two panel buttons hide the input or output column so you can work on a single side, centered with its rail. Any annotation that can live on both sides moves onto the visible rail and stays there; one-sided annotations simply wait until you show the side again. Grouping and connections keep working exactly as before."
+            "[data-tutorial^='provenance-side-visibility-']"
+        explain
             "undo"
             "Undo"
             "Every published edit can be taken back with one step - even after switching layers. The button is enabled whenever there is something to undo."

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -128,6 +128,8 @@
     <Compile Include="Composite\ThemeSelector\ThemeSelector.fs" />
     <Compile Include="Composite\FolderedDraggableList\Types.fs" />
     <Compile Include="Composite\FolderedDraggableList\FolderedDraggableList.fs" />
+    <Compile Include="Composite\TutorialOverlay\Types.fs" />
+    <Compile Include="Composite\TutorialOverlay\TutorialOverlay.fs" />
     <Compile Include="Composite\TermSearch\Types.fs" />
     <Compile Include="Composite\TermSearch\Context\ActiveKeysContext.fs" />
     <Compile Include="Composite\TermSearch\Context\AllKeysContext.fs" />
@@ -231,6 +233,7 @@
     <Compile Include="Page\ProvenanceGrouping\EditorPropertyShelf.fs" />
     <Compile Include="Page\ProvenanceGrouping\EditorPanels.fs" />
     <Compile Include="Page\ProvenanceGrouping\EditorSurface.fs" />
+    <Compile Include="Page\ProvenanceGrouping\Tutorial.fs" />
     <Compile Include="Page\ProvenanceGrouping\ProvenanceGrouping.fs" />
     <Compile Include="Page\SettingsPage\SettingsPage.fs" />
     <Compile Include="Page\Metadata\FormComponents\Helpers.fs" />

--- a/src/Components/src/index.ts
+++ b/src/Components/src/index.ts
@@ -53,6 +53,7 @@ export { default as TermSearch } from './dist/Composite/TermSearch/TermSearch.fs
 export { default as TermSearchConfigProvider } from './dist/Composite/TermSearch/ConfigProvider.fs';
 export { default as ThemeProvider } from './dist/Composite/ThemeSelector/ThemeProvider.fs';
 export { default as ThemeSelector } from './dist/Composite/ThemeSelector/ThemeSelector.fs';
+export { default as TutorialOverlay } from './dist/Composite/TutorialOverlay/TutorialOverlay.fs';
 
 export { Main as NoteSearch, SearchSuggestion } from './dist/Composite/Notes/NoteSearch/NoteSearch.fs';
 export { WidgetController, Entry as WidgetEntry } from './dist/Composite/Widgets/Widgets.fs';


### PR DESCRIPTION
This PR builds out the Provenance Grouping page with a set of largely independent
features, and introduces a reusable tutorial-overlay component. Terminology
across the page moves from "properties" to **annotations** to match the rest of
Swate.

### New component: TutorialOverlay

A standalone, host-agnostic guided-tour overlay (`Composite/TutorialOverlay`).
It wraps arbitrary content and drives a step sequence over it

- **Checkpoint remounting**: a step can name the state its instructions assume.
  When the active step's (inherited) checkpoint changes, the overlay rebuilds
  the wrapped content through the host's `render` function, so jumping or going
  back to a step always restores a state in which its task is doable. Steps
  without their own checkpoint inherit the nearest earlier one.
- **Spotlight**: highlights every selector match, merging overlapping/nested
  holes into single regions so the dimmed cutout reads cleanly.
- **Draggable, self-measuring step card**: measures its own size and picks the
  first placement (below/above/right/left of the highlight) that clears every
  spotlighted element, falling back to the least-overlapping spot; the card can
  be dragged by its header.
- **Content-scoped completion**: event-based advancement only counts events
  inside the wrapped content, so matches in unrelated host UI don't complete a
  step. Steps are defined against caller-provided selectors, keeping the
  component decoupled from any host's copy.

### Provenance editor tour

The editor configures TutorialOverlay into a full tour (`ProvenanceGrouping/Tutorial.fs`).

- Runs on its own **sandboxed sample-data editor** instance seeded per
  checkpoint (`initUiState`/`initialOpenRail`), so trying interactions never
  touches the host session. The in-sandbox tutorial trigger is suppressed to
  avoid nested modals.
- Steps target stable `data-tutorial*` anchors and `data-provenance-*`
  measurement attributes rather than button text, so rewording UI can't break
  the tour.
- Free-form task steps (assign a value, create a connection) complete on the
  first *published edit* rather than a raw handle click.

### Sankey ribbon connectors

Group- and member-level connections render as weighted **sankey ribbons**
instead of stroked bezier lines (`ProvenanceGrouping/ConnectorMeasurement.fs`,
new `measureSankeyRibbons`).

- Each ribbon claims a share of its cards' facing edges proportional to the
  number of underlying connections it represents, so heavy bundles read as
  thicker flows and the ribbons on one edge together cover it completely.
- Ribbons taper smoothly between endpoints of different heights and stack by
  their opposite endpoint's vertical order to minimize crossings at the card
  edge.
- Expanding a grouped card fans its group ribbon out into per-member ribbons
  (unit weight each) instead of falling back to plain lines.
- Translucent fills compound into a denser flow by design; the filled band
  itself is the pointer/keyboard hit target, with the centerline retained only
  for midpoint badges. `MeasuredConnector`/`ConnectorSpec` gain
  `RibbonPath`/`SankeyWeight`, and group-node/member-row DOM measurement was
  added.

### Side hiding (focus one side)

Toolbar toggles hide the input or output column so you can work on a single
side (`State.SideVisibility`).

- Every switchable annotation on the hidden side is permanently relocated onto
  the visible rail (a solo grouping it held on the hidden side is dropped);
  one-sided annotations wait until the side is shown again. Grouping and
  connection state keep running on both sides.
- The visible rail and its cards render as a single centered cluster
  (`soloSurface`) across wide/medium tiers, with narrow handled too. Side
  visibility is per-layer and resets on layer switch, since consolidation only
  runs for the layer it was triggered on.

### Annotation shelf redesign (index-card tabs + search)

`FolderedDraggableList` moves from an expandable-folder model to **index-card
tabs**.

- One active tab at a time, styled as an index card sitting on the card body.
- Per-folder search with its own draft state, so switching tabs never loses or
  leaks a card's query; drafts for folders the host removes are pruned, and
  item rows grow with their content instead of clipping.
- API changed from `expandedFolderIds`/`onExpandedFolderIdsChange` to
  `activeFolderId`/`onActiveFolderIdChange`, with a stale/missing id falling
  back to the first tab. Stable `data-foldered-*` hooks added.

### Layer navigation, toolbar & rails

- `LayerTabs` replaced by a bottom-pinned, container-sized **`LayerPagination`**
  control that shows the current layer's position on its jump button.
- Search / sort / filter toolbar moved onto its own line above the shelf; undo,
  side-visibility, connector, density and tutorial actions grouped on the top
  row.
- Unified group-card visuals and connected index headers to their card;
  annotation rails get a taller default drop zone.
