### PR TITLE
Enforce DataHub Git LFS tracking rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Enforce the DataHub Git LFS tracking ruleset: `isa.*.xlsx` metadata files are never tracked with Git LFS (skipped by automatic tracking, exempt from the commit size policy, and blocked from manual marking), while files inside a `dataset` folder or larger than 25 MB can no longer be unmarked #1316.
+
 ### Changed
 
 -   Simplify Electron FileTree navigation so ARC editors initialize the requested Metadata, table, or DataMap view directly, and show the DataHub download action only in the sidebar.

--- a/docs/GitFunctionalityUserGuide.md
+++ b/docs/GitFunctionalityUserGuide.md
@@ -284,6 +284,14 @@ Settings are stored in local repository config:
 
 Renderer state starts with `DownloadLargeFiles = false` until repository settings are loaded. Use `getGitLfsSettings` after opening an ARC to get the effective repository values.
 
+Manual LFS marking follows the DataHub tracking ruleset (`Swate.Components.Shared.GitLfsRules`):
+
+- `isa.*.xlsx` metadata files must never be tracked with Git LFS. They cannot be marked manually and are exempt from stage-time auto tracking and commit-time size validation.
+- Files below a `dataset` folder must stay tracked with Git LFS and cannot be unmarked.
+- LFS files larger than 25 MB must stay tracked with Git LFS and cannot be unmarked.
+
+The file tree context menu disables blocked toggle actions, and the Main process rejects blocked `Track`/`Untrack` requests as a second line of defense.
+
 When Git LFS is required but unavailable, operations return `FailureKind = Some GitFailureKind.LfsInstallRequired` with a message suitable for the install prompt. The renderer workflow calls `installGitLfs` and retries the original operation after a successful install.
 
 Clone always sets `GIT_LFS_SKIP_SMUDGE=1` first. If `DownloadLargeFiles = true`, clone then persists the setting and runs `git lfs pull` to hydrate content.

--- a/src/Components/src/Page/FileExplorer/FileExplorerGitLfsHelper.fs
+++ b/src/Components/src/Page/FileExplorer/FileExplorerGitLfsHelper.fs
@@ -2,6 +2,7 @@ module Swate.Components.Page.FileExplorer.FileExplorerGitLfsHelper
 
 open Fable.Core
 open Swate.Components.Page.FileExplorer.Types
+open Swate.Components.Shared
 
 module FileItemHelper = Swate.Components.Page.FileExplorer.Helper
 
@@ -22,11 +23,14 @@ let toggleLfsMark
                 if System.String.IsNullOrWhiteSpace relativePath then
                     setError (Some "Cannot mark ARC root as a Git LFS file.")
                 else
-                    let! result = runToggle relativePath markAsLfs
+                    match GitLfsRules.tryGetToggleBlockedReason relativePath item.Size markAsLfs with
+                    | Some blockedReason -> setError (Some blockedReason)
+                    | None ->
+                        let! result = runToggle relativePath markAsLfs
 
-                    match result with
-                    | Ok _ -> setError None
-                    | Error msg -> setError (Some $"Git LFS update failed for '{item.Name}': {msg}")
+                        match result with
+                        | Ok _ -> setError None
+                        | Error msg -> setError (Some $"Git LFS update failed for '{item.Name}': {msg}")
         }
         |> Promise.start
 
@@ -113,14 +117,25 @@ let contextMenuItems
         let needsDownload = FileItemHelper.needsLfsDownload item
         let hasLocalCopy = FileItemHelper.hasLocalLfsCopy item
 
+        let toggleBlockedReason =
+            item.Path
+            |> Option.bind (fun relativePath ->
+                GitLfsRules.tryGetToggleBlockedReason relativePath item.Size (not isMarked)
+            )
+
+        let toggleLabel = if isMarked then "Unmark Git LFS" else "Mark Git LFS"
+
+        let toggleIcon =
+            if isMarked then
+                "swt:fluent--document-dismiss-24-regular"
+            else
+                "swt:fluent--document-add-24-regular"
+
         [
-            ContextMenuItem.create
-                (if isMarked then "Unmark Git LFS" else "Mark Git LFS")
-                (if isMarked then
-                     "swt:fluent--document-dismiss-24-regular"
-                 else
-                     "swt:fluent--document-add-24-regular")
-                (fun () -> onToggleLfsMark item (not isMarked))
+            if toggleBlockedReason.IsSome then
+                ContextMenuItem.disabled toggleLabel toggleIcon
+            else
+                ContextMenuItem.create toggleLabel toggleIcon (fun () -> onToggleLfsMark item (not isMarked))
 
             if isMarked then
                 yield!

--- a/src/Electron/src/Main/Git/GitLfsService.fs
+++ b/src/Electron/src/Main/Git/GitLfsService.fs
@@ -130,6 +130,20 @@ let run
 /// Runs Git LFS without progress or cancellation hooks.
 let runSilently (request: GitLfsRequest) : JS.Promise<Result<GitLfsResult, exn>> = run request ignore (fun () -> false)
 
+/// Validates manual Track/Untrack requests against the DataHub LFS tracking ruleset.
+/// File sizes are not available here, so the size rule is enforced by the callers that know them.
+let validateTrackingRulesetRequest (command: GitLfsCommand) (filePath: string option) : Result<unit, string> =
+    match command, filePath with
+    | Track, Some relativePath ->
+        match GitLfsRules.tryGetMarkAsLfsBlockedReason relativePath with
+        | Some blockedReason -> Error blockedReason
+        | None -> Ok()
+    | Untrack, Some relativePath ->
+        match GitLfsRules.tryGetUnmarkAsLfsBlockedReason relativePath None with
+        | Some blockedReason -> Error blockedReason
+        | None -> Ok()
+    | _ -> Ok()
+
 /// Tracks a repository-relative path in Git LFS. GitService uses this during automatic large-file staging.
 let track (repoPath: string) (relativePath: string) : JS.Promise<Result<unit, string>> = promise {
     let! result = createRequest repoPath Track (Some relativePath) None |> runSilently

--- a/src/Electron/src/Main/Git/GitService.fs
+++ b/src/Electron/src/Main/Git/GitService.fs
@@ -835,6 +835,8 @@ let private getOversizedWorkingTreePaths
             | None ->
                 match tryResolveArcRelativePath arcPath selectedPath with
                 | Error validationError -> failure <- Some(toFailure validationError)
+                // isa.*.xlsx metadata files must never be tracked with Git LFS, regardless of size.
+                | Ok(relativePath, _) when Swate.Components.Shared.GitLfsRules.isIsaMetadataFile relativePath -> ()
                 | Ok(_, absolutePath) ->
                     let! fileSizeOption = tryGetFileSizeInBytes absolutePath
 
@@ -968,6 +970,8 @@ let private validateCommitLfsPolicy (git: ISimpleGit) : JS.Promise<GitResult<uni
             valueOrEmptyArray status.files
             |> Array.filter (fun fileStatus -> GitStatusCode.isStagedIndexStatus fileStatus.index)
             |> Array.map _.path
+            // isa.*.xlsx metadata files must never be tracked with Git LFS, so they are exempt from the size policy.
+            |> Array.filter (Swate.Components.Shared.GitLfsRules.isIsaMetadataFile >> not)
             |> Array.distinct
 
         let oversizedPaths = ResizeArray<string>()

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -711,21 +711,25 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                 match vault.path with
                 | None -> return Error(exn "ARC is not loaded.")
                 | Some arcPath ->
-                    // Always enforce the active ARC root to avoid running against arbitrary repos.
-                    let enforcedRequest = { request with RepoPath = arcPath }
-                    let! result = GitLfs.runChannel vault.window enforcedRequest
+                    match Main.Git.GitLfsService.validateTrackingRulesetRequest request.Command request.FilePath with
+                    | Error blockedReason -> return Error(exn blockedReason)
+                    | Ok() ->
 
-                    match result with
-                    | Error e ->
-                        Swate.Components.console.log ($"Error: {e.Message}")
-                        return Error e
-                    | Ok successResult ->
-                        match enforcedRequest.Command with
-                        | Track
-                        | Untrack -> do! vault.RefreshFileTree()
-                        | _ -> ()
+                        // Always enforce the active ARC root to avoid running against arbitrary repos.
+                        let enforcedRequest = { request with RepoPath = arcPath }
+                        let! result = GitLfs.runChannel vault.window enforcedRequest
 
-                        return Ok successResult
+                        match result with
+                        | Error e ->
+                            Swate.Components.console.log ($"Error: {e.Message}")
+                            return Error e
+                        | Ok successResult ->
+                            match enforcedRequest.Command with
+                            | Track
+                            | Untrack -> do! vault.RefreshFileTree()
+                            | _ -> ()
+
+                            return Ok successResult
         }
     cancelGitLfs = fun (requestId: string) -> GitLfs.cancelChannel requestId
     resolveCloseRequest =

--- a/src/Shared/GitLfsRules.fs
+++ b/src/Shared/GitLfsRules.fs
@@ -1,0 +1,74 @@
+namespace Swate.Components.Shared
+
+open System
+
+/// DataHub ruleset for Git LFS tracking (nfdi4plants/Swate#1316):
+/// isa.*.xlsx metadata files must never be LFS, files inside a dataset folder
+/// and files larger than 25 MB must stay LFS.
+[<RequireQualifiedAccess>]
+module GitLfsRules =
+
+    [<Literal>]
+    let MaxNonLfsFileSizeMb = 25
+
+    let maxNonLfsFileSizeBytes = int64 MaxNonLfsFileSizeMb * 1024L * 1024L
+
+    let private isaFileNamePrefix = "isa."
+    let private isaFileNameSuffix = ".xlsx"
+
+    /// Matches isa.*.xlsx metadata file names (e.g. isa.investigation.xlsx, isa.study.xlsx).
+    let isIsaMetadataFile (relativePath: string) =
+        if String.IsNullOrWhiteSpace relativePath then
+            false
+        else
+            let fileName =
+                relativePath |> PathHelpers.normalizeRelativePath |> PathHelpers.getFileName
+
+            fileName.Length > isaFileNamePrefix.Length + isaFileNameSuffix.Length
+            && fileName.StartsWith(isaFileNamePrefix, StringComparison.OrdinalIgnoreCase)
+            && fileName.EndsWith(isaFileNameSuffix, StringComparison.OrdinalIgnoreCase)
+
+    /// Matches files below a dataset folder anywhere in the relative path.
+    let isInDatasetFolder (relativePath: string) =
+        if String.IsNullOrWhiteSpace relativePath then
+            false
+        else
+            let segments =
+                relativePath
+                |> PathHelpers.normalizeRelativePath
+                |> fun path -> path.Split([| '/' |], StringSplitOptions.RemoveEmptyEntries)
+
+            segments.Length > 1
+            && segments.[.. segments.Length - 2]
+               |> Array.exists (fun segment ->
+                   PathHelpers.pathsEqual segment ARCtrl.ArcPathHelper.AssayDatasetFolderName
+               )
+
+    let exceedsNonLfsSizeLimit (sizeInBytes: int64 option) =
+        sizeInBytes |> Option.exists (fun size -> size > maxNonLfsFileSizeBytes)
+
+    /// Explains why a file must not be marked as Git LFS, if a rule forbids it.
+    let tryGetMarkAsLfsBlockedReason (relativePath: string) =
+        if isIsaMetadataFile relativePath then
+            let fileName = PathHelpers.getFileName relativePath
+            Some $"'{fileName}' is an ARC metadata file (isa.*.xlsx) and must not be tracked with Git LFS."
+        else
+            None
+
+    /// Explains why a file must stay marked as Git LFS, if a rule forbids unmarking it.
+    let tryGetUnmarkAsLfsBlockedReason (relativePath: string) (sizeInBytes: int64 option) =
+        if isInDatasetFolder relativePath then
+            let fileName = PathHelpers.getFileName relativePath
+            Some $"'{fileName}' is inside a dataset folder and must stay tracked with Git LFS."
+        elif exceedsNonLfsSizeLimit sizeInBytes then
+            let fileName = PathHelpers.getFileName relativePath
+            Some $"'{fileName}' is larger than {MaxNonLfsFileSizeMb} MB and must stay tracked with Git LFS."
+        else
+            None
+
+    /// Explains why toggling the Git LFS mark in the given direction is not allowed, if any rule forbids it.
+    let tryGetToggleBlockedReason (relativePath: string) (sizeInBytes: int64 option) (markAsLfs: bool) =
+        if markAsLfs then
+            tryGetMarkAsLfsBlockedReason relativePath
+        else
+            tryGetUnmarkAsLfsBlockedReason relativePath sizeInBytes

--- a/src/Shared/Swate.Components.Core.fsproj
+++ b/src/Shared/Swate.Components.Core.fsproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Content Include="@(Compile)" Pack="true" PackagePath="fable/%(RelativeDir)%(Filename)%(Extension)" />
     <Compile Include="PathHelpers.fs" />
+    <Compile Include="GitLfsRules.fs" />
     <Compile Include="Database.fs" />
     <Compile Include="ARCtrl.Helper.fs" />
     <Compile Include="DTOs\AdvancedSearch.fs" />

--- a/tests/Electron.Core/GitValidation.test.fs
+++ b/tests/Electron.Core/GitValidation.test.fs
@@ -17,6 +17,7 @@ open Swate.Electron.Shared.IPCTypes
 open Vitest
 
 module GitService = Main.Git.GitService
+module GitLfsService = Main.Git.GitLfsService
 module GitProvisioningService = Main.Git.GitProvisioningService
 module GitAuthAdapter = Main.Git.GitAuthAdapter
 module GitCommandResolver = Main.Git.GitCommandResolver
@@ -492,6 +493,60 @@ Vitest.describe (
                             "remote.origin.lfsurl=https://oauth2:abc123@git.nfdi4plants.org/caroott/TestARCGit.git/info/lfs"
                     )
                     .toBe (true)
+        )
+)
+
+Vitest.describe (
+    "GitLfsService.validateTrackingRulesetRequest",
+    fun () ->
+        let expectBlocked (result: Result<unit, string>) =
+            match result with
+            | Ok() -> failwith "Expected the request to be blocked."
+            | Error _ -> ()
+
+        let expectAllowed (result: Result<unit, string>) =
+            match result with
+            | Ok() -> ()
+            | Error reason -> failwith $"Expected the request to be allowed but got: {reason}"
+
+        Vitest.test (
+            "blocks tracking isa metadata files",
+            fun () ->
+                GitLfsService.validateTrackingRulesetRequest Track (Some "studies/study_01/isa.study.xlsx")
+                |> expectBlocked
+        )
+
+        Vitest.test (
+            "blocks tracking the root investigation file",
+            fun () ->
+                GitLfsService.validateTrackingRulesetRequest Track (Some "isa.investigation.xlsx")
+                |> expectBlocked
+        )
+
+        Vitest.test (
+            "allows tracking ordinary files",
+            fun () ->
+                GitLfsService.validateTrackingRulesetRequest Track (Some "assays/assay_01/dataset/raw.bin")
+                |> expectAllowed
+        )
+
+        Vitest.test (
+            "blocks untracking files below a dataset folder",
+            fun () ->
+                GitLfsService.validateTrackingRulesetRequest Untrack (Some "assays/assay_01/dataset/raw.bin")
+                |> expectBlocked
+        )
+
+        Vitest.test (
+            "allows untracking ordinary files",
+            fun () ->
+                GitLfsService.validateTrackingRulesetRequest Untrack (Some "docs/large-report.pdf")
+                |> expectAllowed
+        )
+
+        Vitest.test (
+            "allows commands without a file path",
+            fun () -> GitLfsService.validateTrackingRulesetRequest Pull None |> expectAllowed
         )
 )
 

--- a/tests/Electron.Renderer/FileTreeContextMenu.test.fs
+++ b/tests/Electron.Renderer/FileTreeContextMenu.test.fs
@@ -438,6 +438,93 @@ Vitest.describe (
         )
 
         Vitest.test (
+            "composed menu disables marking isa metadata files as Git LFS",
+            fun () -> promise {
+                let item = createFileItem "isa.study.xlsx" (Some "studies/study_01/isa.study.xlsx")
+
+                let mutable toggledPath = None
+
+                let config = {
+                    createContextMenuConfig () with
+                        runToggleLfsMark =
+                            fun path _ -> promise {
+                                toggledPath <- Some path
+                                return Ok()
+                            }
+                }
+
+                let menuItems = createComposedContextMenuItems config item
+
+                let markItem =
+                    menuItems |> List.find (fun menuItem -> menuItem.Label = "Mark Git LFS")
+
+                Vitest.expect(markItem.Disabled).toEqual (Some true)
+
+                markItem.OnClick()
+                do! Promise.sleep 0
+
+                Vitest.expect(toggledPath).toEqual (None)
+            }
+        )
+
+        Vitest.test (
+            "composed menu keeps marking ordinary files as Git LFS enabled",
+            fun () ->
+                let item = createFileItem "raw.bin" (Some "assays/AssayA/raw.bin")
+                let menuItems = createComposedContextMenuItems (createContextMenuConfig ()) item
+
+                let markItem =
+                    menuItems |> List.find (fun menuItem -> menuItem.Label = "Mark Git LFS")
+
+                Vitest.expect(markItem.Disabled).toEqual (None)
+        )
+
+        Vitest.test (
+            "composed menu disables unmarking dataset files from Git LFS",
+            fun () ->
+                let item = createLfsFileItem "raw.bin" "assays/AssayA/dataset/raw.bin" true false
+
+                let menuItems = createComposedContextMenuItems (createContextMenuConfig ()) item
+
+                let unmarkItem =
+                    menuItems |> List.find (fun menuItem -> menuItem.Label = "Unmark Git LFS")
+
+                Vitest.expect(unmarkItem.Disabled).toEqual (Some true)
+        )
+
+        Vitest.test (
+            "composed menu disables unmarking LFS files larger than 25 MB",
+            fun () ->
+                let item = {
+                    createLfsFileItem "large.bin" "data/large.bin" true false with
+                        Size = Some(26L * 1024L * 1024L)
+                }
+
+                let menuItems = createComposedContextMenuItems (createContextMenuConfig ()) item
+
+                let unmarkItem =
+                    menuItems |> List.find (fun menuItem -> menuItem.Label = "Unmark Git LFS")
+
+                Vitest.expect(unmarkItem.Disabled).toEqual (Some true)
+        )
+
+        Vitest.test (
+            "composed menu keeps unmarking small non-dataset LFS files enabled",
+            fun () ->
+                let item = {
+                    createLfsFileItem "small.bin" "data/small.bin" true false with
+                        Size = Some 1024L
+                }
+
+                let menuItems = createComposedContextMenuItems (createContextMenuConfig ()) item
+
+                let unmarkItem =
+                    menuItems |> List.find (fun menuItem -> menuItem.Label = "Unmark Git LFS")
+
+                Vitest.expect(unmarkItem.Disabled).toEqual (None)
+        )
+
+        Vitest.test (
             "delete action is styled as destructive ARC action",
             fun () ->
                 let item = createFileItem "protocol.md" (Some "assays/AssayA/protocol.md")

--- a/tests/Shared/GitLfsRules.Tests.fs
+++ b/tests/Shared/GitLfsRules.Tests.fs
@@ -1,0 +1,154 @@
+module GitLfsRulesTests
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+
+open Swate.Components.Shared
+
+let tests =
+    testList "GitLfsRules" [
+        testList "isIsaMetadataFile" [
+            testCase "matches isa.investigation.xlsx at the ARC root"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.isIsaMetadataFile "isa.investigation.xlsx")
+                    "Root level isa metadata files should match."
+
+            testCase "matches nested isa.study.xlsx"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.isIsaMetadataFile "studies/study_01/isa.study.xlsx")
+                    "Nested isa metadata files should match."
+
+            testCase "matches isa metadata files case-insensitively"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.isIsaMetadataFile "assays/assay_01/ISA.Assay.XLSX")
+                    "Casing should not affect the match."
+
+            testCase "matches windows-style separators"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.isIsaMetadataFile "studies\\study_01\\isa.datamap.xlsx")
+                    "Backslash paths should be normalized before matching."
+
+            testCase "does not match ordinary xlsx files"
+            <| fun _ ->
+                Expect.isFalse
+                    (GitLfsRules.isIsaMetadataFile "assays/assay_01/measurements.xlsx")
+                    "Ordinary spreadsheets should not match."
+
+            testCase "does not match isa.xlsx without a middle segment"
+            <| fun _ ->
+                Expect.isFalse (GitLfsRules.isIsaMetadataFile "isa.xlsx") "isa.*.xlsx requires a middle name segment."
+
+            testCase "does not match files inside an isa-named folder"
+            <| fun _ ->
+                Expect.isFalse
+                    (GitLfsRules.isIsaMetadataFile "isa.study.xlsx/raw.bin")
+                    "Only the file name itself should be inspected."
+
+            testCase "does not match empty paths"
+            <| fun _ -> Expect.isFalse (GitLfsRules.isIsaMetadataFile "") "Empty paths should not match."
+        ]
+
+        testList "isInDatasetFolder" [
+            testCase "matches files directly inside a dataset folder"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.isInDatasetFolder "assays/assay_01/dataset/raw.bin")
+                    "Files below a dataset folder should match."
+
+            testCase "matches files nested deeper below a dataset folder"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.isInDatasetFolder "assays/assay_01/dataset/run_01/raw.bin")
+                    "Deeper nesting below a dataset folder should match."
+
+            testCase "matches dataset segments case-insensitively"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.isInDatasetFolder "assays/assay_01/DataSet/raw.bin")
+                    "Casing of the dataset segment should not matter."
+
+            testCase "does not match a file named dataset"
+            <| fun _ ->
+                Expect.isFalse
+                    (GitLfsRules.isInDatasetFolder "assays/assay_01/dataset")
+                    "The dataset segment must be a folder, not the item itself."
+
+            testCase "does not match folders that only start with dataset"
+            <| fun _ ->
+                Expect.isFalse
+                    (GitLfsRules.isInDatasetFolder "assays/assay_01/datasets/raw.bin")
+                    "Only exact dataset segments should match."
+
+            testCase "does not match empty paths"
+            <| fun _ -> Expect.isFalse (GitLfsRules.isInDatasetFolder "") "Empty paths should not match."
+        ]
+
+        testList "exceedsNonLfsSizeLimit" [
+            testCase "does not flag files at exactly 25 MB"
+            <| fun _ ->
+                Expect.isFalse
+                    (GitLfsRules.exceedsNonLfsSizeLimit (Some(25L * 1024L * 1024L)))
+                    "Exactly 25 MB should still be allowed outside LFS."
+
+            testCase "flags files above 25 MB"
+            <| fun _ ->
+                Expect.isTrue
+                    (GitLfsRules.exceedsNonLfsSizeLimit (Some(25L * 1024L * 1024L + 1L)))
+                    "Files above 25 MB must stay in LFS."
+
+            testCase "does not flag unknown sizes"
+            <| fun _ ->
+                Expect.isFalse
+                    (GitLfsRules.exceedsNonLfsSizeLimit None)
+                    "Unknown sizes should not trigger the size rule."
+        ]
+
+        testList "toggle blocking" [
+            testCase "blocks marking isa metadata files as LFS"
+            <| fun _ ->
+                Expect.isSome
+                    (GitLfsRules.tryGetMarkAsLfsBlockedReason "studies/study_01/isa.study.xlsx")
+                    "isa.*.xlsx must not be marked as LFS."
+
+            testCase "allows marking ordinary files as LFS"
+            <| fun _ ->
+                Expect.isNone
+                    (GitLfsRules.tryGetMarkAsLfsBlockedReason "assays/assay_01/dataset/raw.bin")
+                    "Ordinary files may be marked as LFS."
+
+            testCase "blocks unmarking files inside a dataset folder"
+            <| fun _ ->
+                Expect.isSome
+                    (GitLfsRules.tryGetUnmarkAsLfsBlockedReason "assays/assay_01/dataset/raw.bin" None)
+                    "Files below dataset folders must stay LFS."
+
+            testCase "blocks unmarking files above the size limit"
+            <| fun _ ->
+                Expect.isSome
+                    (GitLfsRules.tryGetUnmarkAsLfsBlockedReason "large.bin" (Some(26L * 1024L * 1024L)))
+                    "Files above 25 MB must stay LFS."
+
+            testCase "allows unmarking small files outside dataset folders"
+            <| fun _ ->
+                Expect.isNone
+                    (GitLfsRules.tryGetUnmarkAsLfsBlockedReason "docs/readme.pdf" (Some 1024L))
+                    "Small files outside dataset folders may be unmarked."
+
+            testCase "tryGetToggleBlockedReason routes by direction"
+            <| fun _ ->
+                Expect.isSome
+                    (GitLfsRules.tryGetToggleBlockedReason "isa.investigation.xlsx" None true)
+                    "Marking an isa metadata file must be blocked."
+
+                Expect.isNone
+                    (GitLfsRules.tryGetToggleBlockedReason "isa.investigation.xlsx" None false)
+                    "Unmarking an isa metadata file must stay possible."
+        ]
+    ]

--- a/tests/Shared/Shared.Tests.fs
+++ b/tests/Shared/Shared.Tests.fs
@@ -14,6 +14,7 @@ let shared =
         example_tests
         LandingTests.tests
         PathHelpersTests.tests
+        GitLfsRulesTests.tests
         ProvenanceGroupingTests.tests
         ProvenanceGroupingARCtrlConverterTests.tests
     ]

--- a/tests/Shared/Shared.Tests.fsproj
+++ b/tests/Shared/Shared.Tests.fsproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <Compile Include="Landing.Tests.fs"/>
     <Compile Include="PathHelpers.Tests.fs"/>
+    <Compile Include="GitLfsRules.Tests.fs"/>
     <Compile Include="ProvenanceGrouping.Tests.fs"/>
     <Compile Include="ProvenanceGrouping.ARCtrlConverter.Tests.fs"/>
     <Compile Include="Shared.Tests.fs"/>


### PR DESCRIPTION
Closes #1316

Swate now enforces the DataHub ruleset for Git LFS tracking:

- `isa.*.xlsx` metadata files are never tracked with LFS — they are skipped by stage-time auto-tracking, exempt from the commit size policy, and can't be marked as LFS manually.
- Files inside a `dataset` folder and LFS files larger than 25 MB can no longer be unmarked.

The rules live in a new shared module (`GitLfsRules`) and are applied in three places: the file explorer context menu (blocked toggles are disabled), the toggle handler (shows the reason instead of running git), and the main-process IPC endpoint (rejects blocked Track/Untrack requests before spawning git).
