### PR TITLE
Fix Property assignment and overwrite

### DIFF
--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorMeasurement.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorMeasurement.fs
@@ -328,10 +328,10 @@ module ConnectorHandles =
         ParentGroupId = Some groupId
     }
 
-    let propertyHeader side header : ConnectionHandleRef = {
+    let propertyHeader side property : ConnectionHandleRef = {
         Kind = ConnectionHandleKind.PropertyHeader
         Side = side
-        Id = DragDrop.propertyHeaderIdentity header
+        Id = DragDrop.propertyKeyIdentity property
         ParentGroupId = None
     }
 

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorPaths.fs
@@ -278,13 +278,15 @@ module ConnectorPaths =
         overlayState
         =
         railProjection.Headers
-        |> List.filter (fun header -> not (ConnectorOverlayState.isPropertyExpanded layerId side header overlayState))
-        |> List.collect (fun header ->
+        |> List.filter (fun property ->
+            not (ConnectorOverlayState.isPropertyExpanded layerId side property overlayState)
+        )
+        |> List.collect (fun property ->
             let color =
                 railProjection.ColorByHeader
-                |> Map.tryFind header
+                |> Map.tryFind property
                 |> Option.bind id
-                |> Option.orElseWith (fun () -> colorByHeader |> Map.tryFind header |> Option.bind id)
+                |> Option.orElseWith (fun () -> colorByHeader |> Map.tryFind property.Header |> Option.bind id)
 
             groups
             |> List.collect (
@@ -293,13 +295,13 @@ module ConnectorPaths =
                     inputGroups
                     outputGroups
                     connections
-                    (fun propertyValue -> propertyValue.Header = header)
+                    (ProvenancePropertyValue.belongsTo property)
                     side
                     overlayState
             )
             |> List.map (fun target ->
                 spec
-                    $"property:{side}:{DragDrop.propertyHeaderIdentity header}:{target.KeySuffix}"
+                    $"property:{side}:{DragDrop.propertyKeyIdentity property}:{target.KeySuffix}"
                     "provenance-property-connection"
                     "swt:text-secondary swt:pointer-events-none"
                     1.75
@@ -308,13 +310,13 @@ module ConnectorPaths =
                     None
                     color
                     true
-                    (ConnectorHandles.propertyHeader side header)
+                    (ConnectorHandles.propertyHeader side property)
                     target.Handle
             )
         )
 
-    let private propertyValueMatches header value unit' (propertyValue: ProvenancePropertyValue) =
-        propertyValue.Header = header
+    let private propertyValueMatches property value unit' (propertyValue: ProvenancePropertyValue) =
+        ProvenancePropertyValue.belongsTo property propertyValue
         && propertyValue.Value = value
         && propertyValue.Unit = unit'
 
@@ -331,16 +333,16 @@ module ConnectorPaths =
         overlayState
         =
         railProjection.Headers
-        |> List.filter (fun header -> ConnectorOverlayState.isPropertyExpanded layerId side header overlayState)
-        |> List.collect (fun header ->
+        |> List.filter (fun property -> ConnectorOverlayState.isPropertyExpanded layerId side property overlayState)
+        |> List.collect (fun property ->
             let color =
                 railProjection.ColorByHeader
-                |> Map.tryFind header
+                |> Map.tryFind property
                 |> Option.bind id
-                |> Option.orElseWith (fun () -> colorByHeader |> Map.tryFind header |> Option.bind id)
+                |> Option.orElseWith (fun () -> colorByHeader |> Map.tryFind property.Header |> Option.bind id)
 
             railProjection.ValuesByHeader
-            |> Map.tryFind header
+            |> Map.tryFind property
             |> Option.defaultValue []
             |> List.collect (fun propertyValue ->
                 groups
@@ -350,13 +352,13 @@ module ConnectorPaths =
                         inputGroups
                         outputGroups
                         connections
-                        (propertyValueMatches header propertyValue.Value propertyValue.Unit)
+                        (propertyValueMatches property propertyValue.Value propertyValue.Unit)
                         side
                         overlayState
                 )
                 |> List.map (fun target ->
                     spec
-                        $"value:{side}:{DragDrop.propertyHeaderIdentity header}:{Formatting.formatValue propertyValue.Value propertyValue.Unit}:{target.KeySuffix}"
+                        $"value:{side}:{DragDrop.propertyKeyIdentity property}:{Formatting.formatValue propertyValue.Value propertyValue.Unit}:{target.KeySuffix}"
                         "provenance-value-connection"
                         "swt:text-accent swt:pointer-events-none"
                         2.0

--- a/src/Components/src/Page/ProvenanceGrouping/ConnectorTypes.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ConnectorTypes.fs
@@ -84,8 +84,8 @@ module ConnectorOverlayState =
     /// exact cards open.
     let followsExpandedNeighbors state = state.ExpandedGroups.Count = 1
 
-    let isPropertyExpanded layerId side header state =
-        state.ExpandedProperties.Contains(layerId, side, { Header = header })
+    let isPropertyExpanded layerId side property state =
+        state.ExpandedProperties.Contains(layerId, side, property)
 
 type ConnectorMeasureContext = {
     Container: HTMLElement

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -588,12 +588,9 @@ type Controls =
 
     [<ReactComponent>]
     static member private PropertySwapButton
-        (
-            side: ProvenanceSide,
-            header: ProvenancePropertyHeader,
-            onSwitch: ProvenancePropertyHeader -> unit,
-            ?debug: bool
-        ) =
+        (side: ProvenanceSide, property: ProvenancePropertyKey, onSwitch: ProvenancePropertyKey -> unit, ?debug: bool)
+        =
+        let header = property.Header
         let sideName = SideLabels.sideName side
 
         Html.button [
@@ -603,8 +600,8 @@ type Controls =
             prop.ariaLabel $"Move {header.Category.Name} from {sideName}"
             if defaultArg debug false then
                 prop.testId $"provenance-property-drag-{side}-{header.Category.Name}"
-            prop.onPointerUp (fun _ -> onSwitch header)
-            prop.onClick (fun _ -> onSwitch header)
+            prop.onPointerUp (fun _ -> onSwitch property)
+            prop.onClick (fun _ -> onSwitch property)
             prop.children [
                 Html.i [
                     prop.className "swt:iconify swt:fluent--arrow-swap-20-regular swt:size-4"
@@ -617,16 +614,16 @@ type Controls =
         (
             side: ProvenanceSide,
             activeSourceId: ProvenanceSourceId,
-            header: ProvenancePropertyHeader,
+            property: ProvenancePropertyKey,
             propertyValues: ProvenancePropertyValue list,
             active: GroupingAssignment list,
             canSwitch: bool,
             expanded: bool,
-            onToggleSide: ProvenancePropertyHeader -> unit,
-            onToggleBoth: ProvenancePropertyHeader -> unit,
-            onSwitch: ProvenancePropertyHeader -> unit,
-            onToggleExpanded: ProvenancePropertyHeader -> unit,
-            onAddValue: ProvenancePropertyHeader -> ProvenanceValue -> ProvenanceTerm option -> unit,
+            onToggleSide: ProvenancePropertyKey -> unit,
+            onToggleBoth: ProvenancePropertyKey -> unit,
+            onSwitch: ProvenancePropertyKey -> unit,
+            onToggleExpanded: ProvenancePropertyKey -> unit,
+            onAddValue: ProvenancePropertyKey -> ProvenanceValue -> ProvenanceTerm option -> unit,
             setIsValueChipDragging: bool -> unit,
             ?debug: bool,
             ?key: string,
@@ -640,10 +637,12 @@ type Controls =
             ?onApplyValueToSelection: ProvenancePropertyValue -> unit,
             ?applySelectionLabel: string
         ) =
+        let header = property.Header
+
         let draggable =
             DndKit.useDraggable (
                 {|
-                    id = DragDrop.propertyDragId side header
+                    id = DragDrop.propertyDragId side property
                     data = {| label = header.Category.Name |}
                 |}
             )
@@ -658,11 +657,11 @@ type Controls =
 
         let sideSelected =
             active
-            |> List.exists (fun assignment -> assignment.Key.Header = header && assignment.Scope = sideScope)
+            |> List.exists (fun assignment -> assignment.Key = property && assignment.Scope = sideScope)
 
         let bothSelected =
             active
-            |> List.exists (fun assignment -> assignment.Key.Header = header && assignment.Scope = GroupingScope.Both)
+            |> List.exists (fun assignment -> assignment.Key = property && assignment.Scope = GroupingScope.Both)
 
         let sideName = SideLabels.sideName side
 
@@ -675,7 +674,7 @@ type Controls =
                 {
                     Kind = ConnectionHandleKind.PropertyHeader
                     Side = side
-                    Id = DragDrop.propertyHeaderIdentity header
+                    Id = DragDrop.propertyKeyIdentity property
                     ParentGroupId = None
                 },
                 (match side with
@@ -725,7 +724,8 @@ type Controls =
                 prop.custom ("data-tutorial-group-by", $"{side}:{header.Category.Name}")
                 if defaultArg debug false then
                     prop.testId $"provenance-property-{side}-{header.Category.Name}"
-                prop.onClick (fun _ -> onToggleSide header)
+                prop.custom ("data-provenance-property-origin", property.OriginSource.Id)
+                prop.onClick (fun _ -> onToggleSide property)
                 prop.children [
                     propertyAnchor
                     match color with
@@ -817,7 +817,7 @@ type Controls =
                     else
                         $"Expand {header.Category.Name} values"
                 )
-                prop.onClick (fun _ -> onToggleExpanded header)
+                prop.onClick (fun _ -> onToggleExpanded property)
                 prop.children [
                     Html.i [
                         prop.className [
@@ -862,7 +862,7 @@ type Controls =
                 if defaultArg debug false then
                     prop.testId $"provenance-property-both-{side}-{header.Category.Name}"
                 prop.ariaLabel $"Group {header.Category.Name} on both sides"
-                prop.onClick (fun _ -> onToggleBoth header)
+                prop.onClick (fun _ -> onToggleBoth property)
                 prop.children [
                     Html.i [
                         prop.className "swt:iconify swt:fluent--link-multiple-20-regular swt:size-4"
@@ -872,7 +872,7 @@ type Controls =
 
         let swapButton =
             if canSwitch then
-                Controls.PropertySwapButton(side, header, onSwitch, ?debug = debug)
+                Controls.PropertySwapButton(side, property, onSwitch, ?debug = debug)
             else
                 Html.button [
                     prop.type'.button
@@ -999,7 +999,7 @@ type Controls =
                                 )
                             Controls.AddValuePopover(
                                 Some header,
-                                (fun addedHeader value unit -> onAddValue addedHeader value unit),
+                                (fun _ value unit -> onAddValue property value unit),
                                 label = "Add value",
                                 ?debug = debug
                             )
@@ -1016,25 +1016,25 @@ type Controls =
     static member PropertyRail
         (
             side: ProvenanceSide,
-            activeSourceId: ProvenanceSourceId,
-            headers: ProvenancePropertyHeader list,
+            activeSource: ProvenanceSourceRef,
+            headers: ProvenancePropertyKey list,
             active: GroupingAssignment list,
-            valuesForHeader: ProvenancePropertyHeader -> ProvenancePropertyValue list,
-            isExpanded: ProvenancePropertyHeader -> bool,
-            onToggleSide: ProvenancePropertyHeader -> unit,
-            onToggleBoth: ProvenancePropertyHeader -> unit,
-            onSwitch: ProvenancePropertyHeader -> unit,
-            onToggleExpanded: ProvenancePropertyHeader -> unit,
-            onAddValue: ProvenancePropertyHeader -> ProvenanceValue -> ProvenanceTerm option -> unit,
-            canSwitch: ProvenancePropertyHeader -> bool,
+            valuesForHeader: ProvenancePropertyKey -> ProvenancePropertyValue list,
+            isExpanded: ProvenancePropertyKey -> bool,
+            onToggleSide: ProvenancePropertyKey -> unit,
+            onToggleBoth: ProvenancePropertyKey -> unit,
+            onSwitch: ProvenancePropertyKey -> unit,
+            onToggleExpanded: ProvenancePropertyKey -> unit,
+            onAddValue: ProvenancePropertyKey -> ProvenanceValue -> ProvenanceTerm option -> unit,
+            canSwitch: ProvenancePropertyKey -> bool,
             isDropRejected: bool,
             isDropAvailable: bool,
             setIsValueChipDragging: bool -> unit,
-            statsForHeader: ProvenancePropertyHeader -> PropertyStats option,
-            badgeForHeader: ProvenancePropertyHeader -> PropertyCountBadge option,
-            colorForHeader: ProvenancePropertyHeader -> ProvenanceColor option,
-            originsForHeader: ProvenancePropertyHeader -> Set<ProvenancePropertyOrigin> option,
-            onSetColor: ProvenancePropertyHeader -> ProvenanceColor option -> unit,
+            statsForHeader: ProvenancePropertyKey -> PropertyStats option,
+            badgeForHeader: ProvenancePropertyKey -> PropertyCountBadge option,
+            colorForHeader: ProvenancePropertyKey -> ProvenanceColor option,
+            originsForHeader: ProvenancePropertyKey -> Set<ProvenancePropertyOrigin> option,
+            onSetColor: ProvenancePropertyKey -> ProvenanceColor option -> unit,
             sourceInfoForValue: ProvenancePropertyValue -> PropertyValueSourceInfo option,
             ?sideId: ProvenanceLayerSideId,
             ?isUnassignedValue: ProvenancePropertyValue -> bool,
@@ -1056,7 +1056,7 @@ type Controls =
         let collapseThreshold = 6
 
         let isPinned header =
-            active |> List.exists (fun assignment -> assignment.Key.Header = header)
+            active |> List.exists (fun assignment -> assignment.Key = header)
             || isExpanded header
 
         let visibleHeaders =
@@ -1116,7 +1116,20 @@ type Controls =
                     Html.div [
                         prop.className "swt:w-fit"
                         prop.children [
-                            Controls.AddValuePopover(None, onAddValue, label = "Add annotation", ?debug = debug)
+                            Controls.AddValuePopover(
+                                None,
+                                (fun header value unit ->
+                                    onAddValue
+                                        {
+                                            Header = header
+                                            OriginSource = activeSource
+                                        }
+                                        value
+                                        unit
+                                ),
+                                label = "Add annotation",
+                                ?debug = debug
+                            )
                         ]
                     ]
                 else
@@ -1133,7 +1146,7 @@ type Controls =
                     for header in visibleHeaders do
                         Controls.PropertyRailItem(
                             side,
-                            activeSourceId,
+                            activeSource.Id,
                             header,
                             valuesForHeader header,
                             active,
@@ -1155,7 +1168,7 @@ type Controls =
                             ?onApplyValueToSelection = onApplyValueToSelection,
                             ?applySelectionLabel = applySelectionLabel,
                             debug = defaultArg debug false,
-                            key = DragDrop.propertyHeaderIdentity header
+                            key = DragDrop.propertyKeyIdentity header
                         )
 
                     if hiddenHeaderCount > 0 || showAllHeaders && headers.Length > collapseThreshold then
@@ -1184,7 +1197,20 @@ type Controls =
                                 "swt:self-end"
                         ]
                         prop.children [
-                            Controls.AddValuePopover(None, onAddValue, label = "Add annotation", ?debug = debug)
+                            Controls.AddValuePopover(
+                                None,
+                                (fun header value unit ->
+                                    onAddValue
+                                        {
+                                            Header = header
+                                            OriginSource = activeSource
+                                        }
+                                        value
+                                        unit
+                                ),
+                                label = "Add annotation",
+                                ?debug = debug
+                            )
                         ]
                     ]
             ]

--- a/src/Components/src/Page/ProvenanceGrouping/Controls.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Controls.fs
@@ -849,7 +849,7 @@ type Controls =
             Html.button [
                 prop.type'.button
                 prop.title
-                    $"Group both sides by {header.Category.Name}. Inputs without their own value use values inherited from connected outputs."
+                    $"Group both sides by {header.Category.Name}. Connected inputs and outputs share their values for grouping."
                 prop.className [
                     "swt:btn swt:btn-xs swt:btn-square swt:z-10"
                     if bothSelected then

--- a/src/Components/src/Page/ProvenanceGrouping/EditorActions.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorActions.fs
@@ -16,7 +16,7 @@ open Swate.Components.Page.ProvenanceGrouping.Types
 
 type EditorLookups = {
     FindGroup: ProvenanceSide -> string -> DisplayGroup option
-    FindHeader: string -> ProvenancePropertyHeader option
+    FindProperty: string -> ProvenancePropertyKey option
     FindPropertyValue: ProvenancePropertyValueId -> ProvenancePropertyValue option
     SourceForValue: ProvenancePropertyValueId -> ProvenancePropertyValue -> ValueAssignmentSource
 }
@@ -38,7 +38,7 @@ type ActiveDrag = {
 }
 
 type PropertyShelfItemPayload = {
-    Header: ProvenancePropertyHeader
+    Property: ProvenancePropertyKey
     SourceSide: ProvenanceSide
 }
 
@@ -57,18 +57,18 @@ module EditorLookups =
 
         // Built lazily and at most once per lookups instance; drag handlers call
         // FindHeader repeatedly and must not rescan the whole model each time.
-        let knownHeaders =
+        let knownProperties =
             lazy
                 ([
                     yield! PropertyRails.headersForModel layer.Model
-                    yield! State.Palette.headersForSide layer.Id ProvenanceSide.Input uiState
-                    yield! State.Palette.headersForSide layer.Id ProvenanceSide.Output uiState
+                    yield! State.Palette.propertiesForSide layer.Id ProvenanceSide.Input uiState
+                    yield! State.Palette.propertiesForSide layer.Id ProvenanceSide.Output uiState
                  ]
                  |> List.distinct)
 
-        let findHeader headerId =
-            knownHeaders.Value
-            |> List.tryFind (fun header -> DragDrop.propertyHeaderIdentity header = headerId)
+        let findProperty propertyId =
+            knownProperties.Value
+            |> List.tryFind (fun property -> DragDrop.propertyKeyIdentity property = propertyId)
 
         let findPropertyValue propertyValueId =
             layer.Model.PropertyValues.TryFind propertyValueId
@@ -80,14 +80,14 @@ module EditorLookups =
                     Some propertyValueId
                 else
                     None
-            Header = propertyValue.Header
+            Property = ProvenancePropertyValue.propertyKey propertyValue
             Value = propertyValue.Value
             Unit = propertyValue.Unit
         }
 
         {
             FindGroup = findGroup
-            FindHeader = findHeader
+            FindProperty = findProperty
             FindPropertyValue = findPropertyValue
             SourceForValue = sourceForValue
         }
@@ -124,11 +124,13 @@ module AssignmentErrors =
     let text error =
         match error with
         | ValueAssignmentError.EmptyTarget -> "Drop a value onto a group with at least one entity."
-        | ValueAssignmentError.MixedPropertyValueCounts header ->
-            $"Cannot assign {header.Category.Name}: every target must either have no value or exactly one value for this annotation."
-        | ValueAssignmentError.MultiplePropertyValues(header, setIds) ->
+        | ValueAssignmentError.MixedPropertyValueCounts property ->
+            $"Cannot assign {property.Header.Category.Name}: every target must either have no value or exactly one value for this annotation."
+        | ValueAssignmentError.MultiplePropertyValues(property, setIds) ->
             let targets = setIds |> String.concat ", "
-            $"Cannot overwrite {header.Category.Name}: {targets} already has multiple values for this annotation."
+            $"Cannot overwrite {property.Header.Category.Name}: {targets} already has multiple values for this annotation."
+        | ValueAssignmentError.UpstreamPropertyNotAssigned property ->
+            $"Cannot assign {property.Header.Category.Name} to a new entity in this layer. This annotation originated in '{property.OriginSource.Name}' and can only replace an existing assignment."
 
 /// Session-changing actions that publish patches back to the host component.
 module EditorActions =
@@ -343,7 +345,10 @@ module DragHandlers =
                 pulsedCard <- true
 
             let identity =
-                DragDrop.groupingValueIdentity propertyValue.Header propertyValue.Value propertyValue.Unit
+                DragDrop.groupingValueIdentity
+                    (ProvenancePropertyValue.propertyKey propertyValue)
+                    propertyValue.Value
+                    propertyValue.Unit
 
             let sidePrefix = $"provenance-node::{side}::"
 
@@ -554,24 +559,24 @@ module DragHandlers =
         | Some(DragDrop.Payload.PropertyValue propertyValueId), Some(side, groupId), _ ->
             routePropertyValueDrop context side groupId propertyValueId
         | Some(DragDrop.Payload.FolderPropertyHeader(sourceSide, headerId)), _, Some targetSide ->
-            match context.Lookups.FindHeader headerId with
-            | Some header when
+            match context.Lookups.FindProperty headerId with
+            | Some property when
                 sourceSide = targetSide
-                || PropertyRails.canSwitchHeader header context.Layer.Model
+                || PropertyRails.canSwitchHeader property context.Layer.Model
                 ->
                 context.GetUiState()
-                |> State.PropertyPlacement.place context.Layer.Id targetSide header
+                |> State.PropertyPlacement.place context.Layer.Id targetSide property
                 |> context.SetUiState
             | _ -> ()
         | Some(DragDrop.Payload.PropertyHeader(sourceSide, headerId)), _, Some targetSide when sourceSide <> targetSide ->
-            match context.Lookups.FindHeader headerId with
-            | Some header when PropertyRails.canSwitchHeader header context.Layer.Model ->
+            match context.Lookups.FindProperty headerId with
+            | Some property when PropertyRails.canSwitchHeader property context.Layer.Model ->
                 State.GroupingAssignments.move
                     context.Layer.Id
                     (layerIdForSide context.Layer sourceSide)
                     (layerIdForSide context.Layer targetSide)
                     targetSide
-                    header
+                    property
                     (context.GetUiState())
                 |> context.SetUiState
             | _ -> ()

--- a/src/Components/src/Page/ProvenanceGrouping/EditorActions.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorActions.fs
@@ -128,7 +128,7 @@ module AssignmentErrors =
             $"Cannot assign {property.Header.Category.Name}: every target must either have no value or exactly one value for this annotation."
         | ValueAssignmentError.MultiplePropertyValues(property, setIds) ->
             let targets = setIds |> String.concat ", "
-            $"Cannot overwrite {property.Header.Category.Name}: {targets} already has multiple values for this annotation."
+            $"Cannot overwrite {property.Header.Category.Name}: {targets} hold more than one distinct value for this annotation, so no single value can be replaced."
         | ValueAssignmentError.UpstreamPropertyNotAssigned property ->
             $"Cannot assign {property.Header.Category.Name} to a new entity in this layer. This annotation originated in '{property.OriginSource.Name}' and can only replace an existing assignment."
 

--- a/src/Components/src/Page/ProvenanceGrouping/EditorPropertyShelf.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorPropertyShelf.fs
@@ -44,20 +44,20 @@ module PropertyShelf =
         | Some(PropertyCountBadge.DistinctValues count) -> Some(string count)
         | Some(PropertyCountBadge.Coverage(withValue, total)) -> Some($"{withValue}/{total}")
 
-    let private headerIdentity (header: ProvenancePropertyHeader) = DragDrop.propertyHeaderIdentity header
+    let private headerIdentity (property: ProvenancePropertyKey) = DragDrop.propertyKeyIdentity property
 
-    let private headerId (header: ProvenancePropertyHeader) = headerIdentity header |> slug
+    let private headerId (property: ProvenancePropertyKey) = headerIdentity property |> slug
 
     let private sourceSideForHeader
         (layerId: ProvenanceLayerId)
         (inputProjection: PropertyRails.RailProjection)
         (outputProjection: PropertyRails.RailProjection)
         (uiState: UiState)
-        (header: ProvenancePropertyHeader)
+        (property: ProvenancePropertyKey)
         =
-        match uiState.PropertyRailPlacements |> Map.tryFind (layerId, { Header = header }) with
+        match uiState.PropertyRailPlacements |> Map.tryFind (layerId, property) with
         | Some side -> side
-        | None when outputProjection.Headers |> List.contains header -> ProvenanceSide.Output
+        | None when outputProjection.Headers |> List.contains property -> ProvenanceSide.Output
         | _ -> ProvenanceSide.Input
 
     let private originsForHeader
@@ -65,11 +65,11 @@ module PropertyShelf =
         (_sourceSide: ProvenanceSide)
         (inputProjection: PropertyRails.RailProjection)
         (outputProjection: PropertyRails.RailProjection)
-        (header: ProvenancePropertyHeader)
+        (property: ProvenancePropertyKey)
         =
         [
-            inputProjection.OriginByHeader |> Map.tryFind header
-            outputProjection.OriginByHeader |> Map.tryFind header
+            inputProjection.OriginByHeader |> Map.tryFind property
+            outputProjection.OriginByHeader |> Map.tryFind property
         ]
         |> List.choose id
         |> List.fold Set.union Set.empty
@@ -138,18 +138,18 @@ module PropertyShelf =
             1, layerIndex, folderName key
         | UnknownFolder -> 2, Int32.MaxValue, folderName key
 
-    let private manualColor (session: ProvenanceSession) (uiState: UiState) (header: ProvenancePropertyHeader) =
+    let private manualColor (session: ProvenanceSession) (uiState: UiState) (property: ProvenancePropertyKey) =
         let layer = Session.activeLayer session
         let colorContext = State.PropertyColors.visibleColorContextForLayer session layer
 
         uiState.PropertyColors.ManualPropertyColors
         |> Map.tryFind {
             ContextId = colorContext.Id
-            Header = header
+            Property = property
         }
 
-    let private isPlacedInCurrentLayer (layer: ProvenanceLayer) (uiState: UiState) header =
-        let key = State.Keys.groupingKey header
+    let private isPlacedInCurrentLayer (layer: ProvenanceLayer) (uiState: UiState) property =
+        let key = State.Keys.groupingKey property
 
         let placedInRail = uiState.PropertyRailPlacements |> Map.containsKey (layer.Id, key)
 
@@ -168,12 +168,14 @@ module PropertyShelf =
         (inputProjection: PropertyRails.RailProjection)
         (outputProjection: PropertyRails.RailProjection)
         (uiState: UiState)
-        (header: ProvenancePropertyHeader)
+        (property: ProvenancePropertyKey)
         : FolderedDraggableItem<PropertyShelfItemPayload> =
+        let header = property.Header
+
         let badge =
             outputProjection.BadgeByHeader
-            |> Map.tryFind header
-            |> Option.orElseWith (fun () -> inputProjection.BadgeByHeader |> Map.tryFind header)
+            |> Map.tryFind property
+            |> Option.orElseWith (fun () -> inputProjection.BadgeByHeader |> Map.tryFind property)
             |> badgeText
 
         let tooltip =
@@ -185,13 +187,13 @@ module PropertyShelf =
             |> String.concat " · "
 
         {
-            Id = $"{folderKeyId folderKey}-{headerId header}"
+            Id = $"{folderKeyId folderKey}-{headerId property}"
             Label = header.Category.Name
             Payload = {
-                Header = header
+                Property = property
                 SourceSide = sourceSide
             }
-            Color = manualColor session uiState header
+            Color = manualColor session uiState property
             Badge = badge
             Tooltip =
                 if String.IsNullOrWhiteSpace tooltip then
@@ -223,20 +225,16 @@ module PropertyShelf =
 
         let itemEntries =
             headers
-            |> List.collect (fun header ->
+            |> List.collect (fun property ->
                 let sourceSide =
-                    sourceSideForHeader layer.Id inputProjection outputProjection uiState header
+                    sourceSideForHeader layer.Id inputProjection outputProjection uiState property
 
-                originsForHeader layer.Id sourceSide inputProjection outputProjection header
-                |> Set.toList
-                |> function
-                    | [] -> [ UnknownFolder ]
-                    | origins -> origins |> List.map folderKeyForOrigin
-                |> List.distinct
-                |> List.map (fun folderKey ->
+                let folderKey = SourceFolder property.OriginSource
+
+                [
                     folderKey,
-                    itemForHeader session sourceSide folderKey inputProjection outputProjection uiState header
-                )
+                    itemForHeader session sourceSide folderKey inputProjection outputProjection uiState property
+                ]
             )
 
         let folderKeys =

--- a/src/Components/src/Page/ProvenanceGrouping/EditorSurface.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EditorSurface.fs
@@ -22,13 +22,13 @@ module EditorSurface =
             [
                 yield!
                     activeAssignments
-                    |> List.map (fun (assignment: GroupingAssignment) -> assignment.Key.Header)
+                    |> List.map (fun (assignment: GroupingAssignment) -> assignment.Key)
                 yield!
                     uiState.PropertyRailPlacements
                     |> Map.toList
                     |> List.choose (fun ((currentLayerId, key), placedSide) ->
                         if currentLayerId = layerId && placedSide = side then
-                            Some key.Header
+                            Some key
                         else
                             None
                     )
@@ -57,7 +57,7 @@ module EditorSurface =
 
     let propertyRail
         side
-        activeSourceId
+        activeSource
         sideId
         (projection: PropertyRails.RailProjection)
         activeAssignments
@@ -80,7 +80,7 @@ module EditorSurface =
         =
         Controls.PropertyRail(
             side,
-            activeSourceId,
+            activeSource,
             projection.Headers,
             activeAssignments,
             (fun header -> projection.ValuesByHeader |> Map.tryFind header |> Option.defaultValue []),

--- a/src/Components/src/Page/ProvenanceGrouping/EndpointAndAssignment.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/EndpointAndAssignment.fs
@@ -45,11 +45,11 @@ module ValueAssignment =
         | ProvenanceSide.Input -> ProvenancePropertyTarget.InputSets ids
         | ProvenanceSide.Output -> ProvenancePropertyTarget.OutputSets ids
 
-    let private memberValuesForHeader header (model: ProvenanceModel) (member': DisplayMember) =
+    let private memberValuesForProperty property (model: ProvenanceModel) (member': DisplayMember) =
         member'.PropertyValueIds
         |> List.distinct
         |> List.choose (fun propertyValueId -> model.PropertyValues.TryFind propertyValueId)
-        |> List.filter (fun propertyValue -> propertyValue.Header = header)
+        |> List.filter (ProvenancePropertyValue.belongsTo property)
 
     let planPropertyValueDrop
         (source: ValueAssignmentSource)
@@ -58,28 +58,35 @@ module ValueAssignment =
         : Result<ValueAssignmentPlan, ValueAssignmentError> =
         let memberValues =
             group.Members
-            |> List.map (fun member' -> member'.SetId, memberValuesForHeader source.Header model member')
+            |> List.map (fun member' -> member'.SetId, memberValuesForProperty source.Property model member')
 
         if memberValues.IsEmpty then
             Error ValueAssignmentError.EmptyTarget
         else
-            let membersWithMultipleValues =
-                memberValues
-                |> List.choose (fun (setId, values) -> if values.Length > 1 then Some setId else None)
+            let allValues = memberValues |> List.collect snd
 
-            if not membersWithMultipleValues.IsEmpty then
-                Error(ValueAssignmentError.MultiplePropertyValues(source.Header, membersWithMultipleValues))
-            elif memberValues |> List.forall (fun (_, values) -> values.IsEmpty) then
-                Ok(
-                    AddCurrent {
-                        Target = targetForGroup group.Side group
-                        CopiedFrom = source.CopiedFrom
-                        Header = source.Header
-                        Value = source.Value
-                        Unit = source.Unit
-                    }
-                )
-            elif memberValues |> List.forall (fun (_, values) -> values.Length = 1) then
+            let distinctAssignedValues =
+                allValues
+                |> List.map (fun propertyValue -> propertyValue.Value, propertyValue.Unit)
+                |> List.distinct
+
+            if memberValues |> List.forall (fun (_, values) -> values.IsEmpty) then
+                if source.Property.OriginSource.Id = model.Source.Id then
+                    Ok(
+                        AddCurrent {
+                            Target = targetForGroup group.Side group
+                            CopiedFrom = source.CopiedFrom
+                            Header = source.Property.Header
+                            Value = source.Value
+                            Unit = source.Unit
+                        }
+                    )
+                else
+                    Error(ValueAssignmentError.UpstreamPropertyNotAssigned source.Property)
+            elif
+                memberValues |> List.forall (fun (_, values) -> not values.IsEmpty)
+                && distinctAssignedValues.Length = 1
+            then
                 Ok(
                     ConfirmOverwrite {
                         Target = targetForGroup group.Side group
@@ -87,13 +94,19 @@ module ValueAssignment =
                             memberValues
                             |> List.collect (fun (_, values) -> values |> List.map (fun value -> value.Id))
                             |> List.distinct
-                        Header = source.Header
+                        Header = source.Property.Header
                         Value = source.Value
                         Unit = source.Unit
                     }
                 )
+            elif memberValues |> List.exists (fun (_, values) -> values.IsEmpty) then
+                Error(ValueAssignmentError.MixedPropertyValueCounts source.Property)
             else
-                Error(ValueAssignmentError.MixedPropertyValueCounts source.Header)
+                let assignedSetIds =
+                    memberValues
+                    |> List.choose (fun (setId, values) -> if values.IsEmpty then None else Some setId)
+
+                Error(ValueAssignmentError.MultiplePropertyValues(source.Property, assignedSetIds))
 
     let private combineGroupsForAssignment (groups: DisplayGroup list) : DisplayGroup option =
         match groups with

--- a/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/GroupCard.fs
@@ -560,7 +560,7 @@ type GroupCard =
                                             category,
                                             valueText,
                                             DragDrop.groupingValueIdentity
-                                                groupingValue.Key.Header
+                                                groupingValue.Key
                                                 groupingValue.Value
                                                 groupingValue.Unit,
                                             tabPalette.[index % tabPalette.Length],

--- a/src/Components/src/Page/ProvenanceGrouping/Helper.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Helper.fs
@@ -13,29 +13,29 @@ module Exports =
         | "Output" -> ProvenanceSide.Output
         | side -> failwithf "Unknown provenance side '%s'." side
 
-    let private propertyHeaderByName propertyName (model: ProvenanceModel) =
+    let private propertyByName propertyName (model: ProvenanceModel) =
         model.PropertyValues
         |> Map.toList
-        |> List.map (fun (_, value) -> value.Header)
+        |> List.map (snd >> ProvenancePropertyValue.propertyKey)
         |> List.distinct
-        |> List.find (fun header -> header.Category.Name = propertyName)
+        |> List.find (fun property -> property.Header.Category.Name = propertyName)
 
     let sampleDroppedPropertyRailColor sideName propertyName layerColor =
         let session = StoryFixtures.createSampleSession ()
         let layer = Session.activeLayer session
         let side = sideFromName sideName
-        let header = propertyHeaderByName propertyName layer.Model
+        let property = propertyByName propertyName layer.Model
 
         let uiState =
             State.init session
             |> State.Sides.ensure session
-            |> State.PropertyPlacement.place layer.Id side header
+            |> State.PropertyPlacement.place layer.Id side property
             |> State.PropertyColors.setSourceColor layer.Model.Source.Id layerColor
 
         let projection =
             PropertyProjection.railProjectionWithFilters session layer.Id side layer.Model uiState
 
         projection.ColorByHeader
-        |> Map.tryFind header
+        |> Map.tryFind property
         |> Option.bind id
         |> Option.defaultValue ""

--- a/src/Components/src/Page/ProvenanceGrouping/Interaction.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Interaction.fs
@@ -17,6 +17,9 @@ module DragDrop =
     let propertyHeaderIdentity (header: ProvenancePropertyHeader) =
         $"{encode header.Kind.Id}:{termIdentity header.Category}"
 
+    let propertyKeyIdentity (property: ProvenancePropertyKey) =
+        $"{propertyHeaderIdentity property.Header}:Origin:{encode property.OriginSource.Id}"
+
     let propertyValueIdentity (propertyValue: ProvenancePropertyValue) =
         let value =
             match propertyValue.Value with
@@ -31,11 +34,7 @@ module DragDrop =
     /// Id-free identity for one grouping value, so a freshly dropped value can be
     /// found again on the card it regrouped into (the model assigns it a new id
     /// there). Quote-safe for use inside quoted attribute selectors.
-    let groupingValueIdentity
-        (header: ProvenancePropertyHeader)
-        (value: ProvenanceValue)
-        (unit: ProvenanceTerm option)
-        =
+    let groupingValueIdentity (property: ProvenancePropertyKey) (value: ProvenanceValue) (unit: ProvenanceTerm option) =
         let valueText =
             match value with
             | ProvenanceValue.Text text -> $"Text:{encode text}"
@@ -46,16 +45,16 @@ module DragDrop =
         let unitText = unit |> Option.map termIdentity |> Option.defaultValue ""
 
         // encode maps to encodeURIComponent, which leaves apostrophes alone.
-        $"{propertyHeaderIdentity header}:{valueText}:Unit:{unitText}".Replace("'", "%27")
+        $"{propertyKeyIdentity property}:{valueText}:Unit:{unitText}".Replace("'", "%27")
 
     let valueDragId propertyValueId =
         $"provenance-value|{encode propertyValueId}"
 
-    let propertyDragId side header =
-        $"provenance-property|{side}|{encode (propertyHeaderIdentity header)}"
+    let propertyDragId side property =
+        $"provenance-property|{side}|{encode (propertyKeyIdentity property)}"
 
-    let folderPropertyDragId side header =
-        $"provenance-folder-property|{side}|{encode (propertyHeaderIdentity header)}"
+    let folderPropertyDragId side property =
+        $"provenance-folder-property|{side}|{encode (propertyKeyIdentity property)}"
 
     let propertyRailDropId side = $"provenance-property-drop|{side}"
 

--- a/src/Components/src/Page/ProvenanceGrouping/PropertyModel.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/PropertyModel.fs
@@ -41,15 +41,15 @@ module PropertyRails =
     open Swate.Components.Page.ProvenanceGrouping.Types
 
     type RailProjection = {
-        Headers: ProvenancePropertyHeader list
-        ValuesByHeader: Map<ProvenancePropertyHeader, ProvenancePropertyValue list>
-        ExpandedHeaders: Set<ProvenancePropertyHeader>
-        CanSwitchHeaders: Set<ProvenancePropertyHeader>
-        StatsByHeader: Map<ProvenancePropertyHeader, PropertyStats>
-        ConnectionCountByHeader: Map<ProvenancePropertyHeader, int>
-        BadgeByHeader: Map<ProvenancePropertyHeader, PropertyCountBadge>
-        ColorByHeader: Map<ProvenancePropertyHeader, ProvenanceColor option>
-        OriginByHeader: Map<ProvenancePropertyHeader, Set<ProvenancePropertyOrigin>>
+        Headers: ProvenancePropertyKey list
+        ValuesByHeader: Map<ProvenancePropertyKey, ProvenancePropertyValue list>
+        ExpandedHeaders: Set<ProvenancePropertyKey>
+        CanSwitchHeaders: Set<ProvenancePropertyKey>
+        StatsByHeader: Map<ProvenancePropertyKey, PropertyStats>
+        ConnectionCountByHeader: Map<ProvenancePropertyKey, int>
+        BadgeByHeader: Map<ProvenancePropertyKey, PropertyCountBadge>
+        ColorByHeader: Map<ProvenancePropertyKey, ProvenanceColor option>
+        OriginByHeader: Map<ProvenancePropertyKey, Set<ProvenancePropertyOrigin>>
         OriginFilterOptions: PropertyOriginFilter list
     }
 
@@ -69,10 +69,10 @@ module PropertyRails =
         |> List.collect (fun (_, set) ->
             propertyValueIds set
             |> List.choose (fun id -> model.PropertyValues.TryFind id)
-            |> List.map (fun value -> value.Header)
+            |> List.map ProvenancePropertyValue.propertyKey
         )
         |> List.distinct
-        |> List.sortBy (fun header -> header.Category.Name)
+        |> List.sortBy (fun property -> property.Header.Category.Name, property.OriginSource.Id)
 
     let headersForSide side (model: ProvenanceModel) =
         headersFromSets ProvenanceSet.effectivePropertyValueIds side model
@@ -83,34 +83,27 @@ module PropertyRails =
             yield! headersForSide ProvenanceSide.Output model
         ]
         |> List.distinct
-        |> List.sortBy (fun header -> header.Category.Name)
+        |> List.sortBy (fun property -> property.Header.Category.Name, property.OriginSource.Id)
 
-    let hasHeaderForSide side header (model: ProvenanceModel) =
-        headersForSide side model |> List.contains header
+    let hasHeaderForSide side property (model: ProvenanceModel) =
+        headersForSide side model |> List.contains property
 
-    let canSwitchHeader header (model: ProvenanceModel) =
-        hasHeaderForSide ProvenanceSide.Input header model
-        && hasHeaderForSide ProvenanceSide.Output header model
+    let canSwitchHeader property (model: ProvenanceModel) =
+        hasHeaderForSide ProvenanceSide.Input property model
+        && hasHeaderForSide ProvenanceSide.Output property model
 
     let private placedHeadersForSide layerId side (uiState: UiState) =
         uiState.PropertyRailPlacements
         |> Map.toList
         |> List.choose (fun ((currentLayerId, key), targetSide) ->
             if currentLayerId = layerId && targetSide = side then
-                Some key.Header
+                Some key
             else
                 None
         )
 
-    let private railPlacement layerId header (uiState: UiState) =
-        uiState.PropertyRailPlacements |> Map.tryFind (layerId, { Header = header })
-
-    let private anchorOfOrigin =
-        function
-        | ProvenancePropertyOrigin.Real anchor -> anchor
-        | ProvenancePropertyOrigin.Virtual anchor -> anchor
-
-    let private sourceOfOrigin origin = (anchorOfOrigin origin).Source
+    let private railPlacement layerId property (uiState: UiState) =
+        uiState.PropertyRailPlacements |> Map.tryFind (layerId, property)
 
     /// One-pass caches over a side's sets. Rail projection asks per-header questions
     /// (values, stats, origins, connection counts) for every header, so the shared
@@ -119,11 +112,11 @@ module PropertyRails =
         SetCount: int
         /// Id-distinct property values for the side, in set iteration order.
         Values: ProvenancePropertyValue list
-        ValuesByHeader: Map<ProvenancePropertyHeader, ProvenancePropertyValue list>
-        HeaderSet: Set<ProvenancePropertyHeader>
-        DistinctValueCountByHeader: Map<ProvenancePropertyHeader, int>
-        SetsWithValueCountByHeader: Map<ProvenancePropertyHeader, int>
-        HeadersBySetId: Map<ProvenanceSetId, Set<ProvenancePropertyHeader>>
+        ValuesByHeader: Map<ProvenancePropertyKey, ProvenancePropertyValue list>
+        HeaderSet: Set<ProvenancePropertyKey>
+        DistinctValueCountByHeader: Map<ProvenancePropertyKey, int>
+        SetsWithValueCountByHeader: Map<ProvenancePropertyKey, int>
+        HeadersBySetId: Map<ProvenanceSetId, Set<ProvenancePropertyKey>>
     }
 
     let buildSideIndex side (model: ProvenanceModel) : SideIndex =
@@ -144,13 +137,15 @@ module PropertyRails =
             |> List.choose (fun propertyValueId -> model.PropertyValues.TryFind propertyValueId)
 
         let valuesByHeader =
-            values |> List.groupBy (fun propertyValue -> propertyValue.Header) |> Map.ofList
+            values |> List.groupBy ProvenancePropertyValue.propertyKey |> Map.ofList
 
         let distinctValueCountByHeader =
             resolvedBySet
             |> List.collect (fun (_, resolved) ->
                 resolved
-                |> List.map (fun propertyValue -> propertyValue.Header, (propertyValue.Value, propertyValue.Unit))
+                |> List.map (fun propertyValue ->
+                    ProvenancePropertyValue.propertyKey propertyValue, (propertyValue.Value, propertyValue.Unit)
+                )
             )
             |> List.distinct
             |> List.countBy fst
@@ -159,9 +154,7 @@ module PropertyRails =
         let setsWithValueCountByHeader =
             resolvedBySet
             |> List.collect (fun (_, resolved) ->
-                resolved
-                |> List.map (fun propertyValue -> propertyValue.Header)
-                |> List.distinct
+                resolved |> List.map ProvenancePropertyValue.propertyKey |> List.distinct
             )
             |> List.countBy id
             |> Map.ofList
@@ -169,7 +162,7 @@ module PropertyRails =
         let headersBySetId =
             resolvedBySet
             |> List.map (fun (setId, resolved) ->
-                setId, resolved |> List.map (fun propertyValue -> propertyValue.Header) |> Set.ofList
+                setId, resolved |> List.map ProvenancePropertyValue.propertyKey |> Set.ofList
             )
             |> Map.ofList
 
@@ -186,9 +179,9 @@ module PropertyRails =
     /// Same result as headersForSide, read from a prebuilt index.
     let headersFromIndex (index: SideIndex) =
         index.Values
-        |> List.map (fun propertyValue -> propertyValue.Header)
+        |> List.map ProvenancePropertyValue.propertyKey
         |> List.distinct
-        |> List.sortBy (fun header -> header.Category.Name)
+        |> List.sortBy (fun property -> property.Header.Category.Name, property.OriginSource.Id)
 
     /// Same rail-side selection as before, but every per-header question is answered
     /// from the prebuilt side indexes instead of rescanning the model.
@@ -206,17 +199,19 @@ module PropertyRails =
                 yield! headersFromIndex outputIndex
             ]
             |> List.distinct
-            |> List.sortBy (fun header -> header.Category.Name)
+            |> List.sortBy (fun property -> property.Header.Category.Name, property.OriginSource.Id)
 
         let modelHeaderSet = Set.ofList modelHeaders
 
         let paletteInputSet =
-            State.Palette.headersForSide layerId ProvenanceSide.Input uiState |> Set.ofList
+            State.Palette.propertiesForSide layerId ProvenanceSide.Input uiState
+            |> Set.ofList
 
         let paletteOutputSet =
-            State.Palette.headersForSide layerId ProvenanceSide.Output uiState |> Set.ofList
+            State.Palette.propertiesForSide layerId ProvenanceSide.Output uiState
+            |> Set.ofList
 
-        let paletteHeaders = State.Palette.headersForSide layerId side uiState
+        let paletteHeaders = State.Palette.propertiesForSide layerId side uiState
 
         let paletteSetFor paletteSide =
             if paletteSide = ProvenanceSide.Input then
@@ -224,27 +219,20 @@ module PropertyRails =
             else
                 paletteOutputSet
 
-        let hasPalette header =
-            paletteInputSet.Contains header || paletteOutputSet.Contains header
+        let hasPalette property =
+            paletteInputSet.Contains property || paletteOutputSet.Contains property
 
         let currentSourceId = model.Source.Id
 
-        let hasPreviousOriginIndexed header =
-            let hasUpstream (index: SideIndex) =
-                index.ValuesByHeader
-                |> Map.tryFind header
-                |> Option.exists (
-                    List.exists (fun propertyValue -> (sourceOfOrigin propertyValue.Origin).Id <> currentSourceId)
-                )
+        let hasPreviousOriginIndexed property =
+            property.OriginSource.Id <> currentSourceId
 
-            hasUpstream inputIndex || hasUpstream outputIndex
-
-        let defaultSideForHeader header =
-            if hasPreviousOriginIndexed header then
+        let defaultSideForHeader property =
+            if hasPreviousOriginIndexed property then
                 Some ProvenanceSide.Input
-            elif outputIndex.HeaderSet.Contains header then
+            elif outputIndex.HeaderSet.Contains property then
                 Some ProvenanceSide.Output
-            elif inputIndex.HeaderSet.Contains header then
+            elif inputIndex.HeaderSet.Contains property then
                 Some ProvenanceSide.Input
             else
                 None
@@ -270,7 +258,7 @@ module PropertyRails =
                 defaultSideForHeader header = Some side
                 || (defaultSideForHeader header).IsNone && (paletteSetFor side).Contains header
         )
-        |> List.sortBy (fun header -> header.Category.Name)
+        |> List.sortBy (fun property -> property.Header.Category.Name, property.OriginSource.Id)
 
     let propertyRailHeadersForSideInSession _session layerId side model uiState =
         propertyRailHeadersFromIndexes
@@ -281,24 +269,24 @@ module PropertyRails =
             model
             uiState
 
-    let propertyValuesForSideHeader layerId side header (model: ProvenanceModel) uiState =
+    let propertyValuesForSideHeader layerId side property (model: ProvenanceModel) uiState =
         let modelValues =
             setsForSide side model
             |> Map.toList
             |> List.collect (fun (_, set) -> ProvenanceSet.effectivePropertyValueIds set)
             |> List.distinct
             |> List.choose (fun propertyValueId -> model.PropertyValues.TryFind propertyValueId)
-            |> List.filter (fun propertyValue -> propertyValue.Header = header)
+            |> List.filter (ProvenancePropertyValue.belongsTo property)
 
         [
             yield! modelValues
-            yield! State.Palette.valuesForHeader layerId side header uiState
+            yield! State.Palette.valuesForProperty layerId side property uiState
         ]
         |> List.groupBy (fun propertyValue -> propertyValue.Value, propertyValue.Unit)
         |> List.map (fun (_, values) -> values |> List.sortBy (fun value -> value.Id) |> List.head)
         |> List.sortBy (fun propertyValue -> Formatting.formatValue propertyValue.Value propertyValue.Unit)
 
-    let propertyOriginsForSideHeader layerId side header (model: ProvenanceModel) uiState =
+    let propertyOriginsForSideHeader layerId side property (model: ProvenanceModel) uiState =
         [
             yield!
                 setsForSide side model
@@ -306,10 +294,10 @@ module PropertyRails =
                 |> List.collect (fun (_, set) -> ProvenanceSet.effectivePropertyValueIds set)
                 |> List.distinct
                 |> List.choose (fun propertyValueId -> model.PropertyValues.TryFind propertyValueId)
-                |> List.filter (fun propertyValue -> propertyValue.Header = header)
+                |> List.filter (ProvenancePropertyValue.belongsTo property)
                 |> List.map (fun propertyValue -> propertyValue.Origin)
             yield!
-                State.Palette.valuesForHeader layerId side header uiState
+                State.Palette.valuesForProperty layerId side property uiState
                 |> List.map (fun propertyValue -> propertyValue.Origin)
         ]
         |> Set.ofList
@@ -344,7 +332,7 @@ module PropertyProjection =
 
     let propertyStatsForSide
         (side: ProvenanceSide)
-        (header: ProvenancePropertyHeader)
+        (property: ProvenancePropertyKey)
         (model: ProvenanceModel)
         : PropertyStats =
         let sets = PropertyRails.setsForSide side model
@@ -356,7 +344,7 @@ module PropertyProjection =
             |> List.collect (fun (_, set) ->
                 ProvenanceSet.effectivePropertyValueIds set
                 |> List.choose (fun id -> model.PropertyValues.TryFind id)
-                |> List.filter (fun pv -> pv.Header = header)
+                |> List.filter (ProvenancePropertyValue.belongsTo property)
                 |> List.map (fun pv -> pv.Value, pv.Unit)
             )
             |> List.distinct
@@ -367,13 +355,14 @@ module PropertyProjection =
             |> List.filter (fun (_, set) ->
                 ProvenanceSet.effectivePropertyValueIds set
                 |> List.exists (fun id ->
-                    model.PropertyValues.TryFind id |> Option.exists (fun pv -> pv.Header = header)
+                    model.PropertyValues.TryFind id
+                    |> Option.exists (ProvenancePropertyValue.belongsTo property)
                 )
             )
             |> List.length
 
         {
-            Header = header
+            Property = property
             DistinctValueCount = distinctValues.Length
             SetsWithValueCount = setsWithValue
             TotalSetCount = setCount
@@ -389,12 +378,12 @@ module PropertyProjection =
 
     let headerMatchesProjectedValues
         (searchText: string)
-        (header: ProvenancePropertyHeader)
+        (property: ProvenancePropertyKey)
         (projectedValues: ProvenancePropertyValue list)
         =
-        Search.contains searchText header.Category.Name
-        || Search.contains searchText header.Kind.Id
-        || Search.contains searchText (ProvenanceKind.displayName header.Kind)
+        Search.contains searchText property.Header.Category.Name
+        || Search.contains searchText property.Header.Kind.Id
+        || Search.contains searchText (ProvenanceKind.displayName property.Header.Kind)
         || projectedValues
            |> List.exists (fun propertyValue ->
                Search.contains searchText (Formatting.formatValue propertyValue.Value propertyValue.Unit)
@@ -421,21 +410,20 @@ module PropertyProjection =
         | PropertyOriginFilter.Source sourceId ->
             origins |> Set.exists (fun origin -> (sourceOfOrigin origin).Id = sourceId)
 
-    let private headerNameSortKey (header: ProvenancePropertyHeader) =
-        header.Category.Name.Trim().ToLowerInvariant(), header.Category.Name, header.Kind.Id
+    let private headerNameSortKey (property: ProvenancePropertyKey) =
+        property.Header.Category.Name.Trim().ToLowerInvariant(),
+        property.Header.Category.Name,
+        property.Header.Kind.Id,
+        property.OriginSource.Id
 
-    let private setHasHeader header model (set: ProvenanceSet) =
+    let private setHasHeader property model (set: ProvenanceSet) =
         ProvenanceSet.effectivePropertyValueIds set
         |> List.exists (fun propertyValueId ->
             model.PropertyValues.TryFind propertyValueId
-            |> Option.exists (fun propertyValue -> propertyValue.Header = header)
+            |> Option.exists (ProvenancePropertyValue.belongsTo property)
         )
 
-    let connectionCountForSideHeader
-        (side: ProvenanceSide)
-        (header: ProvenancePropertyHeader)
-        (model: ProvenanceModel)
-        =
+    let connectionCountForSideHeader (side: ProvenanceSide) (property: ProvenancePropertyKey) (model: ProvenanceModel) =
         let sets = PropertyRails.setsForSide side model
 
         model.Connections
@@ -450,7 +438,7 @@ module PropertyProjection =
                     | ProvenanceSide.Output -> connection.OutputSetId
 
                 match sets.TryFind setId with
-                | Some set when setHasHeader header model set -> 1
+                | Some set when setHasHeader property model set -> 1
                 | _ -> 0
         )
 
@@ -465,9 +453,9 @@ module PropertyProjection =
 
     let sortHeaders
         (sort: PropertySort)
-        (statsByHeader: Map<ProvenancePropertyHeader, PropertyStats>)
-        (connectionCountsByHeader: Map<ProvenancePropertyHeader, int>)
-        (headers: ProvenancePropertyHeader list)
+        (statsByHeader: Map<ProvenancePropertyKey, PropertyStats>)
+        (connectionCountsByHeader: Map<ProvenancePropertyKey, int>)
+        (headers: ProvenancePropertyKey list)
         =
         match sort with
         | PropertySort.ValueCountDesc ->
@@ -478,9 +466,9 @@ module PropertyProjection =
                     |> Option.map (fun stats -> stats.DistinctValueCount)
                     |> Option.defaultValue 0
 
-                let name, rawName, kindId = headerNameSortKey header
+                let name, rawName, kindId, originId = headerNameSortKey header
 
-                -count, name, rawName, kindId
+                -count, name, rawName, kindId, originId
             )
         | PropertySort.NameAsc -> headers |> List.sortBy headerNameSortKey
         | PropertySort.ConnectionCountDesc ->
@@ -488,13 +476,13 @@ module PropertyProjection =
             |> List.sortBy (fun header ->
                 let count = connectionCountsByHeader.TryFind header |> Option.defaultValue 0
 
-                let name, rawName, kindId = headerNameSortKey header
+                let name, rawName, kindId, originId = headerNameSortKey header
 
-                -count, name, rawName, kindId
+                -count, name, rawName, kindId, originId
             )
 
     let originFilterOptions
-        (_originByHeader: Map<ProvenancePropertyHeader, Set<ProvenancePropertyOrigin>>)
+        (_originByHeader: Map<ProvenancePropertyKey, Set<ProvenancePropertyOrigin>>)
         : PropertyOriginFilter list =
         [
             PropertyOriginFilter.AnyOrigin
@@ -526,18 +514,18 @@ module PropertyProjection =
         let modelValuesForHeader header =
             sideIndex.ValuesByHeader |> Map.tryFind header |> Option.defaultValue []
 
-        let paletteValuesForHeader header =
-            State.Palette.valuesForHeader layerId side header uiState
+        let paletteValuesForHeader property =
+            State.Palette.valuesForProperty layerId side property uiState
 
         let valuesByHeader =
             headers
-            |> List.map (fun header ->
+            |> List.map (fun property ->
                 let merged = [
-                    yield! modelValuesForHeader header
-                    yield! paletteValuesForHeader header
+                    yield! modelValuesForHeader property
+                    yield! paletteValuesForHeader property
                 ]
 
-                header,
+                property,
                 merged
                 |> List.groupBy (fun propertyValue -> propertyValue.Value, propertyValue.Unit)
                 |> List.map (fun (_, values) -> values |> List.sortBy (fun value -> value.Id) |> List.head)
@@ -547,17 +535,17 @@ module PropertyProjection =
 
         let statsByHeader =
             headers
-            |> List.map (fun header ->
-                header,
+            |> List.map (fun property ->
+                property,
                 {
-                    Header = header
+                    Property = property
                     DistinctValueCount =
                         sideIndex.DistinctValueCountByHeader
-                        |> Map.tryFind header
+                        |> Map.tryFind property
                         |> Option.defaultValue 0
                     SetsWithValueCount =
                         sideIndex.SetsWithValueCountByHeader
-                        |> Map.tryFind header
+                        |> Map.tryFind property
                         |> Option.defaultValue 0
                     TotalSetCount = sideIndex.SetCount
                 }
@@ -586,22 +574,22 @@ module PropertyProjection =
                 |> Map.ofList
 
             headers
-            |> List.map (fun header -> header, countedHeaders |> Map.tryFind header |> Option.defaultValue 0)
+            |> List.map (fun property -> property, countedHeaders |> Map.tryFind property |> Option.defaultValue 0)
             |> Map.ofList
 
         let originByHeader =
             headers
-            |> List.map (fun header ->
+            |> List.map (fun property ->
                 let origins = [
                     yield!
-                        modelValuesForHeader header
+                        modelValuesForHeader property
                         |> List.map (fun propertyValue -> propertyValue.Origin)
                     yield!
-                        paletteValuesForHeader header
+                        paletteValuesForHeader property
                         |> List.map (fun propertyValue -> propertyValue.Origin)
                 ]
 
-                header, Set.ofList origins
+                property, Set.ofList origins
             )
             |> Map.ofList
 
@@ -610,9 +598,9 @@ module PropertyProjection =
         let colorContext =
             State.PropertyColors.visibleColorContextForLayer session (Session.layerById layerId session)
 
-        let visibleColorKey header = {
+        let visibleColorKey property = {
             ContextId = colorContext.Id
-            Header = header
+            Property = property
         }
 
         let latestExplicitSourceColor sourceIds =
@@ -626,10 +614,10 @@ module PropertyProjection =
             |> List.tryHead
             |> Option.bind (fun (_, sourceId) -> uiState.PropertyColors.SourceColors |> Map.tryFind sourceId)
 
-        let resolvedColorForHeader header origins =
+        let resolvedColorForHeader property origins =
             match
                 uiState.PropertyColors.ManualPropertyColors
-                |> Map.tryFind (visibleColorKey header)
+                |> Map.tryFind (visibleColorKey property)
             with
             | Some color -> Some color
             | None ->
@@ -649,17 +637,17 @@ module PropertyProjection =
 
         let colorByHeader =
             headers
-            |> List.map (fun header -> header, resolvedColorForHeader header originByHeader.[header])
+            |> List.map (fun property -> property, resolvedColorForHeader property originByHeader.[property])
             |> Map.ofList
 
         let filtered =
             headers
-            |> List.filter (fun header ->
-                let badge = badgeByHeader.[header]
-                let values = valuesByHeader.[header]
-                let origins = originByHeader.[header]
+            |> List.filter (fun property ->
+                let badge = badgeByHeader.[property]
+                let values = valuesByHeader.[property]
+                let origins = originByHeader.[property]
 
-                headerMatchesProjectedValues filters.SearchText header values
+                headerMatchesProjectedValues filters.SearchText property values
                 && valueCountFilterMatches filters.ValueCountFilter badge
                 && originFilterMatches model filters.OriginFilter origins
             )
@@ -674,7 +662,7 @@ module PropertyProjection =
 
         let expandedHeaders =
             sorted
-            |> List.filter (fun header -> State.PropertyExpansion.isExpanded layerId side header uiState)
+            |> List.filter (fun property -> State.PropertyExpansion.isExpanded layerId side property uiState)
             |> Set.ofList
 
         let canSwitchHeaders =
@@ -684,11 +672,17 @@ module PropertyProjection =
 
         {
             Headers = sorted
-            ValuesByHeader = sorted |> List.map (fun header -> header, valuesByHeader.[header]) |> Map.ofList
+            ValuesByHeader =
+                sorted
+                |> List.map (fun property -> property, valuesByHeader.[property])
+                |> Map.ofList
             StatsByHeader = statsByHeader
             ConnectionCountByHeader = connectionCountsByHeader
             BadgeByHeader = badgeByHeader
-            ColorByHeader = sorted |> List.map (fun header -> header, colorByHeader.[header]) |> Map.ofList
+            ColorByHeader =
+                sorted
+                |> List.map (fun property -> property, colorByHeader.[property])
+                |> Map.ofList
             OriginByHeader = originByHeader
             OriginFilterOptions = originFilterOptions originByHeader
             ExpandedHeaders = expandedHeaders

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.fs
@@ -404,7 +404,7 @@ type ProvenanceGrouping =
                                 FolderedDraggableList.FolderedDraggableList<PropertyShelfItemPayload>(
                                     propertyShelfFolders,
                                     (fun _ item ->
-                                        DragDrop.folderPropertyDragId item.Payload.SourceSide item.Payload.Header
+                                        DragDrop.folderPropertyDragId item.Payload.SourceSide item.Payload.Property
                                     ),
                                     ?activeFolderId = propertyShelfActiveFolderId,
                                     onActiveFolderIdChange = setPropertyShelfActiveFolderId,
@@ -642,9 +642,9 @@ type ProvenanceGrouping =
         let createSet =
             React.useCallback ((fun command -> EditorActions.createSet latestSession.current publish command), [||])
 
-        let addPaletteValue side header value unit =
+        let addPaletteValue side property value unit =
             let layer = latestLayer.current
-            applyUiState (State.Palette.addValue layer.Id layer.Model.Source side header value unit)
+            applyUiState (State.Palette.addValue layer.Id side property value unit)
 
         let toggleSideGrouping sideId side header =
             applyUiState (State.GroupingAssignments.toggleSide sideId side header)
@@ -895,8 +895,8 @@ type ProvenanceGrouping =
         let isRejectedPropertyRailDrop targetSide =
             let headerCannotSwitch sourceSide headerId =
                 sourceSide <> targetSide
-                && (lookups.FindHeader headerId
-                    |> Option.exists (fun header -> PropertyRails.canSwitchHeader header layer.Model |> not))
+                && (lookups.FindProperty headerId
+                    |> Option.exists (fun property -> PropertyRails.canSwitchHeader property layer.Model |> not))
 
             match activeDrag with
             | Some {
@@ -1005,7 +1005,7 @@ type ProvenanceGrouping =
 
             EditorSurface.propertyRail
                 side
-                layer.Model.Source.Id
+                layer.Model.Source
                 sideId
                 (match side with
                  | ProvenanceSide.Input -> activeInputRailProjection
@@ -1028,9 +1028,11 @@ type ProvenanceGrouping =
                 // some entity; the palette copy keeps rendering after a drop, so the
                 // check must look at value identity rather than the chip's own id.
                 (fun propertyValue ->
+                    let property = ProvenancePropertyValue.propertyKey propertyValue
+
                     layer.Model.PropertyValues
                     |> Map.exists (fun _ existing ->
-                        existing.Header = propertyValue.Header
+                        ProvenancePropertyValue.belongsTo property existing
                         && existing.Value = propertyValue.Value
                         && existing.Unit = propertyValue.Unit
                     )

--- a/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
+++ b/src/Components/src/Page/ProvenanceGrouping/ProvenanceGrouping.stories.tsx
@@ -7,6 +7,7 @@ import {
   Exports_createSampleSession as createSampleSession,
   Exports_createInputOnlySession as createInputOnlySession,
   Exports_createOutputOnlySession as createOutputOnlySession,
+  Exports_createDisconnectedPropertySession as createDisconnectedPropertySession,
   Exports_createSwitchablePropertySession as createSwitchablePropertySession,
   Exports_createTypedSampleSession as createTypedSampleSession,
   Exports_createDataOutputOnlySession as createDataOutputOnlySession,
@@ -14,7 +15,7 @@ import {
   Exports_patchLog as patchLog,
 } from './Types.fs.js';
 
-type Fixture = 'sample' | 'inputOnly' | 'outputOnly' | 'switchableProperty' | 'typedSample' | 'dataOutputOnly';
+type Fixture = 'sample' | 'inputOnly' | 'outputOnly' | 'disconnectedProperty' | 'switchableProperty' | 'typedSample' | 'dataOutputOnly';
 
 function createSessionForFixture(selected: Fixture) {
   switch (selected) {
@@ -22,6 +23,8 @@ function createSessionForFixture(selected: Fixture) {
       return createInputOnlySession();
     case 'outputOnly':
       return createOutputOnlySession();
+    case 'disconnectedProperty':
+      return createDisconnectedPropertySession();
     case 'switchableProperty':
       return createSwitchablePropertySession();
     case 'typedSample':
@@ -448,7 +451,7 @@ export const RejectedShelfPropertyDropRestoresFolderItem: Story = {
 };
 
 export const SingleSidedShelfPropertiesCannotDropOnOppositeSide: Story = {
-  render: () => <Harness />,
+  render: () => <Harness fixture="disconnectedProperty" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const source = await shelfProperty(canvas, 'Analysis');
@@ -748,7 +751,7 @@ export const RailValueShowsDragIndicatorWhileDragging: Story = {
 };
 
 export const SingleSidedPropertiesCannotSwitchSides: Story = {
-  render: () => <Harness />,
+  render: () => <Harness fixture="disconnectedProperty" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -780,7 +783,8 @@ export const SwitchesPropertyGroupingSideByDrag: Story = {
       expect(canvas.queryByTestId('provenance-group-Output-output:Batch=A')).not.toBeInTheDocument();
       expect(canvas.getByTestId('provenance-group-Output-output:output-a')).toBeInTheDocument();
       expect(canvas.getByTestId('provenance-group-Input-input:Batch=A')).toBeInTheDocument();
-      expect(canvas.getByTestId('provenance-group-Input-input:input-b')).toBeInTheDocument();
+      expect(canvas.getByTestId('provenance-group-Input-input:Batch=B')).toBeInTheDocument();
+      expect(canvas.queryByTestId('provenance-group-Input-input:input-b')).not.toBeInTheDocument();
     });
   },
 };

--- a/src/Components/src/Page/ProvenanceGrouping/State.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/State.fs
@@ -8,9 +8,14 @@ open Swate.Components.Page.ProvenanceGrouping.Types
 /// Shared key helpers used by the UI state maps and sets.
 module Keys =
 
-    let groupingKey header : GroupingKey = { Header = header }
+    let groupingKey (property: ProvenancePropertyKey) : GroupingKey = property
 
-    let propertySlot layerId side header = layerId, side, groupingKey header
+    let propertyKey originSource header : ProvenancePropertyKey = {
+        Header = header
+        OriginSource = originSource
+    }
+
+    let propertySlot layerId side property = layerId, side, groupingKey property
 
     let paletteKey layerId side = layerId, side
 
@@ -145,13 +150,13 @@ module PropertyColors =
             DefaultSourceId = rootLayer.Model.Source.Id
         }
 
-    let private visiblePropertyColorKey contextId header = {
+    let private visiblePropertyColorKey contextId property = {
         ContextId = contextId
-        Header = header
+        Property = property
     }
 
-    let setColor contextId (header: ProvenancePropertyHeader) color state =
-        let key = visiblePropertyColorKey contextId header
+    let setColor contextId (property: ProvenancePropertyKey) color state =
+        let key = visiblePropertyColorKey contextId property
 
         {
             state with
@@ -161,8 +166,8 @@ module PropertyColors =
                 }
         }
 
-    let clearColor contextId (header: ProvenancePropertyHeader) state =
-        let key = visiblePropertyColorKey contextId header
+    let clearColor contextId (property: ProvenancePropertyKey) state =
+        let key = visiblePropertyColorKey contextId property
 
         {
             state with
@@ -423,7 +428,7 @@ module RailOrder =
     let get layerId side state =
         tryGet layerId side state |> Option.defaultValue []
 
-    let apply (order: ProvenancePropertyHeader list) (headers: ProvenancePropertyHeader list) =
+    let apply (order: ProvenancePropertyKey list) (headers: ProvenancePropertyKey list) =
         let headerSet = headers |> Set.ofList
         let ordered = order |> List.filter (fun header -> headerSet.Contains header)
         let orderedSet = ordered |> Set.ofList
@@ -477,15 +482,15 @@ module RailOrder =
 /// Tracks explicit side drop-zone placement without changing grouping selection.
 module PropertyPlacement =
 
-    let place layerId side header state =
-        let key = Keys.groupingKey header
+    let place layerId side property state =
+        let key = Keys.groupingKey property
 
         {
             state with
                 PropertyRailPlacements = state.PropertyRailPlacements |> Map.add (layerId, key) side
                 Error = None
         }
-        |> RailOrder.appendHeader layerId side header
+        |> RailOrder.appendHeader layerId side property
 
 /// Consolidates a hidden side's switchable annotations onto the still-visible rail.
 module SideVisibility =
@@ -499,7 +504,7 @@ module SideVisibility =
         layerId
         (hiddenSide: ProvenanceSide)
         (hiddenSideId: ProvenanceLayerSideId)
-        (canSwitch: ProvenancePropertyHeader -> bool)
+        (canSwitch: ProvenancePropertyKey -> bool)
         state
         =
         let visibleSide =
@@ -514,7 +519,7 @@ module SideVisibility =
             |> Map.toList
             |> List.choose (fun ((placementLayerId, key), side) ->
                 if placementLayerId = layerId && side = hiddenSide then
-                    Some key.Header
+                    Some key
                 else
                     None
             )
@@ -522,7 +527,7 @@ module SideVisibility =
         let soloGroupedHeaders =
             (Sides.get hiddenSideId state).GroupingAssignments
             |> List.filter (fun assignment -> assignment.Scope = hiddenScope)
-            |> List.map (fun assignment -> assignment.Key.Header)
+            |> List.map (fun assignment -> assignment.Key)
 
         let headers =
             [ yield! placedHeaders; yield! soloGroupedHeaders ]
@@ -531,8 +536,8 @@ module SideVisibility =
 
         headers
         |> List.fold
-            (fun state header ->
-                let key = Keys.groupingKey header
+            (fun state property ->
+                let key = Keys.groupingKey property
 
                 let withoutSolo =
                     Sides.update
@@ -552,19 +557,20 @@ module SideVisibility =
                         PropertyRailPlacements =
                             withoutSolo.PropertyRailPlacements |> Map.add (layerId, key) visibleSide
                 }
-                |> RailOrder.removeHeader layerId hiddenSide header
-                |> RailOrder.appendHeader layerId visibleSide header
+                |> RailOrder.removeHeader layerId hiddenSide property
+                |> RailOrder.appendHeader layerId visibleSide property
             )
             state
 
 /// Tracks expanded property value panels on the side rails.
 module PropertyExpansion =
 
-    let isExpanded layerId side header state =
-        state.ExpandedProperties |> Set.contains (Keys.propertySlot layerId side header)
+    let isExpanded layerId side property state =
+        state.ExpandedProperties
+        |> Set.contains (Keys.propertySlot layerId side property)
 
-    let toggle layerId side header state =
-        let slot = Keys.propertySlot layerId side header
+    let toggle layerId side property state =
+        let slot = Keys.propertySlot layerId side property
 
         let expanded =
             if state.ExpandedProperties.Contains slot then
@@ -585,15 +591,15 @@ module Palette =
         |> Map.tryFind (Keys.paletteKey layerId side)
         |> Option.defaultValue []
 
-    let valuesForHeader layerId side header state =
+    let valuesForProperty layerId side property state =
         valuesForSide layerId side state
-        |> List.filter (fun propertyValue -> propertyValue.Header = header)
+        |> List.filter (ProvenancePropertyValue.belongsTo property)
 
-    let headersForSide layerId side state =
+    let propertiesForSide layerId side state =
         valuesForSide layerId side state
-        |> List.map (fun propertyValue -> propertyValue.Header)
+        |> List.map ProvenancePropertyValue.propertyKey
         |> List.distinct
-        |> List.sortBy (fun header -> header.Category.Name)
+        |> List.sortBy (fun property -> property.Header.Category.Name, property.OriginSource.Id)
 
     let tryFindValue propertyValueId state =
         state.PaletteValues
@@ -620,21 +626,21 @@ module Palette =
 
         loop (existing.Count + 1)
 
-    let addValue layerId source side header value unit state =
+    let addValue layerId side property value unit state =
         let key = Keys.paletteKey layerId side
 
         let anchor = {
-            Source = source
+            Source = property.OriginSource
             ProcessId = None
             ProcessName = None
-            Header = header
+            Header = property.Header
             InputNames = []
             OutputNames = []
         }
 
         let propertyValue: ProvenancePropertyValue = {
             Id = nextValueId layerId side state
-            Header = header
+            Header = property.Header
             Value = value
             Unit = unit
             Origin = ProvenancePropertyOrigin.Virtual anchor
@@ -645,11 +651,13 @@ module Palette =
         {
             state with
                 PaletteValues = state.PaletteValues |> Map.add key nextValues
-                PropertyRailPlacements = state.PropertyRailPlacements |> Map.add (layerId, Keys.groupingKey header) side
-                ExpandedProperties = state.ExpandedProperties |> Set.add (Keys.propertySlot layerId side header)
+                PropertyRailPlacements =
+                    state.PropertyRailPlacements
+                    |> Map.add (layerId, Keys.groupingKey property) side
+                ExpandedProperties = state.ExpandedProperties |> Set.add (Keys.propertySlot layerId side property)
                 Error = None
         }
-        |> RailOrder.appendHeader layerId side header
+        |> RailOrder.appendHeader layerId side property
 
 /// Manages batch assignment confirmation state for dropped property values.
 module AssignmentBatch =
@@ -668,12 +676,12 @@ module AssignmentBatch =
 /// Updates grouping assignments and side placement for properties.
 module GroupingAssignments =
 
-    let private removeHeader header (assignments: GroupingAssignment list) : GroupingAssignment list =
-        let key = Keys.groupingKey header
+    let private removeProperty property (assignments: GroupingAssignment list) : GroupingAssignment list =
+        let key = Keys.groupingKey property
         assignments |> List.filter (fun assignment -> assignment.Key <> key)
 
-    let private removeHeaderScope header scope (assignments: GroupingAssignment list) : GroupingAssignment list =
-        let key = Keys.groupingKey header
+    let private removePropertyScope property scope (assignments: GroupingAssignment list) : GroupingAssignment list =
+        let key = Keys.groupingKey property
 
         assignments
         |> List.filter (fun assignment -> assignment.Key <> key || assignment.Scope <> scope)
@@ -686,11 +694,11 @@ module GroupingAssignments =
         |> List.filter (fun current -> current.Key <> assignment.Key)
         |> fun retained -> retained @ [ assignment ]
 
-    let toggleSide sideId side header state =
+    let toggleSide sideId side property state =
         Sides.update
             sideId
             (fun current ->
-                let key = Keys.groupingKey header
+                let key = Keys.groupingKey property
                 let scope = scopeForSide side
                 let assignment: GroupingAssignment = { Key = key; Scope = scope }
 
@@ -700,7 +708,7 @@ module GroupingAssignments =
 
                 let nextAssignments =
                     if isSelected then
-                        removeHeaderScope header scope current.GroupingAssignments
+                        removePropertyScope property scope current.GroupingAssignments
                     else
                         upsert assignment current.GroupingAssignments
 
@@ -711,8 +719,8 @@ module GroupingAssignments =
             )
             state
 
-    let toggleBoth inputSideId outputSideId header state =
-        let key = Keys.groupingKey header
+    let toggleBoth inputSideId outputSideId property state =
+        let key = Keys.groupingKey property
 
         let isSelected =
             [ inputSideId; outputSideId ]
@@ -727,7 +735,7 @@ module GroupingAssignments =
                 (fun current ->
                     let nextAssignments =
                         if isSelected then
-                            removeHeaderScope header GroupingScope.Both current.GroupingAssignments
+                            removePropertyScope property GroupingScope.Both current.GroupingAssignments
                         else
                             upsert
                                 ({
@@ -747,8 +755,8 @@ module GroupingAssignments =
         let withInput = setSide state inputSideId
         setSide withInput outputSideId
 
-    let move layerId sourceSideId targetSideId targetSide header state =
-        let key = Keys.groupingKey header
+    let move layerId sourceSideId targetSideId targetSide property state =
+        let key = Keys.groupingKey property
 
         let sourceSide =
             match targetSide with
@@ -766,7 +774,7 @@ module GroupingAssignments =
                 sourceSideId
                 (fun current -> {
                     current with
-                        GroupingAssignments = removeHeader header current.GroupingAssignments
+                        GroupingAssignments = removeProperty property current.GroupingAssignments
                 })
                 state
 
@@ -791,8 +799,8 @@ module GroupingAssignments =
             withTarget with
                 PropertyRailPlacements = withTarget.PropertyRailPlacements |> Map.add (layerId, key) targetSide
         }
-        |> RailOrder.removeHeader layerId sourceSide header
-        |> RailOrder.appendHeader layerId targetSide header
+        |> RailOrder.removeHeader layerId sourceSide property
+        |> RailOrder.appendHeader layerId targetSide property
 
 /// Tracks selected input/output groups for layer creation.
 module Selection =

--- a/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Tutorial.fs
@@ -234,21 +234,30 @@ module ProvenanceTutorialSteps =
     let private speciesHeader =
         Fixtures.propertyHeader Fixtures.FixtureKinds.characteristicProperty "Species"
 
+    let private speciesProperty (session: ProvenanceSession) =
+        let layer = Session.activeLayer session
+
+        layer.Model.PropertyValues
+        |> Map.toList
+        |> List.map snd
+        |> List.find (fun propertyValue -> propertyValue.Header = speciesHeader)
+        |> ProvenancePropertyValue.propertyKey
+
     let private withSpeciesOnInputRail (session: ProvenanceSession) (state: UiState) =
         let layer = Session.activeLayer session
-        State.PropertyPlacement.place layer.Id ProvenanceSide.Input speciesHeader state
+        State.PropertyPlacement.place layer.Id ProvenanceSide.Input (speciesProperty session) state
 
     let private withSpeciesGrouped (session: ProvenanceSession) (state: UiState) =
         let layer = Session.activeLayer session
 
         withSpeciesOnInputRail session state
-        |> State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input speciesHeader
+        |> State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input (speciesProperty session)
 
     let private withSpeciesValuesExpanded (session: ProvenanceSession) (state: UiState) =
         let layer = Session.activeLayer session
 
         withSpeciesGrouped session state
-        |> State.PropertyExpansion.toggle layer.Id ProvenanceSide.Input speciesHeader
+        |> State.PropertyExpansion.toggle layer.Id ProvenanceSide.Input (speciesProperty session)
 
     /// The stock sample plus one input without any annotation values. Every
     /// stock entity already has a species (inputs their own, outputs an

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -27,7 +27,7 @@ type ProvenanceDetail =
 
 type ValueAssignmentSource = {
     CopiedFrom: ProvenancePropertyValueId option
-    Header: ProvenancePropertyHeader
+    Property: ProvenancePropertyKey
     Value: ProvenanceValue
     Unit: ProvenanceTerm option
 }
@@ -47,8 +47,9 @@ type ValueAssignmentPlan =
 [<RequireQualifiedAccess>]
 type ValueAssignmentError =
     | EmptyTarget
-    | MixedPropertyValueCounts of ProvenancePropertyHeader
-    | MultiplePropertyValues of ProvenancePropertyHeader * ProvenanceSetId list
+    | MixedPropertyValueCounts of ProvenancePropertyKey
+    | MultiplePropertyValues of ProvenancePropertyKey * ProvenanceSetId list
+    | UpstreamPropertyNotAssigned of ProvenancePropertyKey
 
 type PropertyAssignmentBatch = {
     Adds: CreateLoadedPropertyValueCommand list
@@ -110,7 +111,7 @@ type VisiblePropertyColorContext = {
 
 type VisiblePropertyColorKey = {
     ContextId: ProvenanceColorContextId
-    Header: ProvenancePropertyHeader
+    Property: ProvenancePropertyKey
 }
 
 type PropertyColorSettings = {
@@ -155,7 +156,7 @@ type FilterState = {
 }
 
 type PropertyStats = {
-    Header: ProvenancePropertyHeader
+    Property: ProvenancePropertyKey
     DistinctValueCount: int
     SetsWithValueCount: int
     TotalSetCount: int
@@ -169,7 +170,7 @@ type PropertyCountBadge =
 type UiState = {
     SideStates: Map<ProvenanceLayerSideId, SideViewState>
     PropertyRailPlacements: Map<ProvenanceLayerId * GroupingKey, ProvenanceSide>
-    PropertyRailOrders: Map<ProvenanceLayerId * ProvenanceSide, ProvenancePropertyHeader list>
+    PropertyRailOrders: Map<ProvenanceLayerId * ProvenanceSide, ProvenancePropertyKey list>
     ExpandedProperties: Set<ProvenanceLayerId * ProvenanceSide * GroupingKey>
     PaletteValues: Map<ProvenanceLayerId * ProvenanceSide, ProvenancePropertyValue list>
     PendingAssignmentBatch: PendingAssignmentBatch option

--- a/src/Components/src/Page/ProvenanceGrouping/Types.fs
+++ b/src/Components/src/Page/ProvenanceGrouping/Types.fs
@@ -194,6 +194,9 @@ module StoryFixtures =
     let createInputOnlySession () = inputOnlyModel () |> Session.init
     let createOutputOnlySession () = outputOnlyModel () |> Session.init
 
+    let createDisconnectedPropertySession () =
+        disconnectedPropertyModel () |> Session.init
+
     let createSwitchablePropertySession () =
         switchablePropertyModel () |> Session.init
 
@@ -264,6 +267,9 @@ module Exports =
 
     let createOutputOnlySession () =
         StoryFixtures.createOutputOnlySession ()
+
+    let createDisconnectedPropertySession () =
+        StoryFixtures.createDisconnectedPropertySession ()
 
     let createSwitchablePropertySession () =
         StoryFixtures.createSwitchablePropertySession ()

--- a/src/Shared/ProvenanceGrouping/ARCtrlConverter.fs
+++ b/src/Shared/ProvenanceGrouping/ARCtrlConverter.fs
@@ -609,7 +609,7 @@ module internal Dedup =
                 OutputSets = state.OutputSets
                 Connections = state.Connections
              }
-             |> ProvenanceModel.refreshInheritedOutputProperties)
+             |> ProvenanceModel.refreshInheritedProperties)
         Index = {
             LoadedTable = loadedTable
             EndpointLocations = state.EndpointLocations

--- a/src/Shared/ProvenanceGrouping/Edit.fs
+++ b/src/Shared/ProvenanceGrouping/Edit.fs
@@ -371,7 +371,7 @@ let createLoadedPropertyValue (command: CreateLoadedPropertyValueCommand) (model
                         InputSets = model.InputSets |> updateSets propertyValueId inputSetIds
                         OutputSets = model.OutputSets |> updateSets propertyValueId outputSetIds
                 }
-                |> ProvenanceModel.refreshInheritedOutputProperties
+                |> ProvenanceModel.refreshInheritedProperties
 
             if nextModel = model then
                 Ok(model, [])
@@ -406,7 +406,7 @@ let createLoadedPropertyValue (command: CreateLoadedPropertyValueCommand) (model
                         InputSets = model.InputSets |> updateSets propertyValueId inputSetIds
                         OutputSets = model.OutputSets |> updateSets propertyValueId outputSetIds
                 }
-                |> ProvenanceModel.refreshInheritedOutputProperties
+                |> ProvenanceModel.refreshInheritedProperties
 
             Ok(
                 nextModel,
@@ -439,12 +439,21 @@ let removeConnection (connectionId: ProvenanceConnectionId) (model: ProvenanceMo
     match chooseConnection model connectionId with
     | Error error -> Error error
     | Ok connection ->
+        // Strip the removed connection's inherited entries explicitly: once the
+        // connection is gone from the map, the refresh would treat them as
+        // carried-in upstream entries and preserve them.
+        let dropInherited setId sets =
+            sets
+            |> Map.change setId (Option.map (ProvenanceSet.removeInheritedPropertyValueIds connectionId))
+
         let nextModel =
             {
                 model with
                     Connections = model.Connections |> Map.remove connectionId
+                    InputSets = model.InputSets |> dropInherited connection.InputSetId
+                    OutputSets = model.OutputSets |> dropInherited connection.OutputSetId
             }
-            |> ProvenanceModel.refreshInheritedOutputProperties
+            |> ProvenanceModel.refreshInheritedProperties
 
         Ok(
             nextModel,
@@ -492,7 +501,7 @@ let connectSets inputSetId outputSetId processName (model: ProvenanceModel) : Ed
                 model with
                     Connections = model.Connections |> Map.add connectionId connection
             }
-            |> ProvenanceModel.refreshInheritedOutputProperties
+            |> ProvenanceModel.refreshInheritedProperties
 
         Ok(
             nextModel,

--- a/src/Shared/ProvenanceGrouping/Fixtures.fs
+++ b/src/Shared/ProvenanceGrouping/Fixtures.fs
@@ -97,7 +97,7 @@ let model
             |> List.map (fun connection -> connection.Id, connection)
             |> Map.ofList
     }
-    |> ProvenanceModel.refreshInheritedOutputProperties
+    |> ProvenanceModel.refreshInheritedProperties
 
 let sampleModel () : ProvenanceModel =
     let assaySource = source "fixture:assay-table" "assay-table"
@@ -264,6 +264,40 @@ let outputOnlyModel () : ProvenanceModel =
         ]
         [] [
             outputSet "output-only-a" outputOnlySource outputHeader "Output Only A" [ "pv-output-only-analysis" ]
+        ] []
+
+let disconnectedPropertyModel () : ProvenanceModel =
+    let modelSource =
+        source "fixture:disconnected-property-table" "disconnected-property-table"
+
+    let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+    let outputHeader = ioHeader FixtureKinds.sampleEndpoint "Output [Sample Name]"
+    let analysis = propertyHeader FixtureKinds.parameterProperty "Analysis"
+    let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
+
+    model
+        modelSource
+        [
+            propertyValue
+                "pv-disconnected-output-analysis"
+                analysis
+                (ProvenanceValue.Text "Mass Spectrometry")
+                None
+                (real modelSource None analysis [] [ "Disconnected Output" ])
+            propertyValue
+                "pv-disconnected-output-replicate"
+                replicate
+                (ProvenanceValue.Text "1")
+                None
+                (real modelSource None replicate [] [ "Disconnected Output" ])
+        ]
+        [
+            inputSet "disconnected-input" modelSource inputHeader "Disconnected Input" []
+        ] [
+            outputSet "disconnected-output" modelSource outputHeader "Disconnected Output" [
+                "pv-disconnected-output-analysis"
+                "pv-disconnected-output-replicate"
+            ]
         ] []
 
 let switchablePropertyModel () : ProvenanceModel =

--- a/src/Shared/ProvenanceGrouping/Grouping.fs
+++ b/src/Shared/ProvenanceGrouping/Grouping.fs
@@ -2,7 +2,7 @@ module Swate.Components.Shared.ProvenanceGrouping.Grouping
 
 open Swate.Components.Shared.ProvenanceGrouping.Types
 
-type GroupingKey = { Header: ProvenancePropertyHeader }
+type GroupingKey = ProvenancePropertyKey
 
 [<RequireQualifiedAccess>]
 type GroupingScope =
@@ -57,9 +57,9 @@ let valueText (value: ProvenanceValue) (unit: ProvenanceTerm option) =
     | None -> text
 
 let private groupingKeySortText (key: GroupingKey) =
-    sprintf "%s:%s" key.Header.Kind.Id key.Header.Category.Name
+    sprintf "%s:%s:%s" key.Header.Kind.Id key.Header.Category.Name key.OriginSource.Id
 
-let private groupingValuesText keyValueSeparator keySeparator values =
+let private groupingValuesText duplicateHeaders keyValueSeparator keySeparator values =
     values
     |> List.groupBy (fun value -> value.Key)
     |> List.sortBy (fun (key, _) -> groupingKeySortText key)
@@ -70,7 +70,13 @@ let private groupingValuesText keyValueSeparator keySeparator values =
             |> List.map (fun groupingValue -> valueText groupingValue.Value groupingValue.Unit)
             |> String.concat " | "
 
-        sprintf "%s%s%s" key.Header.Category.Name keyValueSeparator valuesText
+        let keyText =
+            if duplicateHeaders |> Set.contains key.Header then
+                $"{key.Header.Category.Name}@{key.OriginSource.Id}"
+            else
+                key.Header.Category.Name
+
+        sprintf "%s%s%s" keyText keyValueSeparator valuesText
     )
     |> String.concat keySeparator
 
@@ -99,7 +105,7 @@ type private GroupingValue = GroupingKey * ProvenanceValue * ProvenanceTerm opti
 let private valueSetForKey key propertyValues : GroupingValue list list =
     let values =
         propertyValues
-        |> List.filter (fun (propertyValue: ProvenancePropertyValue) -> propertyValue.Header = key.Header)
+        |> List.filter (ProvenancePropertyValue.belongsTo key)
         |> List.groupBy (fun propertyValue -> propertyValue.Value, propertyValue.Unit)
         |> List.map (fun ((value, unit), propertyValues) ->
             key,
@@ -158,20 +164,29 @@ let private displayMember (set: ProvenanceSet) propertyValueIds = {
     PropertyValueIds = propertyValueIds |> List.distinct
 }
 
-let private groupId side (values: DisplayGroupingValue list) fallbackSetId =
+let private groupId duplicateHeaders side (values: DisplayGroupingValue list) fallbackSetId =
     match values with
     | [] -> sprintf "%s:%s" (sideText side) fallbackSetId
-    | _ -> values |> groupingValuesText "=" "|" |> sprintf "%s:%s" (sideText side)
+    | _ ->
+        values
+        |> groupingValuesText duplicateHeaders "=" "|"
+        |> sprintf "%s:%s" (sideText side)
 
 let displayGroupsForAssignments (model: ProvenanceModel) side assignments =
     let sets = loadedSets model side
     let assignments = normalizeAssignments side assignments
 
+    let duplicateHeaders =
+        assignments
+        |> List.countBy (fun assignment -> assignment.Key.Header)
+        |> List.choose (fun (header, count) -> if count > 1 then Some header else None)
+        |> Set.ofList
+
     match assignments with
     | [] ->
         sets
         |> List.map (fun set -> {
-            Id = groupId side [] set.Id
+            Id = groupId duplicateHeaders side [] set.Id
             TableName = set.Source.Name
             Side = side
             GroupingValues = []
@@ -189,7 +204,7 @@ let displayGroupsForAssignments (model: ProvenanceModel) side assignments =
 
                 if keyValues.IsEmpty then
                     yield
-                        groupId side [] set.Id,
+                        groupId duplicateHeaders side [] set.Id,
                         set.Source.Name,
                         [],
                         displayMember set (ProvenanceSet.effectivePropertyValueIds set)
@@ -205,7 +220,7 @@ let displayGroupsForAssignments (model: ProvenanceModel) side assignments =
                             })
 
                         yield
-                            groupId side groupingValues set.Id,
+                            groupId duplicateHeaders side groupingValues set.Id,
                             set.Source.Name,
                             groupingValues,
                             displayMember set (ProvenanceSet.effectivePropertyValueIds set)

--- a/src/Shared/ProvenanceGrouping/Grouping.fs
+++ b/src/Shared/ProvenanceGrouping/Grouping.fs
@@ -117,36 +117,6 @@ let private valueSetForKey key propertyValues : GroupingValue list list =
 let private valuesForKey model set key =
     setPropertyValues model set |> valueSetForKey key
 
-let private combineValueSets key valueSets : GroupingValue list list =
-    let values =
-        valueSets
-        |> List.collect id
-        |> List.groupBy (fun (_, value, unit, _) -> value, unit)
-        |> List.map (fun ((value, unit), grouped) ->
-            let propertyValueIds =
-                grouped
-                |> List.collect (fun (_, _, _, propertyValueIds) -> propertyValueIds)
-                |> List.distinct
-                |> List.sort
-
-            key, value, unit, propertyValueIds
-        )
-        |> List.sortBy (fun (_, value, unit, _) -> valueText value unit)
-
-    if values.IsEmpty then [] else [ values ]
-
-let private connectedOutputSets model inputSetId =
-    model.Connections
-    |> mapValues
-    |> List.filter (fun connection -> connection.Source.Id = model.Source.Id && connection.InputSetId = inputSetId)
-    |> List.choose (fun connection -> model.OutputSets.TryFind connection.OutputSetId)
-    |> List.filter (fun set -> set.Source.Id = model.Source.Id)
-
-let private inheritedOutputValuesForKey model inputSetId key =
-    connectedOutputSets model inputSetId
-    |> List.collect (fun outputSet -> valuesForKey model outputSet key)
-    |> combineValueSets key
-
 let private scopeApplies side scope =
     match side, scope with
     | ProvenanceSide.Input, GroupingScope.Input
@@ -173,17 +143,6 @@ let private normalizeAssignments side assignments =
         else
             grouped.Head
     )
-
-let private valuesForAssignment model side set assignment =
-    match side, assignment.Scope with
-    | ProvenanceSide.Input, GroupingScope.Both ->
-        let ownValues = valuesForKey model set assignment.Key
-
-        if ownValues.IsEmpty then
-            inheritedOutputValuesForKey model set.Id assignment.Key
-        else
-            ownValues
-    | _ -> valuesForKey model set assignment.Key
 
 let private combinations values =
     let rec loop collected remaining =
@@ -225,7 +184,7 @@ let displayGroupsForAssignments (model: ProvenanceModel) side assignments =
             for set in sets do
                 let keyValues =
                     activeAssignments
-                    |> List.map (valuesForAssignment model side set)
+                    |> List.map (fun assignment -> valuesForKey model set assignment.Key)
                     |> List.filter (fun values -> values |> List.isEmpty |> not)
 
                 if keyValues.IsEmpty then

--- a/src/Shared/ProvenanceGrouping/Session.fs
+++ b/src/Shared/ProvenanceGrouping/Session.fs
@@ -391,7 +391,7 @@ module Session =
                     OutputSets = targetLayer.Model.OutputSets |> Map.add targetSet.Id targetSet
                     PropertyValues = propertyValues
               }
-            |> ProvenanceModel.refreshInheritedOutputProperties
+            |> ProvenanceModel.refreshInheritedProperties
 
         replaceLayer { targetLayer with Model = targetModel } session
 

--- a/src/Shared/ProvenanceGrouping/Types.fs
+++ b/src/Shared/ProvenanceGrouping/Types.fs
@@ -96,6 +96,13 @@ type ProvenancePropertyHeader = {
     Category: ProvenanceTerm
 }
 
+/// Identity of one logical property throughout the provenance editor.
+/// The overall source is the origin; process and occurrence metadata are not.
+type ProvenancePropertyKey = {
+    Header: ProvenancePropertyHeader
+    OriginSource: ProvenanceSourceRef
+}
+
 /// Source metadata needed to update an existing property value in its source model.
 /// This is a writeback anchor, not a graph edge and not an ARCtrl object reference.
 type ProvenanceWritebackAnchor = {
@@ -118,6 +125,15 @@ type ProvenancePropertyOrigin =
     | Real of ProvenanceWritebackAnchor
     | Virtual of ProvenanceWritebackAnchor
 
+module ProvenancePropertyOrigin =
+
+    let anchor origin =
+        match origin with
+        | ProvenancePropertyOrigin.Real anchor
+        | ProvenancePropertyOrigin.Virtual anchor -> anchor
+
+    let source origin = (anchor origin).Source
+
 /// One concrete editable key/value in the normalized model.
 /// Distinct values must remain distinct; exact duplicate source occurrences may collapse when they are not meaningfully distinguishable in the source-agnostic core model.
 type ProvenancePropertyValue = {
@@ -132,6 +148,17 @@ type ProvenancePropertyValue = {
     /// Required origin and writeback anchor metadata.
     Origin: ProvenancePropertyOrigin
 }
+
+module ProvenancePropertyValue =
+
+    let propertyKey (propertyValue: ProvenancePropertyValue) : ProvenancePropertyKey = {
+        Header = propertyValue.Header
+        OriginSource = ProvenancePropertyOrigin.source propertyValue.Origin
+    }
+
+    let belongsTo (key: ProvenancePropertyKey) (propertyValue: ProvenancePropertyValue) =
+        propertyValue.Header = key.Header
+        && (ProvenancePropertyOrigin.source propertyValue.Origin).Id = key.OriginSource.Id
 
 /// One actual loaded input or output endpoint.
 /// This is the first-class UI item before grouping; it is not a collapsed graph node.

--- a/src/Shared/ProvenanceGrouping/Types.fs
+++ b/src/Shared/ProvenanceGrouping/Types.fs
@@ -225,38 +225,112 @@ type ProvenanceModel = {
 
 module ProvenanceModel =
 
-    let refreshInheritedOutputProperties (model: ProvenanceModel) =
-        let inheritedByOutput =
+    /// Recomputes same-layer property inheritance in both directions: a value
+    /// on any endpoint spreads through this model's connections to every
+    /// transitively connected endpoint, regardless of side. Entries stay keyed
+    /// by connection ID so removing a connection retracts them; entries keyed
+    /// by connections of other models (carried in from upstream layers) are
+    /// preserved untouched. A set never inherits its own values back.
+    let refreshInheritedProperties (model: ProvenanceModel) =
+        let localConnections =
             model.Connections
             |> Map.toList
-            |> List.choose (fun (connectionId, connection) ->
-                match
-                    model.InputSets.TryFind connection.InputSetId, model.OutputSets.TryFind connection.OutputSetId
-                with
-                | Some inputSet, Some _ when connection.Source.Id = model.Source.Id ->
-                    let propertyValueIds = ProvenanceSet.effectivePropertyValueIds inputSet
-
-                    if propertyValueIds.IsEmpty then
-                        None
-                    else
-                        Some(connection.OutputSetId, connectionId, propertyValueIds)
-                | _ -> None
+            |> List.filter (fun (_, connection) ->
+                connection.Source.Id = model.Source.Id
+                && model.InputSets.ContainsKey connection.InputSetId
+                && model.OutputSets.ContainsKey connection.OutputSetId
             )
-            |> List.groupBy (fun (outputSetId, _, _) -> outputSetId)
-            |> List.map (fun (outputSetId, inherited) ->
-                outputSetId,
-                inherited
-                |> List.map (fun (_, connectionId, propertyValueIds) -> connectionId, propertyValueIds)
-                |> Map.ofList
-            )
-            |> Map.ofList
 
-        let outputSets =
-            model.OutputSets
-            |> Map.map (fun outputSetId outputSet -> {
-                outputSet with
-                    InheritedPropertyValueIds =
-                        inheritedByOutput |> Map.tryFind outputSetId |> Option.defaultValue Map.empty
-            })
+        // Entries keyed by connections this model does not own were carried in
+        // from an upstream layer; they seed inheritance but are never rebuilt.
+        let carriedEntries (set: ProvenanceSet) =
+            set.InheritedPropertyValueIds
+            |> Map.filter (fun connectionId _ -> not (model.Connections.ContainsKey connectionId))
 
-        { model with OutputSets = outputSets }
+        let seedIds (set: ProvenanceSet) =
+            [
+                yield! set.PropertyValueIds
+                yield! carriedEntries set |> Map.toList |> List.sortBy fst |> List.collect snd
+            ]
+            |> List.distinct
+
+        let inputSeeds = model.InputSets |> Map.map (fun _ set -> seedIds set)
+        let outputSeeds = model.OutputSets |> Map.map (fun _ set -> seedIds set)
+
+        let entriesExcept
+            connectionId
+            setId
+            (entries: Map<ProvenanceSetId, Map<ProvenanceConnectionId, ProvenancePropertyValueId list>>)
+            =
+            entries
+            |> Map.tryFind setId
+            |> Option.defaultValue Map.empty
+            |> Map.toList
+            |> List.filter (fun (entryConnectionId, _) -> entryConnectionId <> connectionId)
+            |> List.sortBy fst
+            |> List.collect snd
+
+        let setEntry connectionId setId propertyValueIds entries =
+            if List.isEmpty propertyValueIds then
+                entries
+            else
+                let current = entries |> Map.tryFind setId |> Option.defaultValue Map.empty
+                entries |> Map.add setId (current |> Map.add connectionId propertyValueIds)
+
+        // One hop of inheritance per pass, repeated to a fixpoint so values
+        // spread through chains (output -> shared input -> sibling output).
+        // Excluding the entry that arrived through the connection itself keeps
+        // a value from echoing straight back to its origin.
+        let step (inputEntries, outputEntries) =
+            localConnections
+            |> List.fold
+                (fun (inputEntries, outputEntries) (connectionId, connection) ->
+                    let inputSeed = inputSeeds.[connection.InputSetId]
+                    let outputSeed = outputSeeds.[connection.OutputSetId]
+
+                    let toOutput =
+                        [
+                            yield! inputSeed
+                            yield! entriesExcept connectionId connection.InputSetId inputEntries
+                        ]
+                        |> List.distinct
+                        |> List.filter (fun id -> not (List.contains id outputSeed))
+
+                    let toInput =
+                        [
+                            yield! outputSeed
+                            yield! entriesExcept connectionId connection.OutputSetId outputEntries
+                        ]
+                        |> List.distinct
+                        |> List.filter (fun id -> not (List.contains id inputSeed))
+
+                    setEntry connectionId connection.InputSetId toInput inputEntries,
+                    setEntry connectionId connection.OutputSetId toOutput outputEntries
+                )
+                (inputEntries, outputEntries)
+
+        let rec fixpoint state =
+            let next = step state
+
+            if next = state then state else fixpoint next
+
+        let inputEntries, outputEntries = fixpoint (Map.empty, Map.empty)
+
+        let withRefreshedEntries localEntries (set: ProvenanceSet) = {
+            set with
+                InheritedPropertyValueIds =
+                    localEntries
+                    |> Map.tryFind set.Id
+                    |> Option.defaultValue Map.empty
+                    |> Map.fold
+                        (fun state connectionId propertyValueIds -> state |> Map.add connectionId propertyValueIds)
+                        (carriedEntries set)
+        }
+
+        {
+            model with
+                InputSets = model.InputSets |> Map.map (fun _ set -> withRefreshedEntries inputEntries set)
+                OutputSets =
+                    model.OutputSets
+                    |> Map.map (fun _ set -> withRefreshedEntries outputEntries set)
+        }

--- a/tests/Electron.Core/ProvenanceGroupingState.test.fs
+++ b/tests/Electron.Core/ProvenanceGroupingState.test.fs
@@ -24,9 +24,16 @@ Vitest.describe (
             fun () ->
                 let session = sampleSession ()
                 let pair = Session.activePair session
-                let header = pair.Model.PropertyValues |> Map.toList |> List.head |> snd |> _.Header
 
-                let staleSlot = "removed-pair", ProvenanceSide.Input, State.Keys.groupingKey header
+                let property =
+                    pair.Model.PropertyValues
+                    |> Map.toList
+                    |> List.head
+                    |> snd
+                    |> ProvenancePropertyValue.propertyKey
+
+                let staleSlot =
+                    "removed-pair", ProvenanceSide.Input, State.Keys.groupingKey property
 
                 let state = {
                     State.Sides.ensure session (State.init session) with

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -17,6 +17,22 @@ module Fixture = Swate.Components.Shared.ProvenanceGrouping.Fixtures
 
 let private sourceRef (tableName: string) : ProvenanceSourceRef = Fixture.source tableName tableName
 
+let private propertyKey (tableName: string) (header: ProvenancePropertyHeader) : ProvenancePropertyKey = {
+    Header = header
+    OriginSource = sourceRef tableName
+}
+
+let private propertyKeyIn (model: ProvenanceModel) (header: ProvenancePropertyHeader) : ProvenancePropertyKey =
+    model.PropertyValues
+    |> Map.toList
+    |> List.map snd
+    |> List.tryFind (fun propertyValue -> propertyValue.Header = header)
+    |> Option.map ProvenancePropertyValue.propertyKey
+    |> Option.defaultValue {
+        Header = header
+        OriginSource = model.Source
+    }
+
 let private pendingModelSource = sourceRef "__pending-model-source__"
 
 let private anchor
@@ -96,6 +112,42 @@ let private model
 
 let typeTests =
     testList "Types" [
+        testCase "property identity uses header and overall origin source only"
+        <| fun _ ->
+            let temperature = propertyHeader FixtureKinds.parameterProperty "Temperature"
+            let growth = sourceRef "growth"
+            let cultivation = sourceRef "cultivation"
+
+            let value id origin =
+                Fixture.propertyValue id temperature (ProvenanceValue.Text "20") None origin
+
+            let growthAnchor = Fixture.anchor growth (Some "process-a") temperature [ "A" ] []
+
+            let sameReal = value "real" (ProvenancePropertyOrigin.Real growthAnchor)
+
+            let sameVirtual =
+                value
+                    "virtual"
+                    (ProvenancePropertyOrigin.Virtual {
+                        growthAnchor with
+                            ProcessId = Some "new-process-id"
+                            ProcessName = Some "process-b"
+                            InputNames = [ "B" ]
+                    })
+
+            let otherOrigin =
+                value "other" (ProvenancePropertyOrigin.Real(Fixture.anchor cultivation None temperature [ "A" ] []))
+
+            Expect.equal
+                (ProvenancePropertyValue.propertyKey sameReal)
+                (ProvenancePropertyValue.propertyKey sameVirtual)
+                "Real/virtual form and process metadata must not split one property origin."
+
+            Expect.notEqual
+                (ProvenancePropertyValue.propertyKey sameReal)
+                (ProvenancePropertyValue.propertyKey otherOrigin)
+                "The same header from another overall source is a different property."
+
         testCase "loaded input set carries the actual input name"
         <| fun _ ->
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
@@ -385,7 +437,8 @@ let groupingTests =
                         ]
                     ] [] []
 
-            let groups = displayGroups built ProvenanceSide.Input [ { Header = species } ]
+            let groups =
+                displayGroups built ProvenanceSide.Input [ propertyKeyIn built species ]
 
             let membersByTitle =
                 groups
@@ -437,7 +490,9 @@ let groupingTests =
         <| fun _ ->
             let model = sampleModel ()
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
-            let groups = displayGroups model ProvenanceSide.Input [ { Header = species } ]
+
+            let groups =
+                displayGroups model ProvenanceSide.Input [ propertyKeyIn model species ]
 
             let inputA =
                 groups
@@ -654,7 +709,9 @@ let groupingTests =
                         outputSet "output-a" "assay-table" outputHeader "Output A" [ "pv-rep-1a"; "pv-rep-1b" ]
                     ] []
 
-            let groups = displayGroups built ProvenanceSide.Output [ { Header = replicate } ]
+            let groups =
+                displayGroups built ProvenanceSide.Output [ propertyKeyIn built replicate ]
+
             let members = groups |> List.collect (fun group -> group.Members)
 
             Expect.equal groups.Length 1 "Identical equal values should collapse into one output group."
@@ -695,7 +752,8 @@ let groupingTests =
                         inputSet "input-b" "assay-table" inputHeader "Input B" [ "pv-temp-f" ]
                     ] [] []
 
-            let groups = displayGroups built ProvenanceSide.Input [ { Header = temperature } ]
+            let groups =
+                displayGroups built ProvenanceSide.Input [ propertyKeyIn built temperature ]
 
             Expect.equal groups.Length 2 "Values with the same scalar value but different units must not collapse."
 
@@ -731,7 +789,7 @@ let groupingTests =
             let groups =
                 displayGroupsForAssignments built ProvenanceSide.Input [
                     {
-                        Key = { Header = replicate }
+                        Key = propertyKeyIn built replicate
                         Scope = GroupingScope.Input
                     }
                 ]
@@ -790,7 +848,7 @@ let groupingTests =
             let groups =
                 displayGroupsForAssignments built ProvenanceSide.Input [
                     {
-                        Key = { Header = replicate }
+                        Key = propertyKeyIn built replicate
                         Scope = GroupingScope.Both
                     }
                 ]
@@ -842,7 +900,7 @@ let groupingTests =
             let groups =
                 displayGroupsForAssignments built ProvenanceSide.Input [
                     {
-                        Key = { Header = replicate }
+                        Key = propertyKeyIn built replicate
                         Scope = GroupingScope.Both
                     }
                 ]
@@ -881,7 +939,10 @@ let groupingTests =
         <| fun _ ->
             let model = validModel ()
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
-            let inputGroups = displayGroups model ProvenanceSide.Input [ { Header = species } ]
+
+            let inputGroups =
+                displayGroups model ProvenanceSide.Input [ propertyKeyIn model species ]
+
             let outputGroups = displayGroups model ProvenanceSide.Output []
             let connections = displayConnections model inputGroups outputGroups
 
@@ -2457,10 +2518,11 @@ let uiStateTests =
             let session = Session.init (sampleModel ())
             let layer1 = Session.activeLayer session
             let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
+            let replicateKey = propertyKeyIn layer1.Model replicate
 
             let grouped =
                 State.init session
-                |> State.GroupingAssignments.toggleSide layer1.OutputSideId ProvenanceSide.Output replicate
+                |> State.GroupingAssignments.toggleSide layer1.OutputSideId ProvenanceSide.Output replicateKey
 
             let layered =
                 match
@@ -2493,9 +2555,10 @@ let uiStateTests =
             let layer = Session.activeLayer session
             let state = State.init session
             let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
+            let replicateKey = propertyKeyIn layer.Model replicate
 
             let next =
-                State.GroupingAssignments.toggleSide layer.OutputSideId ProvenanceSide.Output replicate state
+                State.GroupingAssignments.toggleSide layer.OutputSideId ProvenanceSide.Output replicateKey state
 
             Expect.equal
                 (State.Sides.get layer.InputSideId next).GroupingAssignments
@@ -2506,7 +2569,7 @@ let uiStateTests =
                 (State.Sides.get layer.OutputSideId next).GroupingAssignments
                 [
                     {
-                        Key = { Header = replicate }
+                        Key = replicateKey
                         Scope = GroupingScope.Output
                     }
                 ]
@@ -2518,13 +2581,14 @@ let uiStateTests =
             let layer = Session.activeLayer session
             let state = State.init session
             let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
+            let replicateKey = propertyKeyIn layer.Model replicate
 
             let next =
-                State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId replicate state
+                State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId replicateKey state
 
             let expected = [
                 {
-                    Key = { Header = replicate }
+                    Key = replicateKey
                     Scope = GroupingScope.Both
                 }
             ]
@@ -2545,9 +2609,10 @@ let uiStateTests =
             let layer = Session.activeLayer session
             let state = State.init session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+            let speciesKey = propertyKeyIn layer.Model species
 
             let selected =
-                State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input species state
+                State.GroupingAssignments.toggleSide layer.InputSideId ProvenanceSide.Input speciesKey state
 
             let next =
                 State.GroupingAssignments.move
@@ -2555,7 +2620,7 @@ let uiStateTests =
                     layer.InputSideId
                     layer.OutputSideId
                     ProvenanceSide.Output
-                    species
+                    speciesKey
                     selected
 
             Expect.equal
@@ -2567,14 +2632,14 @@ let uiStateTests =
                 (State.Sides.get layer.OutputSideId next).GroupingAssignments
                 [
                     {
-                        Key = { Header = species }
+                        Key = speciesKey
                         Scope = GroupingScope.Output
                     }
                 ]
                 "Dragging a property to output should make it output-only."
 
             Expect.equal
-                (next.PropertyRailPlacements |> Map.tryFind (layer.Id, { Header = species }))
+                (next.PropertyRailPlacements |> Map.tryFind (layer.Id, speciesKey))
                 (Some ProvenanceSide.Output)
                 "Dragging a property to output should move its rail control to the output side."
 
@@ -2584,7 +2649,7 @@ let uiStateTests =
             let layer = Session.activeLayer session
             let state = State.init session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
-            let key = { Header = species }
+            let key = propertyKeyIn layer.Model species
 
             let sideAssignment = {
                 Key = key
@@ -2609,7 +2674,7 @@ let uiStateTests =
             }
 
             let next =
-                State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId species inconsistent
+                State.GroupingAssignments.toggleBoth layer.InputSideId layer.OutputSideId key inconsistent
 
             Expect.equal
                 (State.Sides.get layer.InputSideId next).GroupingAssignments
@@ -2867,7 +2932,7 @@ let uiStateTests =
 
             let source: Types.ValueAssignmentSource = {
                 CopiedFrom = None
-                Header = treatment
+                Property = propertyKeyIn model treatment
                 Value = ProvenanceValue.Text "Drought"
                 Unit = None
             }
@@ -2882,14 +2947,16 @@ let uiStateTests =
                 Expect.equal command.Header treatment "Add plan should preserve the dropped property."
             | other -> failwithf "Expected an add plan, got %A" other
 
-            let mixedSource: Types.ValueAssignmentSource = { source with Header = species }
+            let speciesKey = propertyKeyIn model species
+
+            let mixedSource: Types.ValueAssignmentSource = { source with Property = speciesKey }
 
             match ValueAssignment.planPropertyValueDrop mixedSource group model with
-            | Error(Types.ValueAssignmentError.MixedPropertyValueCounts header) ->
-                Expect.equal header species "Mixed zero/one members should reject the drop for that property."
+            | Error(Types.ValueAssignmentError.MixedPropertyValueCounts property) ->
+                Expect.equal property speciesKey "Mixed zero/one members should reject the drop for that property."
             | other -> failwithf "Expected a mixed-count rejection, got %A" other
 
-        testCase "property value drop plan warns only when every group member has exactly one value"
+        testCase "property value drop plan warns when the exact property has one distinct assigned value"
         <| fun _ ->
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
             let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
@@ -2899,7 +2966,7 @@ let uiStateTests =
                     "assay-table"
                     [
                         propertyValue "pv-input-a-species" species (ProvenanceValue.Text "Arabidopsis") None None
-                        propertyValue "pv-input-b-species" species (ProvenanceValue.Text "Chlamydomonas") None None
+                        propertyValue "pv-input-b-species" species (ProvenanceValue.Text "Arabidopsis") None None
                     ]
                     [
                         inputSet "input-a" "assay-table" inputHeader "Input A" [ "pv-input-a-species" ]
@@ -2927,7 +2994,7 @@ let uiStateTests =
 
             let source: Types.ValueAssignmentSource = {
                 CopiedFrom = None
-                Header = species
+                Property = propertyKeyIn model species
                 Value = ProvenanceValue.Text "A. thaliana"
                 Unit = None
             }
@@ -2984,16 +3051,245 @@ let uiStateTests =
 
             let source: Types.ValueAssignmentSource = {
                 CopiedFrom = None
-                Header = species
+                Property = propertyKeyIn model species
                 Value = ProvenanceValue.Text "A. thaliana"
                 Unit = None
             }
 
             match ValueAssignment.planPropertyValueDrop source group model with
-            | Error(Types.ValueAssignmentError.MultiplePropertyValues(header, setIds)) ->
-                Expect.equal header species "Multi-value members should reject the drop for that property."
-                Expect.equal setIds [ "input-b" ] "The rejection should identify the multi-value member."
+            | Error(Types.ValueAssignmentError.MultiplePropertyValues(property, setIds)) ->
+                Expect.equal
+                    property
+                    (propertyKeyIn model species)
+                    "The rejection should retain exact property identity."
+
+                Expect.equal setIds [ "input-a"; "input-b" ] "The rejection should identify the assigned targets."
             | other -> failwithf "Expected a multiple-value rejection, got %A" other
+
+        testCase "property value drop plan overwrites one distinct value represented by several occurrence IDs"
+        <| fun _ ->
+            let temperature = propertyHeader FixtureKinds.parameterProperty "Temperature"
+            let treatment = propertyHeader FixtureKinds.characteristicProperty "Treatment"
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+
+            let model =
+                model
+                    "growth"
+                    [
+                        propertyValue "pv-temperature-a" temperature (ProvenanceValue.Text "20") None None
+                        propertyValue "pv-temperature-b" temperature (ProvenanceValue.Text "20") None None
+                        propertyValue "pv-treatment" treatment (ProvenanceValue.Text "Heat") None None
+                    ]
+                    [
+                        inputSet "input-a" "growth" inputHeader "Input A" [
+                            "pv-temperature-a"
+                            "pv-temperature-b"
+                            "pv-treatment"
+                        ]
+                    ] [] []
+
+            let group: DisplayGroup = {
+                Id = "manual"
+                TableName = "growth"
+                Side = ProvenanceSide.Input
+                GroupingValues = []
+                Members = [
+                    {
+                        SetId = "input-a"
+                        Name = "Input A"
+                        PropertyValueIds = [ "pv-temperature-a"; "pv-temperature-b"; "pv-treatment" ]
+                    }
+                ]
+            }
+
+            let source: Types.ValueAssignmentSource = {
+                CopiedFrom = None
+                Property = propertyKeyIn model temperature
+                Value = ProvenanceValue.Text "21"
+                Unit = None
+            }
+
+            match ValueAssignment.planPropertyValueDrop source group model with
+            | Ok(Types.ValueAssignmentPlan.ConfirmOverwrite warning) ->
+                Expect.equal
+                    warning.ExistingValueIds
+                    [ "pv-temperature-a"; "pv-temperature-b" ]
+                    "All IDs representing the one assigned value should be updated."
+            | other -> failwithf "Expected an overwrite warning, got %A" other
+
+        testCase "property value drop plan ignores the same header from another origin"
+        <| fun _ ->
+            let temperature = propertyHeader FixtureKinds.parameterProperty "Temperature"
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+
+            let growthValue =
+                propertyValue
+                    "pv-growth-temperature"
+                    temperature
+                    (ProvenanceValue.Text "20")
+                    None
+                    (Some(anchor "growth" None temperature [ "Input A" ] []))
+
+            let cultivationValue =
+                propertyValue
+                    "pv-cultivation-temperature"
+                    temperature
+                    (ProvenanceValue.Text "30")
+                    None
+                    (Some(anchor "cultivation" None temperature [ "Input A" ] []))
+
+            let model =
+                model
+                    "assay-table"
+                    [ growthValue; cultivationValue ]
+                    [
+                        inputSet "input-a" "assay-table" inputHeader "Input A" [ growthValue.Id; cultivationValue.Id ]
+                    ] [] []
+
+            let group: DisplayGroup = {
+                Id = "manual"
+                TableName = "assay-table"
+                Side = ProvenanceSide.Input
+                GroupingValues = []
+                Members = [
+                    {
+                        SetId = "input-a"
+                        Name = "Input A"
+                        PropertyValueIds = [ growthValue.Id; cultivationValue.Id ]
+                    }
+                ]
+            }
+
+            let source: Types.ValueAssignmentSource = {
+                CopiedFrom = None
+                Property = ProvenancePropertyValue.propertyKey growthValue
+                Value = ProvenanceValue.Text "21"
+                Unit = None
+            }
+
+            match ValueAssignment.planPropertyValueDrop source group model with
+            | Ok(Types.ValueAssignmentPlan.ConfirmOverwrite warning) ->
+                Expect.equal
+                    warning.ExistingValueIds
+                    [ growthValue.Id ]
+                    "Cultivation/Temperature must not block or join Growth/Temperature overwrite."
+            | other -> failwithf "Expected an origin-specific overwrite warning, got %A" other
+
+        testCase "upstream property values cannot create new assignments in a downstream layer"
+        <| fun _ ->
+            let temperature = propertyHeader FixtureKinds.parameterProperty "Temperature"
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+
+            let model =
+                model
+                    "cultivation"
+                    []
+                    [
+                        inputSet "input-a" "cultivation" inputHeader "Input A" []
+                    ] [] []
+
+            let group: DisplayGroup = {
+                Id = "manual"
+                TableName = "cultivation"
+                Side = ProvenanceSide.Input
+                GroupingValues = []
+                Members = [
+                    {
+                        SetId = "input-a"
+                        Name = "Input A"
+                        PropertyValueIds = []
+                    }
+                ]
+            }
+
+            let upstreamProperty = propertyKey "growth" temperature
+
+            let source: Types.ValueAssignmentSource = {
+                CopiedFrom = None
+                Property = upstreamProperty
+                Value = ProvenanceValue.Text "21"
+                Unit = None
+            }
+
+            match ValueAssignment.planPropertyValueDrop source group model with
+            | Error(Types.ValueAssignmentError.UpstreamPropertyNotAssigned property) ->
+                Expect.equal property upstreamProperty "The rejection should identify the upstream property."
+            | other -> failwithf "Expected an upstream-add rejection, got %A" other
+
+        testCase "current property can be assigned despite the same header from another origin"
+        <| fun _ ->
+            let temperature = propertyHeader FixtureKinds.parameterProperty "Temperature"
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+
+            let growthValue =
+                propertyValue
+                    "pv-growth-temperature"
+                    temperature
+                    (ProvenanceValue.Text "20")
+                    None
+                    (Some(anchor "growth" None temperature [ "Input A" ] []))
+
+            let model =
+                model
+                    "cultivation"
+                    [ growthValue ]
+                    [
+                        inputSet "input-a" "cultivation" inputHeader "Input A" [ growthValue.Id ]
+                    ] [] []
+
+            let group: DisplayGroup = {
+                Id = "manual"
+                TableName = "cultivation"
+                Side = ProvenanceSide.Input
+                GroupingValues = []
+                Members = [
+                    {
+                        SetId = "input-a"
+                        Name = "Input A"
+                        PropertyValueIds = [ growthValue.Id ]
+                    }
+                ]
+            }
+
+            let currentProperty = propertyKey "cultivation" temperature
+
+            let source: Types.ValueAssignmentSource = {
+                CopiedFrom = None
+                Property = currentProperty
+                Value = ProvenanceValue.Text "30"
+                Unit = None
+            }
+
+            match ValueAssignment.planPropertyValueDrop source group model with
+            | Ok(Types.ValueAssignmentPlan.AddCurrent command) ->
+                Expect.equal command.Header temperature "The current property should remain assignable."
+            | other -> failwithf "Expected a current-layer add plan, got %A" other
+
+        testCase "palette value added from an upstream property keeps that property origin"
+        <| fun _ ->
+            let session = Session.init (sampleModel ())
+            let layer = Session.activeLayer session
+            let state = State.init session
+            let analysis = propertyHeader FixtureKinds.parameterProperty "Analysis"
+            let upstreamProperty = propertyKey "growth" analysis
+
+            let next =
+                State.Palette.addValue
+                    layer.Id
+                    ProvenanceSide.Input
+                    upstreamProperty
+                    (ProvenanceValue.Text "Imaging")
+                    None
+                    state
+
+            let added =
+                State.Palette.valuesForProperty layer.Id ProvenanceSide.Input upstreamProperty next
+                |> List.exactlyOne
+
+            Expect.equal
+                (ProvenancePropertyValue.propertyKey added)
+                upstreamProperty
+                "The active layer must not become the origin of a replacement value."
 
         testCase "default state initializes with empty colors and filters"
         <| fun _ ->
@@ -3013,13 +3309,14 @@ let uiStateTests =
             let layer = Session.activeLayer session
             let state = State.init session
             let header = propertyHeader FixtureKinds.characteristicProperty "Species"
+            let property = propertyKeyIn layer.Model header
             let context = State.PropertyColors.visibleColorContextForLayer session layer
 
-            let withColor = State.PropertyColors.setColor context.Id header "#2563eb" state
+            let withColor = State.PropertyColors.setColor context.Id property "#2563eb" state
 
             let key: Types.VisiblePropertyColorKey = {
                 ContextId = context.Id
-                Header = header
+                Property = property
             }
 
             Expect.equal
@@ -3027,7 +3324,7 @@ let uiStateTests =
                 "#2563eb"
                 "Property color should be set by visible context and header."
 
-            let cleared = State.PropertyColors.clearColor context.Id header withColor
+            let cleared = State.PropertyColors.clearColor context.Id property withColor
 
             Expect.isFalse
                 (cleared.PropertyColors.ManualPropertyColors.ContainsKey key)
@@ -3211,20 +3508,22 @@ let uiStateTests =
         <| fun _ ->
             let highCount = propertyHeader (ProvenanceKind.create "z-kind" "Zeta kind") "Zeta"
             let lowCount = propertyHeader (ProvenanceKind.create "a-kind" "Alpha kind") "Alpha"
+            let highCountKey = propertyKey "assay-table" highCount
+            let lowCountKey = propertyKey "assay-table" lowCount
 
             let stats =
                 Map.ofList [
-                    highCount,
+                    highCountKey,
                     ({
-                        Header = highCount
+                        Property = highCountKey
                         DistinctValueCount = 3
                         SetsWithValueCount = 3
                         TotalSetCount = 3
                     }
                     : Types.PropertyStats)
-                    lowCount,
+                    lowCountKey,
                     ({
-                        Header = lowCount
+                        Property = lowCountKey
                         DistinctValueCount = 1
                         SetsWithValueCount = 1
                         TotalSetCount = 1
@@ -3233,30 +3532,34 @@ let uiStateTests =
                 ]
 
             let sorted =
-                PropertyProjection.sortHeaders Types.PropertySort.ValueCountDesc stats Map.empty [ lowCount; highCount ]
+                PropertyProjection.sortHeaders Types.PropertySort.ValueCountDesc stats Map.empty [
+                    lowCountKey
+                    highCountKey
+                ]
 
-            Expect.equal sorted [ highCount; lowCount ] "Higher value count should sort before name/kind."
+            Expect.equal sorted [ highCountKey; lowCountKey ] "Higher value count should sort before name/kind."
 
         testCase "rail projection applies search and resolves manual property color"
         <| fun _ ->
             let session = Session.init (sampleModel ())
             let layer = Session.activeLayer session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+            let speciesKey = propertyKeyIn layer.Model species
             let context = State.PropertyColors.visibleColorContextForLayer session layer
 
             let uiState =
                 State.init session
                 |> State.Filters.setSearch "Arabidopsis"
-                |> State.PropertyColors.setColor context.Id species "#2563eb"
+                |> State.PropertyColors.setColor context.Id speciesKey "#2563eb"
 
             let projection =
                 PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model uiState
 
             Expect.isTrue
-                (projection.Headers |> List.contains species)
+                (projection.Headers |> List.contains speciesKey)
                 "Search should keep headers with matching projected values."
 
-            Expect.equal projection.ColorByHeader.[species] (Some "#2563eb") "Manual color should be projected."
+            Expect.equal projection.ColorByHeader.[speciesKey] (Some "#2563eb") "Manual color should be projected."
 
             let nonMatching =
                 uiState |> State.Filters.setSearch "definitely-not-a-provenance-value"
@@ -3287,15 +3590,17 @@ let uiStateTests =
             let previousTreatment =
                 propertyHeader FixtureKinds.characteristicProperty "Previous Treatment"
 
+            let previousTreatmentKey = propertyKeyIn layer.Model previousTreatment
+
             let projection =
                 PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state
 
             Expect.isTrue
-                (projection.Headers |> List.contains previousTreatment)
+                (projection.Headers |> List.contains previousTreatmentKey)
                 "Attached previous context should still appear in the property rail."
 
             Expect.equal
-                projection.ColorByHeader.[previousTreatment]
+                projection.ColorByHeader.[previousTreatmentKey]
                 (state.PropertyColors.SourceColors |> Map.tryFind "fixture:previous-study-table")
                 "Single-origin headers should use their source color."
 
@@ -3305,24 +3610,26 @@ let uiStateTests =
             let layer = Session.activeLayer session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
             let temperature = propertyHeader FixtureKinds.parameterProperty "Temperature"
+            let speciesKey = propertyKeyIn layer.Model species
+            let temperatureKey = propertyKeyIn layer.Model temperature
             let context = State.PropertyColors.visibleColorContextForLayer session layer
 
             let state =
                 State.init session
                 |> State.PropertyColors.setSourceColor layer.Model.Source.Id "#16a34a"
-                |> State.PropertyColors.setColor context.Id species "#2563eb"
+                |> State.PropertyColors.setColor context.Id speciesKey "#2563eb"
 
             let projection =
                 PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Output layer.Model state
 
-            Expect.equal projection.ColorByHeader.[species] (Some "#2563eb") "Manual color should win for Species."
+            Expect.equal projection.ColorByHeader.[speciesKey] (Some "#2563eb") "Manual color should win for Species."
 
             Expect.equal
-                projection.ColorByHeader.[temperature]
+                projection.ColorByHeader.[temperatureKey]
                 (Some "#16a34a")
                 "Other current-source headers should keep the source color."
 
-        testCase "multi-origin visible header uses last changed origin source color"
+        testCase "same header from different origins projects as separate colored properties"
         <| fun _ ->
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
             let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
@@ -3362,10 +3669,25 @@ let uiStateTests =
             let projection =
                 PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state
 
+            let currentKey = propertyKey "assay-table" species
+            let previousKey = propertyKey "previous-table" species
+
             Expect.equal
-                projection.ColorByHeader.[species]
+                (projection.Headers
+                 |> List.filter (fun property -> property.Header = species)
+                 |> Set.ofList)
+                (Set.ofList [ currentKey; previousKey ])
+                "Same-named properties from different overall sources must remain separate rail rows."
+
+            Expect.equal
+                projection.ColorByHeader.[currentKey]
+                (Some "#2563eb")
+                "The current-source property should keep its own source color."
+
+            Expect.equal
+                projection.ColorByHeader.[previousKey]
                 (Some "#be185d")
-                "A multi-origin header should use the most recently changed origin source color."
+                "The upstream property should keep its own source color."
 
         testCase "same header shares manual color in downstream connected layer"
         <| fun _ ->
@@ -3382,11 +3704,12 @@ let uiStateTests =
             let layer1 = Session.layerById "layer-1" layered
             let layer2 = Session.layerById "layer-2" layered
             let analysis = propertyHeader FixtureKinds.parameterProperty "Analysis"
+            let analysisKey = propertyKeyIn layer1.Model analysis
             let context = State.PropertyColors.visibleColorContextForLayer layered layer2
 
             let state =
                 State.init layered
-                |> State.PropertyColors.setColor context.Id analysis "#2563eb"
+                |> State.PropertyColors.setColor context.Id analysisKey "#2563eb"
 
             let upstreamProjection =
                 PropertyProjection.railProjectionWithFilters layered layer1.Id ProvenanceSide.Output layer1.Model state
@@ -3395,12 +3718,12 @@ let uiStateTests =
                 PropertyProjection.railProjectionWithFilters layered layer2.Id ProvenanceSide.Input layer2.Model state
 
             Expect.equal
-                upstreamProjection.ColorByHeader.[analysis]
+                upstreamProjection.ColorByHeader.[analysisKey]
                 (Some "#2563eb")
                 "Upstream visible header should use the manual color."
 
             Expect.equal
-                downstreamProjection.ColorByHeader.[analysis]
+                downstreamProjection.ColorByHeader.[analysisKey]
                 (Some "#2563eb")
                 "Connected downstream visible header should share the root manual color."
 
@@ -3427,11 +3750,13 @@ let uiStateTests =
             }
 
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+            let layer1Species = propertyKeyIn layer1.Model species
+            let independentSpecies = propertyKeyIn independentLayer.Model species
 
             let state =
                 State.init session
-                |> State.PropertyColors.setColor layer1.Id species "#2563eb"
-                |> State.PropertyColors.setColor independentLayer.Id species "#be185d"
+                |> State.PropertyColors.setColor layer1.Id layer1Species "#2563eb"
+                |> State.PropertyColors.setColor independentLayer.Id independentSpecies "#be185d"
 
             let layer1Projection =
                 PropertyProjection.railProjectionWithFilters session layer1.Id ProvenanceSide.Output layer1.Model state
@@ -3445,12 +3770,12 @@ let uiStateTests =
                     state
 
             Expect.equal
-                layer1Projection.ColorByHeader.[species]
+                layer1Projection.ColorByHeader.[layer1Species]
                 (Some "#2563eb")
                 "Layer 1 should use its own visible-context color."
 
             Expect.equal
-                independentProjection.ColorByHeader.[species]
+                independentProjection.ColorByHeader.[independentSpecies]
                 (Some "#be185d")
                 "Independent layer should use its own visible-context color for the same header."
 
@@ -3460,6 +3785,7 @@ let uiStateTests =
             let layer = Session.activeLayer session
             let state = State.init session
             let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+            let speciesKey = propertyKeyIn layer.Model species
 
             let inputHeaders =
                 (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state)
@@ -3470,11 +3796,11 @@ let uiStateTests =
                     .Headers
 
             Expect.isFalse
-                (inputHeaders |> List.contains species)
+                (inputHeaders |> List.contains speciesKey)
                 "A connected current input property should not be duplicated on the input rail by default."
 
             Expect.isTrue
-                (outputHeaders |> List.contains species)
+                (outputHeaders |> List.contains speciesKey)
                 "A connected current input property should default to the output rail."
 
         testCase "previous context properties stay on input rail even when inherited by outputs"
@@ -3486,6 +3812,8 @@ let uiStateTests =
             let previousTreatment =
                 propertyHeader FixtureKinds.characteristicProperty "Previous Treatment"
 
+            let previousTreatmentKey = propertyKeyIn layer.Model previousTreatment
+
             let inputHeaders =
                 (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state)
                     .Headers
@@ -3495,11 +3823,11 @@ let uiStateTests =
                     .Headers
 
             Expect.isTrue
-                (inputHeaders |> List.contains previousTreatment)
+                (inputHeaders |> List.contains previousTreatmentKey)
                 "A previous-context property should stay on the input rail."
 
             Expect.isFalse
-                (outputHeaders |> List.contains previousTreatment)
+                (outputHeaders |> List.contains previousTreatmentKey)
                 "A previous-context property should not move to the output rail just because it is inherited."
 
         testCase "current input properties remain on input rail until an output is designated"
@@ -3520,6 +3848,7 @@ let uiStateTests =
             let session = Session.init model
             let layer = Session.activeLayer session
             let state = State.init session
+            let speciesKey = propertyKeyIn layer.Model species
 
             let inputHeaders =
                 (PropertyProjection.railProjectionWithFilters session layer.Id ProvenanceSide.Input layer.Model state)
@@ -3530,11 +3859,11 @@ let uiStateTests =
                     .Headers
 
             Expect.isTrue
-                (inputHeaders |> List.contains species)
+                (inputHeaders |> List.contains speciesKey)
                 "An incomplete layer with no output should keep current properties on the input rail."
 
             Expect.isFalse
-                (outputHeaders |> List.contains species)
+                (outputHeaders |> List.contains speciesKey)
                 "A property should not move to the output rail before any output is designated."
 
         testCase "selected drop targets include selected inputs and outputs only when dropped group is selected"

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -3066,6 +3066,65 @@ let uiStateTests =
                 Expect.equal setIds [ "input-a"; "input-b" ] "The rejection should identify the assigned targets."
             | other -> failwithf "Expected a multiple-value rejection, got %A" other
 
+        testCase "property value drop plan rejects members whose single values conflict across the group"
+        <| fun _ ->
+            let species = propertyHeader FixtureKinds.characteristicProperty "Species"
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+
+            let model =
+                model
+                    "assay-table"
+                    [
+                        propertyValue "pv-input-a-species" species (ProvenanceValue.Text "Arabidopsis") None None
+                        propertyValue "pv-input-b-species" species (ProvenanceValue.Text "Chlamydomonas") None None
+                    ]
+                    [
+                        inputSet "input-a" "assay-table" inputHeader "Input A" [ "pv-input-a-species" ]
+                        inputSet "input-b" "assay-table" inputHeader "Input B" [ "pv-input-b-species" ]
+                    ] [] []
+
+            let group: DisplayGroup = {
+                Id = "manual"
+                TableName = "assay-table"
+                Side = ProvenanceSide.Input
+                GroupingValues = []
+                Members = [
+                    {
+                        SetId = "input-a"
+                        Name = "Input A"
+                        PropertyValueIds = [ "pv-input-a-species" ]
+                    }
+                    {
+                        SetId = "input-b"
+                        Name = "Input B"
+                        PropertyValueIds = [ "pv-input-b-species" ]
+                    }
+                ]
+            }
+
+            let source: Types.ValueAssignmentSource = {
+                CopiedFrom = None
+                Property = propertyKeyIn model species
+                Value = ProvenanceValue.Text "A. thaliana"
+                Unit = None
+            }
+
+            // Intentionally stricter than the pre-origin-aware planner: each member
+            // has exactly one value, but no single existing group value can be
+            // replaced safely, so the drop is rejected instead of confirmed.
+            match ValueAssignment.planPropertyValueDrop source group model with
+            | Error(Types.ValueAssignmentError.MultiplePropertyValues(property, setIds)) ->
+                Expect.equal
+                    property
+                    (propertyKeyIn model species)
+                    "The rejection should retain exact property identity."
+
+                Expect.equal
+                    setIds
+                    [ "input-a"; "input-b" ]
+                    "Every member holding a conflicting value should be identified."
+            | other -> failwithf "Expected a cross-member conflict rejection, got %A" other
+
         testCase "property value drop plan overwrites one distinct value represented by several occurrence IDs"
         <| fun _ ->
             let temperature = propertyHeader FixtureKinds.parameterProperty "Temperature"

--- a/tests/Shared/ProvenanceGrouping.Tests.fs
+++ b/tests/Shared/ProvenanceGrouping.Tests.fs
@@ -537,6 +537,97 @@ let groupingTests =
                 [ "pv-input-a-species"; "pv-input-b-species" ]
                 "Adding a connection should add that input's properties to the output's effective properties."
 
+        testCase "inputs expose output properties inherited through current loaded connections"
+        <| fun _ ->
+            let analysis = propertyHeader FixtureKinds.parameterProperty "Analysis"
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+            let outputHeader = ioHeader FixtureKinds.sampleEndpoint "Output [Sample Name]"
+
+            let built =
+                model
+                    "assay-table"
+                    [
+                        propertyValue "pv-output-a-analysis" analysis (ProvenanceValue.Text "LC-MS") None None
+                    ]
+                    [
+                        inputSet "input-a" "assay-table" inputHeader "Input A" []
+                    ] [
+                        outputSet "output-a" "assay-table" outputHeader "Output A" [ "pv-output-a-analysis" ]
+                    ] [
+                        connection "connection-a" "assay-table" None "input-a" "output-a"
+                    ]
+
+            Expect.equal
+                (ProvenanceSet.effectivePropertyValueIds built.InputSets.["input-a"])
+                [ "pv-output-a-analysis" ]
+                "An input should expose properties inherited from its directly connected loaded output."
+
+        testCase "same-layer inheritance spreads transitively across connected endpoints"
+        <| fun _ ->
+            let analysis = propertyHeader FixtureKinds.parameterProperty "Analysis"
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+            let outputHeader = ioHeader FixtureKinds.sampleEndpoint "Output [Sample Name]"
+
+            let built =
+                model
+                    "assay-table"
+                    [
+                        propertyValue "pv-output-b-analysis" analysis (ProvenanceValue.Text "LC-MS") None None
+                    ]
+                    [
+                        inputSet "input-a" "assay-table" inputHeader "Input A" []
+                    ] [
+                        outputSet "output-a" "assay-table" outputHeader "Output A" []
+                        outputSet "output-b" "assay-table" outputHeader "Output B" [ "pv-output-b-analysis" ]
+                    ] [
+                        connection "connection-a" "assay-table" None "input-a" "output-a"
+                        connection "connection-b" "assay-table" None "input-a" "output-b"
+                    ]
+
+            Expect.equal
+                (ProvenanceSet.effectivePropertyValueIds built.InputSets.["input-a"])
+                [ "pv-output-b-analysis" ]
+                "A value added to one connected output should reach the shared input."
+
+            Expect.equal
+                (ProvenanceSet.effectivePropertyValueIds built.OutputSets.["output-a"])
+                [ "pv-output-b-analysis" ]
+                "A value added to one connected output should reach sibling outputs through the shared input."
+
+            Expect.isFalse
+                (built.OutputSets.["output-b"].InheritedPropertyValueIds
+                 |> Map.exists (fun _ ids -> ids |> List.contains "pv-output-b-analysis"))
+                "A value must never be inherited back onto the endpoint that owns it."
+
+        testCase "refresh preserves inherited entries carried in from upstream connections"
+        <| fun _ ->
+            let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
+            let outputHeader = ioHeader FixtureKinds.sampleEndpoint "Output [Sample Name]"
+            let modelSource = Fixture.source "layer-2:next-table" "next-table"
+
+            let carriedInput = {
+                Fixture.inputSet "carried-input" modelSource inputHeader "Carried Input" [] with
+                    InheritedPropertyValueIds = Map.ofList [ "upstream-connection", [ "pv-upstream" ] ]
+            }
+
+            let built =
+                Fixture.model modelSource [] [ carriedInput ] [
+                    Fixture.outputSet "output-a" modelSource outputHeader "Output A" []
+                ] [
+                    Fixture.connection "local-connection" modelSource None "carried-input" "output-a"
+                ]
+
+            Expect.equal
+                (built.InputSets.["carried-input"].InheritedPropertyValueIds
+                 |> Map.tryFind "upstream-connection")
+                (Some [ "pv-upstream" ])
+                "Entries keyed by upstream connections must survive a same-layer refresh."
+
+            Expect.equal
+                (ProvenanceSet.effectivePropertyValueIds built.OutputSets.["output-a"])
+                [ "pv-upstream" ]
+                "Carried upstream values should flow on to connected outputs in the current layer."
+
         testCase "grouping collapses identical equal values for one set into one display member"
         <| fun _ ->
             let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
@@ -717,7 +808,7 @@ let groupingTests =
                 [ ProvenanceValue.Text "1"; ProvenanceValue.Text "2" ]
                 "A missing input property should inherit direct connected output values as one combined value-set group."
 
-        testCase "both-side grouping prefers input values over inherited output values"
+        testCase "both-side grouping combines input values with connected output values"
         <| fun _ ->
             let replicate = propertyHeader FixtureKinds.parameterProperty "Replicate"
             let inputHeader = ioHeader FixtureKinds.sampleEndpoint "Input [Sample Name]"
@@ -758,18 +849,16 @@ let groupingTests =
 
             let groupedValues =
                 groups
-                |> List.filter (fun group -> group.Members |> List.exists (fun member' -> member'.SetId = "input-a"))
-                |> List.choose (fun group ->
+                |> List.find (fun group -> group.Members |> List.exists (fun member' -> member'.SetId = "input-a"))
+                |> fun group ->
                     group.GroupingValues
-                    |> List.tryExactlyOne
-                    |> Option.map (fun groupingValue -> groupingValue.Value)
-                )
-                |> List.sort
+                    |> List.map (fun groupingValue -> groupingValue.Value)
+                    |> List.sort
 
             Expect.equal
                 groupedValues
-                [ ProvenanceValue.Text "3" ]
-                "An input's own values should be used before direct connected output values are considered."
+                [ ProvenanceValue.Text "1"; ProvenanceValue.Text "3" ]
+                "An input's own values and direct connected output values belong to the same combined group."
 
         testCase "displayGroups works for input-only loaded models"
         <| fun _ ->
@@ -904,6 +993,35 @@ let editTests =
                     (nextModel.InputSets.["input-c"].PropertyValueIds.Length)
                     1
                     "Target input set should point to the new value."
+            | other -> failwithf "Expected one AddLoadedPropertyValue patch, got %A" other
+
+        testCase "createLoadedPropertyValue on an output reaches connected inputs through inheritance"
+        <| fun _ ->
+            let model = validModel ()
+            let treatment = propertyHeader FixtureKinds.characteristicProperty "Treatment"
+
+            let command = {
+                Target = ProvenancePropertyTarget.OutputSets [ "output-a" ]
+                CopiedFrom = None
+                Header = treatment
+                Value = ProvenanceValue.Text "Drought"
+                Unit = None
+            }
+
+            match createLoadedPropertyValue command model with
+            | Ok(nextModel, [ ProvenanceTablePatch.AddLoadedPropertyValue _ ]) ->
+                let addedId =
+                    nextModel.OutputSets.["output-a"].PropertyValueIds
+                    |> List.find (fun id -> not (model.OutputSets.["output-a"].PropertyValueIds |> List.contains id))
+
+                Expect.isTrue
+                    (ProvenanceSet.effectivePropertyValueIds nextModel.InputSets.["input-a"]
+                     |> List.contains addedId)
+                    "A value added to an output should be inherited by its connected inputs."
+
+                Expect.isFalse
+                    (nextModel.InputSets.["input-a"].PropertyValueIds |> List.contains addedId)
+                    "The connected input must inherit the value, not own it."
             | other -> failwithf "Expected one AddLoadedPropertyValue patch, got %A" other
 
         testCase "copyPropertyValueToLoadedTarget copies previous value to existing loaded connection"
@@ -1161,6 +1279,10 @@ let editTests =
                 Expect.isTrue
                     (nextModel.OutputSets.["output-b"].InheritedPropertyValueIds.ContainsKey "connection-b")
                     "Other connections keep their inherited values."
+
+                Expect.isFalse
+                    (nextModel.InputSets.["input-b"].InheritedPropertyValueIds.ContainsKey "connection-c")
+                    "The input side of the removed connection should drop its inherited values too."
             | other -> failwithf "Expected one RemoveLoadedConnection patch, got %A" other
 
         testCase "removeConnection rejects unknown connections"


### PR DESCRIPTION
## Property inheritance and origin-aware overwrites in the provenance editor

This PR fixes two related problems in the provenance grouping editor: property values
not staying in sync across connected endpoints, and same-named properties from
different source tables being treated as one property.

### Fix connection annotation inheritance

Inheritance is again bidirectional: a value on any endpoint spreads through the layer's
connections to every transitively connected endpoint, no matter which side it lives on.
Removing a connection retracts exactly the values that arrived through it, and values
carried in from upstream layers are left untouched. An endpoint never inherits its own
values back.

### Same header, different source = different property

"Temperature" from the Growth table and "Temperature" from the Cultivation table used
to collapse into a single property. Grouping by one would mix in the other's values,
and overwriting one could silently touch both.

A property's identity is now its header *plus* the source it originated in. Each origin
gets its own rail row, its own color, its own drag identity, and its own connector
lines. So two same-named properties stay visually and behaviorally separate throughout
the editor.

### Overwrites respect the property's origin

Dropping a replacement value onto a group now only targets existing assignments of that
exact property:

- A same-named property from another source can neither join nor block the overwrite.
- When one value is represented by several writeback occurrences (e.g. through
  inheritance), all of them are updated together.
- A property that originated upstream can only *replace* existing assignments
  downstream. It can't be attached to entities that never had it. Trying to do so
  shows a clear error instead of quietly creating a new assignment.
- If the targeted entities don't share a single existing value, the drop is rejected,
  because there is no one value that can be replaced safely.

