### PR TITLE
Prevent recent-ARC broadcasts to destroyed Electron windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Prevent simultaneous Swate Electron window shutdowns from sending recent-ARC updates to already destroyed windows.
 -   Prevent deleted ARC table tabs from reappearing by applying rename, delete, and add operations to a fresh copy of the current editor state without mutating refs during React rendering.
 -   Keep active-view ownership inside the reusable ARC editor, preserve valid table selections across immutable ARC updates, and remount it for Electron sidebar Metadata, table, and DataMap selections.
 -   Preserve stable table identifiers across rerenders and reorder operations, use one shared prefix for drag-ID generation and parsing, and normalize the active view after table deletion so drag-and-drop and tab state remain valid.

--- a/src/Electron/src/Main/ArcVault/ArcVault.fs
+++ b/src/Electron/src/Main/ArcVault/ArcVault.fs
@@ -551,10 +551,11 @@ type ArcVaults() =
             if arr.Length > 0 then
                 arr
                 |> Array.iter (fun vault ->
-                    Remoting.createIpc ()
-                    |> Remoting.withWindow vault.window
-                    |> Remoting.buildProxySender<IRecentArcsRendererApi>
-                    |> fun client -> client.recentARCsUpdate recentARCs
+                    if not (vault.window.isDestroyed ()) then
+                        Remoting.createIpc ()
+                        |> Remoting.withWindow vault.window
+                        |> Remoting.buildProxySender<IRecentArcsRendererApi>
+                        |> fun client -> client.recentARCsUpdate recentARCs
                 )
 
     /// Centralized side-effect: update recent ARCs store and broadcast to all windows.

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -14,8 +14,12 @@ open Swate.Electron.Shared.FileIOHelper
 open Vitest
 
 let private lifecycleTestWindow id isDestroyed onSend =
+    // The remoting proxy calls webContents.send with channel and payload arguments.
+    // Discard those transport details so lifecycle tests only observe whether a send occurred.
     let send: obj = emitJsExpr onSend "((..._args) => $0())"
 
+    // ArcVault only needs this subset of BrowserWindow for lifecycle broadcasts. Keeping the
+    // fixture minimal avoids constructing a real Electron window in the Vitest environment.
     createObj [
         "id" ==> id
         "isDestroyed" ==> (fun () -> isDestroyed)

--- a/tests/Electron.Core/ArcVaultHelper.test.fs
+++ b/tests/Electron.Core/ArcVaultHelper.test.fs
@@ -1,6 +1,8 @@
 module ElectronCore.ArcVaultHelperTests
 
 open ARCtrl
+open Fable.Core.JsInterop
+open Fable.Electron.Main
 open Main.ARCtrlExtensions
 open Main.ArcVault
 open Main.ArcVaultHelper
@@ -10,6 +12,16 @@ open Main.Notes.NoteConstants
 open Swate.Components.Shared
 open Swate.Electron.Shared.FileIOHelper
 open Vitest
+
+let private lifecycleTestWindow id isDestroyed onSend =
+    let send: obj = emitJsExpr onSend "((..._args) => $0())"
+
+    createObj [
+        "id" ==> id
+        "isDestroyed" ==> (fun () -> isDestroyed)
+        "webContents" ==> createObj [ "send" ==> send ]
+    ]
+    |> unbox<BrowserWindow>
 
 let private mkdirRecursiveAsync (directoryPath: string) = promise {
     let! _ = mkdirAsync directoryPath (MkdirOptions(recursive = true))
@@ -44,6 +56,26 @@ let private addDataMapToAllEntityTypes (arc: ARC) =
 Vitest.describe (
     "ArcVaultHelper",
     fun () ->
+        Vitest.test (
+            "recent ARC broadcasts skip windows destroyed during simultaneous shutdown",
+            fun () ->
+                let mutable aliveWindowSendCount = 0
+
+                let aliveWindow =
+                    lifecycleTestWindow 1 false (fun () -> aliveWindowSendCount <- aliveWindowSendCount + 1)
+
+                let destroyedWindow =
+                    lifecycleTestWindow 2 true (fun () -> failwith "Destroyed window received an IPC message.")
+
+                let vaults = ArcVaults()
+                vaults.Vaults.Add(aliveWindow.id, ArcVault(aliveWindow))
+                vaults.Vaults.Add(destroyedWindow.id, ArcVault(destroyedWindow))
+
+                vaults.BroadcastRecentARCs()
+
+                Vitest.expect(aliveWindowSendCount).toBe (1)
+        )
+
         Vitest.test (
             "file watcher polling defaults to Windows only",
             fun () ->


### PR DESCRIPTION
* Add a check to prevent broadcasting updates to closed ARC windows.