### PR TITLE
Fix overscroll bug with scrolling to last column/row with whitespace …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Report a missing git identity as its own failure with setup guidance instead of passing git's raw "Please tell me who you are" output to the user #1305.
 -   Respect GitLab's "use a private email in commits" setting by signing commits with the account's commit email instead of its primary email.
 -   Fix Template bug "You've hit dummy code" #1266, #1264 (by @Freymaurer) 
+-   Fix overscroll issue on last table column on smaller screens (by @Freymaurer)
 
 ## 2.0.7 - 2026-08-06
 

--- a/src/Components/playground/App.tsx
+++ b/src/Components/playground/App.tsx
@@ -218,7 +218,7 @@ function WorkspaceContainer() {
 
 const App = () => {
     return (
-        <WorkspaceContainer />
+        <TableContainer />
     );
 };
 

--- a/src/Components/src/Composite/Table/Table.fs
+++ b/src/Components/src/Composite/Table/Table.fs
@@ -125,17 +125,18 @@ swt:p-0"""
             )
 
         /// ⚠️ There is bug with the ``scrollToIndex`` function and the ``paddingEnd`` option for ``useVirtualizer``.
-        /// It seems like ``scrollToIndex(lastIndex)`` does not actually scroll to the element, but instead scrolls to the end of the scroll container. 
-        /// Using ``align = center`` is a workaround for this issue, but it is not ideal. 
+        /// It seems like ``scrollToIndex(lastIndex)`` does not actually scroll to the element, but instead scrolls to the end of the scroll container.
+        /// Using ``align = center`` is a workaround for this issue, but it is not ideal.
         /// This is a issue with the library and is being tracked here: https://github.com/TanStack/virtual/issues/1257
         let scrollTo =
             fun (coordinate: CellCoordinate) ->
                 if coordinate.y = rowCount - 1 then
-                    rowVirtualizer.scrollToIndex(coordinate.y, align = Virtual.AlignOption.Center)
+                    rowVirtualizer.scrollToIndex (coordinate.y, align = Virtual.AlignOption.Center)
                 else
                     rowVirtualizer.scrollToIndex (coordinate.y)
+
                 if coordinate.x = columnCount - 1 then
-                    columnVirtualizer.scrollToIndex(coordinate.x, align = Virtual.AlignOption.Center)
+                    columnVirtualizer.scrollToIndex (coordinate.x, align = Virtual.AlignOption.Center)
                 else
                     columnVirtualizer.scrollToIndex (coordinate.x)
 

--- a/src/Components/src/Composite/Table/Table.fs
+++ b/src/Components/src/Composite/Table/Table.fs
@@ -78,6 +78,8 @@ swt:p-0"""
             ?debug: bool
         ) =
 
+        let WhiteSpacePX = 800
+
         // check for navigator agent if it is safari
         let isSafari =
             let userAgent = Browser.Dom.window?navigator?userAgent |> string
@@ -98,6 +100,7 @@ swt:p-0"""
                 gap = 0,
                 scrollPaddingStart = 1.5 * float Constants.Table.DefaultRowHeight,
                 scrollPaddingEnd = 1.5 * float Constants.Table.DefaultRowHeight,
+                paddingEnd = WhiteSpacePX, // extra space to improve UX with rightmost columns
                 rangeExtractor =
                     (fun range ->
                         let next = set [ 0; yield! Virtual.defaultRangeExtractor range ]
@@ -112,7 +115,7 @@ swt:p-0"""
                 estimateSize = (fun _ -> Constants.Table.DefaultColumnWidth),
                 overscan = 2,
                 gap = 0,
-                scrollPaddingEnd = 1.5 * float Constants.Table.DefaultColumnWidth,
+                paddingEnd = WhiteSpacePX, // extra space to improve UX with rightmost columns
                 horizontal = true,
                 rangeExtractor =
                     (fun range ->
@@ -121,11 +124,20 @@ swt:p-0"""
                     )
             )
 
-
+        /// ⚠️ There is bug with the ``scrollToIndex`` function and the ``paddingEnd`` option for ``useVirtualizer``.
+        /// It seems like ``scrollToIndex(lastIndex)`` does not actually scroll to the element, but instead scrolls to the end of the scroll container. 
+        /// Using ``align = center`` is a workaround for this issue, but it is not ideal. 
+        /// This is a issue with the library and is being tracked here: https://github.com/TanStack/virtual/issues/1257
         let scrollTo =
             fun (coordinate: CellCoordinate) ->
-                rowVirtualizer.scrollToIndex (coordinate.y)
-                columnVirtualizer.scrollToIndex (coordinate.x)
+                if coordinate.y = rowCount - 1 then
+                    rowVirtualizer.scrollToIndex(coordinate.y, align = Virtual.AlignOption.Center)
+                else
+                    rowVirtualizer.scrollToIndex (coordinate.y)
+                if coordinate.x = columnCount - 1 then
+                    columnVirtualizer.scrollToIndex(coordinate.x, align = Virtual.AlignOption.Center)
+                else
+                    columnVirtualizer.scrollToIndex (coordinate.x)
 
         let onSelect =
             fun cell newCellRange ->
@@ -278,11 +290,11 @@ swt:p-0"""
                                 if isSafari then
                                     style.custom ("willChange", "transform")
                                     style.custom ("minHeight", $"{rowVirtualizer.getTotalSize ()}px")
-                                    style.minWidth (columnVirtualizer.getTotalSize () + 800)
+                                    style.minWidth (columnVirtualizer.getTotalSize ())
                                     style.custom ("contain", "size layout paint")
                                 else
                                     style.height (rowVirtualizer.getTotalSize ())
-                                    style.width (columnVirtualizer.getTotalSize () + 800) // extra space to improve UX with rightmost columns
+                                    style.width (columnVirtualizer.getTotalSize ())
 
                                 style.position.relative
                             ]
@@ -504,6 +516,14 @@ swt:p-0"""
                     prop.onClick (fun _ ->
                         TableHandler.current.SelectHandle.selectAt ({| x = 500; y = 500 |}, false)
                         TableHandler.current.scrollTo ({| x = 500; y = 500 |})
+                    )
+                ]
+                Html.button [
+                    prop.className "swt:btn swt:btn-primary"
+                    prop.text "scroll to 999, 999"
+                    prop.onClick (fun _ ->
+                        TableHandler.current.SelectHandle.selectAt ({| x = 999; y = 999 |}, false)
+                        TableHandler.current.scrollTo ({| x = 999; y = 999 |})
                     )
                 ]
                 Table.Table(

--- a/src/Components/src/JsBindings/Virtual.fs
+++ b/src/Components/src/JsBindings/Virtual.fs
@@ -41,16 +41,17 @@ module Virtual =
         member this.getVirtualIndexes() : int[] = jsNative
         member this.getTotalSize() : int = jsNative
 
-        member this.scrollToIndex
-            (
-                index: int,
-                ?options:
-                    {|
-                        align: AlignOption option
-                        behavior: ScrollBehavior option
-                    |}
-            ) : unit =
-            jsNative
+        [<ParamObject(1)>]
+        member this.scrollToIndex(index: int, ?align: AlignOption, ?behavior: ScrollBehavior) : unit = jsNative
+
+        [<ParamObject>]
+        member this.scrollToEnd(?behavior: ScrollBehavior option) : unit = jsNative
+
+        [<ParamObject(1)>]
+        member this.scrollBy(delta: int, ?behavior: ScrollBehavior option) : unit = jsNative
+
+        [<ParamObject(1)>]
+        member this.scrollToOffset(offset: int, ?align: AlignOption, ?behavior: ScrollBehavior) : unit = jsNative
 
         member this.scrollRect: {| height: int; width: int |} = jsNative
         member this.scrollOffset: int = jsNative
@@ -82,6 +83,7 @@ type Virtual =
             ?paddingStart: int,
             ?paddingEnd: int,
             ?gap: int,
-            ?lanes: int
+            ?lanes: int,
+            ?scrollEndThreshold: int
         ) : Virtual.Virtualizer<obj, obj> =
         jsNative


### PR DESCRIPTION
# The Bug

1. Have the window smaller than the whitespace in the Table component, then have multiple columns to allow scrolling.
2. Use either keyboard navigation or mouseclicks to navigate to the last column.
3. ⚠️ the last column MUST NOT be fully visible or the bug is not triggered. This is most easily done by doing it with keyboard navigation
4. During the transition to the last column, instead of scrolling the last column into view, tanstack virtual will scroll to the scroll container element end 🐛 This is a bug in tanstack virtual, tracked here: https://github.com/TanStack/virtual/issues/1257

## What i did

- Implement a hotfix, forcing a different scroll behavior for the last index, by using `align=center`, which changes scroll behavior. This is not optimal, as it will not scroll the element into view, instead it will position it in the view center. **This is different behavior to earlier scrolls**, but acceptable.
- Create minimal reproduction and issue in tanstack virtual to have this solved at the source of the issue
- add a comment to my bandaid fix, with reference to the issue and description.

## What i tried

- calculating the exact position of the element and scrolling there. This is not possible as tanstacks `_.getVirtualItem` only returns the currently renderer items (so like 12 items). This will propably work for keyboard navigation, but will not work if we at some point implement a search function and are scrolling across the table.