### PR TITLE
Expand datamap update to table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add Download ARC from the ARC selector into the sidebar below Git.
 -   Update FileTree ARC entity navigation: selecting an entity name opens Metadata, expansion and collapse are controlled only by the arrow, and table/DataMap files open their corresponding tabs.
+-   Store File Picker and Data Annotator references with an explicit `./` ARC-root-relative path in both table and DataMap views.
 
 ### 🐛 Fixed
 
 -   Load templates through ARCtrl's JavaScript web API in Electron's main process, avoiding incompatible .NET/Fable server bindings and browser CORS restrictions.
 -   Show Actionbar overflow options whenever the button count exceeds the configured visible-button limit.
+-   Use consistent clipboard formatting across normal table and DataMap views, preserving data selectors after `#` when copying single or multiple cells.
 - Ensure switching between FileTree ARC files refreshes the selected editor tab instead of retaining the previous entity's tab.
 
 ## 2.0.5 - 2026-08-05

--- a/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
+++ b/src/Components/src/ARCtrl/Extensions/CompositeCell.fs
@@ -87,6 +87,13 @@ type CompositeCell with
     member this.ToTabStr() =
         this.GetContentSwate() |> String.concat "\t"
 
+    /// Serialize one displayed grid cell for the clipboard. Data cells keep their
+    /// selector in the compact `path#selector` representation used by the table UI.
+    member this.ToClipboardStr() =
+        match this with
+        | CompositeCell.Data data -> data.Name |> Option.defaultValue ""
+        | _ -> this.ToTabStr()
+
     static member fromTabStr(str: string, header: CompositeHeader) =
         let content = str.Split('\t') |> Array.map _.Trim()
         CompositeCell.fromContentValid (content, header)
@@ -120,6 +127,11 @@ type CompositeCell with
             |> Array.map (fun row -> row |> Array.map (fun cell -> cell.ToTabStr()) |> String.concat "\t")
 
         rows |> String.concat (System.Environment.NewLine)
+
+    static member ToClipboardTableTxt(cells: CompositeCell[][]) =
+        cells
+        |> Array.map (Array.map (fun cell -> CompositeCell.FreeText(cell.ToClipboardStr())))
+        |> CompositeCell.ToTableTxt
 
     static member fromTabTxt (tabTxt: string) (header: CompositeHeader) =
         let lines =

--- a/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
+++ b/src/Components/src/Composite/AnnotationTable/ContextMenu.fs
@@ -139,7 +139,7 @@ type AnnotationTableContextMenuUtil =
                     |> Array.map (fun row -> row |> String.concat "\t")
                     |> String.concat System.Environment.NewLine
                 else
-                    CompositeCell.ToTableTxt(cells)
+                    CompositeCell.ToClipboardTableTxt(cells)
             else if cellIndex.y - 1 < 0 then
                 let column = table.GetColumn(cellIndex.x - 1)
                 let table = ArcTable.init ("placeholder")
@@ -150,7 +150,7 @@ type AnnotationTableContextMenuUtil =
                 |> String.concat System.Environment.NewLine
             else
                 let cell = table.GetCellAt((cellIndex.x - 1, cellIndex.y - 1))
-                cell.ToTabStr()
+                cell.ToClipboardStr()
 
         navigator.clipboard.writeText result
 

--- a/src/Components/src/Composite/DataMapTable/Types.fs
+++ b/src/Components/src/Composite/DataMapTable/Types.fs
@@ -24,13 +24,11 @@ module ARCtrlExtensions =
             |> Seq.map (fun (_, row) ->
                 row
                 |> Seq.sortBy _.x
-                // Copy the value displayed by the DataMap grid as one clipboard cell. ToTabStr
-                // expands composite metadata into multiple columns and adds trailing tabs for
-                // empty fields, while ToString keeps `path#selector` compact and complete.
-                |> Seq.map (fun coordinate -> this.GetCell(coordinate.x - 1, coordinate.y - 1).ToString())
-                |> String.concat "\t"
+                |> Seq.map (fun coordinate -> this.GetCell(coordinate.x - 1, coordinate.y - 1))
+                |> Seq.toArray
             )
-            |> String.concat System.Environment.NewLine
+            |> Seq.toArray
+            |> CompositeCell.ToClipboardTableTxt
 
         member this.PasteTabText(startCoordinate: CellCoordinate, clipboardText: string) =
             let rows =

--- a/src/Components/src/Page/ArcFileEditor/Helper.fs
+++ b/src/Components/src/Page/ArcFileEditor/Helper.fs
@@ -32,6 +32,11 @@ let applyDataAnnotatorInputToArcFile
         let nextArcFile = ArcFiles.refreshRef arcFile
 
         let result =
+            let rootRelativeInput = {
+                annotationInput with
+                    FileName = toArcRootRelativeFilePath arcFile annotationInput.FileName
+            }
+
             match destination with
             | AnnotationDestination.Table table ->
                 let tableIndex =
@@ -42,14 +47,9 @@ let applyDataAnnotatorInputToArcFile
                 | Some index when index < nextArcFile.Tables().Count ->
                     let nextTable = nextArcFile.Tables().[index]
 
-                    Swate.Components.Composite.Widgets.DataAnnotator.Helper.applyToTable nextTable annotationInput
+                    Swate.Components.Composite.Widgets.DataAnnotator.Helper.applyToTable nextTable rootRelativeInput
                 | _ -> Error "The Data Annotator target table is no longer available."
             | AnnotationDestination.DataMap _ ->
-                let rootRelativeInput = {
-                    annotationInput with
-                        FileName = toArcRootRelativeFilePath arcFile annotationInput.FileName
-                }
-
                 match nextArcFile.TryGetDataMap() with
                 | Some dataMap ->
                     Swate.Components.Composite.Widgets.DataAnnotator.Helper.applyToDataMap dataMap rootRelativeInput

--- a/src/Shared/ARCtrl.Helper.fs
+++ b/src/Shared/ARCtrl.Helper.fs
@@ -227,7 +227,11 @@ module ARCtrlHelper =
 
         let withExplicitRelativePrefix (path: string) =
             let normalizedPath = path.Replace('\\', '/')
-            if normalizedPath.StartsWith("./") then normalizedPath else $"./{normalizedPath}"
+
+            if normalizedPath.StartsWith("./") then
+                normalizedPath
+            else
+                $"./{normalizedPath}"
 
         match parentInfo, ARCtrl.ArcPathHelper.split filePath with
         // Browser uploads expose only the bare file name, while stored references are ARC-root-relative.

--- a/src/Shared/ARCtrl.Helper.fs
+++ b/src/Shared/ARCtrl.Helper.fs
@@ -225,6 +225,10 @@ module ARCtrlHelper =
             | ArcFiles.DataMap(Some parentInfo, _) -> Some parentInfo
             | _ -> None
 
+        let withExplicitRelativePrefix (path: string) =
+            let normalizedPath = path.Replace('\\', '/')
+            if normalizedPath.StartsWith("./") then normalizedPath else $"./{normalizedPath}"
+
         match parentInfo, ARCtrl.ArcPathHelper.split filePath with
         // Browser uploads expose only the bare file name, while stored references are ARC-root-relative.
         | Some parentInfo, [| _ |] ->
@@ -242,6 +246,8 @@ module ARCtrlHelper =
             |]
             |> Array.choose id
             |> ARCtrl.ArcPathHelper.combineMany
+            |> withExplicitRelativePrefix
+        | _, segments when segments.Length > 1 -> withExplicitRelativePrefix filePath
         | _ -> filePath
 
     [<RequireQualifiedAccess>]

--- a/tests/Client/Components/Table/ContextMenu.tests.fs
+++ b/tests/Client/Components/Table/ContextMenu.tests.fs
@@ -221,6 +221,19 @@ type TestCases =
             "DatamapTesting.txt"
             "Copied DataMap data should not include trailing tabs for empty metadata."
 
+    static member TableCopyIncludesSelector() =
+        let dataCell = CompositeCell.createDataFromString "DatamapTesting.txt#row=2"
+
+        Expect.equal
+            (dataCell.ToClipboardStr())
+            "DatamapTesting.txt#row=2"
+            "Copied table data should include its selector in the displayed clipboard cell."
+
+        Expect.equal
+            (CompositeCell.ToClipboardTableTxt [| [| dataCell; CompositeCell.FreeText "label" |] |])
+            "DatamapTesting.txt#row=2\tlabel"
+            "A table data cell and its selector must occupy one clipboard cell."
+
     static member DataMapCellPastePreservesSelector() =
         let dataMap = DataMap(ResizeArray [ DataContext() ])
 
@@ -410,6 +423,8 @@ let Main =
         testList "Regression" [
             testCase "DataMap cell copy includes the selector behind #"
             <| fun _ -> TestCases.DataMapCopyIncludesSelector()
+            testCase "Table cell copy includes the selector behind #"
+            <| fun _ -> TestCases.TableCopyIncludesSelector()
             testCase "DataMap cell paste includes the selector behind #"
             <| fun _ -> TestCases.DataMapCellPastePreservesSelector()
             testCase "DataMap labels survive ARC file refreshes"

--- a/tests/Client/Spreadsheet/DataAnnotator.tests.fs
+++ b/tests/Client/Spreadsheet/DataAnnotator.tests.fs
@@ -155,7 +155,10 @@ let Main =
 
             let actual = toArcRootRelativeFilePath arcFile rootRelativePath
 
-            Expect.equal actual $"./{rootRelativePath}" "Existing ARC-root-relative paths must use an explicit relative prefix."
+            Expect.equal
+                actual
+                $"./{rootRelativePath}"
+                "Existing ARC-root-relative paths must use an explicit relative prefix."
 
         testCase "stores table-view uploads relative to the ARC root"
         <| fun _ ->
@@ -175,9 +178,10 @@ let Main =
                     FileName = "test.csv"
                     FileType = "text/csv"
                     Target =
-                        ComponentDataAnnotatorTypes.AnnotationTarget.Table
-                            (ComponentDataAnnotatorTypes.TargetColumn.Autodetect,
-                             ComponentDataAnnotatorTypes.WriteMode.Replace)
+                        ComponentDataAnnotatorTypes.AnnotationTarget.Table(
+                            ComponentDataAnnotatorTypes.TargetColumn.Autodetect,
+                            ComponentDataAnnotatorTypes.WriteMode.Replace
+                        )
                 }
             |> Result.defaultWith failwith
             |> ignore

--- a/tests/Client/Spreadsheet/DataAnnotator.tests.fs
+++ b/tests/Client/Spreadsheet/DataAnnotator.tests.fs
@@ -123,7 +123,7 @@ let Main =
 
             Expect.equal
                 nextDataMap.DataContexts.[0].FilePath
-                (Some "assays/MyAssay/dataset/test.csv")
+                (Some "./assays/MyAssay/dataset/test.csv")
                 "DataMap file paths must be relative to the ARC root."
 
             Expect.equal
@@ -134,12 +134,12 @@ let Main =
         testCase "creates ARC-root-relative paths for every DataMap parent"
         <| fun _ ->
             let cases = [|
-                ArcFiles.Assay(ArcAssay.init "MyAssay"), "assays/MyAssay/dataset/test.csv"
-                ArcFiles.Study(ArcStudy.init "MyStudy", []), "studies/MyStudy/resources/test.csv"
-                ArcFiles.Run(ArcRun.init "MyRun"), "runs/MyRun/test.csv"
-                ArcFiles.Workflow(ArcWorkflow.init "MyWorkflow"), "workflows/MyWorkflow/test.csv"
+                ArcFiles.Assay(ArcAssay.init "MyAssay"), "./assays/MyAssay/dataset/test.csv"
+                ArcFiles.Study(ArcStudy.init "MyStudy", []), "./studies/MyStudy/resources/test.csv"
+                ArcFiles.Run(ArcRun.init "MyRun"), "./runs/MyRun/test.csv"
+                ArcFiles.Workflow(ArcWorkflow.init "MyWorkflow"), "./workflows/MyWorkflow/test.csv"
                 ArcFiles.DataMap(Some(DatamapParentInfo.create "MyStudy" DataMapParent.Study), DataMap.init ()),
-                "studies/MyStudy/resources/test.csv"
+                "./studies/MyStudy/resources/test.csv"
             |]
 
             for arcFile, expected in cases do
@@ -155,5 +155,37 @@ let Main =
 
             let actual = toArcRootRelativeFilePath arcFile rootRelativePath
 
-            Expect.equal actual rootRelativePath "Existing ARC-root-relative paths must not be prefixed again."
+            Expect.equal actual $"./{rootRelativePath}" "Existing ARC-root-relative paths must use an explicit relative prefix."
+
+        testCase "stores table-view uploads relative to the ARC root"
+        <| fun _ ->
+            let table = ArcTable.init "MyTable"
+            table.AddColumn(CompositeHeader.FreeText "Source", ResizeArray [ CompositeCell.FreeText "sample" ])
+            let assay = ArcAssay.init "MyAssay"
+            assay.AddTable table
+            let arcFile = ArcFiles.Assay assay
+            let mutable nextArcFile = None
+
+            Swate.Components.Page.ArcFileEditor.Helper.applyDataAnnotatorInputToArcFile
+                (ComponentDataAnnotatorTypes.AnnotationDestination.Table table,
+                 arcFile,
+                 (fun value -> nextArcFile <- Some value))
+                {
+                    Selectors = [| "row=2" |]
+                    FileName = "test.csv"
+                    FileType = "text/csv"
+                    Target =
+                        ComponentDataAnnotatorTypes.AnnotationTarget.Table
+                            (ComponentDataAnnotatorTypes.TargetColumn.Autodetect,
+                             ComponentDataAnnotatorTypes.WriteMode.Replace)
+                }
+            |> Result.defaultWith failwith
+            |> ignore
+
+            let outputColumn = nextArcFile.Value.Tables().[0].GetOutputColumn()
+
+            Expect.equal
+                outputColumn.Cells.[0].AsData.FilePath
+                (Some "./assays/MyAssay/dataset/test.csv")
+                "Table-view Data Annotator paths must be relative to the ARC root."
     ]


### PR DESCRIPTION
* Store File Picker and Data Annotator references with an explicit `./` ARC-root-relative path in both table and DataMap views
* Preserve data selectors after `#` when copying single or multiple cells from the normal table view