### PR TITLE
Bugfix: Single, external xlsx files do only change one file

### DIFF
--- a/src/Components/src/Composite/TermSearch/ConfigProvider.fs
+++ b/src/Components/src/Composite/TermSearch/ConfigProvider.fs
@@ -133,8 +133,7 @@ type TermSearchConfigProvider =
 
         // From v1.0.7 to v2.0.0 the field was renamed from `aktiveKeys` to `activeKeys`. This migration code ensures that users who have the old field in their local storage will have it removed and replaced with the new field.
         match activeKeys.activeKeys with
-        | null -> 
-            Browser.Dom.window.localStorage.removeItem(localStorageKey)
+        | null -> Browser.Dom.window.localStorage.removeItem (localStorageKey)
         | _ -> ()
 
         let allKeys =

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -105,6 +105,11 @@ module ArcVaultExtensions =
                         "Unable to reload ARC after file watcher event: %s"
                         (PathHelpers.formatContractErrors loadError)
                 | Ok reloadedArc ->
+                    // The file watcher is our source of truth for changes made on disk. Establish the reloaded
+                    // ARC as a clean hash baseline before merging it; without this, unchanged entities have
+                    // missing/stale hashes and the next save can unnecessarily overwrite multiple XLSX files.
+                    baselineArcStaticHashes reloadedArc
+
                     let! mergeResult = promise {
                         try
                             return Ok(ARC.merge arcLocal reloadedArc events)
@@ -116,6 +121,10 @@ module ArcVaultExtensions =
                     | Error mergeError ->
                         swatelogfn this.window.id "Unable to merge ARC after file watcher event: %s" mergeError.Message
                     | Ok mergedArc ->
+                        // ARC.merge may copy or reconstruct entities without retaining the hashes established
+                        // above, so transfer the disk baseline to the merged ARC. Watcher-applied values then
+                        // stay clean, while values that still differ because of local edits remain unsaved.
+                        syncArcStaticHashes reloadedArc mergedArc
                         this.SetArc mergedArc
                         this.RefreshHasUnsavedArcChangesFlag()
             | Some _, None -> do! this.LoadArc()


### PR DESCRIPTION
Goal: Make sure that only the adaped XLSX files are loaded into git and not unaltered XLSX files

* The reloads of the file watch can lose the static hash baseline during an ARC merge. As a result, unchanged entities are treated as modified files and multipleXLSX files are overwritten when saving. 
* All of them appear in the GIT changes then.
* The changes preserve the disk hash baseline across watcher merges but also keep local changes detectable