### PR TITLE
Update sidebar and filenode handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,19 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔄 Changed
 
--   Move Electron ARC open, create, and download actions from the selector dropdown into the navbar beside Save, using a folder-plus icon for Create ARC.
--   Move Download ARC from the ARC selector into the sidebar below Git.
+-   Add Download ARC from the ARC selector into the sidebar below Git.
+-   Update FileTree ARC entity navigation: selecting an entity name opens Metadata, expansion and collapse are controlled only by the arrow, and table/DataMap files open their corresponding tabs.
 
 ### 🐛 Fixed
 
 -   Load templates through ARCtrl's JavaScript web API in Electron's main process, avoiding incompatible .NET/Fable server bindings and browser CORS restrictions.
-
-### Changed
-
-- Update FileTree ARC entity navigation: selecting an entity name opens Metadata, expansion and collapse are controlled only by the arrow, and table/DataMap files open their corresponding tabs.
-
-### Fixed
-
+-   Show Actionbar overflow options whenever the button count exceeds the configured visible-button limit.
 - Ensure switching between FileTree ARC files refreshes the selected editor tab instead of retaining the previous entity's tab.
 
 ## 2.0.5 - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🔄 Changed
+
+-   Move Electron ARC open, create, and download actions from the selector dropdown into the navbar beside Save, using a folder-plus icon for Create ARC.
+
 ### 🐛 Fixed
 
 -   Load templates through ARCtrl's JavaScript web API in Electron's main process, avoiding incompatible .NET/Fable server bindings and browser CORS restrictions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔄 Changed
 
 -   Move Electron ARC open, create, and download actions from the selector dropdown into the navbar beside Save, using a folder-plus icon for Create ARC.
+-   Move Download ARC from the ARC selector into the sidebar below Git.
 
 ### 🐛 Fixed
 
 -   Load templates through ARCtrl's JavaScript web API in Electron's main process, avoiding incompatible .NET/Fable server bindings and browser CORS restrictions.
+
+### Changed
+
+- Update FileTree ARC entity navigation: selecting an entity name opens Metadata, expansion and collapse are controlled only by the arrow, and table/DataMap files open their corresponding tabs.
+
+### Fixed
+
+- Ensure switching between FileTree ARC files refreshes the selected editor tab instead of retaining the previous entity's tab.
 
 ## 2.0.5 - 2026-08-05
 

--- a/src/Components/src/Composite/ArcSelector/ArcSelector.fs
+++ b/src/Components/src/Composite/ArcSelector/ArcSelector.fs
@@ -264,19 +264,6 @@ type ArcSelector =
                 "Open an existing ARC",
                 closeDropdown
             )
-
-            ButtonInfo.create (
-                "swt:fluent--cloud-arrow-down-24-regular swt:size-5",
-                "Download an existing ARC",
-                closeDropdown
-            )
-
-            ButtonInfo.create ("swt:fluent--document-add-24-regular swt:size-5", "Create a new ARC", closeDropdown)
-            ButtonInfo.create (
-                "swt:fluent--folder-arrow-up-24-regular swt:size-5",
-                "Open an existing ARC",
-                closeDropdown
-            )
         |]
 
         let actionbar = Actionbar.Main(actionbarButtons, maxNumberActionbar, ?debug = debug)

--- a/src/Components/src/Composite/ArcSelector/ArcSelector.stories.tsx
+++ b/src/Components/src/Composite/ArcSelector/ArcSelector.stories.tsx
@@ -91,7 +91,7 @@ export const ClickingActionbarButtonClosesDropdown: Story = {
 
 export const RestButtonShowsOptionsAndOptionsClickable: Story = {
   args: {
-    maxNumberActionbar: 3,
+    maxNumberActionbar: 1,
     debug: true
   },
   play: async ({ canvasElement }) => {

--- a/src/Components/src/Composite/ArcSelector/ArcSelector.stories.tsx
+++ b/src/Components/src/Composite/ArcSelector/ArcSelector.stories.tsx
@@ -106,7 +106,7 @@ export const RestButtonShowsOptionsAndOptionsClickable: Story = {
     const menu = await screen.findByTestId('context_menu');
     expect(menu).toBeVisible();
 
-    const menuItem = within(menu).getByText('Create a new ARC');
+    const menuItem = within(menu).getByText('Open an existing ARC');
     await userEvent.click(menuItem);
 
     await waitFor(() => {

--- a/src/Components/src/Page/ArcFileEditor/ArcFileEditor.fs
+++ b/src/Components/src/Page/ArcFileEditor/ArcFileEditor.fs
@@ -296,9 +296,16 @@ type Main =
         let activeView, setActiveView =
             React.useState (startingActiveView |> Option.defaultValue ActiveView.Metadata)
 
+        let arcFileNavigationKey =
+            arcFile.TryGetRelativePath()
+            |> Option.defaultValue (string arcFile.RelatedArcFilesDiscriminate)
+
+        let startingActiveViewKey =
+            startingActiveView |> Option.map _.ViewIndex |> Option.defaultValue -3
+
         React.useEffect (
             (fun () -> setActiveView (startingActiveView |> Option.defaultValue ActiveView.Metadata)),
-            [| box arcFile; box startingActiveView |]
+            [| box arcFileNavigationKey; box startingActiveViewKey |]
         )
 
         React.useEffect (

--- a/src/Components/src/Page/ArcFileEditor/ArcFileEditor.fs
+++ b/src/Components/src/Page/ArcFileEditor/ArcFileEditor.fs
@@ -297,6 +297,11 @@ type Main =
             React.useState (startingActiveView |> Option.defaultValue ActiveView.Metadata)
 
         React.useEffect (
+            (fun () -> setActiveView (startingActiveView |> Option.defaultValue ActiveView.Metadata)),
+            [| box arcFile; box startingActiveView |]
+        )
+
+        React.useEffect (
             (fun () ->
                 let nextActiveView = ActiveView.Forward(arcFile, activeView)
 

--- a/src/Components/src/Page/FileExplorer/FileExplorer.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorer.fs
@@ -122,6 +122,7 @@ type FileExplorer =
             ?onDirectoryArrowToggle: FileItem -> bool -> unit,
             ?directoryInteractionMode: DirectoryInteractionMode,
             ?directoryChevronToggleOnly: bool,
+            ?directoryChevronToggleOnlyForItem: FileItem -> bool,
             ?delegateHorizontalScrollToParent: bool,
             ?truncateOverflowingItemNames: bool,
             ?getItemIconClass: FileItem -> string option,
@@ -137,6 +138,9 @@ type FileExplorer =
             defaultArg directoryInteractionMode DirectoryInteractionMode.SingleClickToggle
 
         let directoryChevronToggleOnly = defaultArg directoryChevronToggleOnly false
+
+        let directoryChevronToggleOnlyForItem =
+            defaultArg directoryChevronToggleOnlyForItem (fun _ -> directoryChevronToggleOnly)
 
         let delegateHorizontalScrollToParent =
             defaultArg delegateHorizontalScrollToParent false
@@ -212,6 +216,7 @@ type FileExplorer =
             if
                 directoryInteractionMode = DirectoryInteractionMode.SingleClickToggle
                 && canExpand
+                && not (directoryChevronToggleOnlyForItem item)
             then
                 setExpanded item (not (model.ExpandedIds.Contains item.Id))
 
@@ -315,7 +320,7 @@ type FileExplorer =
                     rowHighlightClass,
                     selectedNameClass,
                     isExpanded,
-                    directoryChevronToggleOnly,
+                    directoryChevronToggleOnlyForItem item,
                     canExpand,
                     getItemIconClass,
                     handleDirectorySelection item canExpand,

--- a/src/Components/src/Primitive/Actionbar/Actionbar.fs
+++ b/src/Components/src/Primitive/Actionbar/Actionbar.fs
@@ -132,7 +132,7 @@ type Actionbar =
             let event = Actionbar.createMouseEvent "contextmenu" options
             element.dispatchEvent (event) |> ignore
 
-        if buttons.Length > 0 && buttons.Length <= maxNumber + 1 then
+        if buttons.Length > 0 && buttons.Length <= maxNumber then
             Html.none
         else
             let buttonInfo =
@@ -185,7 +185,7 @@ type Actionbar =
         let selectedElements =
             React.useMemo (
                 (fun _ ->
-                    if buttons.Length > 0 && buttons.Length > maxNumber + 1 then
+                    if buttons.Length > 0 && buttons.Length > maxNumber then
                         Array.take maxNumber buttons
                     else
                         buttons

--- a/src/Electron/src/Renderer/App.fs
+++ b/src/Electron/src/Renderer/App.fs
@@ -130,6 +130,8 @@ let private LeftActionButtons (leftSidebarTarget: LeftSidebarPage) setLeftSideba
     let leftSidebarCtx =
         Swate.Components.Composite.Layout.LeftSidebarContext.useLeftSidebarCtx ()
 
+    let pageStateCtx = Renderer.Context.PageStateContext.usePageStateCtx ()
+
     let toggleTarget target =
         if leftSidebarTarget = target then
             leftSidebarCtx.setState (not leftSidebarCtx.state)
@@ -149,6 +151,12 @@ let private LeftActionButtons (leftSidebarTarget: LeftSidebarPage) setLeftSideba
             tooltip = "Git",
             isActive = (leftSidebarTarget = LeftSidebarPage.Git),
             onClick = fun () -> toggleTarget LeftSidebarPage.Git
+        )
+        Layout.LayoutBtn(
+            iconClassName = "swt:fluent--cloud-beaker-24-regular",
+            tooltip = "Download ARC from DataHub",
+            isActive = false,
+            onClick = fun () -> pageStateCtx.setState (Some PageState.DataHubBrowser)
         )
     ]
 

--- a/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
+++ b/src/Electron/src/Renderer/Components/FileExplorerDeleteHelper.fs
@@ -21,6 +21,7 @@ module FileExplorerDeleteHelper =
     let private resetsWhenSelectionIsRemoved =
         function
         | PageState.ArcFilePage _
+        | PageState.ArcFilePageWithStartingView _
         | PageState.MarkdownPage _
         | PageState.TextPage _
         | PageState.UnknownPage

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTree.fs
@@ -129,18 +129,50 @@ type FileTree =
                 FileTreeMaterialization.toMaterializedFileItemTree Helper.createItem reconciledMaterializedState.Paths
             )
 
-        let openSelectedPreview (itemName: string) (selectedPath: string) = promise {
-            let! result = openView selectedPath
-
+        let applyPreviewResult itemName result =
             match result with
-            | Ok pageState ->
-                console.log ("[Renderer] Received data, processing...")
-                pageStateCtx.setState (Some pageState)
+            | Ok pageState -> pageStateCtx.setState (Some pageState)
             | Error errorMessage ->
                 let fullErrorMessage = $"Could not open preview for '{itemName}': {errorMessage}"
                 console.log ($"[Renderer] Error: {fullErrorMessage}")
                 pageStateCtx.setState (Some(Renderer.Types.PageState.ErrorPage fullErrorMessage))
+
+        let withStartingView activeView =
+            function
+            | Renderer.Types.PageState.ArcFilePage arcFile
+            | Renderer.Types.PageState.ArcFilePageWithStartingView(arcFile, _) ->
+                Renderer.Types.PageState.ArcFilePageWithStartingView(arcFile, activeView)
+            | pageState -> pageState
+
+        let openSelectedPreview (itemName: string) (selectedPath: string) = promise {
+            let! openedResult = openView selectedPath
+
+            let result =
+                if
+                    selectedPath.EndsWith(
+                        ARCtrl.ArcPathHelper.DataMapFileName,
+                        System.StringComparison.OrdinalIgnoreCase
+                    )
+                then
+                    openedResult
+                    |> Result.map (withStartingView Swate.Components.Page.ArcFileEditor.Types.ActiveView.DataMap)
+                else
+                    openedResult
+
+            applyPreviewResult itemName result
         }
+
+        let tryGetArcEntityWorkbookName (path: string) =
+            ArcEntityPathRules.tryGetRenameEntityFolderTarget (PathHelpers.normalizePath path)
+            |> Option.map (fun (zone, identifier) ->
+                ArcEntityPathRules.buildCanonicalEntityPaths zone identifier
+                |> List.head
+                |> PathHelpers.getFileName
+            )
+
+        let isArcEntityDirectory (item: FileItem) =
+            item.IsDirectory
+            && item.Path |> Option.bind tryGetArcEntityWorkbookName |> Option.isSome
 
         let openPreview (item: FileItem) =
             promise {
@@ -152,7 +184,20 @@ type FileTree =
                 | Some path when item.IsDirectory ->
                     let selectedPath = PathHelpers.normalizePath path
                     fileStateCtx.setSelection (ArcSelection.forTreePath (Some selectedPath))
-                    pageStateCtx.setState None
+
+                    if isArcEntityDirectory item then
+                        match tryGetArcEntityWorkbookName selectedPath with
+                        | Some workbookName ->
+                            let! result = openView $"{selectedPath}/{workbookName}"
+
+                            result
+                            |> Result.map (
+                                withStartingView Swate.Components.Page.ArcFileEditor.Types.ActiveView.Metadata
+                            )
+                            |> applyPreviewResult item.Name
+                        | None -> pageStateCtx.setState None
+                    else
+                        pageStateCtx.setState None
                 | Some path ->
                     let selectedPath = PathHelpers.normalizePath path
                     fileStateCtx.setSelection (ArcSelection.forTreePath (Some selectedPath))
@@ -498,6 +543,7 @@ type FileTree =
                         Swate.Components.Page.FileExplorer.FileExplorer.FileExplorer(
                             initialItems = visibleItems,
                             onItemClick = openPreview,
+                            directoryChevronToggleOnlyForItem = isArcEntityDirectory,
                             onDirectoryExpansionChange = handleExpansionChange,
                             onContextMenu = createContextMenuItems,
                             getItemIconClass = getItemIconClass,

--- a/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRename.fs
+++ b/src/Electron/src/Renderer/Components/LeftSidebar/FileExplorer/FileTreeRename.fs
@@ -39,6 +39,9 @@ module FileTreeRenameWorkflow =
         | Some(Renderer.Types.PageState.ArcFilePage arcFile) ->
             arcFile.TryGetRelativePath()
             |> Option.bind (fun arcFilePath -> tryRemapSelectionPath sourcePath targetPath (Some arcFilePath))
+        | Some(Renderer.Types.PageState.ArcFilePageWithStartingView(arcFile, _)) ->
+            arcFile.TryGetRelativePath()
+            |> Option.bind (fun arcFilePath -> tryRemapSelectionPath sourcePath targetPath (Some arcFilePath))
         | _ -> None
 
     let requestRenameItem

--- a/src/Electron/src/Renderer/Components/MainContent/ArcFilePreviewTarget.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/ArcFilePreviewTarget.fs
@@ -60,7 +60,10 @@ let ArcFilePreviewTarget (arcFile: ArcFiles, startingActiveView: ActiveView opti
     let errorModal = useErrorModalCtx ()
 
     let setArcFilePageState (nextArcFile: ArcFiles) =
-        let page = Renderer.Types.PageState.ArcFilePage nextArcFile
+        let page =
+            match startingActiveView with
+            | Some activeView -> Renderer.Types.PageState.ArcFilePageWithStartingView(nextArcFile, activeView)
+            | None -> Renderer.Types.PageState.ArcFilePage nextArcFile
 
         pageStateCtx.setState (Some page)
 

--- a/src/Electron/src/Renderer/Components/MainContent/ArcFilePreviewTarget.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/ArcFilePreviewTarget.fs
@@ -10,6 +10,7 @@ open Swate.Components
 open Swate.Components.Shared
 open Swate.Components.Primitive.ErrorModal.Context
 open Swate.Components.Primitive.ErrorModal.Types
+open Swate.Components.Page.ArcFileEditor.Types
 
 [<ReactComponent>]
 let private TableNavbarActions (props: ArcFileEditorHeaderProps, setArcFile: ArcFiles -> unit) =
@@ -54,7 +55,7 @@ let private TableNavbarActions (props: ArcFileEditorHeaderProps, setArcFile: Arc
     | _ -> Html.none
 
 [<ReactComponent>]
-let ArcFilePreviewTarget (arcFile: ArcFiles) =
+let ArcFilePreviewTarget (arcFile: ArcFiles, startingActiveView: ActiveView option) =
     let pageStateCtx = Renderer.Context.PageStateContext.usePageStateCtx ()
     let errorModal = useErrorModalCtx ()
 
@@ -119,6 +120,7 @@ let ArcFilePreviewTarget (arcFile: ArcFiles) =
         setArcFile,
         pickFilePaths,
         trailingNavbarElements = trailingNavbarElements,
+        startingActiveView = (startingActiveView |> Option.defaultValue ActiveView.Metadata),
         onImportJson = importJson,
         onError =
             (fun message ->

--- a/src/Electron/src/Renderer/Components/MainContent/Main.fs
+++ b/src/Electron/src/Renderer/Components/MainContent/Main.fs
@@ -94,7 +94,9 @@ let Main (appRootPath: ArcRootPath, pageState: PageState option) =
                                 "swt:flex-1 swt:min-w-0 swt:min-h-0 swt:flex swt:justify-center swt:items-center"
                             prop.children [ Renderer.Components.InitState.InitState() ]
                         ]
-                    | Some _, Some(PageState.ArcFilePage arcFile) -> ArcFilePreviewTarget arcFile
+                    | Some _, Some(PageState.ArcFilePage arcFile) -> ArcFilePreviewTarget(arcFile, None)
+                    | Some _, Some(PageState.ArcFilePageWithStartingView(arcFile, startingActiveView)) ->
+                        ArcFilePreviewTarget(arcFile, Some startingActiveView)
                     | Some _, Some(PageState.MarkdownPage content) ->
                         React.Suspense(
                             [ LazyComponents.LazyMarkdownEditorTarget(content) ],

--- a/src/Electron/src/Renderer/Components/Navbar.fs
+++ b/src/Electron/src/Renderer/Components/Navbar.fs
@@ -14,31 +14,10 @@ open Swate.Components.Primitive.ErrorModal.Types
 open Swate.Electron.Shared.IPCTypes.MainToRendererIpc
 open Renderer.Types
 
-module NavbarHelper =
-
-    module Selector =
-
-        /// Unified open: main process decides current window / new window / focus existing.
-        let openARC (onError: string -> unit) () =
-            Renderer.Components.Helper.ArcVaultHelper.openArc onError |> Promise.start
-
-        /// Click on a recent ARC: main process decides open-or-focus.
-        let openArcByPath (onError: string -> unit) (clickedARC: ARCPointer) =
-            Renderer.Components.Helper.ArcVaultHelper.openArcByPath onError clickedARC.path
-            |> Promise.start
-
-        let rmvRecentArc (onError: string -> unit) (pointer: ARCPointer) =
-            promise {
-                match! Api.ipcArcVaultApi.removeRecentARC pointer with
-                | Ok _ -> ()
-                | Error exn -> onError exn.Message
-            }
-            |> Promise.start
-
 type private Selector =
 
     static member CreateArcActionBtn(onClick: Browser.Types.MouseEvent -> unit) =
-        ButtonInfo.create ("swt:fluent--document-add-24-regular swt:size-5", "Create a new ARC", onClick)
+        ButtonInfo.create ("swt:fluent--folder-add-24-regular swt:size-5", "Create a new ARC", onClick)
 
     static member OpenArcActionBtn(onClick: Browser.Types.MouseEvent -> unit) =
         ButtonInfo.create ("swt:fluent--folder-open-24-regular swt:size-5", "Open an existing ARC", onClick)
@@ -47,25 +26,15 @@ type private Selector =
         ButtonInfo.create ("swt:fluent--cloud-beaker-24-regular swt:size-5", "Download ARC from DataHub", onClick)
 
     [<ReactComponent>]
-    static member private Actionbar
-        (setNewArcModalIsOpen: bool -> unit, toggleSelector: unit -> unit, onArcError: string -> unit)
-        =
+    static member Actionbar(setNewArcModalIsOpen: bool -> unit, onArcError: string -> unit) =
         let pageStateCtx = Renderer.Context.PageStateContext.usePageStateCtx ()
 
-        let onCreateARC =
-            fun _ ->
-                setNewArcModalIsOpen true
-                toggleSelector ()
+        let onCreateARC = fun _ -> setNewArcModalIsOpen true
 
-        let onOpenARC =
-            fun _ ->
-                NavbarHelper.Selector.openARC onArcError ()
-                toggleSelector ()
+        let onOpenARC = fun _ -> openArc onArcError |> Promise.start
 
         let openDataHubBrowser =
-            fun _ ->
-                pageStateCtx.setState (Some Renderer.Types.PageState.DataHubBrowser)
-                toggleSelector ()
+            fun _ -> pageStateCtx.setState (Some Renderer.Types.PageState.DataHubBrowser)
 
         Actionbar.Main(
             [|
@@ -77,13 +46,7 @@ type private Selector =
         )
 
     [<ReactComponent>]
-    static member Main() =
-        let appStateCtx = Renderer.Context.AppStateContext.useAppStateCtx ()
-        let newArcModalIsOpen, setNewArcModalIsOpen = React.useState false
-        let errorCtx = useErrorModalCtx ()
-
-        let onArcError =
-            createErrorModalCallback errorCtx.enqueue "ARC action failed" appStateCtx
+    static member Main(onArcError: string -> unit) =
 
         let recentArcs =
             Renderer.MainSyncedState.useMainSyncedState {
@@ -105,23 +68,23 @@ type private Selector =
                 if isOpen then
                     recentArcs.refresh ()
 
-        React.Fragment [
-            BaseModal.BaseModal(
-                newArcModalIsOpen,
-                setNewArcModalIsOpen,
-                Renderer.Components.InitState.CreateNewArcModalContent(fun () -> setNewArcModalIsOpen false)
-            )
-            Swate.Components.Composite.ArcSelector.ArcSelector.Main(
-                recentArcs.state,
-                NavbarHelper.Selector.openArcByPath onArcError,
-                rmvRecentArc = NavbarHelper.Selector.rmvRecentArc onArcError,
-                onOpenChange = onOpen,
-                actionbar = Selector.Actionbar(setNewArcModalIsOpen, selectorControlRef.current.toggle, onArcError),
-                isLoading = recentArcs.isLoading,
-                controlRef = selectorControlRef,
-                ?currentlyOpenArcPath = appStateCtx
-            )
-        ]
+        let removeRecentArc pointer =
+            promise {
+                match! Api.ipcArcVaultApi.removeRecentARC pointer with
+                | Ok _ -> ()
+                | Error exn -> onArcError exn.Message
+            }
+            |> Promise.start
+
+        Swate.Components.Composite.ArcSelector.ArcSelector.Main(
+            recentArcs.state,
+            (fun clickedARC -> openArcByPath onArcError clickedARC.path |> Promise.start),
+            rmvRecentArc = removeRecentArc,
+            onOpenChange = onOpen,
+            isLoading = recentArcs.isLoading,
+            controlRef = selectorControlRef,
+            ?currentlyOpenArcPath = Renderer.Context.AppStateContext.useAppStateCtx ()
+        )
 
 module private Authentication =
 
@@ -313,14 +276,20 @@ type Navbar =
     static member Main() =
 
         let appStateCtx = Renderer.Context.AppStateContext.useAppStateCtx ()
+        let newArcModalIsOpen, setNewArcModalIsOpen = React.useState false
+        let errorCtx = useErrorModalCtx ()
+
+        let onArcError =
+            createErrorModalCallback errorCtx.enqueue "ARC action failed" appStateCtx
 
         let left =
             Html.div [
                 prop.className "swt:flex swt:items-center swt:gap-2"
                 prop.children [
                     Navbar.SettingsButton()
-                    Selector.Main()
+                    Selector.Main(onArcError)
                     Navbar.SaveArcButton()
+                    Selector.Actionbar(setNewArcModalIsOpen, onArcError)
                 ]
             ]
 
@@ -335,4 +304,11 @@ type Navbar =
                 ]
             ]
 
-        Swate.Components.Primitive.Navbar.Navbar.Main(left = left, right = right)
+        React.Fragment [
+            BaseModal.BaseModal(
+                newArcModalIsOpen,
+                setNewArcModalIsOpen,
+                Renderer.Components.InitState.CreateNewArcModalContent(fun () -> setNewArcModalIsOpen false)
+            )
+            Swate.Components.Primitive.Navbar.Navbar.Main(left = left, right = right)
+        ]

--- a/src/Electron/src/Renderer/Components/Navbar.fs
+++ b/src/Electron/src/Renderer/Components/Navbar.fs
@@ -16,37 +16,34 @@ open Renderer.Types
 
 type private Selector =
 
-    static member CreateArcActionBtn(onClick: Browser.Types.MouseEvent -> unit) =
-        ButtonInfo.create ("swt:fluent--folder-add-24-regular swt:size-5", "Create a new ARC", onClick)
-
-    static member OpenArcActionBtn(onClick: Browser.Types.MouseEvent -> unit) =
-        ButtonInfo.create ("swt:fluent--folder-open-24-regular swt:size-5", "Open an existing ARC", onClick)
-
-    static member DownloadArcActionBtn(onClick: Browser.Types.MouseEvent -> unit) =
-        ButtonInfo.create ("swt:fluent--cloud-beaker-24-regular swt:size-5", "Download ARC from DataHub", onClick)
-
     [<ReactComponent>]
     static member Actionbar(setNewArcModalIsOpen: bool -> unit, onArcError: string -> unit) =
         let pageStateCtx = Renderer.Context.PageStateContext.usePageStateCtx ()
 
-        let onCreateARC = fun _ -> setNewArcModalIsOpen true
-
-        let onOpenARC = fun _ -> openArc onArcError |> Promise.start
-
-        let openDataHubBrowser =
-            fun _ -> pageStateCtx.setState (Some Renderer.Types.PageState.DataHubBrowser)
 
         Actionbar.Main(
             [|
-                Selector.CreateArcActionBtn(onCreateARC)
-                Selector.OpenArcActionBtn(onOpenARC)
-                Selector.DownloadArcActionBtn(openDataHubBrowser)
+                ButtonInfo.create (
+                    "swt:fluent--folder-add-24-regular swt:size-5",
+                    "Create a new ARC",
+                    fun _ -> setNewArcModalIsOpen true
+                )
+                ButtonInfo.create (
+                    "swt:fluent--folder-open-24-regular swt:size-5",
+                    "Open an existing ARC",
+                    fun _ -> openArc onArcError |> Promise.start
+                )
+                ButtonInfo.create (
+                    "swt:fluent--cloud-beaker-24-regular swt:size-5",
+                    "Download ARC from DataHub",
+                    fun _ -> pageStateCtx.setState (Some Renderer.Types.PageState.DataHubBrowser)
+                )
             |],
             4
         )
 
     [<ReactComponent>]
-    static member Main(onArcError: string -> unit) =
+    static member Main(onArcError: string -> unit, setNewArcModalIsOpen: bool -> unit) =
 
         let recentArcs =
             Renderer.MainSyncedState.useMainSyncedState {
@@ -80,6 +77,7 @@ type private Selector =
             recentArcs.state,
             (fun clickedARC -> openArcByPath onArcError clickedARC.path |> Promise.start),
             rmvRecentArc = removeRecentArc,
+            actionbar = Selector.Actionbar(setNewArcModalIsOpen, onArcError),
             onOpenChange = onOpen,
             isLoading = recentArcs.isLoading,
             controlRef = selectorControlRef,
@@ -287,9 +285,8 @@ type Navbar =
                 prop.className "swt:flex swt:items-center swt:gap-2"
                 prop.children [
                     Navbar.SettingsButton()
-                    Selector.Main(onArcError)
+                    Selector.Main(onArcError, setNewArcModalIsOpen)
                     Navbar.SaveArcButton()
-                    Selector.Actionbar(setNewArcModalIsOpen, onArcError)
                 ]
             ]
 

--- a/src/Electron/src/Renderer/Types.fs
+++ b/src/Electron/src/Renderer/Types.fs
@@ -5,6 +5,7 @@ open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOTypes
 open Swate.Electron.Shared.FileIOHelper
 open Swate.Electron.Shared.GitTypes
+open Swate.Components.Page.ArcFileEditor.Types
 
 [<RequireQualifiedAccess>]
 type LeftSidebarPage =
@@ -16,6 +17,7 @@ type GitUnsupportedPageData = GitUnsupportedContentDto
 [<RequireQualifiedAccess>]
 type PageState =
     | ArcFilePage of ArcFiles
+    | ArcFilePageWithStartingView of ArcFiles * ActiveView
     | MarkdownPage of string
     | TextPage of string
     | UnknownPage
@@ -38,7 +40,26 @@ type PageState =
             let arcfile = FileContentDTO.toArcFile dto
 
             match arcfile with
-            | Some arcFile -> PageState.ArcFilePage arcFile
+            | Some arcFile ->
+                let normalizedPath = PathHelpers.normalizePath dto.path
+
+                if
+                    normalizedPath.EndsWith(
+                        ARCtrl.ArcPathHelper.DataMapFileName,
+                        System.StringComparison.OrdinalIgnoreCase
+                    )
+                then
+                    PageState.ArcFilePageWithStartingView(arcFile, ActiveView.DataMap)
+                elif normalizedPath.EndsWith(".xlsx", System.StringComparison.OrdinalIgnoreCase) then
+                    let startingView =
+                        if arcFile.Tables().Count > 0 then
+                            ActiveView.Table 0
+                        else
+                            ActiveView.Metadata
+
+                    PageState.ArcFilePageWithStartingView(arcFile, startingView)
+                else
+                    PageState.ArcFilePage arcFile
             | None ->
                 PageState.ErrorPage
                     $"Failed to parse ARC file: {dto.path} - {dto.fileType} - unsupported format or corrupted content."


### PR DESCRIPTION
* Added the button Download ARC to the sidebar
* Added tablenode selection feature
* Assays, Workflows, Studies and do only collapse and expand when the arrow is selected
* When the table xlsx is selected, it selects the first table tab
* When the datatab xlsx is selected, it selects the datamap tab
* When the parent folder is selected, it selects the metadtaview tab