### PR TITLE
Remove extra column space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Keep the last column visible when selected in the main table and DataMap tab by removing the trailing blank horizontal scroll area.
 -   Prevent deleted ARC table tabs from reappearing by applying rename, delete, and add operations to a fresh copy of the current editor state without mutating refs during React rendering.
 -   Keep active-view ownership inside the reusable ARC editor, preserve valid table selections across immutable ARC updates, and remount it for Electron sidebar Metadata, table, and DataMap selections.
 -   Preserve stable table identifiers across rerenders and reorder operations, use one shared prefix for drag-ID generation and parsing, and normalize the active view after table deletion so drag-and-drop and tab state remain valid.

--- a/src/Components/src/Composite/Table/Table.fs
+++ b/src/Components/src/Composite/Table/Table.fs
@@ -278,11 +278,11 @@ swt:p-0"""
                                 if isSafari then
                                     style.custom ("willChange", "transform")
                                     style.custom ("minHeight", $"{rowVirtualizer.getTotalSize ()}px")
-                                    style.minWidth (columnVirtualizer.getTotalSize () + 800)
+                                    style.minWidth (columnVirtualizer.getTotalSize ())
                                     style.custom ("contain", "size layout paint")
                                 else
                                     style.height (rowVirtualizer.getTotalSize ())
-                                    style.width (columnVirtualizer.getTotalSize () + 800) // extra space to improve UX with rightmost columns
+                                    style.width (columnVirtualizer.getTotalSize ())
 
                                 style.position.relative
                             ]


### PR DESCRIPTION
* Remove the extra column space, so that the focus no longer jumps when the last colum is selected