### PR TITLE
Open the error modal when the selected ARC no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Show the error modal when a recently used ARC no longer exists at its saved path instead of opening an Electron system error.
 -   Prevent deleted ARC table tabs from reappearing by applying rename, delete, and add operations to a fresh copy of the current editor state without mutating refs during React rendering.
 -   Keep active-view ownership inside the reusable ARC editor, preserve valid table selections across immutable ARC updates, and remount it for Electron sidebar Metadata, table, and DataMap selections.
 -   Preserve stable table identifiers across rerenders and reorder operations, use one shared prefix for drag-ID generation and parsing, and normalize the active view after table deletion so drag-and-drop and tab state remain valid.

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -147,7 +147,7 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
                 let! arcPathExists = pathExistsAsync arcPath
 
                 if not arcPathExists then
-                    return Error(exn $"The ARC path no longer exists: '{arcPath}'.")
+                    return Error(exn $"The ARC cannot be found at location: '{arcPath}'.")
                 else
                     let windowId = windowIdFromIpcEvent event
                     let! disposition = ARC_VAULTS.OpenOrFocusArc(windowId, arcPath)

--- a/src/Electron/src/Main/IPC/IArcVaultsApi.fs
+++ b/src/Electron/src/Main/IPC/IArcVaultsApi.fs
@@ -144,9 +144,14 @@ let api (event: IpcMainInvokeEvent) : IPCTypes.IArcVaultsApi = {
         fun (arcPath: string) -> promise {
             try
                 let arcPath = PathHelpers.normalizePath arcPath
-                let windowId = windowIdFromIpcEvent event
-                let! disposition = ARC_VAULTS.OpenOrFocusArc(windowId, arcPath)
-                return Ok(ArcOpenDisposition.path disposition)
+                let! arcPathExists = pathExistsAsync arcPath
+
+                if not arcPathExists then
+                    return Error(exn $"The ARC path no longer exists: '{arcPath}'.")
+                else
+                    let windowId = windowIdFromIpcEvent event
+                    let! disposition = ARC_VAULTS.OpenOrFocusArc(windowId, arcPath)
+                    return Ok(ArcOpenDisposition.path disposition)
             with e ->
                 return Error e
         }


### PR DESCRIPTION
* Originally, a system error was thrown when the opening of a no longer existing ARC was tried
* Now an error modal is opened instead