### PR TITLE
Add workaround for empty cell serialization

### DIFF
--- a/src/Components/src/ARCtrl/EmptyColumnJson.fs
+++ b/src/Components/src/ARCtrl/EmptyColumnJson.fs
@@ -1,0 +1,73 @@
+module internal ARCtrl.EmptyColumnJson
+
+open Fable.Core
+open Fable.Core.JsInterop
+
+module private NativeJson =
+    [<Emit("JSON.parse($0, $1)")>]
+    let parseWithReviver (json: string) (reviver: System.Func<string, obj, obj>) : obj = jsNative
+
+    [<Emit("Array.isArray($0)")>]
+    let isArray (value: obj) : bool = jsNative
+
+    [<Emit("$0 !== null && typeof $0 === 'object' && !Array.isArray($0)")>]
+    let isObject (value: obj) : bool = jsNative
+
+    [<Emit("$0 === null")>]
+    let isNull (value: obj) : bool = jsNative
+
+    [<Emit("Number.isInteger($0)")>]
+    let isInteger (value: obj) : bool = jsNative
+
+[<AllowNullLiteral>]
+type private TableJson =
+    abstract headers: obj
+    abstract rowCount: float
+    abstract columns: obj
+    abstract h: obj
+    abstract r: float
+    abstract c: obj
+
+/// Temporary workaround for ARCtrl encoding an empty sparse column as null,
+/// although its decoder expects an array. Operates only on serialized table
+/// payloads; the source ARC and its sparse cells are never mutated.
+let normalize (compressed: bool) (json: string) =
+    if not (json.Contains "null") then
+        json
+    else
+        let mutable changed = false
+
+        let normalizeTable (value: obj) =
+            if NativeJson.isObject value then
+                let table = unbox<TableJson> value
+
+                let headers, rowCount, columns =
+                    if compressed then
+                        table.h, table.r, table.c
+                    else
+                        table.headers, table.rowCount, table.columns
+
+                if rowCount > 0. && NativeJson.isArray headers && NativeJson.isArray columns then
+                    for entry in unbox<obj[]> columns do
+                        if NativeJson.isArray entry then
+                            let pair = unbox<obj[]> entry
+
+                            if pair.Length = 2 && NativeJson.isInteger pair.[0] && NativeJson.isNull pair.[1] then
+                                pair.[1] <- box ([||]: obj[])
+                                changed <- true
+
+        let parsed =
+            NativeJson.parseWithReviver
+                json
+                (System.Func<_, _, _>(fun key value ->
+                    // Both ARCtrl formats use Tables for assay/study/run tables
+                    // and table for templates, including nested ARC documents.
+                    if key = "Tables" && NativeJson.isArray value then
+                        unbox<obj[]> value |> Array.iter normalizeTable
+                    elif key = "table" then
+                        normalizeTable value
+
+                    value
+                ))
+
+        if changed then JS.JSON.stringify parsed else json

--- a/src/Components/src/ARCtrl/EmptyColumnJson.test.fs
+++ b/src/Components/src/ARCtrl/EmptyColumnJson.test.fs
@@ -1,0 +1,122 @@
+module internal Swate.Components.Tests.EmptyColumnJson
+
+open ARCtrl
+open ARCtrl.Json
+open Swate.Components.Shared
+open Vitest
+
+let private makeAssay withData =
+    let table = ArcTable.init "Empty columns"
+    table.AddColumn(CompositeHeader.Input IOType.Sample, ResizeArray())
+    table.AddColumn(CompositeHeader.Comment "Notes", ResizeArray())
+
+    if withData then
+        table.AddColumn(CompositeHeader.Output IOType.Data, ResizeArray [ CompositeCell.emptyData ])
+
+    let assay = ArcAssay.init "empty-column-test"
+    assay.AddTable table
+    assay, table
+
+let private roundTrip format arcFile =
+    let _, json = Export.parseToJsonString (arcFile, format)
+    Generic.readFromJsonMap.[arcFile.RelatedArcFilesDiscriminate, format] json
+
+for format in
+    [
+        JsonExportFormat.ARCtrl
+        JsonExportFormat.ARCtrlCompressed
+    ] do
+    Vitest.describe (
+        $"Empty sparse columns ({format})",
+        fun () ->
+            Vitest.test (
+                "round-trips empty columns followed by a data column without mutating the source",
+                fun () ->
+                    let assay, table = makeAssay true
+                    let before = ArcAssay.toJsonString 0 assay
+                    let restored = roundTrip format (ArcFiles.Assay assay)
+                    let restoredTable = restored.Tables().[0]
+
+                    Vitest.expect(restoredTable.RowCount).toBe 1
+                    Vitest.expect(restoredTable.Headers |> Seq.toArray).toEqual (table.Headers |> Seq.toArray)
+                    Vitest.expect(restoredTable.GetCellAt(0, 0)).toEqual CompositeCell.emptyFreeText
+                    Vitest.expect(restoredTable.GetCellAt(2, 0)).toEqual CompositeCell.emptyData
+                    Vitest.expect(ArcAssay.toJsonString 0 assay).toBe before
+            )
+
+            Vitest.test (
+                "preserves zero-row tables",
+                fun () ->
+                    let assay, _ = makeAssay false
+                    let restored = roundTrip format (ArcFiles.Assay assay)
+                    Vitest.expect(restored.Tables().[0].RowCount).toBe 0
+                    Vitest.expect(restored.Tables().[0].ColumnCount).toBe 2
+            )
+
+            Vitest.test (
+                "preserves populated sparse cells alongside an empty column",
+                fun () ->
+                    let assay, table = makeAssay true
+                    table.SetCellAt(0, 0, CompositeCell.createFreeText "sample-1")
+                    table.SetCellAt(0, 1, CompositeCell.createFreeText "sample-2")
+                    let restored = roundTrip format (ArcFiles.Assay assay)
+                    let restoredTable = restored.Tables().[0]
+                    Vitest.expect(restoredTable.RowCount).toBe 2
+                    Vitest.expect(restoredTable.GetCellAt(0, 0)).toEqual (CompositeCell.createFreeText "sample-1")
+                    Vitest.expect(restoredTable.GetCellAt(0, 1)).toEqual (CompositeCell.createFreeText "sample-2")
+            )
+
+            Vitest.test (
+                "round-trips template tables",
+                fun () ->
+                    let _, table = makeAssay true
+
+                    let template =
+                        Template.create (System.Guid.NewGuid(), table, name = "Empty columns")
+
+                    match roundTrip format (ArcFiles.Template template) with
+                    | ArcFiles.Template restored ->
+                        Vitest.expect(restored.Table.RowCount).toBe 1
+                        Vitest.expect(restored.Table.ColumnCount).toBe 3
+                        Vitest.expect(restored.Table.GetCellAt(0, 0)).toEqual CompositeCell.emptyFreeText
+                    | _ -> failwith "Expected a template"
+            )
+
+            Vitest.test (
+                "repairs tables nested in an investigation",
+                fun () ->
+                    let assay, _ = makeAssay true
+                    let investigation = ArcInvestigation.init "nested"
+                    investigation.AddAssay assay
+
+                    match roundTrip format (ArcFiles.Investigation investigation) with
+                    | ArcFiles.Investigation restored ->
+                        Vitest.expect(restored.Assays.[0].Tables.[0].RowCount).toBe 1
+
+                        Vitest.expect(restored.Assays.[0].Tables.[0].GetCellAt(0, 0)).toEqual
+                            CompositeCell.emptyFreeText
+                    | _ -> failwith "Expected an investigation"
+            )
+    )
+
+Vitest.test (
+    "normalization leaves unrelated nulls and JSON-looking strings untouched",
+    fun () ->
+        let json =
+            """{"columns":[[0,null]],"c":[[0,null]],"other":null,"text":"\"columns\":[[0,null]]"}"""
+
+        Vitest.expect(EmptyColumnJson.normalize false json).toBe json
+        Vitest.expect(EmptyColumnJson.normalize true json).toBe json
+)
+
+Vitest.test (
+    "repairs template tables without altering unrelated null metadata",
+    fun () ->
+        let json =
+            """{"table":{"headers":[],"rowCount":1,"columns":[[0,null]]},"other":null}"""
+
+        let expected =
+            """{"table":{"headers":[],"rowCount":1,"columns":[[0,[]]]},"other":null}"""
+
+        Vitest.expect(EmptyColumnJson.normalize false json).toBe expected
+)

--- a/src/Components/src/ARCtrl/Json.fs
+++ b/src/Components/src/ARCtrl/Json.fs
@@ -279,6 +279,12 @@ module Export =
             | ArcFiles.DataMap(_, _), anyElse ->
                 failwithf "Error. It is not intended to parse Datamap to %s format." (string anyElse)
 
+        let jsonString =
+            match jef with
+            | JsonExportFormat.ARCtrl -> EmptyColumnJson.normalize false jsonString
+            | JsonExportFormat.ARCtrlCompressed -> EmptyColumnJson.normalize true jsonString
+            | _ -> jsonString
+
         name, jsonString
 
     let tryParseToJsonString (arcfile: ArcFiles, jef: JsonExportFormat) =

--- a/src/Components/src/Swate.Components.fsproj
+++ b/src/Components/src/Swate.Components.fsproj
@@ -78,7 +78,9 @@
     <Compile Include="ARCtrl\TermCollection.fs" />
     <Compile Include="ARCtrl\Helper.fs" />
     <Compile Include="ARCtrl\ArcIO.fs" />
+    <Compile Include="ARCtrl\EmptyColumnJson.fs" />
     <Compile Include="ARCtrl\Json.fs" />
+    <Compile Include="ARCtrl\EmptyColumnJson.test.fs" />
     <Compile Include="ARCtrl\Types\CompositeCellDiscriminate.fs" />
     <Compile Include="ARCtrl\Types\CompositeHeaderDiscriminate.fs" />
     <Compile Include="ARCtrl\ArcTable.fs" />


### PR DESCRIPTION
Workaround for #1324

1. `Input [Sample Name]` creates a column with zero cells.
2. `Output [Data]` creates one empty data cell, raising the table’s row count to one. The input column remains empty.
3. ARCtrl serializes the empty input column as `null`, but its decoder rejects `null`.

- ArcFilePreviewTarget updates the editor before synchronizing the in-memory ARC
- Subsequent updates serialize the same empty column
- Adding rows resolves by populating the empty column

**Recommended fix:** make ARCtrl encode empty sparse columns as `[]` instead of `null`

This workaround converts empty sparse-column null values to [] at Swate’s shared export boundary, covering Electron synchronization and both ARCtrl JSON formats. It preserves table contents and zero-row tables.